### PR TITLE
boot - default conf was never loaded

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -51,7 +51,7 @@ module Src
     end
 
     # Load the katello.yml.  Details from it are used in setting some config elements of the environment.
-    katello_config = YAML.load_file('/etc/katello/katello.yml')
+    katello_config = YAML.load_file('/etc/katello/katello.yml') rescue nil
     if katello_config.nil?
       katello_config = YAML.load_file("#{Rails.root}/config/katello.yml") rescue nil
     end


### PR DESCRIPTION
I noticed default configuration was never loaded when /etc/katello/katello.yml was missing. It was throwing an error:

/usr/lib/ruby/1.8/yaml.rb:143:in `initialize': No such file or directory - /etc/katello/katello.yml (Errno::ENOENT)
    from /usr/lib/ruby/1.8/yaml.rb:143:in`open'
    from /usr/lib/ruby/1.8/yaml.rb:143:in `load_file'
    from /home/lzap/CloudForms/katello/src/config/application.rb:54
    from /home/lzap/CloudForms/katello/src/vendor/ruby/1.8/gems/railties-3.0.10/lib/rails/commands.rb:21:in`require'
    from /home/lzap/CloudForms/katello/src/vendor/ruby/1.8/gems/railties-3.0.10/lib/rails/commands.rb:21
    from script/rails:45:in `require'
    from script/rails:45

I want to initialize Katello without configuration in Hudson for some tests, fixing this.
