### PR TITLE
812842 - complete removal of skipping None values in verbose print strategy

### DIFF
--- a/cli/src/katello/client/utils/printer.py
+++ b/cli/src/katello/client/utils/printer.py
@@ -111,9 +111,6 @@ class VerboseStrategy(PrinterStrategy):
         print
         for column in columns:
             value = self._get_column_value(column, item)
-            #skip missing attributes
-            if value == None:
-                continue
 
             if not column.get('multiline', False):
                 col_width = self._max_label_width(columns)


### PR DESCRIPTION
In verbose mode we want the field and their labels to be always displayed.
