### PR TITLE
810232 - system templates - fix issue editing multiple templates

### DIFF
--- a/src/public/javascripts/system_template.js
+++ b/src/public/javascripts/system_template.js
@@ -1179,6 +1179,7 @@ KT.template_download = {
 KT.editable = {
     setup_editable_name : function(id, success) {
         $('.edit_template_name').each(function() {
+            $(this).editable('destroy');
             $(this).editable(KT.common.rootURL() + "/system_templates/" + id, {
                 type        :  'text',
                 width       :  250,
@@ -1199,6 +1200,7 @@ KT.editable = {
     },
     setup_editable_description : function(id, success) {
         $('.edit_template_description').each(function() {
+            $(this).editable('destroy');
             $(this).editable(KT.common.rootURL() + "/system_templates/" + id, {
                 type        :  'textarea',
                 rows        :  6,


### PR DESCRIPTION
Prior to this change, when a user edits multiple template names/descriptions, the changes is only applied to the template that was updated first.  This is an issue with how the jeditable is initialized.

For example, before this change:
- setup: create templates
  - name:template1
  - name:template2
  - name:template3
- edit the templates:
  - template1 - change name to template1rename
  - template2 - change name to template2rename
  - template3 - change name to template3rename
- outcome: templates
  - name:template3rename
  - name:template2
  - name:template3
