### PR TITLE
Fixes for missing CSRF meta.

### DIFF
--- a/src/app/views/layouts/_ajax_notices.haml
+++ b/src/app/views/layouts/_ajax_notices.haml
@@ -1,7 +1,6 @@
 - if current_user
-  = javascript do
-    :plain
-      $(document).ready(function(){
-        notices.setup_notices(#{notification_polling_time});
-        notices.addNotices($.parseJSON( "#{escape_javascript(get_new_notices.to_json)}"   ));
-      });
+  :plain
+    $(document).ready(function(){
+      notices.setup_notices(#{notification_polling_time});
+      notices.addNotices($.parseJSON( "#{escape_javascript(get_new_notices.to_json)}"   ));
+    });

--- a/src/app/views/layouts/katello.haml
+++ b/src/app/views/layouts/katello.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %meta(http-equiv="Content-Type" content="text/html; charset=UTF-8")
+    = csrf_meta_tag
     = favicon_link_tag 'favicon.png'
     %title
       = project_name
@@ -16,8 +17,6 @@
       = include_javascripts  :html5
     / [if IE]
       = include_stylesheets  :ie, :embed_assets=>false
-    
-      = csrf_meta_tag
 
   - if controller.respond_to?(:section_id)
     - section_id = controller.section_id
@@ -50,8 +49,8 @@
           var AUTH_TOKEN = #{form_authenticity_token.inspect};
       = render :partial => "common/common_i18n"
       = render :partial => 'common/config'
+      = render :partial => 'layouts/ajax_notices'
+      = render :partial => 'layouts/notification'
       = yield :inline_javascript
 
-    = render :partial => 'layouts/ajax_notices'
-    = render :partial => 'layouts/notification'
     = yield :javascripts


### PR DESCRIPTION
The previous commit related to moving all inline javascript to a single script tag caused the CSRF meta tag to be nested improperly resulting in various issues showing up in the UI (e.g. login breaking, delete redirecting strangely).  This puts it back properly and moves some missing inline scripts under the proper script tag.
