### PR TITLE
Fix for issue with loading roles details due to javascript ordering from changes to having a single inline script tag.

### DIFF
--- a/src/app/views/layouts/_tupane_layout.html.haml
+++ b/src/app/views/layouts/_tupane_layout.html.haml
@@ -32,8 +32,8 @@
 - if content_for?(:custom)
   = yield :custom
 
-= yield :javascripts
 - if content_for?(:inline_javascript)
   %script{ :type => "text/javascript" }
     = yield :inline_javascript
+= yield :javascripts
 = yield :stylesheets


### PR DESCRIPTION
ordering problem caused the role details to not show properly.
