### PR TITLE
812263 - keep the original tomcat server.xml when resetting dbs

### DIFF
--- a/src/script/katello-reset-dbs
+++ b/src/script/katello-reset-dbs
@@ -87,11 +87,14 @@ sleep 10s # let mongo initialize
 echo "Initializing Candlepin database"
 /usr/share/candlepin/cpsetup -s
 
+# cpsetup alters tomcat configuration, use the original
+cp /etc/tomcat6/server.xml.original /etc/tomcat6/server.xml
+
 echo "Starting Pulp instance"
 $SRV pulp-server start
 
 echo "Starting Candlepin instance"
-start_unless_running tomcat6
+$SRV tomcat6 restart
 
 echo "Initializing Katello database"
 # cannot use initdb for this (BZ 745542)


### PR DESCRIPTION
katello-reset-dbs calls cpsetup script which alters /etc/tomcat6/server.xml and
sets another password to a keystore. Using the original file fixes the issue.
