### PR TITLE
767925 - search packages command in CLI/API

### DIFF
--- a/cli/bin/katello
+++ b/cli/bin/katello
@@ -160,6 +160,7 @@ def setup_admin(admin):
     pack_cmd = package.Package()
     pack_cmd.add_action('info', package.Info())
     pack_cmd.add_action('list', package.List())
+    pack_cmd.add_action('search', package.Search())
     admin.add_command('package', pack_cmd)
 
     errata_cmd = errata.Errata()

--- a/cli/src/katello/client/api/package.py
+++ b/cli/src/katello/client/api/package.py
@@ -28,3 +28,8 @@ class PackageAPI(KatelloAPI):
         path = "/api/repositories/%s/packages" % repoId
         pack_list = self.server.GET(path)[1]
         return pack_list
+
+    def search(self, query, repoId):
+        path = "/api/repositories/%s/packages/search" % repoId
+        pack_list = self.server.GET(path, {"search": query})[1]
+        return pack_list

--- a/cli/src/katello/client/core/package.py
+++ b/cli/src/katello/client/core/package.py
@@ -118,32 +118,62 @@ class List(PackageAction):
             self.require_option('product')
 
     def run(self):
+        repoId = self.get_repo_id()
+        if not repoId:
+            return os.EX_DATAERR
+
+        self.printer.set_header(_("Package List For Repo %s") % repoId)
+
+        packages = self.api.packages_by_repo(repoId)
+        self.print_packages(packages)
+
+        return os.EX_OK
+
+    def get_repo_id(self):
         repoId   = self.get_option('repo_id')
         repoName = self.get_option('repo')
         orgName  = self.get_option('org')
         envName  = self.get_option('env')
         prodName = self.get_option('product')
 
+        if not repoId:
+            repo = get_repo(orgName, prodName, repoName, envName)
+            if repo != None:
+                repoId = repo["id"]
+
+        return repoId
+
+    def print_packages(self, packages):
         self.printer.add_column('id')
         self.printer.add_column('name')
         self.printer.add_column('filename')
-
-
-        if not repoId:
-            repo = get_repo(orgName, prodName, repoName, envName)
-            if repo == None:
-                return os.EX_DATAERR
-            repoId = repo["id"]
-
-
-        self.printer.set_header(_("Package List For Repo %s") % repoId)
-
-        packages = self.api.packages_by_repo(repoId)
-
         self.printer.print_items(packages)
+
+
+
+class Search(List):
+
+    description = _('search packages in a repository')
+
+    def setup_parser(self):
+        super(Search, self).setup_parser()
+        self.parser.add_option('--query', dest='query',
+                      help=_("query string for searching packages, e.g. 'kernel*','kernel-3.3.0-4.el6.x86_64'"))
+
+    def check_options(self):
+        super(Search, self).check_options()
+        self.require_option('query')
+
+    def run(self):
+        repoId = self.get_repo_id()
+        if not repoId:
+            return os.EX_DATAERR
+        query   = self.get_option('query')
+        self.printer.set_header(_("Package List For Repo %s and Query %s") % (repoId, query))
+
+        packages = self.api.search(query, repoId)
+        self.print_packages(packages)
         return os.EX_OK
-
-
 
 
 # package command ------------------------------------------------------------

--- a/scripts/system-test/cli-system-test
+++ b/scripts/system-test/cli-system-test
@@ -22,6 +22,7 @@ else
     CMD_NOUSER="katello"
 fi
 CMD="$CMD_NOUSER -u $USER -p $PASSWORD"
+KATELLO_CMD=$CMD
 TEST_DIR=$script_dir'/cli_tests/'
 
 test_cnt=0

--- a/scripts/system-test/cli_tests/package.sh
+++ b/scripts/system-test/cli_tests/package.sh
@@ -6,6 +6,16 @@ header "Package"
 
 test_success "package list by repo id" package list --repo_id="$REPO_ID"
 test_success "package list" package list --repo="$REPO_NAME" --org="$TEST_ORG" --product="$FEWUPS_PRODUCT"
+
+SEARCHED_PACKAGE='monkey-0.3-0.8'
+SEARCH_SUCCESS_QUERY='monkey-0.3*'
+SEARCH_FAIL_QUERY='monkey-0.4*'
+function package_search_test {
+    $KATELLO_CMD package search --repo="$REPO_NAME" --org="$TEST_ORG" --product="$FEWUPS_PRODUCT" --query="$1" | grep -F "$SEARCHED_PACKAGE"
+}
+test_own_cmd_success "package search success" package_search_test $SEARCH_SUCCESS_QUERY
+test_own_cmd_failure "package search fail" package_search_test $SEARCH_FAIL_QUERY
+
 PACK_ID=`$CMD package list --repo_id="$REPO_ID" -g | tail -n 1 | awk '{print $1}'`
 if valid_id $PACK_ID; then
     test_success "package info" package info --id="$PACK_ID" --repo_id="$REPO_ID" 

--- a/src/app/controllers/api/packages_controller.rb
+++ b/src/app/controllers/api/packages_controller.rb
@@ -16,19 +16,25 @@ class Api::PackagesController < Api::ApiController
   respond_to :json
 
   before_filter :find_repository
-  before_filter :find_package, :except => [:index]
+  before_filter :find_package, :only => [:show]
   before_filter :authorize
 
   def rules
     readable = lambda{ @repo.environment.contents_readable? and @repo.product.readable? }
     {
       :index => readable,
+      :search => readable,
       :show => readable,
     }
   end
 
   def index
     render :json => @repo.packages
+  end
+
+  def search
+    packages = Glue::Pulp::Package.search(params[:search], 0, 0, [@repo.pulp_id])
+    render :json => packages.to_a
   end
 
   def show

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -472,7 +472,9 @@ Src::Application.routes.draw do
       resources :sync, :only => [:index, :create] do
         delete :index, :on => :collection, :action => :cancel
       end
-      resources :packages
+      resources :packages do
+        get :search, :on => :collection
+      end
       resources :errata, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z\-\+%_.:]+/ }
       resources :distributions, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z\-\+%_.]+/ }
       resources :filters, :only => [] do

--- a/src/spec/controllers/api/packages_controller_spec.rb
+++ b/src/spec/controllers/api/packages_controller_spec.rb
@@ -79,6 +79,14 @@ describe Api::PackagesController do
       }
       it_should_behave_like "protected action"
     end
+
+    describe "search" do
+      let(:action) { :search }
+      let(:req) {
+        get 'search', :id => 1, :repository_id => repo_id, :query => "cheetah*"
+      }
+      it_should_behave_like "protected action"
+    end
   end
 
   context "tests" do
@@ -96,6 +104,13 @@ describe Api::PackagesController do
       it "should call pulp find package api" do
         Pulp::Package.should_receive(:find).once.with(1)
         get 'show', :id => 1, :repository_id => repo_id
+      end
+    end
+
+    describe "search for a package" do
+      it "should call glue layer" do
+        Glue::Pulp::Package.should_receive(:search).once.with("cheetah*", 0, 0, [@repo.pulp_id])
+        get 'search', :repository_id => repo_id, :search => "cheetah*"
       end
     end
   end


### PR DESCRIPTION
Usage:

```
katello package search --product Product --repo Repo --query 'package*'
```

API:

```
GET /repositories/:repo_id/packages/search?search=:search_query
```

As in UI, it's using Elasticsearch on backend.
