### PR TITLE
Adds logical-insight profiling option

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -83,4 +83,5 @@ end
 group :development do
   # profiler
   gem 'newrelic_rpm'
+  gem 'logical-insight'
 end

--- a/src/config/initializers/logical_insight.rb
+++ b/src/config/initializers/logical_insight.rb
@@ -1,0 +1,5 @@
+require "logical-insight"
+
+if AppConfig.logical_insight
+  Rails.application.config.middleware.use "Insight::App", :secret_key => false, :ip_masks => false
+end


### PR DESCRIPTION
Adds logical-insight (a fork of rack-bug to work with rails3 and provide persistent storage of requests) as a development gem and adds an initializer to allow a developer to turn it on and off via katello.yml.  See https://fedorahosted.org/katello/wiki/WebProfiling for more information.
