### PR TITLE
correcting pulp testing repofile url

### DIFF
--- a/repos/rhel-pulp-testing.repo
+++ b/repos/rhel-pulp-testing.repo
@@ -4,7 +4,7 @@
 # community release)
 [pulp-testing]
 name=Pulp Testing Builds
-baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/testing/$releasever/$basearch/
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/dev/testing/$releasever/$basearch/
 enabled=1
 skip_if_unavailable=1
 gpgcheck=0


### PR DESCRIPTION
Repo file URL for pulp testing was incorrect after Pulp team changed this. Correcting.
