### PR TITLE
809823 - Blocking katello-configure from installing katello if headpin i...

### DIFF
--- a/puppet/bin/katello-configure
+++ b/puppet/bin/katello-configure
@@ -336,8 +336,17 @@ if show_resulting_answer_file
 	exit
 end
 
-#Set the deployment to be the relative url
+# Set the deployment to be the relative url
 url_root = final_options['deployment'].nil? ? default_options['deployment'] : final_options['deployment']
+# Don't let a headpin user install in katello/cfse mode
+if url_root == 'katello' || url_root == 'cfse'
+  if %x[rpm -qa katello-headpin] != ''
+    $stderr.puts "You have attempted to set up #{url_root} with katello-headpin installed."
+    $stderr.puts "Please consult the documentation or use a valid --deployment flag."
+    exit_with :default_option_error
+  end
+end
+
 ENV['RAILS_RELATIVE_URL_ROOT'] = "/" + url_root
 
 


### PR DESCRIPTION
Check to see if katello-headpin is installed; if so do not allow configuration of 'katello mode' since pulp, etsc won't configure correctly

https://bugzilla.redhat.com/show_bug.cgi?id=809823
