### PR TITLE
remove test.rake from rpm package

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -238,6 +238,9 @@ rm -f %{buildroot}%{homedir}/lib/tasks/.gitkeep
 rm -f %{buildroot}%{homedir}/public/stylesheets/.gitkeep
 rm -f %{buildroot}%{homedir}/vendor/plugins/.gitkeep
 
+#remove development tasks
+rm %{buildroot}%{homedir}/lib/tasks/test.rake
+
 #branding
 if [ -d branding ] ; then
   ln -svf %{_datadir}/icons/hicolor/24x24/apps/system-logo-icon.png %{buildroot}%{homedir}/public/images/rh-logo.png


### PR DESCRIPTION
It's a development task not intended to be used in production and causes
troubles with it's dependencies to rspec.
