### PR TITLE
816188 - installer minimum is 2 thins now

### DIFF
--- a/puppet/lib/puppet/parser/functions/katello_process_count.rb
+++ b/puppet/lib/puppet/parser/functions/katello_process_count.rb
@@ -27,9 +27,9 @@ module Puppet::Parser::Functions
       max_processes = (((total_mem - reserve) / consumes)).floor
       notice("Maximum processes: #{max_processes}")
 
-      # safeguard not to have less than 1 or more than max
+      # safeguard not to have less than 2 or more than max
       no_processes = max_processes if no_processes > max_processes
-      no_processes = 1 if no_processes < 1
+      no_processes = 2 if no_processes < 2
 
       notice("Thin processes: #{no_processes}")
       no_processes.to_s


### PR DESCRIPTION
We had some issues when Katello was configured with one thin only (installer detects memory and does heuristic calculations to setup best amount of thin processes). Its minimum was 1 instance. We already fixed deadlocks, but after discussion it is better to have at least 2 thins running minimum:

https://bugzilla.redhat.com/show_bug.cgi?id=816188
