### PR TITLE
818261 - consumer rpm was not installable on RHEL5

### DIFF
--- a/certs-tools/gen-rpm.sh
+++ b/certs-tools/gen-rpm.sh
@@ -340,7 +340,11 @@ RPMOPTS="--define \"_topdir $RPM_BUILD_DIR\"\
  --define '_sourcedir   %{_topdir}'\
  --define '_specdir     %{_topdir}'\
  --define '_rpmdir      %{_topdir}'\
- --define '_srcrpmdir   %{_topdir}'"
+ --define '_srcrpmdir   %{_topdir}'\
+ --define '_source_filedigest_algorithm md5'\
+ --define '_binary_filedigest_algorithm md5'\
+ --define '_source_payload nil'\
+ --define '_binary_payload nil'"
 
 eval "rpmbuild -ta $RPMOPTS --clean $RPM_BUILD_DIR/$TARBALL" || exit 1
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=818261

When configuring katello (katello-configure) on a RHEL system with the
redhat-rpm-config package installed, katello will create a
candlepin-cert-consumer RPM that is not installable on RHEL5 systems.

To avoid this bug, run be sure that redhat-rpm-config is _not_ installed when
running 'katello-configure'

After it happens, to work around this problem, run the following commands to
rebuild a RHEL5 installable candlepin-cert-consumer RPM.

```
cd /var/www/html/pub
rpmbuild --rebuild --define "_source_filedigest_algorithm md5" --define "_binary_filedigest_algorithm md5" --define "_source_payload nil" --define "_binary_payload nil" candlepin-cert-consumer-*.src.rpm
cp /root/rpmbuild/RPMS/noarch/candlepin-cert-consumer-*.noarch.rpm .
```

To prevent this problem from happening in the future, the gen-rpm.sh script
(provided by katello-cert-tools) will need to use the proper rpmbuild
parameters.
