### PR TITLE
Adding back db_user & db_name to cpsetup call

### DIFF
--- a/puppet/modules/candlepin/manifests/config.pp
+++ b/puppet/modules/candlepin/manifests/config.pp
@@ -27,17 +27,17 @@ class candlepin::config {
   }
 
   # this does not really work if you use a password
-   require certs::params
-   exec {"cpsetup":
-     command => "/usr/share/candlepin/cpsetup -k ${certs::params::keystore_password} >> ${candlepin::params::cpsetup_log} 2>&1",
-     timeout => 300, # 5 minutes timeout (cpsetup can be really slow sometimes)
-     require => [
-       File["${katello::params::log_base}"],
-       Postgres::Createuser[$candlepin::params::db_user],
-       Class["certs::config"]
-     ],
-     creates => "/etc/tomcat6/server.xml.original", # another hack not to run it again
-     #creates => "/etc/candlepin/certs/candlepin-ca.crt", # another hack not to run it again
-     before  => Class["apache2::service"]               # another hack, as we reuse cp certs by default
-   }
+  require "certs::params"
+  exec {"cpsetup":
+    command => "/usr/share/candlepin/cpsetup -k ${certs::params::keystore_password} -u ${candlepin::params::db_user} -d ${candlepin::params::db_name} >> ${candlepin::params::cpsetup_log} 2>&1",
+    timeout => 300, # 5 minutes timeout (cpsetup can be really slow sometimes)
+    require => [
+      File["${katello::params::log_base}"],
+      Postgres::Createuser[$candlepin::params::db_user],
+      Class["certs::config"]
+    ],
+    creates => "/etc/tomcat6/server.xml.original", # another hack not to run it again
+    #creates => "/etc/candlepin/certs/candlepin-ca.crt", # another hack not to run it again
+    before  => Class["apache2::service"]               # another hack, as we reuse cp certs by default
+  }
 }


### PR DESCRIPTION
Adding -u & -d calls to cp-setup to correctly set the db username & password
