### PR TITLE
818711 - pull release versions from CDN

### DIFF
--- a/src/app/models/kt_environment.rb
+++ b/src/app/models/kt_environment.rb
@@ -407,7 +407,7 @@ class KTEnvironment < ActiveRecord::Base
     if AppConfig.katello?
       self.repositories.enabled.map(&:minor).compact.uniq.sort
     else
-      self.organization.library.repositories.map(&:minor).compact.uniq.sort
+      self.organization.redhat_provider.available_releases
     end
   end
 


### PR DESCRIPTION
headpin needs to pull release versions from CDN rather than pulp. Code already in-place to switch between two styles of this in kt_environment.rb
