### PR TITLE
Added version information for headpin

### DIFF
--- a/headpin/katello-cli-headpin/bin/headpin
+++ b/headpin/katello-cli-headpin/bin/headpin
@@ -39,6 +39,7 @@ from katello.client.core import (
   provider,
   product,
   ping,
+  version,
   system,
   shell_command,
   client
@@ -101,7 +102,7 @@ def setup_admin(admin):
     admin.add_command('permission', permission_cmd)
 
     admin.add_command('ping', ping.Status())
-
+    admin.add_command('version', version.Info())
     prod_cmd = product.Product()
     prod_cmd.add_action('list', product.List())
     admin.add_command('product', prod_cmd)


### PR DESCRIPTION
Small change needed to be made here to add the same behavior as
https://github.com/Katello/katello/commit/6b6971bc0a173612a54c12461230db1d5706571b 
