### PR TITLE
clear candlepin database when upgrading in development

### DIFF
--- a/scripts/test/katello-stack
+++ b/scripts/test/katello-stack
@@ -39,11 +39,18 @@ post_update()
 {
   pulp-migrate
   # we dont store snapshot for mongodb - its fast enough
-  cp /etc/candlepin/candlepin.conf /etc/candlepin/candlepin.conf.original
-  /usr/share/candlepin/cpsetup
-  mv /etc/candlepin/candlepin.conf.original /etc/candlepin/candlepin.conf
-  su - postgres -c \
-    'pg_dump -c candlepin > /var/lib/pgsql/backups/candlepin_clean.sql'
+
+  if [ -e /usr/share/candlepin/cpdb ]; then
+    /usr/share/candlepin/cpdb --update
+  else
+    # Just for backward compatibility for Candlepin versions < 0.5.28-1
+    # without cpdb tool.
+    # Feel free to remove after some time
+    cp /etc/candlepin/candlepin.conf /etc/candlepin/candlepin.conf.original
+    /usr/share/candlepin/cpsetup
+    mv /etc/candlepin/candlepin.conf.original /etc/candlepin/candlepin.conf
+    su - postgres -c 'pg_dump -c candlepin > /var/lib/pgsql/backups/candlepin_clean.sql'
+  fi
 }
 
 update_system()
@@ -69,9 +76,16 @@ initdb()
   service mongod start
   pulp-migrate
 
+  if [ -e /usr/share/candlepin/cpdb ]; then
+    /usr/share/candlepin/cpdb --create --drop
+  else
+    # Just for backward compatibility for Candlepin versions < 0.5.28-1
+    # without cpdb tool.
+    # Feel free to remove after some time
+    su - postgres -c 'psql candlepin < /var/lib/pgsql/backups/candlepin_clean.sql'
+  fi
+
   # clean candlepin from snapshot
-  su - postgres -c \
-    'psql candlepin < /var/lib/pgsql/backups/candlepin_clean.sql'
   service pulp-server restart
   service tomcat6 restart
 }


### PR DESCRIPTION
Candlepin no longer clears the database on upgrade. Since we produce an sql
file for restoring the status of database to the starting point after upgrading
we need clear CP database. Therefore delete the candlepin database when
upgrading and let it recreate by cpsetup.

Otherwise katello-stack initdb fails when running after update.
