### PR TITLE
817848 - Adding dry-run to candlepin proxy routes

### DIFF
--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -580,6 +580,7 @@ Src::Application.routes.draw do
     match '/consumers/:id/entitlements' => 'candlepin_proxies#get', :via => :get
     match '/consumers/:id/entitlements' => 'candlepin_proxies#post', :via => :post
     match '/consumers/:id/entitlements' => 'candlepin_proxies#delete', :via => :delete
+    match '/consumers/:id/entitlements/dry-run' => 'candlepin_proxies#get', :via => :get
     match '/consumers/:id/owner' => 'candlepin_proxies#get', :via => :get
     match '/consumers/:consumer_id/certificates/:id' => 'candlepin_proxies#delete', :via => :delete
     match '/pools' => 'candlepin_proxies#get', :via => :get


### PR DESCRIPTION
dry-run gets called when registering a system with SLA support
