### PR TITLE
adding the ability to pass in 'development' as your env

### DIFF
--- a/src/script/katello-reset-dbs
+++ b/src/script/katello-reset-dbs
@@ -20,6 +20,16 @@ KATELLO_HOME=${KATELLO_HOME:-/usr/share/katello}
 KATELLO_ENV=${KATELLO_ENV:-production}
 DEPLOYMENT="katello"
 
+if [ -e $1 ]
+then
+  KATELLO_ENV=${KATELLO_ENV:-production}
+  echo "Defaulting to [$KATELLO_ENV] environment"
+else
+  KATELLO_ENV=$1
+fi
+
+
+
 if [ $KATELLO_PREFIX = "/headpin" -o $KATELLO_PREFIX = "/sam" ] ; then
     DEPLOYMENT="sam"
 fi
@@ -54,7 +64,7 @@ while getopts ":f" opt; do
 done
 
 if [ ! "$FORCE" = "1" ]; then
-  read -p "Are you sure you want to proceed (yes/no)? "
+  read -p "Are you sure you want reset your [$KATELLO_ENV] environment? (yes/no)? "
   [ "$REPLY" != "yes" ] && exit 1
 fi
 
@@ -68,11 +78,15 @@ function start_unless_running {
   $SRV "$1" status >/dev/null || $SRV "$1" start
 }
 
-echo "Stopping Katello instance"
-stop_if_running katello
+# Only stop the services if we are in production mode
+if [ $KATELLO_ENV = "production" ]
+then
+    echo "Stopping Katello instance"
+    stop_if_running katello
 
-echo "Stopping Katello jobs instance"
-stop_if_running katello-jobs
+    echo "Stopping Katello jobs instance"
+    stop_if_running katello-jobs
+fi
 
 if [ $DEPLOYMENT = "katello" ] ; then
     echo "Stopping Pulp instance"
@@ -115,10 +129,14 @@ pushd $KATELLO_HOME >/dev/null
 RAILS_ENV=$KATELLO_ENV rake setup --trace 2>&1
 popd >/dev/null
 
-echo "Starting Katello instance"
-$SRV katello start
+# Only stop the services if we are in production mode
+if [ $KATELLO_ENV = "production" ]
+then
+    echo "Starting Katello instance"
+    $SRV katello start
 
-echo "Starting Katello jobs instance"
-$SRV katello-jobs start
+    echo "Starting Katello jobs instance"
+    $SRV katello-jobs start
+fi
 
 echo "DONE. CHECK ALL THE MESSAGES ABOVE!"


### PR DESCRIPTION
This lets the user reset their pulp, candlepin and katello
data without effecting the katello and katello jobs services.  Only
starts/stops pulp and candlepin related services.
