### PR TITLE
772850 - provider status is not relevant to headpin since repos are not sync'ed

### DIFF
--- a/headpin/katello-cli-headpin/bin/headpin
+++ b/headpin/katello-cli-headpin/bin/headpin
@@ -125,7 +125,6 @@ def setup_admin(admin):
     prov_cmd = provider.Provider()
     prov_cmd.add_action('info', provider.Info())
     prov_cmd.add_action('list', provider.List())
-    prov_cmd.add_action('status', provider.Status())
     prov_cmd.add_action('import_manifest', provider.ImportManifest())
     admin.add_command('provider', prov_cmd)
 


### PR DESCRIPTION
Removed 'provider status' command from headpin CLI
