### PR TITLE
795869 - Fixing org name in katello-configure to accept spaces but still...

### DIFF
--- a/puppet/modules/katello/manifests/config.pp
+++ b/puppet/modules/katello/manifests/config.pp
@@ -77,18 +77,6 @@ class katello::config {
     },
   }
 
-  common::simple_replace { "org_description":
-      file => "/usr/share/katello/db/seeds.rb",
-      pattern => "ACME Corporation Organization",
-      replacement => "$katello::params::org_name Organization",
-      before => Exec["katello_seed_db"],
-      require => $katello::params::deployment ? {
-                'katello' => [ Class["candlepin::service"], Class["pulp::service"], Common::Simple_replace["org_name"]  ],
-                'headpin' => [ Class["candlepin::service"], Class["thumbslug::service"], Common::Simple_replace["org_name"] ],
-                default => [],
-    },
-  }
-
   common::simple_replace { "primary_user_pass":
       file => "/usr/share/katello/db/seeds.rb",
       pattern => "password => 'admin'",
@@ -139,7 +127,6 @@ class katello::config {
                   File["${katello::params::config_dir}/katello.yml"],
                   Postgres::Createdb[$katello::params::db_name],
                   Common::Simple_replace["org_name"],
-                  Common::Simple_replace["org_description"],
                   Common::Simple_replace["primary_user_name"],
                   Common::Simple_replace["primary_user_pass"],
                   Common::Simple_replace["primary_user_email"]
@@ -151,7 +138,6 @@ class katello::config {
                   File["${katello::params::config_dir}/katello.yml"],
                   Postgres::Createdb[$katello::params::db_name],
                   Common::Simple_replace["org_name"],
-                  Common::Simple_replace["org_description"],
                   Common::Simple_replace["primary_user_name"],
                   Common::Simple_replace["primary_user_pass"],
                   Common::Simple_replace["primary_user_email"]

--- a/src/db/seeds.rb
+++ b/src/db/seeds.rb
@@ -46,8 +46,11 @@ unless hidden_user = User.hidden.first
 end
 raise "Unable to create hidden user: #{format_errors hidden_user}" if hidden_user.nil? or hidden_user.errors.size > 0
 
+first_org_name = "ACME_Corporation"
+first_org_desc = first_org_name + " Organization"
+first_org_cp_key = first_org_name.gsub(' ', '_')
 # create the default org = "admin" if none exist
-first_org = Organization.find_or_create_by_name(:name => "ACME_Corporation", :description => "ACME Corporation Organization", :cp_key => 'ACME_Corporation')
+first_org = Organization.find_or_create_by_name(:name => first_org_name, :description => first_org_desc, :cp_key => first_org_cp_key)
 raise "Unable to create first org: #{format_errors first_org}" if first_org and first_org.errors.size > 0
 raise "Are you sure you cleared candlepin?! Unable to create first org!" if first_org.environments.nil?
 


### PR DESCRIPTION
... create a proper candlepin key

I refactored the code to make the sed replacement of the usr/share/katello code a little safer. It also creates a proper cp_key that won't have spaces in it
