### PR TITLE
systems - fix error on UI create

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -20,7 +20,7 @@ class SystemsController < ApplicationController
   before_filter :find_environment, :only => [:environments, :new]
   before_filter :authorize
 
-  before_filter :setup_options, :only => [:index, :items, :environments]
+  before_filter :setup_options, :only => [:index, :items, :create, :environments]
 
   # two pane columns and mapping for sortable fields
   COLUMNS = {'name' => 'name_sort', 'lastCheckin' => 'lastCheckin'}


### PR DESCRIPTION
Prior to this change, attempting to create a system in the UI would generate the following error:

You have a nil object when you didn't expect it! You might have expected an instance of Array. The error occurred while evaluating nil.[]
