### PR TITLE
product model - returned last_sync and sync_state fields back to json export

### DIFF
--- a/src/app/models/product.rb
+++ b/src/app/models/product.rb
@@ -100,14 +100,17 @@ class Product < ActiveRecord::Base
   def serializable_hash(options={})
     options = {} if options == nil
 
-
     hash = super(options.merge(:except => [:cp_id, :id]))
     hash = hash.merge(:productContent => self.productContent,
                       :multiplier => self.multiplier,
                       :attributes => self.attrs,
                       :id => self.cp_id)
     if AppConfig.katello?
-      hash = hash.merge(:sync_plan_name => self.sync_plan ? self.sync_plan.name : nil)
+      hash = hash.merge({
+        :sync_plan_name => self.sync_plan ? self.sync_plan.name : nil,
+        :sync_state => self.sync_state,
+        :last_sync => self.last_sync
+      })
     end
     hash
   end


### PR DESCRIPTION
They were removed with headpin merge but cli uses them.
