### PR TITLE
821010 - catch and log errors fetching release versions from cdn

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -221,7 +221,14 @@ class SystemsController < ApplicationController
   end
 
   def edit
-     render :partial=>"edit", :layout=>"tupane_layout", :locals=>{:system=>@system, :editable=>@system.editable?, :name=>controller_display_name}
+    begin
+      releases = @system.available_releases
+    rescue Exception => e
+      # Don't pepper user with notices if there is an error fetching release versions, but do log them
+      Rails.logger.error e.to_str
+      releases = []
+    end
+    render :partial=>"edit", :layout=>"tupane_layout", :locals=>{:system=>@system, :editable=>@system.editable?, :releases=>releases, :name=>controller_display_name}
   end
 
   def update

--- a/src/app/helpers/systems_helper.rb
+++ b/src/app/helpers/systems_helper.rb
@@ -65,9 +65,9 @@ module SystemsHelper
     end
   end
 
-  def system_releasevers_edit system
+  def system_releasevers_edit system, releases
     vers = {}
-    system.available_releases.each { |ver|
+    releases.each { |ver|
       vers[ver] = ver
     }
 

--- a/src/app/models/provider.rb
+++ b/src/app/models/provider.rb
@@ -208,19 +208,23 @@ class Provider < ActiveRecord::Base
 
   def available_releases
     releases = []
-    CDN::CdnVarSubstitutor.with_cache do
-      self.products.engineering.each do |product|
-        cdn_var_substitutor = CDN::CdnVarSubstitutor.new(product.provider[:repository_url],
-                                                         :ssl_client_cert => OpenSSL::X509::Certificate.new(product.certificate),
-                                                         :ssl_client_key => OpenSSL::PKey::RSA.new(product.key))
-        product.productContent.each do |pc|
-          if url_to_releases = pc.content.contentUrl[/^.*\$releasever/]
-            cdn_var_substitutor.substitute_vars(url_to_releases).each do |(substitutions, path)|
-              releases << CDN::Utils.parse_version(substitutions['releasever'])[:minor]
+    begin
+      CDN::CdnVarSubstitutor.with_cache do
+        self.products.engineering.each do |product|
+          cdn_var_substitutor = CDN::CdnVarSubstitutor.new(product.provider[:repository_url],
+                                                           :ssl_client_cert => OpenSSL::X509::Certificate.new(product.certificate),
+                                                           :ssl_client_key => OpenSSL::PKey::RSA.new(product.key))
+          product.productContent.each do |pc|
+            if url_to_releases = pc.content.contentUrl[/^.*\$releasever/]
+              cdn_var_substitutor.substitute_vars(url_to_releases).each do |(substitutions, path)|
+                releases << CDN::Utils.parse_version(substitutions['releasever'])[:minor]
+              end
             end
           end
         end
       end
+    rescue Exception => e
+      raise _("Unable to retrieve release versions from Repository URL %s. Error message: %s") % [self.repository_url, e.to_str]
     end
     releases.uniq.sort
   end

--- a/src/app/views/systems/_edit.html.haml
+++ b/src/app/views/systems/_edit.html.haml
@@ -44,7 +44,7 @@
       %fieldset
         .grid_2.ra.fieldset
           = label :releaseVer, :releaseVer, _("Release Version")
-        .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever" if editable), 'data-url' => system_path(system.id), 'data-options' => system_releasevers_edit(system)}
+        .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever" if editable), 'data-url' => system_path(system.id), 'data-options' => system_releasevers_edit(system, releases)}
           = system.release
       %fieldset
         .grid_2.ra.fieldset


### PR DESCRIPTION
If there were errors fetching release versions from CDN (in headpin mode), the System/Details tab could not be opened. Errors are logged now and the view rendered.
