### PR TITLE
encryption - plain text passwords encryption

### DIFF
--- a/puppet/bin/katello-passwd
+++ b/puppet/bin/katello-passwd
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'optparse'
+begin
+  require File.expand_path('/usr/share/katello/lib/util/password.rb')
+rescue LoadError
+  STDERR.puts "Katello was not installed on this host, cannot continue."
+  exit 1
+end
+
+options = {}
+optparse = OptionParser.new do |opts|
+  opts.banner = <<EOS
+Katello password utility tool.
+
+Encrypts given password for use in all Katello configuration files.
+It's recommended to quote all parameters when using this tool.
+
+Usage:
+  katello-passwd [-s] [password1] ..."
+
+Example:
+  katello-passwd 'test123$ABC'
+  $1$wiWTZz7VT4J2th5OTd75pg==
+
+Options:
+EOS
+
+  options[:stdin] = false
+  opts.on( '-s', '--stdin', 'Take password from STDIN' ) do
+    options[:stdin] = true
+  end
+
+  opts.on( '-v', '--version', 'Display version information' ) do
+    puts 'katello-passwd THE_VERSION'
+    puts 'Copyright (C) 2012 Red Hat, Inc.'
+    puts 'This is free software; see the source for copying conditions.  There is NO'
+    puts 'warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.'
+    puts 'Distributed under GNU GPLv2+, see /usr/share/doc/katello-common-*/LICENSE.'
+    exit
+  end
+
+  opts.on( '-h', '--help', 'Display this screen' ) do
+    puts opts
+    exit
+  end
+end
+
+optparse.parse!
+
+# encrypt, test and return password
+def encrypt(str)
+  pass = Password.encrypt(str)
+  if str != Password.decrypt(pass) or str == ''
+    STDERR.puts "Unable to continue"
+    exit 3
+  end
+  pass
+end
+
+if options[:stdin]
+  # stdin method
+  ARGF.each_line do |line|
+    puts encrypt(line.chomp)
+  end
+elsif ARGV.count > 0
+  # parameter method
+  ARGV.each do |pass|
+    puts encrypt(pass)
+  end
+else
+  # query method
+  begin
+    system "stty -echo"
+    print "Password: "; pass1 = $stdin.gets.chomp; puts "\n"
+    print "Password (repeat): "; pass2 = $stdin.gets.chomp; puts "\n"
+    if pass1 == pass2
+      puts encrypt(pass2)
+    else
+      STDERR.puts "Passwords do not match!"
+      exit 2
+    end
+  ensure
+    system "stty echo"
+  end
+end

--- a/puppet/katello-configure.spec
+++ b/puppet/katello-configure.spec
@@ -43,6 +43,10 @@ THE_VERSION=%version perl -000 -ne 'if ($X) { s/^THE_VERSION/$ENV{THE_VERSION}/;
 #build katello-upgrade man page
 sed -e 's/THE_VERSION/%version/g' man/katello-upgrade.pod | /usr/bin/pod2man --name=katello-upgrade -c "Katello Reference" --section=1 --release=%{version} - man/katello-upgrade.man1
 
+#build katello-passwd man page
+THE_VERSION=%version sed -i "s/THE_VERSION/$THE_VERSION/g" man/katello-passwd.pod bin/katello-passwd
+/usr/bin/pod2man --name=%{name} -c "Katello Reference" --section=1 --release=%{version} man/katello-passwd.pod man/katello-passwd.man1
+
 
 %install
 rm -rf %{buildroot}
@@ -50,6 +54,7 @@ rm -rf %{buildroot}
 install -d -m 0755 %{buildroot}%{_sbindir}
 install -m 0755 bin/katello-configure %{buildroot}%{_sbindir}
 install -m 0755 bin/katello-upgrade %{buildroot}%{_sbindir}
+install -m 0755 bin/katello-passwd %{buildroot}%{_sbindir}
 install -d -m 0755 %{buildroot}%{homedir}
 install -d -m 0755 %{buildroot}%{homedir}/puppet/modules
 cp -Rp modules/* %{buildroot}%{homedir}/puppet/modules
@@ -60,6 +65,7 @@ install -m 0644 options-format-file %{buildroot}%{homedir}
 install -d -m 0755 %{buildroot}%{_mandir}/man1
 install -m 0644 man/katello-configure.man1 %{buildroot}%{_mandir}/man1/katello-configure.1
 install -m 0644 man/katello-upgrade.man1 %{buildroot}%{_mandir}/man1/katello-upgrade.1
+install -m 0644 man/katello-passwd.man1 %{buildroot}%{_mandir}/man1/katello-passwd.1
 install -d -m 0755 %{buildroot}%{homedir}/upgrade-scripts
 cp -Rp upgrade-scripts/* %{buildroot}%{homedir}/upgrade-scripts
 
@@ -71,8 +77,10 @@ rm -rf %{buildroot}
 %{homedir}/
 %{_sbindir}/katello-configure
 %{_sbindir}/katello-upgrade
+%{_sbindir}/katello-passwd
 %{_mandir}/man1/katello-configure.1*
 %{_mandir}/man1/katello-upgrade.1*
+%{_mandir}/man1/katello-passwd.1*
 
 
 %changelog

--- a/puppet/lib/puppet/parser/functions/katello_passencrypt.rb
+++ b/puppet/lib/puppet/parser/functions/katello_passencrypt.rb
@@ -1,0 +1,15 @@
+begin
+  require File.expand_path('/usr/share/katello/lib/util/password.rb')
+rescue LoadError
+  STDERR.puts "Katello was not installed on this host - passwords won't be encrypted"
+  # define dummy encrypt functions that does nothing
+  module Password
+    def Password.encrypt(text); return text; end
+  end
+end
+
+module Puppet::Parser::Functions
+  newfunction(:katello_passencrypt, :type => :rvalue) do |args|
+    return Password.encrypt(args[0])
+  end
+end

--- a/puppet/man/katello-passwd.pod
+++ b/puppet/man/katello-passwd.pod
@@ -1,0 +1,63 @@
+
+=head1 NAME
+
+katello-passwd - Katello password encryption tool
+
+=head1 SYNOPSIS
+
+    katello-passwd
+      [ -s | --stdin ]
+      [ -h | --help ]
+      [ -v | --version ]
+
+=head1 DESCRIPTION
+
+The B<katello-passwd> program encrypts plain text password into format
+that is readable only to Katello. Encrypted paswords are in the format
+of '$N$xxx' where N is version number.
+
+Katello is able to read passwords in both plain text and encrypted form,
+but it is recommended to use encrypted form. If password starts with the
+prefix (see above), it is decrypted, otherwise plain text form is used.
+
+The B<katello-configure> use the same encryption to encrypt all sensitive
+passwords during configuration.
+
+This utility refuses to encrypt empty password, error is thrown.
+
+=head1 COMMAND LINE PARAMETERS
+
+=over
+
+=item --stdin, -s
+
+Read password from STDIN. For each line it prints encrypted password.
+
+=item --version, -v
+
+Display version and licensing information.
+
+=item --help, -h
+
+Display short summary of all options.
+
+=back
+
+=head1 EXIT STATUS
+
+Returns 1 when initialization failed.
+
+Returns 2 when passwords did not match.
+
+Returns 3 when encrypted password was not decrypted successfuly or when
+input was an empty string.
+
+Otherwise, returns 0.
+
+=head1 VERSION
+
+THE_VERSION
+
+=head1 SEE ALSO
+
+katello-configure(1)

--- a/puppet/modules/katello/manifests/config.pp
+++ b/puppet/modules/katello/manifests/config.pp
@@ -21,6 +21,11 @@ class katello::config {
     require => [ Postgres::Createuser[$katello::params::db_user], File["${katello::params::log_base}"] ],
   }
 
+  exec { "generate-passphrase":
+    command => "/usr/share/katello/script/katello-generate-passphrase",
+    creates => "/etc/katello/secure/passphrase"
+  }
+
   file {
     "${katello::params::config_dir}/thin.yml":
       content => template("katello/${katello::params::config_dir}/thin.yml.erb"),
@@ -32,7 +37,8 @@ class katello::config {
       content => template("katello/${katello::params::config_dir}/katello.yml.erb"),
       owner   => $katello::params::user,
       group   => $katello::params::group,
-      mode    => "600";
+      mode    => "600",
+      require => [ Exec["generate-passphrase"] ];
 
     "/etc/sysconfig/katello":
       content => template("katello/etc/sysconfig/katello.erb"),

--- a/puppet/modules/katello/templates/etc/katello/katello.yml.erb
+++ b/puppet/modules/katello/templates/etc/katello/katello.yml.erb
@@ -137,10 +137,12 @@ common:
 #
 # The following configuration values override ones from the common section
 #
+<%# bug #7991 in puppet 2.6 - need to explicitly load custom functions %>
+<% Puppet::Parser::Functions::function('katello_passencrypt') %>
   database:
    adapter: postgresql
    username: <%= scope.lookupvar("katello::params::db_user") %>
-   password: <%= scope.lookupvar("katello::params::db_pass") %>
+   password: <%= scope.function_katello_passencrypt([scope.lookupvar("katello::params::db_pass")]) %>
    database: <%= scope.lookupvar("katello::params::db_name") %>
    host: localhost
    encoding: UTF8

--- a/selinux/katello-selinux/katello-selinux-enable
+++ b/selinux/katello-selinux/katello-selinux-enable
@@ -15,4 +15,5 @@ done
 semanage port -l | grep amqp_port_t | grep tcp | grep 5674 >/dev/null || \
   /usr/sbin/semanage port -a -t amqp_port_t -p tcp 5674
 
-/sbin/restorecon -rvvi /var/lib/katello /var/log/katello
+# TODO this should go to extra script (and should be called from SPEC too)
+/sbin/restorecon -rvvi /var/lib/katello /var/log/katello /usr/share/katello /etc/katello /usr/sbin/katello-*

--- a/selinux/katello-selinux/katello-selinux.spec
+++ b/selinux/katello-selinux/katello-selinux.spec
@@ -101,6 +101,9 @@ install -p -m 755 %{name}-enable %{buildroot}%{_sbindir}/%{name}-enable
 install -d -m 0755 %{buildroot}%{_mandir}/man1
 install -m 0644 katello-selinux-enable.man1 %{buildroot}%{_mandir}/man1/katello-selinux-enable.1
 
+# Install secure (extra protected) directory
+install -d %{buildroot}%{_sysconfdir}/katello/secure
+
 %clean
 rm -rf %{buildroot}
 
@@ -111,7 +114,7 @@ fi
 
 %posttrans
 if /usr/sbin/selinuxenabled ; then
-  /sbin/restorecon -rvvi /var/lib/katello /var/log/katello
+  /sbin/restorecon -rvvi /var/lib/katello /var/log/katello /usr/share/katello /etc/katello /usr/sbin/katello-*
 fi
 
 %postun
@@ -124,7 +127,7 @@ if [ $1 -eq 0 ]; then
     done
 fi
 
-/sbin/restorecon -rvvi /var/lib/katello /var/log/katello
+/sbin/restorecon -rvvi /var/lib/katello /var/log/katello /usr/share/katello /etc/katello /usr/sbin/katello-*
 
 %files
 %defattr(-,root,root,0755)
@@ -133,6 +136,7 @@ fi
 %{_datadir}/selinux/devel/include/%{moduletype}/%{modulename}.if
 %{_mandir}/man1/katello-selinux-enable.1*
 %attr(0755,root,root) %{_sbindir}/%{name}-enable
+%{_sysconfdir}/katello/secure
 
 %changelog
 * Mon Mar 26 2012 Martin Bačovský <mbacovsk@redhat.com> 0.2.4-1

--- a/selinux/katello-selinux/katello.fc
+++ b/selinux/katello-selinux/katello.fc
@@ -1,6 +1,19 @@
+# vim: sw=8:ts=8:et
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-katello		--	gen_context(system_u:object_r:httpd_katello_script_exec_t,s0)
+katello                                         --      gen_context(system_u:object_r:httpd_katello_script_exec_t,s0)
+/var/lib/katello(/.*)?                                  gen_context(system_u:object_r:httpd_katello_script_var_lib_t,s0)
+/var/log/katello(/.*)?                                  gen_context(system_u:object_r:httpd_katello_script_log_t,s0)
 
-/var/lib/katello(/.*)?		gen_context(system_u:object_r:httpd_katello_script_var_lib_t,s0)
-
-/var/log/katello(/.*)?		gen_context(system_u:object_r:httpd_katello_script_log_t,s0)
+/etc/katello/secure                                     gen_context(system_u:object_r:katello_secetc_dir_t,s0)
+/etc/katello/secure/passphrase                          gen_context(system_u:object_r:katello_secetc_file_t,s0)

--- a/selinux/katello-selinux/katello.if
+++ b/selinux/katello-selinux/katello.if
@@ -1,3 +1,15 @@
+# vim: sw=2:ts=2:et
+#
+# Copyright 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 ## <summary>policy for httpd_katello_script</summary>
 
@@ -191,5 +203,30 @@ interface(`httpd_katello_script_admin',`
 
 	files_search_var_lib($1)
 	admin_pattern($1, httpd_katello_script_var_lib_t)
+')
 
+########################################
+## <summary>
+##      Read extra secure config files in /etc/katello/secure.
+## </summary>
+## <desc>
+##      <p>
+##        These files has extra domain because contains sensitive data
+##      </ul>
+## </desc>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <infoflow type="read" weight="10"/>
+#
+interface(`katello_files_read_secetc_files',`
+  gen_require(`
+    type katello_secetc_file_t;
+    ')
+
+  allow $1 katello_secetc_file_t:dir list_dir_perms;
+  read_files_pattern($1, katello_secetc_file_t, katello_secetc_file_t)
+  read_lnk_files_pattern($1, katello_secetc_file_t, katello_secetc_file_t)
 ')

--- a/selinux/katello-selinux/katello.sh
+++ b/selinux/katello-selinux/katello.sh
@@ -42,9 +42,10 @@ set -x
 make -f /usr/share/selinux/devel/Makefile || exit
 /usr/sbin/semodule -i katello.pp
 
-# Fixing the file context on katello
+# fix the file contexts
 /sbin/restorecon -F -R -v katello
-# Fixing the file context on /var/log/katello
 /sbin/restorecon -F -R -v /var/log/katello
-# Fixing the file context on /var/lib/katello
 /sbin/restorecon -F -R -v /var/lib/katello
+/sbin/restorecon -F -R -v /usr/share/katello
+/sbin/restorecon -F -R -v /etc/katello
+/sbin/restorecon -F -R -v /usr/sbin/katello-*

--- a/selinux/katello-selinux/katello.te
+++ b/selinux/katello-selinux/katello.te
@@ -1,4 +1,21 @@
+# vim: sw=2:ts=2:et
+#
+# Copyright 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
 policy_module(katello, 1.0.0)
+
+require {
+  type unconfined_t;
+}
 
 ########################################
 #
@@ -14,6 +31,13 @@ logging_log_file(httpd_katello_script_log_t)
 
 type httpd_katello_script_var_lib_t;
 files_type(httpd_katello_script_var_lib_t)
+
+# extra config file domain for /etc/katello/secure
+type katello_secetc_file_t;
+files_type(katello_secetc_file_t)
+
+type katello_secetc_dir_t;
+files_type(katello_secetc_dir_t)
 
 ########################################
 #
@@ -53,7 +77,10 @@ mta_send_mail(httpd_katello_script_t)
 gen_require(`
 	type qpidd_t;
 ')
-
 files_list_tmp(qpidd_t)
 miscfiles_read_certs(qpidd_t)   
 
+# for extra config file domain
+filetrans_pattern(unconfined_t, katello_secetc_dir_t, katello_secetc_file_t, file)
+# TODO katello runs unconfined temporarily - uncomment this to allow secure files reading
+#katello_files_read_secetc_files(katello_not_yet_defined_t)

--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -1,4 +1,8 @@
-<% config = YAML.load_file('/etc/katello/katello.yml') rescue nil
+<%
+  # Rails has not been initialized yet (no Rails.root defined)
+  require File.expand_path('/usr/share/katello/lib/util/password.rb')
+
+  config = YAML.load_file('/etc/katello/katello.yml') rescue nil
   def find_db(config, env)
     db = nil
     if config
@@ -8,6 +12,8 @@
         db = config['common']['database']
       end
     end
+    # d3crypt password
+    db['password'] = Password.decrypt(db['password'])
     return db.collect {|k,v| "  #{k}: #{v}"}.sort.join("\n") if db
     nil
   end

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -225,6 +225,11 @@ ln -sv %{datadir}/tmp %{buildroot}%{homedir}/tmp
 #create symlink for Gemfile.lock (it's being regenerated each start)
 ln -svf %{datadir}/Gemfile.lock %{buildroot}%{homedir}/Gemfile.lock
 
+#create symlinks for important scripts
+mkdir -p %{buildroot}%{_bindir}
+ln -sv %{homedir}/script/katello-debug %{buildroot}%{_bindir}/katello-debug
+ln -sv %{homedir}/script/katello-generate-passphrase %{buildroot}%{_bindir}/katello-generate-passphrase
+
 #re-configure database to the /var/lib/katello directory
 sed -Ei 's/\s*database:\s+db\/(.*)$/  database: \/var\/lib\/katello\/\1/g' %{buildroot}%{homedir}/config/database.yml
 
@@ -280,6 +285,7 @@ fi
 %files
 %attr(600, katello, katello)
 %defattr(-,root,root)
+%{_bindir}/katello-*
 %{homedir}/app/controllers
 %{homedir}/app/helpers
 %{homedir}/app/mailers

--- a/src/script/katello-generate-passphrase
+++ b/src/script/katello-generate-passphrase
@@ -1,0 +1,40 @@
+#!/bin/bash
+usage() {
+cat <<USAGE
+usage: $0 options
+
+Simple script for creating random passphrase for katello-passwd.
+It is used by katello-installer and can be used when recovering
+a backup (passphrase is not stored in the backup).
+
+OPTIONS:
+  -f       Force re-creation of new passphrase
+  -h       This screen
+
+USAGE
+}
+
+FORCE=0
+
+while getopts "f" opt; do
+  case $opt in
+    f)
+      FORCE=1
+      ;;
+    h)
+      usage
+      exit
+      ;;
+    ?)
+      echo "Invalid option: $OPTARG" >&2
+      usage
+      exit
+      ;;
+  esac
+done
+
+FILE=/etc/katello/secure/passphrase
+[ $FORCE -eq 0 -a -f $FILE ] && \
+  echo "Passphrase file was already generated, you can only generate once" && exit 1
+PASS=$(</dev/urandom tr -dc A-Za-z0-9 | head -c 64)
+echo "$PASS" > $FILE

--- a/src/spec/lib/password_spec.rb
+++ b/src/spec/lib/password_spec.rb
@@ -45,4 +45,19 @@ describe Password do
     Password.check('cba', db).should be_false
   end
 
+  it "should encrypt and decrypt empty string" do
+    # writes some messages to STDERR but works as expected
+    encrypted = Password.encrypt('')
+    Password.decrypt(encrypted).should == ''
+  end
+
+  it "should encrypt and decrypt 'a' string" do
+    encrypted = Password.encrypt('a', 'test')
+    Password.decrypt(encrypted, 'test').should == 'a'
+  end
+
+  it "should encrypt and decrypt very long string" do
+    encrypted = Password.encrypt('a' * 999, 'test')
+    Password.decrypt(encrypted, 'test').should == 'a' * 999
+  end
 end


### PR DESCRIPTION
So I am adding support for plain text passwords encryption (please note this
is encryption for passwords we need to keep - obscurity not security).

1) There is a new utility called katello-passwd (see man page or help
option) to encrypt a password.

2) Encrypted passwords start with $1$ (1 is for version 1) and it can only
be used for database-password setting (we do not have any other plaintext
passwords in Katello yet).

3) Katello can also read unencrypted passwords from this field (if it does
not start with $1$).

4) I will raise a RFE against Candlepin to do the same for database
password. Pulp is fine (no passwords there so far).

5) I modified katello-configure to use the function to encrypt database
password during installation.

6) Encryption is done with passphrase stored in /etc/katello/secure
directory, the file is deployed with katello-generate-passphrase and this is
automatically done by our installer. The file has extra SELinux protection
(it's not in the regular etc_t domain).
