### PR TITLE
system errata - mv js to load on index

### DIFF
--- a/src/app/views/systems/errata/_index.html.haml
+++ b/src/app/views/systems/errata/_index.html.haml
@@ -1,4 +1,4 @@
-= javascript :filtertable, :system_errata
+= javascript :filtertable
 = javascript do
   -if editable
     :plain

--- a/src/config/assets.yml
+++ b/src/config/assets.yml
@@ -88,6 +88,7 @@ javascripts:
     - public/javascripts/headpin.sparkline.js
   system:
     - public/javascripts/systems.js
+    - public/javascripts/system_errata.js
     - public/javascripts/jquery/plugins/ui.spinner.js
   system_edit:
     - public/javascripts/system_edit.js
@@ -99,8 +100,6 @@ javascripts:
     - public/javascripts/system_packages.js
   system_products:
     - public/javascripts/system_products.js
-  system_errata:
-    - public/javascripts/system_errata.js
   system_template:
     - public/javascripts/slidingtree.js
     - public/javascripts/auto_complete.js

--- a/src/public/javascripts/system_errata.js
+++ b/src/public/javascripts/system_errata.js
@@ -14,13 +14,18 @@
 KT.system = KT.system || {};
 
 KT.system.errata = function() {
-    var system_errata_container = $('#system_errata'),
-    	system_id = system_errata_container.data('system_id'),
-    	table_body = system_errata_container.find('tbody'),
-    	load_more = $('#load_more_errata'),
+    var system_errata_container = undefined,
+        system_id = undefined,
+        table_body = undefined,
+        load_more = undefined,
         task_list = {},
         actions_updater,
         init = function(editable){
+            system_errata_container = $('#system_errata');
+            system_id = system_errata_container.data('system_id');
+            table_body = system_errata_container.find('tbody');
+            load_more = $('#load_more_errata');
+
             register_events();
 
             // Not all users have permission to interact with errata; those that don't


### PR DESCRIPTION
This change is to load the system_errata.js when loading the
system's page.  This behavior is consistent w/ how js is loaded for
many of the panes.  In addition, it addresses a JS error that
currently exists when attempting to access the Errata pane.
