### PR TITLE
819941 - missing dependencies in katello-all (common)

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -49,6 +49,7 @@ BuildArch:      noarch
 Summary:        Common bits for all Katello instances
 Requires:       httpd
 Requires:       mod_ssl
+Requires:       mod_authz_ldap
 Requires:       openssl
 Requires:       elasticsearch
 Requires:       rubygems
@@ -121,6 +122,11 @@ Requires:       postgresql-server
 Requires:       postgresql
 Requires:       pulp
 Requires:       candlepin-tomcat6
+# the following backend engine deps are required by <katello-configure>
+Requires:       mongodb mongodb-server
+Requires:       qpid-cpp-server qpid-cpp-client qpid-cpp-client-ssl qpid-cpp-server-ssl
+# </katello-configure>
+
 
 %description all
 This is the Katello meta-package.  If you want to install Katello and all


### PR DESCRIPTION
We are currently relying on katello-configure's puppet manifests to install
qpid and mongodb RPMS. See modules/qpid/manifests/install.pp and
modules/qpid/manifests/install.pp.

We ideally will just add these to the katello-common set of Requires and not
be forced to have katello-configure catch this missing dependency.

Without this it makes it harder to pre-build systems with the right RPM set
and is misleading that you could remove qpid-cpp-server-ssl and nothing
would complain.

So I am adding those to katello-all package rather than katello-common,
because those are dependencies of backend engines which are also installed
in the "all" section. After this patch, we should not see any packages to be
installed using Puppet:

$ grep "yum.*install" /var/log/katello/katello-configure/main.log
