### PR TITLE
reduce usage of require for code in lib dir

### DIFF
--- a/src/app/controllers/activation_keys_controller.rb
+++ b/src/app/controllers/activation_keys_controller.rb
@@ -331,7 +331,7 @@ class ActivationKeysController < ApplicationController
     all_pools = {}
 
     # TODO: should be current_organization.pools (see pool.rb for attributes)
-    cp_pools = Candlepin::Owner.pools current_organization.cp_key
+    cp_pools = Resources::Candlepin::Owner.pools current_organization.cp_key
     cp_pools.each do |pool|
       p = OpenStruct.new
       p.poolId = pool['id']

--- a/src/app/controllers/api/candlepin_proxies_controller.rb
+++ b/src/app/controllers/api/candlepin_proxies_controller.rb
@@ -10,24 +10,22 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/candlepin'
-
 class Api::CandlepinProxiesController < Api::ProxiesController
 
   skip_before_filter :authorize # ok - proxy is consumer only
 
   def get
-    r = ::Candlepin::Proxy.get(@request_path)
+    r = ::Resources::Candlepin::Proxy.get(@request_path)
     Rails.logger.debug r if AppConfig.debug_cp_proxy
     render :text => r, :content_type => :json
   end
 
   def delete
-    head ::Candlepin::Proxy.delete(@request_path).code.to_i
+    head ::Resources::Candlepin::Proxy.delete(@request_path).code.to_i
   end
 
   def post
-    r = ::Candlepin::Proxy.post(@request_path, @request_body)
+    r = ::Resources::Candlepin::Proxy.post(@request_path, @request_body)
     Rails.logger.debug r if AppConfig.debug_cp_proxy
     render :text => r, :content_type => :json
   end

--- a/src/app/controllers/api/distributions_controller.rb
+++ b/src/app/controllers/api/distributions_controller.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/pulp' if AppConfig.katello?
-
 class Api::DistributionsController < Api::ApiController
   respond_to :json
 

--- a/src/app/controllers/api/errata_controller.rb
+++ b/src/app/controllers/api/errata_controller.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/pulp' if AppConfig.katello?
-
 class Api::ErrataController < Api::ApiController
   respond_to :json
 

--- a/src/app/controllers/api/packages_controller.rb
+++ b/src/app/controllers/api/packages_controller.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/pulp' if AppConfig.katello?
-
 class Api::PackagesController < Api::ApiController
   respond_to :json
 
@@ -50,7 +48,7 @@ class Api::PackagesController < Api::ApiController
   end
 
   def find_package
-    @package = Pulp::Package.find(params[:id])
+    @package = Resources::Pulp::Package.find(params[:id])
     raise HttpErrors::NotFound, _("Package with id '#{params[:id]}' not found") if @package.nil?
     # and check ownership of it
     raise HttpErrors::NotFound, _("Package '#{params[:id]}' not found within the repository") unless @package['repoids'].include? @repo.pulp_id

--- a/src/app/controllers/api/providers_controller.rb
+++ b/src/app/controllers/api/providers_controller.rb
@@ -10,9 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/candlepin'
-require 'rest_client'
-
 class Api::ProvidersController < Api::ApiController
 
   before_filter :find_organization, :only => [:index, :create]

--- a/src/app/controllers/api/pulp_proxies_controller.rb
+++ b/src/app/controllers/api/pulp_proxies_controller.rb
@@ -10,31 +10,29 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/pulp' if AppConfig.katello?
-
 class Api::PulpProxiesController < Api::ProxiesController
 
   skip_before_filter :authorize # ok - proxy is consumer only
 
   def get
-    r = ::Pulp::Proxy.get(@request_path)
+    r = Resources::Pulp::Proxy.get(@request_path)
     Rails.logger.debug r if AppConfig.debug_pulp_proxy
     render :text => r, :content_type => :json
   end
 
   def delete
-    head ::Pulp::Proxy.delete(@request_path).code.to_i
+    head Resources::Pulp::Proxy.delete(@request_path).code.to_i
   end
 
   def post
-    r = ::Pulp::Proxy.post(@request_path, @request_body)
+    r = Resources::Pulp::Proxy.post(@request_path, @request_body)
     Rails.logger.debug r if AppConfig.debug_pulp_proxy
     render :text => r, :content_type => :json
   end
   
   # need to unify POST and PUT from rhsm -> katello -> pulp
   def put
-    r = ::Pulp::Proxy.put(@request_path + '/', params[:_json])
+    r = Resources::Pulp::Proxy.put(@request_path + '/', params[:_json])
     Rails.logger.debug r if AppConfig.debug_pulp_proxy
     render :text => r, :content_type => :json
   end

--- a/src/app/controllers/api/repositories_controller.rb
+++ b/src/app/controllers/api/repositories_controller.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/pulp' if AppConfig.katello?
-
 class Api::RepositoriesController < Api::ApiController
   include KatelloUrlHelper
   respond_to :json
@@ -120,7 +118,7 @@ class Api::RepositoriesController < Api::ApiController
 
   # proxy repository discovery call to pulp, so we don't have to create an async task to keep track of async task on pulp side
   def discovery
-    pulp_task = Pulp::Repository.start_discovery(params[:url], params[:type])
+    pulp_task = Resources::Pulp::Repository.start_discovery(params[:url], params[:type])
     task = PulpSyncStatus.using_pulp_task(pulp_task) {|t| t.organization = @organization}
     task.save!
     render :json => task

--- a/src/app/controllers/api/sync_controller.rb
+++ b/src/app/controllers/api/sync_controller.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/pulp' if AppConfig.katello?
-
 class Api::SyncController < Api::ApiController
 
   before_filter :find_object, :only => [:index, :create, :cancel]

--- a/src/app/controllers/api/systems_controller.rb
+++ b/src/app/controllers/api/systems_controller.rb
@@ -150,7 +150,7 @@ class Api::SystemsController < Api::ApiController
   end
 
   def errata
-    render :json => Pulp::Consumer.errata(@system.uuid)
+    render :json => Resources::Pulp::Consumer.errata(@system.uuid)
   end
 
   def upload_package_profile
@@ -319,7 +319,7 @@ class Api::SystemsController < Api::ApiController
   def find_system
     @system = System.first(:conditions => { :uuid => params[:id] })
     if @system.nil?
-      Candlepin::Consumer.get params[:id] # check with candlepin if system is Gone, raises RestClient::Gone
+      Resources::Candlepin::Consumer.get params[:id] # check with candlepin if system is Gone, raises RestClient::Gone
       raise HttpErrors::NotFound, _("Couldn't find system '#{params[:id]}'")
     end
     @system

--- a/src/app/controllers/providers_controller.rb
+++ b/src/app/controllers/providers_controller.rb
@@ -281,7 +281,7 @@ class ProvidersController < ApplicationController
     # TODO: See subscriptions_controller#reformat_subscriptions for a better(?) OpenStruct implementation
 
     @provider = current_organization.redhat_provider
-    all_subs = Candlepin::Owner.pools @provider.organization.cp_key
+    all_subs = Resources::Candlepin::Owner.pools @provider.organization.cp_key
     # We default to none imported until we can properly poll Candlepin for status of the import
     @grouped_subscriptions = {}
     all_subs.each do |sub|

--- a/src/app/controllers/subscriptions_controller.rb
+++ b/src/app/controllers/subscriptions_controller.rb
@@ -21,14 +21,14 @@ class SubscriptionsController < ApplicationController
 
 
   def index
-    all_subs = Candlepin::Owner.pools current_organization.cp_key
+    all_subs = Resources::Candlepin::Owner.pools current_organization.cp_key
     @subscriptions = reformat_subscriptions(all_subs)
   end
 
   # Reformat the subscriptions from our API to a format that the headpin HAML expects
   def reformat_subscriptions(all_subs)
     subscriptions = []
-    org_stats = Candlepin::Owner.statistics current_organization.cp_key
+    org_stats = Resources::Candlepin::Owner.statistics current_organization.cp_key
     converted_stats = []
     org_stats.each do |stat|
       converted_stats << OpenStruct.new(stat)

--- a/src/app/controllers/sync_management_controller.rb
+++ b/src/app/controllers/sync_management_controller.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/pulp' if AppConfig.katello?
-
 class SyncManagementController < ApplicationController
   include TranslationHelper
   include ActionView::Helpers::DateHelper

--- a/src/app/controllers/system_templates_controller.rb
+++ b/src/app/controllers/system_templates_controller.rb
@@ -268,7 +268,7 @@ class SystemTemplatesController < ApplicationController
 
   def auto_complete_package
     name = params[:name]
-    render :json=>Pulp::Package.name_search(name).sort.uniq[0..19]
+    render :json=> Resources::Pulp::Package.name_search(name).sort.uniq[0..19]
   end
 
   def create

--- a/src/app/models/changeset.rb
+++ b/src/app/models/changeset.rb
@@ -581,7 +581,7 @@ class Changeset < ActiveRecord::Base
     from_repo_ids     = from_repos.map { |r| r.pulp_id }
     @next_env_pkg_ids ||= package_ids(to_repos)
 
-    resolved_deps = Pulp::Package.dep_solve(package_names, from_repo_ids)['resolved']
+    resolved_deps = Resources::Pulp::Package.dep_solve(package_names, from_repo_ids)['resolved']
     resolved_deps = resolved_deps.values.flatten(1)
     resolved_deps = resolved_deps.reject { |dep| not @next_env_pkg_ids.index(dep['id']).nil? }
     resolved_deps

--- a/src/app/models/glue/candlepin/environment.rb
+++ b/src/app/models/glue/candlepin/environment.rb
@@ -10,7 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/candlepin'
 require 'set'
 
 module Glue::Candlepin::Environment
@@ -27,7 +26,7 @@ module Glue::Candlepin::Environment
   module InstanceMethods
     def set_environment
       Rails.logger.info _("Creating an environment in candlepin: %s") % name
-      Candlepin::Environment.create(self.organization.cp_key, id, name.gsub(/[^-\w]/,"_"), description)
+      Resources::Candlepin::Environment.create(self.organization.cp_key, id, name.gsub(/[^-\w]/,"_"), description)
     rescue => e
       Rails.logger.error _("Failed to create candlepin environment %s") % "#{name}: #{e}, #{e.backtrace.join("\n")}"
       raise e
@@ -35,7 +34,7 @@ module Glue::Candlepin::Environment
 
     def del_environment
       Rails.logger.info _("Deleteing environment in candlepin: %s") % name
-      Candlepin::Environment.destroy(id)
+      Resources::Candlepin::Environment.destroy(id)
     rescue => e
       Rails.logger.error _("Failed to delete candlepin environment %s") % "#{name}: #{e}, #{e.backtrace.join("\n")}"
       raise e
@@ -54,7 +53,7 @@ module Glue::Candlepin::Environment
 
     def update_cp_content
       new_content_ids = all_env_content_ids - saved_env_content_ids
-      Candlepin::Environment.add_content(self.id, new_content_ids)
+      Resources::Candlepin::Environment.add_content(self.id, new_content_ids)
     end
 
     protected
@@ -66,7 +65,7 @@ module Glue::Candlepin::Environment
     end
 
     def saved_env_content_ids
-      Candlepin::Environment.find(self.id)[:environmentContent].map do |content|
+      Resources::Candlepin::Environment.find(self.id)[:environmentContent].map do |content|
         content[:contentId]
       end
     end

--- a/src/app/models/glue/candlepin/owner.rb
+++ b/src/app/models/glue/candlepin/owner.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/candlepin'
-
 module Glue::Candlepin::Owner
 
   def self.included(base)
@@ -26,8 +24,8 @@ module Glue::Candlepin::Owner
           :presence => true,
           :format => { :with => /^[\w-]*$/ }
 
-      lazy_accessor :events, :initializer => lambda { Candlepin::Owner.events(cp_key) }
-      lazy_accessor :service_levels, :initializer => lambda { Candlepin::Owner.service_levels(cp_key) }
+      lazy_accessor :events, :initializer => lambda { Resources::Candlepin::Owner.events(cp_key) }
+      lazy_accessor :service_levels, :initializer => lambda { Resources::Candlepin::Owner.service_levels(cp_key) }
       lazy_accessor :debug_cert, :initializer => lambda { load_debug_cert}
     end
   end
@@ -42,7 +40,7 @@ module Glue::Candlepin::Owner
 
     def set_owner
       Rails.logger.debug _("Creating an owner in candlepin: %s") % name
-      Candlepin::Owner.create(cp_key, name)
+      Resources::Candlepin::Owner.create(cp_key, name)
     rescue => e
       Rails.logger.error _("Failed to create candlepin owner %s") % "#{name}: #{e}, #{e.backtrace.join("\n")}"
       raise e
@@ -50,7 +48,7 @@ module Glue::Candlepin::Owner
 
     def del_owner
       Rails.logger.debug _("Deleting owner in candlepin: %s") % name
-      Candlepin::Owner.destroy(cp_key)
+      Resources::Candlepin::Owner.destroy(cp_key)
     rescue => e
       Rails.logger.error _("Failed to delete candlepin owner %s") % "#{name}: #{e}, #{e.backtrace.join("\n")}"
       raise e
@@ -112,20 +110,20 @@ module Glue::Candlepin::Owner
 
     def pools consumer_uuid = nil
       if consumer_uuid
-        pools = Candlepin::Owner.pools self.cp_key, { :consumer => consumer_uuid }
+        pools = Resources::Candlepin::Owner.pools self.cp_key, { :consumer => consumer_uuid }
       else
-        pools = Candlepin::Owner.pools self.cp_key
+        pools = Resources::Candlepin::Owner.pools self.cp_key
       end
       pools.collect { |p| KTPool.new p }
     end
 
     def generate_debug_cert
-      Candlepin::Owner.generate_ueber_cert(cp_key)
+      Resources::Candlepin::Owner.generate_ueber_cert(cp_key)
     end
 
     def load_debug_cert
       begin
-        return Candlepin::Owner.get_ueber_cert(cp_key)
+        return Resources::Candlepin::Owner.get_ueber_cert(cp_key)
       rescue RestClient::ResourceNotFound =>  e
         return generate_debug_cert
       end

--- a/src/app/models/glue/candlepin/owner_info.rb
+++ b/src/app/models/glue/candlepin/owner_info.rb
@@ -10,14 +10,12 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/candlepin'
-
 class Glue::Candlepin::OwnerInfo
 
 
 
   def initialize(organization)
-      @info = Candlepin::OwnerInfo.find(organization.cp_key)
+      @info = Resources::Candlepin::OwnerInfo.find(organization.cp_key)
   end
 
 

--- a/src/app/models/glue/candlepin/pool.rb
+++ b/src/app/models/glue/candlepin/pool.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/candlepin'
-
 module Glue::Candlepin::Pool
 
   def self.included(base)
@@ -22,7 +20,7 @@ module Glue::Candlepin::Pool
     base.class_eval do
       lazy_accessor :productName, :productId, :startDate, :endDate, :consumed, :quantity, :attrs, :owner,
         :initializer => lambda {
-          json = Candlepin::Pool.find(cp_id)
+          json = Resources::Candlepin::Pool.find(cp_id)
           # symbol "attributes" is reserved by Rails and cannot be used
           json['attrs'] = json['attributes']
           json
@@ -34,7 +32,7 @@ module Glue::Candlepin::Pool
 
   module ClassMethods
     def find_by_organization_and_id(organization, pool_id)
-      pool = KTPool.find_by_cp_id(pool_id) || KTPool.new(Candlepin::Pool.find(pool_id))
+      pool = KTPool.find_by_cp_id(pool_id) || KTPool.new(Resources::Candlepin::Pool.find(pool_id))
       if pool.organization == organization
         return pool
       end

--- a/src/app/models/glue/candlepin/product_content.rb
+++ b/src/app/models/glue/candlepin/product_content.rb
@@ -20,12 +20,12 @@ class Glue::Candlepin::ProductContent
   end
 
   def create
-    created = Candlepin::Content.create @content
+    created = Resources::Candlepin::Content.create @content
     @content.id = created[:id]
   end
 
   def destroy
-    Candlepin::Content.destroy(@content.id)
+    Resources::Candlepin::Content.destroy(@content.id)
   end
 
 end

--- a/src/app/models/glue/pulp/distribution.rb
+++ b/src/app/models/glue/pulp/distribution.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require_dependency "resources/pulp"
-
 class Glue::Pulp::Distribution
   attr_accessor :id, :description, :files, :family, :variant, :version, :url, :arch
 
@@ -25,7 +23,7 @@ class Glue::Pulp::Distribution
   end
 
   def self.find id
-    Glue::Pulp::Distribution.new(Pulp::Distribution.find(id))
+    Glue::Pulp::Distribution.new(Resources::Pulp::Distribution.find(id))
   end
   
 end

--- a/src/app/models/glue/pulp/errata.rb
+++ b/src/app/models/glue/pulp/errata.rb
@@ -10,7 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require_dependency "resources/pulp"
 require 'set'
 require 'util/search'
 
@@ -27,11 +26,11 @@ class Glue::Pulp::Errata
   end
 
   def self.errata_by_consumer(repos)
-    Pulp::Consumer.errata_by_consumer(repos)
+    Resources::Pulp::Consumer.errata_by_consumer(repos)
   end
 
   def self.find(id)
-    erratum_attrs = Pulp::Errata.find(id)
+    erratum_attrs = Resources::Pulp::Errata.find(id)
     Glue::Pulp::Errata.new(erratum_attrs) if not erratum_attrs.nil?
   end
 
@@ -41,7 +40,7 @@ class Glue::Pulp::Errata
     filter_for_errata = filter.except(*filter_for_repo.keys)
 
     repos = repos_for_filter(filter_for_repo)
-    repos.each {|repo| errata.concat(Pulp::Repository.errata(repo.pulp_id, filter_for_errata)) }
+    repos.each {|repo| errata.concat(Resources::Pulp::Repository.errata(repo.pulp_id, filter_for_errata)) }
     errata
   end
 

--- a/src/app/models/glue/pulp/filter.rb
+++ b/src/app/models/glue/pulp/filter.rb
@@ -10,8 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require "resources/pulp"
-
 module Glue::Pulp::Filter
 
   def self.included(base)
@@ -19,7 +17,7 @@ module Glue::Pulp::Filter
     base.send :include, LazyAccessor
 
     base.class_eval do
-      lazy_accessor :description, :package_list, :initializer => lambda { Pulp::Filter.find(pulp_id) }
+      lazy_accessor :description, :package_list, :initializer => lambda { Resources::Pulp::Filter.find(pulp_id) }
 
       before_save :save_filter_orchestration
       before_destroy :destroy_filter_orchestration
@@ -30,7 +28,7 @@ module Glue::Pulp::Filter
 
     def set_pulp_filter
       Rails.logger.debug "creating pulp filter '#{self.pulp_id}'"
-      Pulp::Filter.create :id => self.pulp_id, :type => "blacklist", :package_list => self.package_list, :description => self.description
+      Resources::Pulp::Filter.create :id => self.pulp_id, :type => "blacklist", :package_list => self.package_list, :description => self.description
     rescue => e
       Rails.logger.error "Failed to create pulp filter #{self.pulp_id}: #{e}, #{e.backtrace.join("\n")}"
       raise e
@@ -38,7 +36,7 @@ module Glue::Pulp::Filter
 
     def del_pulp_filter
       Rails.logger.debug "deleting pulp filter '#{self.pulp_id}'"
-      Pulp::Filter.destroy self.pulp_id
+      Resources::Pulp::Filter.destroy self.pulp_id
     rescue => e
       Rails.logger.error "Failed to delete pulp filter #{self.pulp_id}: #{e}, #{e.backtrace.join("\n")}"
       raise e
@@ -46,7 +44,7 @@ module Glue::Pulp::Filter
 
     def set_packages package_list
       Rails.logger.debug "adding packages to pulp filter '#{self.pulp_id}'"
-      Pulp::Filter.add_packages pulp_id, package_list
+      Resources::Pulp::Filter.add_packages pulp_id, package_list
     rescue => e
       Rails.logger.error "Failed to add packages to pulp filter #{self.pulp_id}: #{e}, #{e.backtrace.join("\n")}"
       raise e
@@ -54,7 +52,7 @@ module Glue::Pulp::Filter
 
     def del_packages package_list
       Rails.logger.debug "removing packages to pulp filter '#{self.pulp_id}'"
-      Pulp::Filter.remove_packages pulp_id, package_list
+      Resources::Pulp::Filter.remove_packages pulp_id, package_list
     rescue => e
       Rails.logger.error "Failed to remove packages from pulp filter #{self.pulp_id}: #{e}, #{e.backtrace.join("\n")}"
       raise e

--- a/src/app/models/glue/pulp/package.rb
+++ b/src/app/models/glue/pulp/package.rb
@@ -10,14 +10,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require_dependency "resources/pulp"
 require "util/search"
 
 class Glue::Pulp::Package < Glue::Pulp::SimplePackage
   attr_accessor :id, :download_url, :checksum, :license, :group, :filename, :requires,  :provides, :description, :size, :buildhost, :repoids
 
   def self.find id
-    package_attrs = Pulp::Package.find(id)
+    package_attrs = Resources::Pulp::Package.find(id)
     Glue::Pulp::Package.new(package_attrs) if not package_attrs.nil?
   end
 

--- a/src/app/models/lazy_accessor.rb
+++ b/src/app/models/lazy_accessor.rb
@@ -21,7 +21,7 @@ module LazyAccessor
     attr_accessor :lazy_attributes
 
     # example: lazy_accessor :a, :b, :c,
-    #   :initializer => lambda { json = Candlepin::Product.get(cp_id)[0] },
+    #   :initializer => lambda { json = Resources::Candlepin::Product.get(cp_id)[0] },
     #   :unless => lambda { cp_id.nil? }
     def lazy_accessor *args
       options = args.extract_options!

--- a/src/app/models/ping.rb
+++ b/src/app/models/ping.rb
@@ -13,8 +13,6 @@
 #:nocov:
 
 require 'rest_client'
-require 'resources/pulp' if AppConfig.katello?
-require 'resources/candlepin'
 
 class Ping
   class << self
@@ -65,13 +63,13 @@ class Ping
       # pulp - ping with oauth
       if AppConfig.katello?
         exception_watch(result[:status][:pulp_auth]) do
-          Pulp::PulpPing.ping
+          Resources::Pulp::PulpPing.ping
         end
       end
 
       # candlepin - ping with oauth
       exception_watch(result[:status][:candlepin_auth]) do
-        Candlepin::CandlepinPing.ping
+        Resources::Candlepin::CandlepinPing.ping
       end
 
       exception_watch(result[:status][:katello_jobs]) do

--- a/src/app/models/provider.rb
+++ b/src/app/models/provider.rb
@@ -209,15 +209,15 @@ class Provider < ActiveRecord::Base
   def available_releases
     releases = []
     begin
-      CDN::CdnVarSubstitutor.with_cache do
+      Resources::CDN::CdnVarSubstitutor.with_cache do
         self.products.engineering.each do |product|
-          cdn_var_substitutor = CDN::CdnVarSubstitutor.new(product.provider[:repository_url],
+          cdn_var_substitutor = Resources::CDN::CdnVarSubstitutor.new(product.provider[:repository_url],
                                                            :ssl_client_cert => OpenSSL::X509::Certificate.new(product.certificate),
                                                            :ssl_client_key => OpenSSL::PKey::RSA.new(product.key))
           product.productContent.each do |pc|
             if url_to_releases = pc.content.contentUrl[/^.*\$releasever/]
               cdn_var_substitutor.substitute_vars(url_to_releases).each do |(substitutions, path)|
-                releases << CDN::Utils.parse_version(substitutions['releasever'])[:minor]
+                releases << Resources::CDN::Utils.parse_version(substitutions['releasever'])[:minor]
               end
             end
           end

--- a/src/app/models/pulp_task_status.rb
+++ b/src/app/models/pulp_task_status.rb
@@ -72,7 +72,7 @@ class PulpTaskStatus < TaskStatus
   end
 
   def self.refresh task_status
-    pulp_task = Pulp::Task.find([task_status.uuid]).first
+    pulp_task = Resources::Pulp::Task.find([task_status.uuid]).first
     task_status.attributes = {
         :state => pulp_task[:state],
         :finish_time => pulp_task[:finish_time],

--- a/src/app/models/puppetclasses.rb
+++ b/src/app/models/puppetclasses.rb
@@ -10,14 +10,12 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'resources/foreman' if AppConfig.katello?
-
 class Puppetclasses
 
   class << self
 
     def all
-      Foreman::Puppetclass.new.list
+      Resources::Foreman::Puppetclass.new.list
     end
 
   end

--- a/src/app/models/system_task.rb
+++ b/src/app/models/system_task.rb
@@ -197,7 +197,7 @@ class SystemTask < ActiveRecord::Base
     def refresh(ids)
       unless ids.nil? || ids.empty?
         uuids = TaskStatus.select(:uuid).where(:id => ids).collect{|t| t.uuid}
-        ret = Pulp::Task.find(uuids)
+        ret = Resources::Pulp::Task.find(uuids)
         ret.each do |pulp_task|
           PulpTaskStatus.dump_state(pulp_task, TaskStatus.find_by_uuid(pulp_task["id"]))
         end

--- a/src/app/models/system_template_distribution.rb
+++ b/src/app/models/system_template_distribution.rb
@@ -25,7 +25,7 @@ class SystemTemplateDistribution < ActiveRecord::Base
   validates_with DistributionValidator
 
   def load_backend_attributes
-    @distribution_glue ||= Glue::Pulp::Distribution.new(Pulp::Distribution.find(self.distribution_pulp_id))
+    @distribution_glue ||= Glue::Pulp::Distribution.new(Resources::Pulp::Distribution.find(self.distribution_pulp_id))
     raise Errors::NotFound.new(_("Distribution '%s' was not found in Pulp.") % distribution_pulp_id) if @distribution_glue.nil?
   end
 

--- a/src/integration_spec/candlepin/consumer_api_spec.rb
+++ b/src/integration_spec/candlepin/consumer_api_spec.rb
@@ -1,27 +1,27 @@
 require 'spec_helper'
 
-describe 'Candlepin::Consumer' do
+describe 'Resources::Candlepin::Consumer' do
   
   before(:each) do
     url = "http://localhost:8080/candlepin"    
-    Candlepin::Consumer.prefix = URI.parse(url).path
-    Candlepin::Consumer.site = url.gsub(Candlepin::Consumer.prefix, "")    
+    Resources::Candlepin::Consumer.prefix = URI.parse(url).path
+    Resources::Candlepin::Consumer.site = url.gsub(Resources::Candlepin::Consumer.prefix, "")    
     
     User.current = User.new(:username => 'admin', :password => 'admin')
     
-    @test_owner = Candlepin::Owner.create('test_owner' + random_string, 'test owner')
-    @consumer_1 = Candlepin::Consumer.create @test_owner[:key], 'test_consumer_' + random_string, 'system', {}
+    @test_owner = Resources::Candlepin::Owner.create('test_owner' + random_string, 'test owner')
+    @consumer_1 = Resources::Candlepin::Consumer.create @test_owner[:key], 'test_consumer_' + random_string, 'system', {}
   end
   
   it "should return a consumer for specified uuid" do
-    consumer = Candlepin::Consumer.get(@consumer_1[:uuid])
+    consumer = Resources::Candlepin::Consumer.get(@consumer_1[:uuid])
     
     consumer[:uuid].should == @consumer_1[:uuid]
     consumer[:name].should == @consumer_1[:name]    
   end
   
   it "should raise RestClient::ResourceNotFound for non-existant uuid" do
-    lambda {consumer = Candlepin::Consumer.get('12345')}.should raise_exception(RestClient::ResourceNotFound)
+    lambda {consumer = Resources::Candlepin::Consumer.get('12345')}.should raise_exception(RestClient::ResourceNotFound)
   end
   
   def random_string

--- a/src/lib/http_resource.rb
+++ b/src/lib/http_resource.rb
@@ -10,10 +10,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'rubygems'
 require 'oauth'
 require 'cgi'
-require 'resource_permissions'
 
 class RestClientException < RuntimeError
   attr_reader :service_code, :code

--- a/src/lib/resource_permissions.rb
+++ b/src/lib/resource_permissions.rb
@@ -10,7 +10,6 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'util/url_matcher'
 
 # Permission callback provider that are called before and after each HTTP call.
 # It can be used for permission check (before) or creation (after).
@@ -43,115 +42,116 @@ class ResourcePermissions
     def after_delete_callback(a_path, headers={}, result='')
     end
   end
-end
 
-# Permission callback provider that are called before and after each HTTP call.
-# It can be used for permission check (before) or creation (after).
-#
-# This is the default provider allowing implementations to define sets of checks.
-#
-class DefaultResourcePermissions < ResourcePermissions
+  # Permission callback provider that are called before and after each HTTP call.
+  # It can be used for permission check (before) or creation (after).
+  #
+  # This is the default provider allowing implementations to define sets of checks.
+  #
+  class DefaultResourcePermissions < ResourcePermissions
 
-  class_inheritable_accessor :url_prefix
+    class_inheritable_accessor :url_prefix
 
-  # arrays of pairs pattern path + action proc
-  @@after_get_actions = []
-  @@after_post_actions = []
-  @@after_put_actions = []
-  @@after_delete_actions = []
-  @@before_get_actions = []
-  @@before_post_actions = []
-  @@before_put_actions = []
-  @@before_delete_actions = []
+    # arrays of pairs pattern path + action proc
+    @@after_get_actions = []
+    @@after_post_actions = []
+    @@after_put_actions = []
+    @@after_delete_actions = []
+    @@before_get_actions = []
+    @@before_post_actions = []
+    @@before_put_actions = []
+    @@before_delete_actions = []
 
-  class << self
-    def call_actions(actions, a_path, payload, result)
-      matched = false
-      actions.each do |regexp_action|
-        pattern = regexp_action[0]
-        action = regexp_action[1]
-        Rails.logger.debug "Checking permission rule #{a_path} == #{url_prefix}#{pattern}"
-        match = UrlMatcher.match a_path, url_prefix + pattern
-        if match[0]
-          if action.arity == 3
-            action.call match, payload, result
-          elsif action.arity == 2
-            action.call match, payload
-          else
-            raise 'Resource permission provider callback must have 2 or 3 parameters'
+    class << self
+      def call_actions(actions, a_path, payload, result)
+        matched = false
+        actions.each do |regexp_action|
+          pattern = regexp_action[0]
+          action = regexp_action[1]
+          Rails.logger.debug "Checking permission rule #{a_path} == #{url_prefix}#{pattern}"
+          match = Util::UrlMatcher.match a_path, url_prefix + pattern
+          if match[0]
+            if action.arity == 3
+              action.call match, payload, result
+            elsif action.arity == 2
+              action.call match, payload
+            else
+              raise 'Resource permission provider callback must have 2 or 3 parameters'
+            end
+            matched = true
           end
-          matched = true
         end
+        matched
       end
-      matched
-    end
 
-    def before_get_callback(a_path, headers)
-      was_called = call_actions @@before_get_actions, a_path, nil, nil
-      Rails.logger.warn "WARNING unprotected REST call: GET #{a_path}" unless was_called
-    end
+      def before_get_callback(a_path, headers)
+        was_called = call_actions @@before_get_actions, a_path, nil, nil
+        Rails.logger.warn "WARNING unprotected REST call: GET #{a_path}" unless was_called
+      end
 
-    def after_get_callback(a_path, headers, result)
-      call_actions @@after_get_actions, a_path, nil, result
-    end
+      def after_get_callback(a_path, headers, result)
+        call_actions @@after_get_actions, a_path, nil, result
+      end
 
-    def before_post_callback(a_path, payload, headers)
-      was_called = call_actions @@before_post_actions, a_path, payload, nil
-      Rails.logger.warn "WARNING unprotected REST call: POST #{a_path}" unless was_called
-    end
+      def before_post_callback(a_path, payload, headers)
+        was_called = call_actions @@before_post_actions, a_path, payload, nil
+        Rails.logger.warn "WARNING unprotected REST call: POST #{a_path}" unless was_called
+      end
 
-    def after_post_callback(a_path, payload, headers, result)
-      call_actions @@after_post_actions, a_path, payload, result
-    end
+      def after_post_callback(a_path, payload, headers, result)
+        call_actions @@after_post_actions, a_path, payload, result
+      end
 
-    def before_put_callback(a_path, payload, headers)
-      was_called = call_actions @@before_put_actions, a_path, payload, nil
-      Rails.logger.warn "WARNING unprotected REST call: PUT #{a_path}" unless was_called
-    end
+      def before_put_callback(a_path, payload, headers)
+        was_called = call_actions @@before_put_actions, a_path, payload, nil
+        Rails.logger.warn "WARNING unprotected REST call: PUT #{a_path}" unless was_called
+      end
 
-    def after_put_callback(a_path, payload, headers, result)
-      call_actions @@after_put_actions, a_path, payload, result
-    end
+      def after_put_callback(a_path, payload, headers, result)
+        call_actions @@after_put_actions, a_path, payload, result
+      end
 
-    def before_delete_callback(a_path, headers)
-      was_called = call_actions @@before_delete_actions, a_path, nil, nil
-      Rails.logger.warn "WARNING unprotected REST call: DELETE #{a_path}" unless was_called
-    end
+      def before_delete_callback(a_path, headers)
+        was_called = call_actions @@before_delete_actions, a_path, nil, nil
+        Rails.logger.warn "WARNING unprotected REST call: DELETE #{a_path}" unless was_called
+      end
 
-    def after_delete_callback(a_path, headers, result)
-      call_actions @@after_delete_actions, a_path, nil, result
-    end
+      def after_delete_callback(a_path, headers, result)
+        call_actions @@after_delete_actions, a_path, nil, result
+      end
 
-    def after_get(for_path, &action)
-      @@after_get_actions << [for_path, action]
-    end
+      def after_get(for_path, &action)
+        @@after_get_actions << [for_path, action]
+      end
 
-    def after_post(for_path, &action)
-      @@after_post_actions << [for_path, action]
-    end
+      def after_post(for_path, &action)
+        @@after_post_actions << [for_path, action]
+      end
 
-    def after_put(for_path, &action)
-      @@after_put_actions << [for_path, action]
-    end
+      def after_put(for_path, &action)
+        @@after_put_actions << [for_path, action]
+      end
 
-    def after_delete(for_path, &action)
-      @@after_delete_actions << [for_path, action]
-    end
+      def after_delete(for_path, &action)
+        @@after_delete_actions << [for_path, action]
+      end
 
-    def before_get(for_path, &action)
-      @@before_get_actions << [for_path, action]
-    end
+      def before_get(for_path, &action)
+        @@before_get_actions << [for_path, action]
+      end
 
-    def before_post(for_path, &action)
-      @@before_post_actions << [for_path, action]
-    end
+      def before_post(for_path, &action)
+        @@before_post_actions << [for_path, action]
+      end
 
-    def before_put(for_path, &action)
-      @@before_put_actions << [for_path, action]
-    end
+      def before_put(for_path, &action)
+        @@before_put_actions << [for_path, action]
+      end
 
-    def before_delete(for_path, &action)
-      @@before_delete_actions << [for_path, action]
+      def before_delete(for_path, &action)
+        @@before_delete_actions << [for_path, action]
+      end
     end
   end
 end
+

--- a/src/lib/resources/candlepin.rb
+++ b/src/lib/resources/candlepin.rb
@@ -10,597 +10,594 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'rubygems'
-require 'rest_client'
-require 'resource_permissions'
-require 'http_resource'
+module Resources
 
-module Candlepin
+  module Candlepin
 
-  class Proxy
-    def self.post path, body
-      Rails.logger.debug "Sending POST request to Candlepin: #{path}"
-      client = CandlepinResource.rest_client(Net::HTTP::Post, :post, path_with_cp_prefix(path))
-      client.post body, {:accept => :json, :content_type => :json}.merge(User.cp_oauth_header)
+    class Proxy
+      def self.post path, body
+        Rails.logger.debug "Sending POST request to Candlepin: #{path}"
+        client = CandlepinResource.rest_client(Net::HTTP::Post, :post, path_with_cp_prefix(path))
+        client.post body, {:accept => :json, :content_type => :json}.merge(User.cp_oauth_header)
+      end
+
+      def self.delete path
+        Rails.logger.debug "Sending DELETE request to Candlepin: #{path}"
+        client = CandlepinResource.rest_client(Net::HTTP::Delete, :delete, path_with_cp_prefix(path))
+        client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
+      end
+
+      def self.get path
+        Rails.logger.debug "Sending GET request to Candlepin: #{path}"
+        client = CandlepinResource.rest_client(Net::HTTP::Get, :get, path_with_cp_prefix(path))
+        client.get({:accept => :json}.merge(User.cp_oauth_header))
+      end
+
+      def self.path_with_cp_prefix path
+        CandlepinResource.prefix + path
+      end
+
     end
 
-    def self.delete path
-      Rails.logger.debug "Sending DELETE request to Candlepin: #{path}"
-      client = CandlepinResource.rest_client(Net::HTTP::Delete, :delete, path_with_cp_prefix(path))
-      client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
+    class CandlepinResourcePermissions < ::ResourcePermissions::DefaultResourcePermissions
+      # /candlepin by default
+      self.url_prefix = URI.parse(AppConfig.candlepin.url).path
     end
 
-    def self.get path
-      Rails.logger.debug "Sending GET request to Candlepin: #{path}"
-      client = CandlepinResource.rest_client(Net::HTTP::Get, :get, path_with_cp_prefix(path))
-      client.get({:accept => :json}.merge(User.cp_oauth_header))
-    end
+    class CandlepinResource < ::HttpResource
+      cfg = AppConfig.candlepin
+      url = cfg.url
+      self.prefix = URI.parse(url).path
+      self.site = url.gsub(self.prefix, "")
+      self.consumer_secret = cfg.oauth_secret
+      self.consumer_key = cfg.oauth_key
+      self.ca_cert_file = cfg.ca_cert_file
+      self.resource_permissions = CandlepinResourcePermissions
 
-    def self.path_with_cp_prefix path
-      CandlepinResource.prefix + path
-    end
+      def self.default_headers
+        {'accept' => 'application/json',
+         'accept-language' => I18n.locale,
+         'content-type' => 'application/json'}.merge(User.cp_oauth_header)
+      end
 
-  end
-
-  class CandlepinResourcePermissions < ::DefaultResourcePermissions
-    # /candlepin by default
-    self.url_prefix = URI.parse(AppConfig.candlepin.url).path
-
-  end
-
-  class CandlepinResource < ::HttpResource
-    cfg = AppConfig.candlepin
-    url = cfg.url
-    self.prefix = URI.parse(url).path
-    self.site = url.gsub(self.prefix, "")
-    self.consumer_secret = cfg.oauth_secret
-    self.consumer_key = cfg.oauth_key
-    self.ca_cert_file = cfg.ca_cert_file
-    self.resource_permissions = CandlepinResourcePermissions
-
-    def self.default_headers
-      {'accept' => 'application/json',
-       'accept-language' => I18n.locale,
-       'content-type' => 'application/json'}.merge(User.cp_oauth_header)
-    end
-
-    def self.name_to_key a_name
-      a_name.tr(' ', '_')
-    end
-  end
-
-  class CandlepinPing < CandlepinResource
-    class << self
-      def ping
-        response = get('/candlepin/status').body
-        JSON.parse(response).with_indifferent_access
+      def self.name_to_key a_name
+        a_name.tr(' ', '_')
       end
     end
-  end
 
-  class Consumer < CandlepinResource
-    class << self
-      def export
-        response = Candlepin::CandlepinResource.get(join_path(path(), 'export'), {:accept => '*/*'})
-        filename = response.headers[:content_disposition] == nil ? "tmp_#{rand}.zip" : response.headers[:content_disposition].split("filename=")[1]
-        File.open(filename, 'w') { |f| f.write(response) }
-      end
-
-      def path(id=nil)
-        "/candlepin/consumers/#{id}"
-      end
-
-      def get uuid
-        JSON.parse(super(path(uuid), self.default_headers).body).with_indifferent_access
-      end
-
-      def create env_id, key, name, type, facts, installedProducts, autoheal=true, releaseVer=nil, service_level=""
-        url = "/candlepin/environments/#{url_encode(env_id)}/consumers/"
-        attrs = {:name => name,
-                 :type => type,
-                 :facts => facts,
-                 :installedProducts => installedProducts,
-                 :autoheal => autoheal,
-                 :releaseVer => releaseVer,
-                 :serviceLevel => service_level}
-        response = self.post(url, attrs.to_json, self.default_headers).body
-        JSON.parse(response).with_indifferent_access
-      end
-
-      def register_hypervisors params
-        url = "/candlepin/hypervisors"
-        url << "?owner=#{params[:owner]}&env=#{params[:env]}"
-        attrs = params.except(:owner, :env)
-        response = self.post(url, attrs.to_json, self.default_headers).body
-        JSON.parse(response).with_indifferent_access
-      end
-
-      def update(uuid, facts, guest_ids = nil, installedProducts = nil, autoheal = nil, releaseVer = nil, service_level=nil)
-        attrs = {:facts => facts,
-                 :guestIds => guest_ids,
-                 :releaseVer => releaseVer,
-                 :installedProducts => installedProducts,
-                 :autoheal => autoheal,
-                 :serviceLevel => service_level}.delete_if {|k,v| v.nil?}
-        unless attrs.empty?
-          response = self.put(path(uuid), attrs.to_json, self.default_headers).body
-        else[]
-          return true
-        end
-        # consumer update doesn't return any data atm
-        # JSON.parse(response).with_indifferent_access
-      end
-
-      def destroy uuid
-        self.delete(path(uuid), User.cp_oauth_header).code.to_i
-      end
-
-      def available_pools(uuid, listall=false)
-        url = Pool.path() + "?consumer=#{uuid}&listall=#{listall}"
-        response = Candlepin::CandlepinResource.get(url,self.default_headers).body
-        JSON.parse(response)
-      end
-
-
-      def regenerate_identity_certificates uuid
-        response = self.post(path(uuid), {}, self.default_headers).body
-        JSON.parse(response).with_indifferent_access
-      end
-
-      def entitlements uuid
-        response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'entitlements'), self.default_headers).body
-        JSON.parse(response).collect { |e| e.with_indifferent_access }
-      end
-
-      def consume_entitlement uuid, pool, quantity = nil
-        uri = join_path(path(uuid), 'entitlements') + "?pool=#{pool}"
-        uri += "&quantity=#{quantity}" if quantity
-        self.post(uri, "", self.default_headers).body
-      end
-
-      def remove_entitlement uuid, ent_id
-        uri = join_path(path(uuid), 'entitlements') + "/#{ent_id}"
-        self.delete(uri, self.default_headers).code.to_i
-      end
-
-      def remove_entitlements uuid
-        uri = join_path(path(uuid), 'entitlements')
-        self.delete(uri, self.default_headers).code.to_i
-      end
-
-      def remove_certificate uuid, serial_id
-        uri = join_path(path(uuid), 'certificates') + "/#{serial_id}"
-        self.delete(uri, self.default_headers).code.to_i
-      end
-
-      def guests uuid
-        response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'guests'), self.default_headers).body
-        JSON.parse(response).map { |e| e.with_indifferent_access }
-      rescue Exception => e
-        return []
-      end
-
-      def host uuid
-        response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'host'), self.default_headers).body
-        unless response.empty?
+    class CandlepinPing < CandlepinResource
+      class << self
+        def ping
+          response = get('/candlepin/status').body
           JSON.parse(response).with_indifferent_access
-        else
-          return nil
         end
-      rescue Exception => e
-        return nil
       end
+    end
 
-      def compliance uuid
-        response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'compliance'), self.default_headers).body
-        unless response.empty?
+    class Consumer < CandlepinResource
+      class << self
+        def export
+          response = Candlepin::CandlepinResource.get(join_path(path(), 'export'), {:accept => '*/*'})
+          filename = response.headers[:content_disposition] == nil ? "tmp_#{rand}.zip" : response.headers[:content_disposition].split("filename=")[1]
+          File.open(filename, 'w') { |f| f.write(response) }
+        end
+
+        def path(id=nil)
+          "/candlepin/consumers/#{id}"
+        end
+
+        def get uuid
+          JSON.parse(super(path(uuid), self.default_headers).body).with_indifferent_access
+        end
+
+        def create env_id, key, name, type, facts, installedProducts, autoheal=true, releaseVer=nil, service_level=""
+          url = "/candlepin/environments/#{url_encode(env_id)}/consumers/"
+          attrs = {:name => name,
+                   :type => type,
+                   :facts => facts,
+                   :installedProducts => installedProducts,
+                   :autoheal => autoheal,
+                   :releaseVer => releaseVer,
+                   :serviceLevel => service_level}
+          response = self.post(url, attrs.to_json, self.default_headers).body
           JSON.parse(response).with_indifferent_access
-        else
-          return nil
-        end
-      end
-
-      def events uuid
-        response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'events'), self.default_headers).body
-        unless response.empty?
-          JSON.parse(response).collect {|s| s.with_indifferent_access}
-        else
-          return []
-        end
-      end
-    end
-  end
-
-  class OwnerInfo < CandlepinResource
-    class << self
-
-      def find key
-          owner_json = self.get(path(key), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
-          JSON.parse(owner_json).with_indifferent_access
-      end
-
-      def path(id=nil)
-        "/candlepin/owners/#{id}/info"
-      end
-    end
-  end
-
-
-  class Owner < CandlepinResource
-    class << self
-      # Set the contentPrefix at creation time so that the client will get
-      # content only for the org it has been subscribed to
-      def create key, description
-        attrs = {:key => key, :displayName => description, :contentPrefix => (AppConfig.katello? ? "/#{key}/$env" : "")}
-        owner_json = self.post(path(), attrs.to_json, self.default_headers).body
-        JSON.parse(owner_json).with_indifferent_access
-      end
-
-      # create the first user for owner
-      def create_user key, username, password
-        # create user with superadmin flag (no role, permissions etc)
-        CPUser.create({:username => name_to_key(username), :password => name_to_key(password), :superAdmin => true})
-      end
-
-      def destroy key
-        self.delete(path(key), User.cp_oauth_header).code.to_i
-      end
-
-      def find key
-          owner_json = self.get(path(key), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
-          JSON.parse(owner_json).with_indifferent_access
-      end
-
-      def update key, organization
-        owner = find key
-        owner['displayName'] = organization.name
-        self.put(path(key), JSON.generate(owner), self.default_headers).body
-      end
-
-      def import organization_name, path_to_file, options
-        path = join_path(path(organization_name), 'imports')
-
-        query_params = {}
-        query_params[:force] = true if options[:force] == "true"
-        unless query_params.empty?
-          path << "?" << query_params.to_param
         end
 
-        self.post(path, {:import => File.new(path_to_file, 'rb')}, self.default_headers.except('content-type'))
-      end
-
-      def imports organization_name
-        imports_json = self.get(join_path(path(organization_name), 'imports'), self.default_headers)
-        JSON.parse(imports_json).collect {|s| s.with_indifferent_access}
-      end
-
-      def pools key, filter = {}
-        if key
-          jsonStr = self.get(join_path(path(key), 'pools') + hash_to_query(filter), self.default_headers).body
-        else
-          jsonStr = self.get(join_path('candlepin', 'pools') + hash_to_query(filter), self.default_headers).body
+        def register_hypervisors params
+          url = "/candlepin/hypervisors"
+          url << "?owner=#{params[:owner]}&env=#{params[:env]}"
+          attrs = params.except(:owner, :env)
+          response = self.post(url, attrs.to_json, self.default_headers).body
+          JSON.parse(response).with_indifferent_access
         end
-        JSON.parse(jsonStr).collect {|p| p.with_indifferent_access }
-      end
 
-      def statistics key
-        jsonStr = self.get(join_path(path(key), 'statistics'), self.default_headers).body
-        JSON.parse(jsonStr).collect {|p| p.with_indifferent_access }
-      end
+        def update(uuid, facts, guest_ids = nil, installedProducts = nil, autoheal = nil, releaseVer = nil, service_level=nil)
+          attrs = {:facts => facts,
+                   :guestIds => guest_ids,
+                   :releaseVer => releaseVer,
+                   :installedProducts => installedProducts,
+                   :autoheal => autoheal,
+                   :serviceLevel => service_level}.delete_if {|k,v| v.nil?}
+          unless attrs.empty?
+            response = self.put(path(uuid), attrs.to_json, self.default_headers).body
+          else[]
+            return true
+          end
+          # consumer update doesn't return any data atm
+          # JSON.parse(response).with_indifferent_access
+        end
 
-      def generate_ueber_cert key
-        ueber_cert_json = self.post(join_path(path(key), "uebercert"), {}.to_json, self.default_headers).body
-        JSON.parse(ueber_cert_json).with_indifferent_access
-      end
+        def destroy uuid
+          self.delete(path(uuid), User.cp_oauth_header).code.to_i
+        end
 
-      def get_ueber_cert key
-        ueber_cert_json = self.get(join_path(path(key), "uebercert"), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
-        JSON.parse(ueber_cert_json).with_indifferent_access
-      end
-
-      def get_ueber_cert_pkcs12 key, name = nil, password = nil
-        certs = get_ueber_cert(key)
-        c =  OpenSSL::X509::Certificate.new certs["cert"]
-        p = OpenSSL::PKey::RSA.new certs["key"]
-        OpenSSL::PKCS12.create(password, name, p, c,nil, "PBE-SHA1-3DES" ,"PBE-SHA1-3DES")
-      end
-
-      def events key
-        response = self.get(join_path(path(key), 'events'), self.default_headers).body
-        JSON.parse(response).collect { |e| e.with_indifferent_access }
-      end
-
-      def service_levels uuid
-        response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'servicelevels'), self.default_headers).body
-        unless response.empty?
+        def available_pools(uuid, listall=false)
+          url = Pool.path() + "?consumer=#{uuid}&listall=#{listall}"
+          response = Candlepin::CandlepinResource.get(url,self.default_headers).body
           JSON.parse(response)
-        else
+        end
+
+
+        def regenerate_identity_certificates uuid
+          response = self.post(path(uuid), {}, self.default_headers).body
+          JSON.parse(response).with_indifferent_access
+        end
+
+        def entitlements uuid
+          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'entitlements'), self.default_headers).body
+          JSON.parse(response).collect { |e| e.with_indifferent_access }
+        end
+
+        def consume_entitlement uuid, pool, quantity = nil
+          uri = join_path(path(uuid), 'entitlements') + "?pool=#{pool}"
+          uri += "&quantity=#{quantity}" if quantity
+          self.post(uri, "", self.default_headers).body
+        end
+
+        def remove_entitlement uuid, ent_id
+          uri = join_path(path(uuid), 'entitlements') + "/#{ent_id}"
+          self.delete(uri, self.default_headers).code.to_i
+        end
+
+        def remove_entitlements uuid
+          uri = join_path(path(uuid), 'entitlements')
+          self.delete(uri, self.default_headers).code.to_i
+        end
+
+        def remove_certificate uuid, serial_id
+          uri = join_path(path(uuid), 'certificates') + "/#{serial_id}"
+          self.delete(uri, self.default_headers).code.to_i
+        end
+
+        def guests uuid
+          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'guests'), self.default_headers).body
+          JSON.parse(response).map { |e| e.with_indifferent_access }
+        rescue Exception => e
           return []
         end
-      end
 
-      def path(id=nil)
-        "/candlepin/owners/#{id}"
-      end
-    end
-  end
+        def host uuid
+          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'host'), self.default_headers).body
+          unless response.empty?
+            JSON.parse(response).with_indifferent_access
+          else
+            return nil
+          end
+        rescue Exception => e
+          return nil
+        end
 
-  class Environment < CandlepinResource
-    class << self
+        def compliance uuid
+          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'compliance'), self.default_headers).body
+          unless response.empty?
+            JSON.parse(response).with_indifferent_access
+          else
+            return nil
+          end
+        end
 
-      def find id
-        JSON.parse(self.get(path(id), self.default_headers).body).with_indifferent_access
-      end
-
-
-      def create owner_id, id, name, description
-        attrs = {:id => id, :name => name, :description => description}
-        path = "/candlepin/owners/#{owner_id}/environments"
-        environment_json = self.post(path, attrs.to_json, self.default_headers).body
-        JSON.parse(environment_json).with_indifferent_access
-      end
-
-      def destroy id
-        self.delete(path(id), User.cp_oauth_header).code.to_i
-      end
-
-      def path(id)
-        "/candlepin/environments/#{id}"
-      end
-
-      def add_content(env_id, content_ids)
-        path = self.path(env_id) + "/content"
-        params = content_ids.map {|content_id| {:contentId => content_id} }
-        JSON.parse(self.post(path, params.to_json, self.default_headers).body).with_indifferent_access
-      end
-
-      def delete_content(env_id, content_ids)
-        path = self.path(env_id) + "/content"
-        params = content_ids.map {|content_id| {:content => content_id}.to_param }.join("&")
-        self.delete("#{path}?#{params}", self.default_headers).code.to_i
+        def events uuid
+          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'events'), self.default_headers).body
+          unless response.empty?
+            JSON.parse(response).collect {|s| s.with_indifferent_access}
+          else
+            return []
+          end
+        end
       end
     end
-  end
 
-  class CPUser < CandlepinResource
-    class << self
-      def create attrs
-        JSON.parse(self.post(path(), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
-      end
+    class OwnerInfo < CandlepinResource
+      class << self
 
-      def path(id=nil)
-        "/candlepin/users/#{id}"
-      end
-    end
-  end
+        def find key
+            owner_json = self.get(path(key), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
+            JSON.parse(owner_json).with_indifferent_access
+        end
 
-  class Pool < CandlepinResource
-    class << self
-      def find pool_id
-        pool_json = self.get(path(pool_id), self.default_headers).body
-        JSON.parse(pool_json).with_indifferent_access
-      end
-
-      def get_for_owner owner_key
-        pools_json = self.get("/candlepin/owners/#{owner_key}/pools", self.default_headers).body
-        JSON.parse(pools_json)
-      end
-
-      def destroy id
-        raise ArgumentError, "pool id has to be specified" unless id
-        self.delete(path(id), self.default_headers).code.to_i
-      end
-
-      def path id=nil
-        "/candlepin/pools/#{id}"
+        def path(id=nil)
+          "/candlepin/owners/#{id}/info"
+        end
       end
     end
-  end
-
-  class Content < CandlepinResource
-    class << self
-      def create attrs
-        JSON.parse(self.post(path(), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
-      end
-
-      def get id
-        content_json = super(path(id), self.default_headers).body
-        JSON.parse(content_json).with_indifferent_access
-      end
-
-      def all
-        content_json = Candlepin::CandlepinResource.get(path(), self.default_headers).body
-        JSON.parse(content_json)
-      end
-
-      def destroy id
-        raise ArgumentError, "content id has to be specified" unless id
-        self.delete(path(id), self.default_headers).code.to_i
-      end
-
-      def path(id=nil)
-        "/candlepin/content/#{id}"
-      end
-    end
-  end
-
-  class Subscription < CandlepinResource
-    class << self
-
-      def destroy subscription_id
-        raise ArgumentError, "subscription id has to be specified" unless subscription_id
-        self.delete(path(subscription_id), self.default_headers).code.to_i
-      end
-
-      def get id=nil
-        content_json = super(path(id), self.default_headers).body
-        content = JSON.parse(content_json)
-      end
-
-      def create_for_owner owner_key, attrs
-        subscription = self.post("/candlepin/owners/#{owner_key}/subscriptions", attrs.to_json, self.default_headers).body
-        self.put("/candlepin/owners/#{owner_key}/subscriptions", {}.to_json, self.default_headers).body
-        subscription
-      end
-
-      def get_for_owner owner_key
-        content_json = Candlepin::CandlepinResource.get("/candlepin/owners/#{owner_key}/subscriptions", self.default_headers).body
-        content = JSON.parse(content_json)
-      end
-
-      def refresh_for_owner owner_key
-        ret = self.put("/candlepin/owners/#{owner_key}/subscriptions", {}.to_json, self.default_headers).body
-        JSON.parse(ret).with_indifferent_access
-      end
-
-      def path(id=nil)
-        "/candlepin/subscriptions/#{id}"
-      end
-    end
-  end
-
-  class Job < CandlepinResource
-    class << self
-
-      NOT_FINISHED_STATES = %w[CREATED PENDING RUNNING] unless defined? NOT_FINISHED_STATES
-
-      def not_finished?(job)
-        NOT_FINISHED_STATES.include?(job[:state])
-      end
-
-      def get id
-        job_json = super(path(id), self.default_headers).body
-        job = JSON.parse(job_json)
-        job.with_indifferent_access
-      end
-
-      def path(id=nil)
-        "/candlepin/jobs/#{id}"
-      end
-    end
-  end
-
-  class Product < CandlepinResource
-    class << self
-
-      def all
-        JSON.parse(Candlepin::CandlepinResource.get(path, self.default_headers).body)
-      end
-
-      def create attr
-        JSON.parse(self.post(path, attr.to_json, self.default_headers).body).with_indifferent_access
-      end
-
-      def get id=nil
-        products_json = super(path(id), self.default_headers).body
-        products = JSON.parse(products_json)
-        products = [products] unless id.nil?
-        products.collect {|p| p.with_indifferent_access }
-      end
 
 
-      def _certificate_and_key id
-        subscriptions_json = Candlepin::CandlepinResource.get('/candlepin/subscriptions', self.default_headers).body
-        subscriptions = JSON.parse(subscriptions_json)
+    class Owner < CandlepinResource
+      class << self
+        # Set the contentPrefix at creation time so that the client will get
+        # content only for the org it has been subscribed to
+        def create key, description
+          attrs = {:key => key, :displayName => description, :contentPrefix => (AppConfig.katello? ? "/#{key}/$env" : "")}
+          owner_json = self.post(path(), attrs.to_json, self.default_headers).body
+          JSON.parse(owner_json).with_indifferent_access
+        end
 
-        for sub in subscriptions
-          if sub["product"]["id"] == id
-            return sub["certificate"]
+        # create the first user for owner
+        def create_user key, username, password
+          # create user with superadmin flag (no role, permissions etc)
+          CPUser.create({:username => name_to_key(username), :password => name_to_key(password), :superAdmin => true})
+        end
+
+        def destroy key
+          self.delete(path(key), User.cp_oauth_header).code.to_i
+        end
+
+        def find key
+            owner_json = self.get(path(key), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
+            JSON.parse(owner_json).with_indifferent_access
+        end
+
+        def update key, organization
+          owner = find key
+          owner['displayName'] = organization.name
+          self.put(path(key), JSON.generate(owner), self.default_headers).body
+        end
+
+        def import organization_name, path_to_file, options
+          path = join_path(path(organization_name), 'imports')
+
+          query_params = {}
+          query_params[:force] = true if options[:force] == "true"
+          unless query_params.empty?
+            path << "?" << query_params.to_param
           end
 
-          for provProds in sub["providedProducts"]
-            if provProds["id"] == id
+          self.post(path, {:import => File.new(path_to_file, 'rb')}, self.default_headers.except('content-type'))
+        end
+
+        def imports organization_name
+          imports_json = self.get(join_path(path(organization_name), 'imports'), self.default_headers)
+          JSON.parse(imports_json).collect {|s| s.with_indifferent_access}
+        end
+
+        def pools key, filter = {}
+          if key
+            jsonStr = self.get(join_path(path(key), 'pools') + hash_to_query(filter), self.default_headers).body
+          else
+            jsonStr = self.get(join_path('candlepin', 'pools') + hash_to_query(filter), self.default_headers).body
+          end
+          JSON.parse(jsonStr).collect {|p| p.with_indifferent_access }
+        end
+
+        def statistics key
+          jsonStr = self.get(join_path(path(key), 'statistics'), self.default_headers).body
+          JSON.parse(jsonStr).collect {|p| p.with_indifferent_access }
+        end
+
+        def generate_ueber_cert key
+          ueber_cert_json = self.post(join_path(path(key), "uebercert"), {}.to_json, self.default_headers).body
+          JSON.parse(ueber_cert_json).with_indifferent_access
+        end
+
+        def get_ueber_cert key
+          ueber_cert_json = self.get(join_path(path(key), "uebercert"), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
+          JSON.parse(ueber_cert_json).with_indifferent_access
+        end
+
+        def get_ueber_cert_pkcs12 key, name = nil, password = nil
+          certs = get_ueber_cert(key)
+          c =  OpenSSL::X509::Certificate.new certs["cert"]
+          p = OpenSSL::PKey::RSA.new certs["key"]
+          OpenSSL::PKCS12.create(password, name, p, c,nil, "PBE-SHA1-3DES" ,"PBE-SHA1-3DES")
+        end
+
+        def events key
+          response = self.get(join_path(path(key), 'events'), self.default_headers).body
+          JSON.parse(response).collect { |e| e.with_indifferent_access }
+        end
+
+        def service_levels uuid
+          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'servicelevels'), self.default_headers).body
+          unless response.empty?
+            JSON.parse(response)
+          else
+            return []
+          end
+        end
+
+        def path(id=nil)
+          "/candlepin/owners/#{id}"
+        end
+      end
+    end
+
+    class Environment < CandlepinResource
+      class << self
+
+        def find id
+          JSON.parse(self.get(path(id), self.default_headers).body).with_indifferent_access
+        end
+
+
+        def create owner_id, id, name, description
+          attrs = {:id => id, :name => name, :description => description}
+          path = "/candlepin/owners/#{owner_id}/environments"
+          environment_json = self.post(path, attrs.to_json, self.default_headers).body
+          JSON.parse(environment_json).with_indifferent_access
+        end
+
+        def destroy id
+          self.delete(path(id), User.cp_oauth_header).code.to_i
+        end
+
+        def path(id)
+          "/candlepin/environments/#{id}"
+        end
+
+        def add_content(env_id, content_ids)
+          path = self.path(env_id) + "/content"
+          params = content_ids.map {|content_id| {:contentId => content_id} }
+          JSON.parse(self.post(path, params.to_json, self.default_headers).body).with_indifferent_access
+        end
+
+        def delete_content(env_id, content_ids)
+          path = self.path(env_id) + "/content"
+          params = content_ids.map {|content_id| {:content => content_id}.to_param }.join("&")
+          self.delete("#{path}?#{params}", self.default_headers).code.to_i
+        end
+      end
+    end
+
+    class CPUser < CandlepinResource
+      class << self
+        def create attrs
+          JSON.parse(self.post(path(), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
+        end
+
+        def path(id=nil)
+          "/candlepin/users/#{id}"
+        end
+      end
+    end
+
+    class Pool < CandlepinResource
+      class << self
+        def find pool_id
+          pool_json = self.get(path(pool_id), self.default_headers).body
+          JSON.parse(pool_json).with_indifferent_access
+        end
+
+        def get_for_owner owner_key
+          pools_json = self.get("/candlepin/owners/#{owner_key}/pools", self.default_headers).body
+          JSON.parse(pools_json)
+        end
+
+        def destroy id
+          raise ArgumentError, "pool id has to be specified" unless id
+          self.delete(path(id), self.default_headers).code.to_i
+        end
+
+        def path id=nil
+          "/candlepin/pools/#{id}"
+        end
+      end
+    end
+
+    class Content < CandlepinResource
+      class << self
+        def create attrs
+          JSON.parse(self.post(path(), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
+        end
+
+        def get id
+          content_json = super(path(id), self.default_headers).body
+          JSON.parse(content_json).with_indifferent_access
+        end
+
+        def all
+          content_json = Candlepin::CandlepinResource.get(path(), self.default_headers).body
+          JSON.parse(content_json)
+        end
+
+        def destroy id
+          raise ArgumentError, "content id has to be specified" unless id
+          self.delete(path(id), self.default_headers).code.to_i
+        end
+
+        def path(id=nil)
+          "/candlepin/content/#{id}"
+        end
+      end
+    end
+
+    class Subscription < CandlepinResource
+      class << self
+
+        def destroy subscription_id
+          raise ArgumentError, "subscription id has to be specified" unless subscription_id
+          self.delete(path(subscription_id), self.default_headers).code.to_i
+        end
+
+        def get id=nil
+          content_json = super(path(id), self.default_headers).body
+          content = JSON.parse(content_json)
+        end
+
+        def create_for_owner owner_key, attrs
+          subscription = self.post("/candlepin/owners/#{owner_key}/subscriptions", attrs.to_json, self.default_headers).body
+          self.put("/candlepin/owners/#{owner_key}/subscriptions", {}.to_json, self.default_headers).body
+          subscription
+        end
+
+        def get_for_owner owner_key
+          content_json = Candlepin::CandlepinResource.get("/candlepin/owners/#{owner_key}/subscriptions", self.default_headers).body
+          content = JSON.parse(content_json)
+        end
+
+        def refresh_for_owner owner_key
+          ret = self.put("/candlepin/owners/#{owner_key}/subscriptions", {}.to_json, self.default_headers).body
+          JSON.parse(ret).with_indifferent_access
+        end
+
+        def path(id=nil)
+          "/candlepin/subscriptions/#{id}"
+        end
+      end
+    end
+
+    class Job < CandlepinResource
+      class << self
+
+        NOT_FINISHED_STATES = %w[CREATED PENDING RUNNING] unless defined? NOT_FINISHED_STATES
+
+        def not_finished?(job)
+          NOT_FINISHED_STATES.include?(job[:state])
+        end
+
+        def get id
+          job_json = super(path(id), self.default_headers).body
+          job = JSON.parse(job_json)
+          job.with_indifferent_access
+        end
+
+        def path(id=nil)
+          "/candlepin/jobs/#{id}"
+        end
+      end
+    end
+
+    class Product < CandlepinResource
+      class << self
+
+        def all
+          JSON.parse(Candlepin::CandlepinResource.get(path, self.default_headers).body)
+        end
+
+        def create attr
+          JSON.parse(self.post(path, attr.to_json, self.default_headers).body).with_indifferent_access
+        end
+
+        def get id=nil
+          products_json = super(path(id), self.default_headers).body
+          products = JSON.parse(products_json)
+          products = [products] unless id.nil?
+          products.collect {|p| p.with_indifferent_access }
+        end
+
+
+        def _certificate_and_key id
+          subscriptions_json = Candlepin::CandlepinResource.get('/candlepin/subscriptions', self.default_headers).body
+          subscriptions = JSON.parse(subscriptions_json)
+
+          for sub in subscriptions
+            if sub["product"]["id"] == id
               return sub["certificate"]
             end
-          end
-        end
-        nil
-      end
 
-      def certificate id
-        self._certificate_and_key(id)["cert"]
-      end
-
-      def key id
-        self._certificate_and_key(id)["key"]
-      end
-
-      def destroy product_id
-        raise ArgumentError, "product id has to be specified" unless product_id
-        self.delete(path(product_id), self.default_headers).code.to_i
-      end
-
-      def add_content product_id, content_id, enabled
-        self.post(join_path(path(product_id), "content/#{content_id}?enabled=#{enabled}"), nil, self.default_headers).code.to_i
-      end
-
-      def remove_content product_id, content_id
-        self.delete(join_path(path(product_id), "content/#{content_id}"), self.default_headers).code.to_i
-      end
-
-      def create_unlimited_subscription owner_key, product_id
-        start_date ||= Date.today
-        # End it 100 years from now
-        end_date ||= start_date + 10950
-
-        subscription = {
-          'startDate' => start_date,
-          'endDate'   => end_date,
-          'quantity'  =>  -1,
-          'accountNumber' => '',
-          'product' => { 'id' => product_id },
-          'providedProducts' => [],
-          'contractNumber' => ''
-        }
-        Candlepin::Subscription.create_for_owner owner_key, subscription
-      end
-
-      def pools owner_key, product_id
-        Candlepin::Pool.get_for_owner(owner_key).find_all {|pool| pool['productId'] == product_id }
-      end
-
-      def delete_subscriptions owner_key, product_id
-        update_subscriptions = false
-        subscriptions = Candlepin::Subscription.get_for_owner owner_key
-        subscriptions.each do |s|
-          products = ([s['product']] + s['providedProducts'])
-          products.each do |p|
-            if p['id'] == product_id
-              Rails.logger.debug "Deleting subscription: " + s.to_json
-              Candlepin::Subscription.destroy s['id']
-              update_subscriptions = true
+            for provProds in sub["providedProducts"]
+              if provProds["id"] == id
+                return sub["certificate"]
+              end
             end
           end
+          nil
         end
 
-        if update_subscriptions
-          return Candlepin::Subscription.refresh_for_owner owner_key
-        else
-          return nil
+        def certificate id
+          self._certificate_and_key(id)["cert"]
+        end
+
+        def key id
+          self._certificate_and_key(id)["key"]
+        end
+
+        def destroy product_id
+          raise ArgumentError, "product id has to be specified" unless product_id
+          self.delete(path(product_id), self.default_headers).code.to_i
+        end
+
+        def add_content product_id, content_id, enabled
+          self.post(join_path(path(product_id), "content/#{content_id}?enabled=#{enabled}"), nil, self.default_headers).code.to_i
+        end
+
+        def remove_content product_id, content_id
+          self.delete(join_path(path(product_id), "content/#{content_id}"), self.default_headers).code.to_i
+        end
+
+        def create_unlimited_subscription owner_key, product_id
+          start_date ||= Date.today
+          # End it 100 years from now
+          end_date ||= start_date + 10950
+
+          subscription = {
+            'startDate' => start_date,
+            'endDate'   => end_date,
+            'quantity'  =>  -1,
+            'accountNumber' => '',
+            'product' => { 'id' => product_id },
+            'providedProducts' => [],
+            'contractNumber' => ''
+          }
+          Candlepin::Subscription.create_for_owner owner_key, subscription
+        end
+
+        def pools owner_key, product_id
+          Candlepin::Pool.get_for_owner(owner_key).find_all {|pool| pool['productId'] == product_id }
+        end
+
+        def delete_subscriptions owner_key, product_id
+          update_subscriptions = false
+          subscriptions = Candlepin::Subscription.get_for_owner owner_key
+          subscriptions.each do |s|
+            products = ([s['product']] + s['providedProducts'])
+            products.each do |p|
+              if p['id'] == product_id
+                Rails.logger.debug "Deleting subscription: " + s.to_json
+                Candlepin::Subscription.destroy s['id']
+                update_subscriptions = true
+              end
+            end
+          end
+
+          if update_subscriptions
+            return Candlepin::Subscription.refresh_for_owner owner_key
+          else
+            return nil
+          end
+        end
+
+        def path(id=nil)
+          "/candlepin/products/#{id}"
         end
       end
+    end
 
-      def path(id=nil)
-        "/candlepin/products/#{id}"
+    class Entitlement < CandlepinResource
+      class << self
+        def regenerate_entitlement_certificates_for_product(product_id)
+          self.put("/candlepin/entitlements/product/#{product_id}", nil, self.default_headers).code.to_i
+        end
+
+        def get id=nil
+          json = Candlepin::CandlepinResource.get(path(id), self.default_headers).body
+          JSON.parse(json)
+        end
+
+        def path(id=nil)
+          "/candlepin/entitlements/#{id}"
+        end
       end
     end
+
   end
-
-  class Entitlement < CandlepinResource
-    class << self
-      def regenerate_entitlement_certificates_for_product(product_id)
-        self.put("/candlepin/entitlements/product/#{product_id}", nil, self.default_headers).code.to_i
-      end
-
-      def get id=nil
-        json = Candlepin::CandlepinResource.get(path(id), self.default_headers).body
-        JSON.parse(json)
-      end
-
-      def path(id=nil)
-        "/candlepin/entitlements/#{id}"
-      end
-    end
-  end
-
 end

--- a/src/lib/resources/cdn.rb
+++ b/src/lib/resources/cdn.rb
@@ -10,222 +10,222 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'rest_client'
-require 'http_resource'
+module Resources
 
-module CDN
+  module CDN
 
-  class Utils
+    class Utils
 
-    # takes releasever from contentUrl (e.g. 6Server, 6.0, 6.1)
-    # returns hash e.g. {:major => 6, :minor => "6.1"}
-    # used to be able to make hierarchial view for RH repos
-    def self.parse_version(releasever)
-      if releasever.to_s =~ /^\d/
-        {:major => releasever[/^\d+/].to_i, :minor => releasever }
-      else
-        {}
-      end
-    end
-  end
-
-  class CdnResource
-    attr_reader :url
-    attr_accessor :proxy_host, :proxy_port, :proxy_user, :proxy_password
-
-    def initialize url, options = {}
-      options.reverse_merge!(:verify_ssl => 9)
-      options.assert_valid_keys(:ssl_client_key, :ssl_client_cert, :ssl_ca_file, :verify_ssl)
-      if options[:ssl_client_cert]
-        options.reverse_merge!(:ssl_ca_file => CdnResource.ca_file)
-      end
-      load_proxy_settings
-
-      @url = url
-      @uri = URI.parse(url)
-      @net = net_http_class.new(@uri.host, @uri.port)
-      @net.use_ssl = @uri.is_a?(URI::HTTPS)
-
-      @net.cert = options[:ssl_client_cert]
-      @net.key = options[:ssl_client_key]
-      @net.ca_file = options[:ssl_ca_file]
-
-      if (options[:verify_ssl] == false) || (options[:verify_ssl] == OpenSSL::SSL::VERIFY_NONE)
-        @net.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      elsif options[:verify_ssl].is_a? Integer
-        @net.verify_mode = options[:verify_ssl]
-        @net.verify_callback = lambda do |preverify_ok, ssl_context|
-          if (!preverify_ok) || ssl_context.error != 0
-            err_msg = "SSL Verification failed -- Preverify: #{preverify_ok}, Error: #{ssl_context.error_string} (#{ssl_context.error})"
-            raise RestClient::SSLCertificateNotVerified.new(err_msg)
-          end
-          true
+      # takes releasever from contentUrl (e.g. 6Server, 6.0, 6.1)
+      # returns hash e.g. {:major => 6, :minor => "6.1"}
+      # used to be able to make hierarchial view for RH repos
+      def self.parse_version(releasever)
+        if releasever.to_s =~ /^\d/
+          {:major => releasever[/^\d+/].to_i, :minor => releasever }
+        else
+          {}
         end
       end
     end
 
-    def get(path, headers={})
-      path = File.join(@uri.request_uri,path)
-      Rails.logger.debug "CDN: Requesting path #{path}"
-      req = Net::HTTP::Get.new(path)
-      begin
-        @net.start do |http|
-          res = http.request(req, nil) { |http_response| http_response.read_body }
-          code = res.code.to_i
-          if code == 200
-            return res.body
-          else
-            # we don't really use RestClient here (it doesn't allow to safely
-            # set the proxy only for a set of requests and we don't want the
-            # backend engines communication to go through the same proxy like
-            # accessing CDN - its another use case)
-            # But RestClient exceptions are really nice and can be handled in
-            # the same way
-            exception_class = RestClient::Exceptions::EXCEPTIONS_MAP[code] || RestClient::RequestFailed
-            raise exception_class.new(nil, code)
-          end
+    class CdnResource
+      attr_reader :url
+      attr_accessor :proxy_host, :proxy_port, :proxy_user, :proxy_password
+
+      def initialize url, options = {}
+        options.reverse_merge!(:verify_ssl => 9)
+        options.assert_valid_keys(:ssl_client_key, :ssl_client_cert, :ssl_ca_file, :verify_ssl)
+        if options[:ssl_client_cert]
+          options.reverse_merge!(:ssl_ca_file => CdnResource.ca_file)
         end
-      rescue EOFError
-        raise RestClient::ServerBrokeConnection
-      rescue Timeout::Error
-        raise RestClient::RequestTimeout
-      rescue RestClient::ResourceNotFound
-        raise Errors::NotFound.new(_("CDN loading error: %s not found") % File.join(url, path))
-      rescue RestClient::Unauthorized, RestClient::Forbidden
-        raise Errors::SecurityViolation.new(_("CDN loading error: access denied to %s") % File.join(url, path))
-      end
-    end
+        load_proxy_settings
 
-    def self.ca_file
-      "#{Rails.root}/ca/redhat-uep.pem"
-    end
+        @url = url
+        @uri = URI.parse(url)
+        @net = net_http_class.new(@uri.host, @uri.port)
+        @net.use_ssl = @uri.is_a?(URI::HTTPS)
 
-    def net_http_class
-      if proxy_host
-        Net::HTTP::Proxy(proxy_host, proxy_port, proxy_user, proxy_password)
-      else
-        Net::HTTP
-      end
-    end
+        @net.cert = options[:ssl_client_cert]
+        @net.key = options[:ssl_client_key]
+        @net.ca_file = options[:ssl_ca_file]
 
-    def load_proxy_settings
-      if AppConfig.cdn_proxy && AppConfig.cdn_proxy.host
-        self.proxy_host = parse_host(AppConfig.cdn_proxy.host)
-        self.proxy_port = AppConfig.cdn_proxy.port
-        self.proxy_user = AppConfig.cdn_proxy.user
-        self.proxy_password = AppConfig.cdn_proxy.password
-      end
-    rescue Exception => e
-      Rails.logger.error "Could not parse cdn_proxy:"
-      Rails.logger.error e.to_s
-    end
-
-    def parse_host(host_or_url)
-      uri = URI.parse(host_or_url)
-      return uri.host || uri.path
-    end
-
- end
-
-  class CdnVarSubstitutor
-    def initialize url, options
-      @url = url
-      @options = options
-      @resource = CdnResource.new(@url, @options)
-      @substitutions = Thread.current[:cdn_var_substitutor_cache] || {}
-    end
-
-    def self.with_cache(&block)
-      Thread.current[:cdn_var_substitutor_cache] = {}
-      yield
-    ensure
-      Thread.current[:cdn_var_substitutor_cache] = nil
-    end
-
-    # precalcuclate all paths at once - let's you discover errors and stop
-    # before it causes more pain
-    def precalculate(paths_with_vars)
-      paths_with_vars.uniq.reduce({}) do |ret, path_with_vars|
-        ret[path_with_vars] = substitute_vars(path_with_vars); ret
-      end
-    end
-
-  # takes path e.g. "/rhel/server/5/$releasever/$basearch/os"
-  # returns hash substituting variables:
-  #
-  #  { {"releasever" => "6Server", "basearch" => "i386"} =>  "/rhel/server/5/6Server/i386/os",
-  #    {"releasever" => "6Server", "basearch" => "x86_64"} =>  "/rhel/server/5/6Server/x84_64/os"}
-  #
-  # values are loaded from CDN
-    def substitute_vars(path_with_vars)
-      if path_with_vars =~ /^(.*\$\w+)(.*)$/
-        prefix_with_vars, suffix_witout_vars =  $1, $2
-      else
-        prefix_with_vars, suffix_witout_vars = "", path_with_vars
-      end
-
-      prefixes_without_vars = substitute_vars_in_prefix(prefix_with_vars)
-      paths_without_vars = prefixes_without_vars.reduce({}) do |h, (substitutions, prefix_without_vars)|
-        h[substitutions] = prefix_without_vars + suffix_witout_vars; h
-      end
-      return paths_without_vars
-    end
-
-    # prefix_with_vars is the part of url containing some vars. We can cache
-    # calcualted values for this parts. So for example for:
-    #   "/a/$b/$c/d"
-    #   "/a/$b/$c/e"
-    # prefix_with_vars is "/a/$b/$c" and we store the result after resolving
-    # for the first path.
-    def substitute_vars_in_prefix(prefix_with_vars)
-      paths_with_vars = { {} => prefix_with_vars}
-      prefixes_without_vars = @substitutions[prefix_with_vars]
-
-      unless prefixes_without_vars
-        prefixes_without_vars = {}
-        while not paths_with_vars.empty?
-          substitutions, path = paths_with_vars.shift
-
-          if is_substituable path
-            for_each_substitute_of_next_var substitutions, path do |new_substitution, new_path|
-              paths_with_vars[new_substitution] = new_path
+        if (options[:verify_ssl] == false) || (options[:verify_ssl] == OpenSSL::SSL::VERIFY_NONE)
+          @net.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        elsif options[:verify_ssl].is_a? Integer
+          @net.verify_mode = options[:verify_ssl]
+          @net.verify_callback = lambda do |preverify_ok, ssl_context|
+            if (!preverify_ok) || ssl_context.error != 0
+              err_msg = "SSL Verification failed -- Preverify: #{preverify_ok}, Error: #{ssl_context.error_string} (#{ssl_context.error})"
+              raise RestClient::SSLCertificateNotVerified.new(err_msg)
             end
-          else
-            prefixes_without_vars[substitutions] = path
+            true
           end
         end
-        @substitutions[prefix_with_vars] = prefixes_without_vars
       end
-      return prefixes_without_vars
-    end
 
-    def is_substituable path
-      path.include?("$")
-    end
-
-    def is_substitute_of(substituted_url, original_url)
-      substitutions = self.substitute_vars(original_url).values
-      substitutions.include? substituted_url
-    end
-
-    protected
-
-    def for_each_substitute_of_next_var(substitutions, path)
-      if path =~ /^(.*?)\$([^\/]*)/
-        base_path, var = $1, $2
-        get_substitutions_from(base_path).each do |value|
-
-          new_substitutions = substitutions.merge(var => value)
-          new_path = path.sub("$#{var}",value)
-
-          yield new_substitutions, new_path
+      def get(path, headers={})
+        path = File.join(@uri.request_uri,path)
+        Rails.logger.debug "CDN: Requesting path #{path}"
+        req = Net::HTTP::Get.new(path)
+        begin
+          @net.start do |http|
+            res = http.request(req, nil) { |http_response| http_response.read_body }
+            code = res.code.to_i
+            if code == 200
+              return res.body
+            else
+              # we don't really use RestClient here (it doesn't allow to safely
+              # set the proxy only for a set of requests and we don't want the
+              # backend engines communication to go through the same proxy like
+              # accessing CDN - its another use case)
+              # But RestClient exceptions are really nice and can be handled in
+              # the same way
+              exception_class = RestClient::Exceptions::EXCEPTIONS_MAP[code] || RestClient::RequestFailed
+              raise exception_class.new(nil, code)
+            end
+          end
+        rescue EOFError
+          raise RestClient::ServerBrokeConnection
+        rescue Timeout::Error
+          raise RestClient::RequestTimeout
+        rescue RestClient::ResourceNotFound
+          raise Errors::NotFound.new(_("CDN loading error: %s not found") % File.join(url, path))
+        rescue RestClient::Unauthorized, RestClient::Forbidden
+          raise Errors::SecurityViolation.new(_("CDN loading error: access denied to %s") % File.join(url, path))
         end
       end
-    end
 
-    def get_substitutions_from(base_path)
-      @resource.get(File.join(base_path,"listing")).split("\n")
-    end
+      def self.ca_file
+        "#{Rails.root}/ca/redhat-uep.pem"
+      end
 
+      def net_http_class
+        if proxy_host
+          Net::HTTP::Proxy(proxy_host, proxy_port, proxy_user, proxy_password)
+        else
+          Net::HTTP
+        end
+      end
+
+      def load_proxy_settings
+        if AppConfig.cdn_proxy && AppConfig.cdn_proxy.host
+          self.proxy_host = parse_host(AppConfig.cdn_proxy.host)
+          self.proxy_port = AppConfig.cdn_proxy.port
+          self.proxy_user = AppConfig.cdn_proxy.user
+          self.proxy_password = AppConfig.cdn_proxy.password
+        end
+      rescue Exception => e
+        Rails.logger.error "Could not parse cdn_proxy:"
+        Rails.logger.error e.to_s
+      end
+
+      def parse_host(host_or_url)
+        uri = URI.parse(host_or_url)
+        return uri.host || uri.path
+      end
+
+   end
+
+    class CdnVarSubstitutor
+      def initialize url, options
+        @url = url
+        @options = options
+        @resource = CdnResource.new(@url, @options)
+        @substitutions = Thread.current[:cdn_var_substitutor_cache] || {}
+      end
+
+      def self.with_cache(&block)
+        Thread.current[:cdn_var_substitutor_cache] = {}
+        yield
+      ensure
+        Thread.current[:cdn_var_substitutor_cache] = nil
+      end
+
+      # precalcuclate all paths at once - let's you discover errors and stop
+      # before it causes more pain
+      def precalculate(paths_with_vars)
+        paths_with_vars.uniq.reduce({}) do |ret, path_with_vars|
+          ret[path_with_vars] = substitute_vars(path_with_vars); ret
+        end
+      end
+
+    # takes path e.g. "/rhel/server/5/$releasever/$basearch/os"
+    # returns hash substituting variables:
+    #
+    #  { {"releasever" => "6Server", "basearch" => "i386"} =>  "/rhel/server/5/6Server/i386/os",
+    #    {"releasever" => "6Server", "basearch" => "x86_64"} =>  "/rhel/server/5/6Server/x84_64/os"}
+    #
+    # values are loaded from CDN
+      def substitute_vars(path_with_vars)
+        if path_with_vars =~ /^(.*\$\w+)(.*)$/
+          prefix_with_vars, suffix_witout_vars =  $1, $2
+        else
+          prefix_with_vars, suffix_witout_vars = "", path_with_vars
+        end
+
+        prefixes_without_vars = substitute_vars_in_prefix(prefix_with_vars)
+        paths_without_vars = prefixes_without_vars.reduce({}) do |h, (substitutions, prefix_without_vars)|
+          h[substitutions] = prefix_without_vars + suffix_witout_vars; h
+        end
+        return paths_without_vars
+      end
+
+      # prefix_with_vars is the part of url containing some vars. We can cache
+      # calcualted values for this parts. So for example for:
+      #   "/a/$b/$c/d"
+      #   "/a/$b/$c/e"
+      # prefix_with_vars is "/a/$b/$c" and we store the result after resolving
+      # for the first path.
+      def substitute_vars_in_prefix(prefix_with_vars)
+        paths_with_vars = { {} => prefix_with_vars}
+        prefixes_without_vars = @substitutions[prefix_with_vars]
+
+        unless prefixes_without_vars
+          prefixes_without_vars = {}
+          while not paths_with_vars.empty?
+            substitutions, path = paths_with_vars.shift
+
+            if is_substituable path
+              for_each_substitute_of_next_var substitutions, path do |new_substitution, new_path|
+                paths_with_vars[new_substitution] = new_path
+              end
+            else
+              prefixes_without_vars[substitutions] = path
+            end
+          end
+          @substitutions[prefix_with_vars] = prefixes_without_vars
+        end
+        return prefixes_without_vars
+      end
+
+      def is_substituable path
+        path.include?("$")
+      end
+
+      def is_substitute_of(substituted_url, original_url)
+        substitutions = self.substitute_vars(original_url).values
+        substitutions.include? substituted_url
+      end
+
+      protected
+
+      def for_each_substitute_of_next_var(substitutions, path)
+        if path =~ /^(.*?)\$([^\/]*)/
+          base_path, var = $1, $2
+          get_substitutions_from(base_path).each do |value|
+
+            new_substitutions = substitutions.merge(var => value)
+            new_path = path.sub("$#{var}",value)
+
+            yield new_substitutions, new_path
+          end
+        end
+      end
+
+      def get_substitutions_from(base_path)
+        @resource.get(File.join(base_path,"listing")).split("\n")
+      end
+
+    end
   end
 end

--- a/src/lib/resources/pulp.rb
+++ b/src/lib/resources/pulp.rb
@@ -10,617 +10,616 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'rubygems'
-require 'rest_client'
-require 'http_resource'
+module Resources
 
-module Pulp
+  module Pulp
 
-  class Proxy
-    def self.post path, body
-      Rails.logger.debug "Sending POST request to Pulp: #{path}"
-      client = PulpResource.rest_client(Net::HTTP::Post, :post, path_with_pulp_prefix(path))
-      client.post body, PulpResource.default_headers
-    end
+    class Proxy
+      def self.post path, body
+        Rails.logger.debug "Sending POST request to Pulp: #{path}"
+        client = PulpResource.rest_client(Net::HTTP::Post, :post, path_with_pulp_prefix(path))
+        client.post body, PulpResource.default_headers
+      end
 
-    def self.delete path
-      Rails.logger.debug "Sending DELETE request to Pulp: #{path}"
-      client = PulpResource.rest_client(Net::HTTP::Delete, :delete, path_with_pulp_prefix(path))
-      client.delete(PulpResource.default_headers)
-    end
+      def self.delete path
+        Rails.logger.debug "Sending DELETE request to Pulp: #{path}"
+        client = PulpResource.rest_client(Net::HTTP::Delete, :delete, path_with_pulp_prefix(path))
+        client.delete(PulpResource.default_headers)
+      end
 
-    def self.get path
-      Rails.logger.debug "Sending GET request to Pulp: #{path}"
-      client = PulpResource.rest_client(Net::HTTP::Get, :get, path_with_pulp_prefix(path))
-      client.get(PulpResource.default_headers)
-    end
+      def self.get path
+        Rails.logger.debug "Sending GET request to Pulp: #{path}"
+        client = PulpResource.rest_client(Net::HTTP::Get, :get, path_with_pulp_prefix(path))
+        client.get(PulpResource.default_headers)
+      end
 
-    def self.path_with_pulp_prefix path
-      PulpResource.prefix + path
-    end
-  end
-
-  class PulpResource < HttpResource
-    if AppConfig.pulp
-      cfg = AppConfig.pulp
-      url = cfg.url
-      self.prefix = URI.parse(url).path
-      self.site = url.gsub(self.prefix, "")
-      self.consumer_secret = cfg.oauth_secret
-      self.consumer_key = cfg.oauth_key
-      self.ca_cert_file = cfg.ca_cert_file
-    end
-
-
-    def self.default_headers
-      {'accept' => 'application/json',
-       'accept-language' => I18n.locale,
-       'content-type' => 'application/json'}.merge(::User.pulp_oauth_header)
-    end
-
-    # some old Pulp API need text/plain content type
-    def self.default_headers_text
-      h = self.default_headers
-      h['content-type'] = 'text/plain'
-      h
-    end
-
-    # the path is expected to have trailing slash
-    def self.path_with_prefix path
-      PulpResource.prefix + path
-    end
-  end
-
-  class PulpPing < PulpResource
-    class << self
-      def ping
-        # For now we have to query repositories because there is no
-        # URL that is available in Pulp that returns something small
-        # but requires authentication.  Please do not change this to
-        # /pulp/api/services/status/ because that path does *not* require
-        # auth and will not accurately report if Katello can talk
-        # to Pulp using OAuth.
-        response = get('/pulp/api/users/', self.default_headers).body
-        JSON.parse(response)
+      def self.path_with_pulp_prefix path
+        PulpResource.prefix + path
       end
     end
-  end
 
-  class Package < PulpResource
-
-    class << self
-
-      # Get all the Repositories known by Pulp
-      def all
-        response = get(package_path, self.default_headers).body
-        JSON.parse(response)
-      end
-
-      def find id
-        response = get(package_path + id + "/", self.default_headers).body
-        JSON.parse(response)
-      rescue JSON::ParserError => e
-        nil
-      end
-
-      def search name, regex=false
-        path = '/pulp/api/services/search/packages/'
-        response = post(path, {:name=>name, :regex=>regex}.to_json, self.default_headers)
-        JSON.parse(response)
-      end
-
-      def name_search name
-        pkgs = search("^" + name, true)
-        pkgs.collect{|pkg| pkg["name"]}
-      end
-
-      def package_path
-        "/pulp/api/packages/"
-      end
-
-      def dep_solve pkgnames, repoids
-        path = "/pulp/api/services/dependencies/"
-        response = post(path, JSON.generate({:pkgnames=>pkgnames, :repoids=>repoids}),  self.default_headers)
-        JSON.parse(response)
+    class PulpResource < HttpResource
+      if AppConfig.pulp
+        cfg = AppConfig.pulp
+        url = cfg.url
+        self.prefix = URI.parse(url).path
+        self.site = url.gsub(self.prefix, "")
+        self.consumer_secret = cfg.oauth_secret
+        self.consumer_key = cfg.oauth_key
+        self.ca_cert_file = cfg.ca_cert_file
       end
 
 
-    end
-  end
-
-  class Errata < PulpResource
-
-    class << self
-      def find(errata_id)
-        response = get(errata_path + errata_id + "/", self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      rescue JSON::ParserError => e
-        nil
+      def self.default_headers
+        {'accept' => 'application/json',
+         'accept-language' => I18n.locale,
+         'content-type' => 'application/json'}.merge(::User.pulp_oauth_header)
       end
 
-      def errata_path
-        "/pulp/api/errata/"
+      # some old Pulp API need text/plain content type
+      def self.default_headers_text
+        h = self.default_headers
+        h['content-type'] = 'text/plain'
+        h
       end
 
-      def filter(filter)
-        path = "#{errata_path}?#{filter.to_param}"
-        response = get(path, self.default_headers)
-        JSON.parse(response.body).map(&:with_indifferent_access)
+      # the path is expected to have trailing slash
+      def self.path_with_prefix path
+        PulpResource.prefix + path
       end
     end
-  end
 
-  class Distribution < PulpResource
-
-    class << self
-      def find dist_id
-        response = get(dist_path + dist_id + "/", self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def dist_path
-        "/pulp/api/distributions/"
-      end
-    end
-  end
-
-  class Repository < PulpResource
-    class << self
-
-      def clone_repo from_repo, to_repo, feed = "parent", filters = []  #clone is a built in method, hence redundant name
-        data = { :clone_id => to_repo.pulp_id,
-                 :feed =>feed,
-                 :clone_name => to_repo.name,
-                 :groupid=>to_repo.groupid,
-                 :relative_path => to_repo.relative_path,
-                 :filters => filters }
-        path = Repository.repository_path + from_repo.pulp_id + "/clone/"
-        response = post(path, JSON.generate(data), self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def find repo_id, yell_on_404 = false
-        response = get(repository_path  + repo_id + "/", self.default_headers)
-        body = response.body
-        JSON.parse(body).with_indifferent_access
-      rescue RestClient::ResourceNotFound => e
-        return nil if !yell_on_404
-        raise e
-      end
-
-      def find_all repo_ids, yell_on_404 = false
-        ids = "id=#{repo_ids.join('&id=')}"
-        response = get(repository_path  + "/?#{ids}", self.default_headers)
-        body = response.body
-        JSON.parse(body).with_indifferent_access
-      rescue RestClient::ResourceNotFound => e
-        return nil if !yell_on_404
-        raise e
-      end
-
-      # Get all the Repositories known by Pulp
-      # currently filtering against only one groupid is supported in PULP
-      def all groupids=nil, search_params = {}
-
-        search_query = get_repo_search_query(groupids, search_params)
-
-        response = get(self.repository_path + search_query , self.default_headers)
-        JSON.parse(response.body)
-      rescue RestClient::ResourceNotFound => e
-        return nil if !yell_on_404
-        raise e
-      end
-
-      def start_discovery url, type
-        response = post("/pulp/api/services/discovery/repo/", JSON.generate(:url => url, :type => type), self.default_headers)
-        return JSON.parse(response.body).with_indifferent_access if response.code == 202
-        Rails.logger.error("Failed to start repository discovery. HTTP status: #{response.code}. #{response.body}")
-        raise RuntimeError, "#{response.code}, failed to start repository discovery: #{response.body}"
-      end
-
-      def repository_path
-        "/pulp/api/repositories/"
-      end
-
-      # :id, :name, :arch, :groupid, :feed
-      def create attrs
-        body = put(Repository.repository_path, JSON.generate(attrs), self.default_headers).body
-        JSON.parse(body).with_indifferent_access
-      end
-
-      # :id, :name, :arch, :groupid, :feed
-      def update repo_id, attrs
-        body = put(Repository.repository_path + repo_id +"/", JSON.generate(attrs), self.default_headers).body
-        find repo_id
-      end
-
-      # specific call to just update the sync schedule for a repo
-      def update_schedule(repo_id, schedule)
-        body = put(Repository.repository_path + repo_id +"/schedules/sync/", JSON.generate(:schedule => schedule), self.default_headers).body
-      end
-
-      def delete_schedule(repo_id)
-        body = self.delete(Repository.repository_path + repo_id +"/schedules/sync/", self.default_headers).body
-      end
-
-      def add_packages repo_id, pkg_id_list
-        body = post(Repository.repository_path + repo_id +"/add_package/", {:packageid=>pkg_id_list}.to_json, self.default_headers).body
-      end
-
-      def add_errata repo_id, errata_id_list
-        body = post(Repository.repository_path + repo_id +"/add_errata/", {:errataid=>errata_id_list}.to_json, self.default_headers).body
-      end
-
-      def add_distribution repo_id, distribution_id
-        body = post(Repository.repository_path + repo_id +"/add_distribution/", {:distributionid=>distribution_id}.to_json, self.default_headers).body
-      end
-
-      def destroy repo_id # TODO remove this unreachable method, it's overridden few lines below
-        raise ArgumentError, "repo id has to be specified" unless repo_id
-        self.delete(repository_path  + repo_id + "/", self.default_headers).code.to_i
-      end
-
-      def sync (repo_id, data = {})
-        data[:limit] ||= AppConfig.pulp.sync_KBlimit if AppConfig.pulp.sync_KBlimit # set bandwidth limit
-        data[:threads] ||= AppConfig.pulp.sync_threads if AppConfig.pulp.sync_threads # set threads per sync
-        path = Repository.repository_path + repo_id + "/sync/"
-        response = post(path, JSON.generate(data), self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def sync_history repo_id
-        begin
-          response = get(Repository.repository_path + repo_id + "/history/sync/", self.default_headers)
-          json_history = JSON.parse(response.body)
-          json_history.collect {|jh| jh.with_indifferent_access }
-        rescue RestClient::ResourceNotFound => error
-          # Return nothing if there is a 404 which indicates there
-          # is no sync status for this repo.  Not an error.
-          return
+    class PulpPing < PulpResource
+      class << self
+        def ping
+          # For now we have to query repositories because there is no
+          # URL that is available in Pulp that returns something small
+          # but requires authentication.  Please do not change this to
+          # /pulp/api/services/status/ because that path does *not* require
+          # auth and will not accurately report if Katello can talk
+          # to Pulp using OAuth.
+          response = get('/pulp/api/users/', self.default_headers).body
+          JSON.parse(response)
         end
       end
+    end
 
-      def sync_status(repo_id)
-        path = Repository.repository_path + repo_id + "/sync/"
-        response = get(path, self.default_headers)
-        parsed = JSON.parse(response.body)
-        return parsed
-      end
+    class Package < PulpResource
 
-      def destroy repo_id
-        raise ArgumentError, "repository id has to be specified" unless repo_id
-        path = Repository.repository_path + repo_id +"/"
-        self.delete(path, self.default_headers).code.to_i
-      end
+      class << self
 
-      def packages repo_id
-        response = get(repository_path  + repo_id + "/packages/", self.default_headers)
-        body = response.body
-        JSON.parse(body)
-      end
-
-      def packages_by_name repo_id, name
-        response = get(repository_path  + repo_id + "/packages/?name=^" + name + "$", self.default_headers)
-        body = response.body
-        JSON.parse(body)
-      end
-
-      def packages_by_nvre repo_id, name, version, release, epoch
-        #TODO: switch to https://fedorahosted.org/pulp/wiki/UGREST-Repositories#GetPackageByNVREA after bug 790909 gets fixed in Pulp
-        path = repository_path + repo_id + "/packages/?name=^" + name +"$"
-        path += "&release=" + release if not release.nil?
-        path += "&version=" + version if not version.nil?
-        path += "&epoch=" + epoch if not epoch.nil?
-        response = get(path, self.default_headers)
-        body = response.body
-        JSON.parse(body)
-      end
-
-      def errata(repo_id, filter = {})
-        path = "#{repository_path}#{repo_id}/errata/?#{filter.to_param}"
-        response = get(path, self.default_headers)
-        body = response.body
-        JSON.parse(body)
-      end
-
-      def distributions(repo_id)
-        response = get(repository_path + repo_id + "/distribution/", self.default_headers)
-        body = response.body
-        JSON.parse(body)
-      end
-
-      def add_filters repo_id, filter_ids
-        response =  post(repository_path + repo_id + "/add_filters/", {:filters => filter_ids}.to_json, self.default_headers)
-        response.body
-      end
-
-      def remove_filters repo_id, filter_ids
-        response =  post(repository_path + repo_id + "/remove_filters/", {:filters => filter_ids}.to_json, self.default_headers)
-        response.body
-      end
-
-      def generate_metadata repo_id
-        response = post(repository_path + repo_id + "/generate_metadata/", {}, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      private
-      def get_repo_search_query groupids=nil, search_params = {}
-        search_query = ""
-
-        if not groupids.nil?
-          search_query = "?_intersect=groupid&" + groupids.collect do |gid|
-            "groupid="+gid
-          end.join("&")
+        # Get all the Repositories known by Pulp
+        def all
+          response = get(package_path, self.default_headers).body
+          JSON.parse(response)
         end
 
-        if not search_params.empty?
-          if search_query.length == 0
-            search_query = "?" + search_params.to_query
-          else
-            search_query += "&" + search_params.to_query
+        def find id
+          response = get(package_path + id + "/", self.default_headers).body
+          JSON.parse(response)
+        rescue JSON::ParserError => e
+          nil
+        end
+
+        def search name, regex=false
+          path = '/pulp/api/services/search/packages/'
+          response = post(path, {:name=>name, :regex=>regex}.to_json, self.default_headers)
+          JSON.parse(response)
+        end
+
+        def name_search name
+          pkgs = search("^" + name, true)
+          pkgs.collect{|pkg| pkg["name"]}
+        end
+
+        def package_path
+          "/pulp/api/packages/"
+        end
+
+        def dep_solve pkgnames, repoids
+          path = "/pulp/api/services/dependencies/"
+          response = post(path, JSON.generate({:pkgnames=>pkgnames, :repoids=>repoids}),  self.default_headers)
+          JSON.parse(response)
+        end
+
+
+      end
+    end
+
+    class Errata < PulpResource
+
+      class << self
+        def find(errata_id)
+          response = get(errata_path + errata_id + "/", self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        rescue JSON::ParserError => e
+          nil
+        end
+
+        def errata_path
+          "/pulp/api/errata/"
+        end
+
+        def filter(filter)
+          path = "#{errata_path}?#{filter.to_param}"
+          response = get(path, self.default_headers)
+          JSON.parse(response.body).map(&:with_indifferent_access)
+        end
+      end
+    end
+
+    class Distribution < PulpResource
+
+      class << self
+        def find dist_id
+          response = get(dist_path + dist_id + "/", self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def dist_path
+          "/pulp/api/distributions/"
+        end
+      end
+    end
+
+    class Repository < PulpResource
+      class << self
+
+        def clone_repo from_repo, to_repo, feed = "parent", filters = []  #clone is a built in method, hence redundant name
+          data = { :clone_id => to_repo.pulp_id,
+                   :feed =>feed,
+                   :clone_name => to_repo.name,
+                   :groupid=>to_repo.groupid,
+                   :relative_path => to_repo.relative_path,
+                   :filters => filters }
+          path = Repository.repository_path + from_repo.pulp_id + "/clone/"
+          response = post(path, JSON.generate(data), self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def find repo_id, yell_on_404 = false
+          response = get(repository_path  + repo_id + "/", self.default_headers)
+          body = response.body
+          JSON.parse(body).with_indifferent_access
+        rescue RestClient::ResourceNotFound => e
+          return nil if !yell_on_404
+          raise e
+        end
+
+        def find_all repo_ids, yell_on_404 = false
+          ids = "id=#{repo_ids.join('&id=')}"
+          response = get(repository_path  + "/?#{ids}", self.default_headers)
+          body = response.body
+          JSON.parse(body).with_indifferent_access
+        rescue RestClient::ResourceNotFound => e
+          return nil if !yell_on_404
+          raise e
+        end
+
+        # Get all the Repositories known by Pulp
+        # currently filtering against only one groupid is supported in PULP
+        def all groupids=nil, search_params = {}
+
+          search_query = get_repo_search_query(groupids, search_params)
+
+          response = get(self.repository_path + search_query , self.default_headers)
+          JSON.parse(response.body)
+        rescue RestClient::ResourceNotFound => e
+          return nil if !yell_on_404
+          raise e
+        end
+
+        def start_discovery url, type
+          response = post("/pulp/api/services/discovery/repo/", JSON.generate(:url => url, :type => type), self.default_headers)
+          return JSON.parse(response.body).with_indifferent_access if response.code == 202
+          Rails.logger.error("Failed to start repository discovery. HTTP status: #{response.code}. #{response.body}")
+          raise RuntimeError, "#{response.code}, failed to start repository discovery: #{response.body}"
+        end
+
+        def repository_path
+          "/pulp/api/repositories/"
+        end
+
+        # :id, :name, :arch, :groupid, :feed
+        def create attrs
+          body = put(Repository.repository_path, JSON.generate(attrs), self.default_headers).body
+          JSON.parse(body).with_indifferent_access
+        end
+
+        # :id, :name, :arch, :groupid, :feed
+        def update repo_id, attrs
+          body = put(Repository.repository_path + repo_id +"/", JSON.generate(attrs), self.default_headers).body
+          find repo_id
+        end
+
+        # specific call to just update the sync schedule for a repo
+        def update_schedule(repo_id, schedule)
+          body = put(Repository.repository_path + repo_id +"/schedules/sync/", JSON.generate(:schedule => schedule), self.default_headers).body
+        end
+
+        def delete_schedule(repo_id)
+          body = self.delete(Repository.repository_path + repo_id +"/schedules/sync/", self.default_headers).body
+        end
+
+        def add_packages repo_id, pkg_id_list
+          body = post(Repository.repository_path + repo_id +"/add_package/", {:packageid=>pkg_id_list}.to_json, self.default_headers).body
+        end
+
+        def add_errata repo_id, errata_id_list
+          body = post(Repository.repository_path + repo_id +"/add_errata/", {:errataid=>errata_id_list}.to_json, self.default_headers).body
+        end
+
+        def add_distribution repo_id, distribution_id
+          body = post(Repository.repository_path + repo_id +"/add_distribution/", {:distributionid=>distribution_id}.to_json, self.default_headers).body
+        end
+
+        def destroy repo_id # TODO remove this unreachable method, it's overridden few lines below
+          raise ArgumentError, "repo id has to be specified" unless repo_id
+          self.delete(repository_path  + repo_id + "/", self.default_headers).code.to_i
+        end
+
+        def sync (repo_id, data = {})
+          data[:limit] ||= AppConfig.pulp.sync_KBlimit if AppConfig.pulp.sync_KBlimit # set bandwidth limit
+          data[:threads] ||= AppConfig.pulp.sync_threads if AppConfig.pulp.sync_threads # set threads per sync
+          path = Repository.repository_path + repo_id + "/sync/"
+          response = post(path, JSON.generate(data), self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def sync_history repo_id
+          begin
+            response = get(Repository.repository_path + repo_id + "/history/sync/", self.default_headers)
+            json_history = JSON.parse(response.body)
+            json_history.collect {|jh| jh.with_indifferent_access }
+          rescue RestClient::ResourceNotFound => error
+            # Return nothing if there is a 404 which indicates there
+            # is no sync status for this repo.  Not an error.
+            return
           end
         end
 
-        search_query
-      end
-    end
-  end
-
-  class Consumer < PulpResource
-
-    class << self
-
-      def create key, uuid, description = "", key_value_pairs = {}
-        url = consumer_path() + "?owner=#{key}"
-        attrs = {:id => uuid, :description => description, :key_value_pairs => key_value_pairs}
-        response = self.post(url, attrs.to_json, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def upload_package_profile uuid, package_profile
-        attrs = {:id => uuid, :package_profile => package_profile}
-        response = put(consumer_path(uuid) + "package_profile/", attrs.to_json, self.default_headers)
-        raise RuntimeError, "update failed" unless response
-        return response
-      end
-
-      def update key, uuid, description = ""
-        url = consumer_path(uuid) + "?owner=#{key}"
-        attrs = {:id => uuid, :description => description}
-        response = self.put(url, attrs.to_json, self.default_headers)
-        raise RuntimeError, "update failed" unless response
-        return response
-      end
-
-      def find consumer_id
-        response = get(consumer_path(consumer_id), self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def installed_packages consumer_id
-        response = get(consumer_path(consumer_id) + "package_profile/", self.default_headers)
-        JSON.parse(response.body)
-      end
-
-      def install_packages consumer_id, package_names
-        url = consumer_path(consumer_id) + "installpackages/"
-        attrs = {:packagenames => package_names}
-        response = self.post(url, attrs.to_json, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def uninstall_packages consumer_id, package_names
-        url = consumer_path(consumer_id) + "uninstallpackages/"
-        attrs = {:packagenames => package_names}
-        response = self.post(url, attrs.to_json, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def update_packages consumer_id, package_names
-        url = consumer_path(consumer_id) + "updatepackages/"
-        attrs = {:packagenames => package_names}
-        response = self.post(url, attrs.to_json, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def install_package_groups consumer_id, package_groups
-        url = consumer_path(consumer_id) + "installpackagegroups/"
-        attrs = {:groupids => package_groups}
-        response = self.post(url, attrs.to_json, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def uninstall_package_groups consumer_id, package_groups
-        url = consumer_path(consumer_id) + "uninstallpackagegroups/"
-        attrs = {:groupids => package_groups}
-        response = self.post(url, attrs.to_json, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def destroy consumer_id
-        raise ArgumentError, "consumer_id id has to be specified" unless consumer_id
-        self.delete(consumer_path(consumer_id), self.default_headers).code.to_i
-      end
-
-      def errata consumer_id
-        response = get(consumer_path(consumer_id) + "errata/", self.default_headers)
-        JSON.parse(response.body)
-      end
-
-      def errata_by_consumer repos
-        repoids_param = nil
-        repos.each do |repo|
-          if repoids_param.nil?
-            repoids_param = "?repoids=" + repo.pulp_id
-          else
-            repoids_param += "&repoids=" + repo.pulp_id
-          end
+        def sync_status(repo_id)
+          path = Repository.repository_path + repo_id + "/sync/"
+          response = get(path, self.default_headers)
+          parsed = JSON.parse(response.body)
+          return parsed
         end
 
-        url = consumer_path() + "applicable_errata_in_repos/" + repoids_param
-        response = get(url, self.default_headers)
-        JSON.parse(response.body)
-      end
+        def destroy repo_id
+          raise ArgumentError, "repository id has to be specified" unless repo_id
+          path = Repository.repository_path + repo_id +"/"
+          self.delete(path, self.default_headers).code.to_i
+        end
 
-      def install_errata consumer_id, errata_ids
-        url = consumer_path(consumer_id) + "installerrata/"
-        attrs = { :errataids => errata_ids }
-        response = self.post(url, attrs.to_json, self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
+        def packages repo_id
+          response = get(repository_path  + repo_id + "/packages/", self.default_headers)
+          body = response.body
+          JSON.parse(body)
+        end
 
-      def repoids consumer_id
-        response = get(consumer_path(consumer_id) + "repoids/", self.default_headers)
-        JSON.parse(response.body)
-      end
+        def packages_by_name repo_id, name
+          response = get(repository_path  + repo_id + "/packages/?name=^" + name + "$", self.default_headers)
+          body = response.body
+          JSON.parse(body)
+        end
 
-      def bind uuid, repoid
-        url = consumer_path(uuid) + "bind/"
-        # this is old-style Pulp API call
-        response = self.post(url, '"' + repoid + '"', self.default_headers_text)
-        response.body
-      end
+        def packages_by_nvre repo_id, name, version, release, epoch
+          #TODO: switch to https://fedorahosted.org/pulp/wiki/UGREST-Repositories#GetPackageByNVREA after bug 790909 gets fixed in Pulp
+          path = repository_path + repo_id + "/packages/?name=^" + name +"$"
+          path += "&release=" + release if not release.nil?
+          path += "&version=" + version if not version.nil?
+          path += "&epoch=" + epoch if not epoch.nil?
+          response = get(path, self.default_headers)
+          body = response.body
+          JSON.parse(body)
+        end
 
-      def unbind uuid, repoid
-        url = consumer_path(uuid) + "unbind/"
-        # this is old-style Pulp API call
-        response = self.post(url, '"' + repoid + '"', self.default_headers_text)
-        response.body
-      end
+        def errata(repo_id, filter = {})
+          path = "#{repository_path}#{repo_id}/errata/?#{filter.to_param}"
+          response = get(path, self.default_headers)
+          body = response.body
+          JSON.parse(body)
+        end
 
-      def consumer_path id = nil
-        id.nil? ? "/pulp/api/consumers/" : "/pulp/api/consumers/#{id}/"
-      end
-    end
-  end
+        def distributions(repo_id)
+          response = get(repository_path + repo_id + "/distribution/", self.default_headers)
+          body = response.body
+          JSON.parse(body)
+        end
 
-  class Task < PulpResource
-    class << self
-      def find uuids
-        ids = "id=#{uuids.join('&id=')}"
-        query_url = path  + "?state=archived&state=current&#{ids}"
-        response = self.get(query_url, self.default_headers)
-        body = response.body
-        JSON.parse(body).collect{|k| k.with_indifferent_access}
-      end
+        def add_filters repo_id, filter_ids
+          response =  post(repository_path + repo_id + "/add_filters/", {:filters => filter_ids}.to_json, self.default_headers)
+          response.body
+        end
 
-      def cancel uuid
-        response = self.post(path(uuid) +"cancel/" , {}, self.default_headers)
+        def remove_filters repo_id, filter_ids
+          response =  post(repository_path + repo_id + "/remove_filters/", {:filters => filter_ids}.to_json, self.default_headers)
+          response.body
+        end
 
-        JSON.parse(response.body).with_indifferent_access
-      end
+        def generate_metadata repo_id
+          response = post(repository_path + repo_id + "/generate_metadata/", {}, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
 
-      def destroy uuid
-        response = self.delete(path(uuid), self.default_headers)
-        JSON.parse(response.body).with_indifferent_access
-      end
+        private
+        def get_repo_search_query groupids=nil, search_params = {}
+          search_query = ""
 
-      def path uuid=nil
-        uuid.nil? ? "/pulp/api/tasks/" : "/pulp/api/tasks/#{uuid}/"
-      end
-    end
-  end
+          if not groupids.nil?
+            search_query = "?_intersect=groupid&" + groupids.collect do |gid|
+              "groupid="+gid
+            end.join("&")
+          end
 
-  class PackageGroup < PulpResource
-    class << self
-      def all repo_id
-        response = get path(repo_id), self.default_headers
-        JSON.parse(response.body).with_indifferent_access
-      end
+          if not search_params.empty?
+            if search_query.length == 0
+              search_query = "?" + search_params.to_query
+            else
+              search_query += "&" + search_params.to_query
+            end
+          end
 
-      def path repo_id
-        self.path_with_prefix("/repositories/#{repo_id}/packagegroups/")
-      end
-    end
-  end
-
-  class PackageGroupCategory < PulpResource
-    class << self
-      def all repo_id
-        response = get path(repo_id), self.default_headers
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def path repo_id
-        self.path_with_prefix("/repositories/#{repo_id}/packagegroupcategories/")
+          search_query
+        end
       end
     end
-  end
 
-  class User < PulpResource
-    class << self
-      def create attrs
-        response = self.post path, attrs.to_json, self.default_headers
-        JSON.parse(response.body).with_indifferent_access
-      end
+    class Consumer < PulpResource
 
-      def destroy login
-        self.delete(path(login), self.default_headers).code.to_i
-      end
+      class << self
 
-      def find login
-        response = self.get path(login), self.default_headers
-        JSON.parse(response.body).with_indifferent_access
-      end
+        def create key, uuid, description = "", key_value_pairs = {}
+          url = consumer_path() + "?owner=#{key}"
+          attrs = {:id => uuid, :description => description, :key_value_pairs => key_value_pairs}
+          response = self.post(url, attrs.to_json, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
 
-      def path(login=nil)
-        users = self.path_with_prefix("/users/")
-        login.nil? ? users : users + "#{login}/"
+        def upload_package_profile uuid, package_profile
+          attrs = {:id => uuid, :package_profile => package_profile}
+          response = put(consumer_path(uuid) + "package_profile/", attrs.to_json, self.default_headers)
+          raise RuntimeError, "update failed" unless response
+          return response
+        end
+
+        def update key, uuid, description = ""
+          url = consumer_path(uuid) + "?owner=#{key}"
+          attrs = {:id => uuid, :description => description}
+          response = self.put(url, attrs.to_json, self.default_headers)
+          raise RuntimeError, "update failed" unless response
+          return response
+        end
+
+        def find consumer_id
+          response = get(consumer_path(consumer_id), self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def installed_packages consumer_id
+          response = get(consumer_path(consumer_id) + "package_profile/", self.default_headers)
+          JSON.parse(response.body)
+        end
+
+        def install_packages consumer_id, package_names
+          url = consumer_path(consumer_id) + "installpackages/"
+          attrs = {:packagenames => package_names}
+          response = self.post(url, attrs.to_json, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def uninstall_packages consumer_id, package_names
+          url = consumer_path(consumer_id) + "uninstallpackages/"
+          attrs = {:packagenames => package_names}
+          response = self.post(url, attrs.to_json, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def update_packages consumer_id, package_names
+          url = consumer_path(consumer_id) + "updatepackages/"
+          attrs = {:packagenames => package_names}
+          response = self.post(url, attrs.to_json, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def install_package_groups consumer_id, package_groups
+          url = consumer_path(consumer_id) + "installpackagegroups/"
+          attrs = {:groupids => package_groups}
+          response = self.post(url, attrs.to_json, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def uninstall_package_groups consumer_id, package_groups
+          url = consumer_path(consumer_id) + "uninstallpackagegroups/"
+          attrs = {:groupids => package_groups}
+          response = self.post(url, attrs.to_json, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def destroy consumer_id
+          raise ArgumentError, "consumer_id id has to be specified" unless consumer_id
+          self.delete(consumer_path(consumer_id), self.default_headers).code.to_i
+        end
+
+        def errata consumer_id
+          response = get(consumer_path(consumer_id) + "errata/", self.default_headers)
+          JSON.parse(response.body)
+        end
+
+        def errata_by_consumer repos
+          repoids_param = nil
+          repos.each do |repo|
+            if repoids_param.nil?
+              repoids_param = "?repoids=" + repo.pulp_id
+            else
+              repoids_param += "&repoids=" + repo.pulp_id
+            end
+          end
+
+          url = consumer_path() + "applicable_errata_in_repos/" + repoids_param
+          response = get(url, self.default_headers)
+          JSON.parse(response.body)
+        end
+
+        def install_errata consumer_id, errata_ids
+          url = consumer_path(consumer_id) + "installerrata/"
+          attrs = { :errataids => errata_ids }
+          response = self.post(url, attrs.to_json, self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def repoids consumer_id
+          response = get(consumer_path(consumer_id) + "repoids/", self.default_headers)
+          JSON.parse(response.body)
+        end
+
+        def bind uuid, repoid
+          url = consumer_path(uuid) + "bind/"
+          # this is old-style Pulp API call
+          response = self.post(url, '"' + repoid + '"', self.default_headers_text)
+          response.body
+        end
+
+        def unbind uuid, repoid
+          url = consumer_path(uuid) + "unbind/"
+          # this is old-style Pulp API call
+          response = self.post(url, '"' + repoid + '"', self.default_headers_text)
+          response.body
+        end
+
+        def consumer_path id = nil
+          id.nil? ? "/pulp/api/consumers/" : "/pulp/api/consumers/#{id}/"
+        end
       end
     end
-  end
 
-  class Roles < PulpResource
-    class << self
-      def add role_name, username
-        added = self.post(path(role_name) + "/add/", {:username => username}.to_json, self.default_headers)
-        added.body == "true"
-      end
+    class Task < PulpResource
+      class << self
+        def find uuids
+          ids = "id=#{uuids.join('&id=')}"
+          query_url = path  + "?state=archived&state=current&#{ids}"
+          response = self.get(query_url, self.default_headers)
+          body = response.body
+          JSON.parse(body).collect{|k| k.with_indifferent_access}
+        end
 
-      def remove role_name, username
-        removed = self.post(path(role_name) + "/remove/", {:username => username}.to_json, self.default_headers)
-        removed.body == "true"
-      end
+        def cancel uuid
+          response = self.post(path(uuid) +"cancel/" , {}, self.default_headers)
 
-      def path(role_name=nil)
-        roles = self.path_with_prefix("/roles/")
-        role_name.nil? ? roles : roles + "#{role_name}/"
-      end
-    end
-  end
+          JSON.parse(response.body).with_indifferent_access
+        end
 
-  class Filter < PulpResource
-    class << self
-      def create attrs
-        response = self.post path, attrs.to_json, self.default_headers
-        JSON.parse(response.body).with_indifferent_access
-      end
+        def destroy uuid
+          response = self.delete(path(uuid), self.default_headers)
+          JSON.parse(response.body).with_indifferent_access
+        end
 
-      def destroy id
-        self.delete(path(id), self.default_headers).code.to_i
-      end
-
-      def find id
-        response = self.get path(id), self.default_headers
-        JSON.parse(response.body).with_indifferent_access
-      end
-
-      def add_packages id, packages
-        response = self.post path(id) + "add_packages/", {:packages => packages}.to_json, self.default_headers
-        return response.body
-      end
-
-      def remove_packages id, packages
-        response = self.post path(id) + "remove_packages/", {:packages => packages}.to_json, self.default_headers
-        return response.body
-      end
-
-      def path(id=nil)
-        filters = self.path_with_prefix("/filters/")
-        id.nil? ? filters : filters + "#{id}/"
+        def path uuid=nil
+          uuid.nil? ? "/pulp/api/tasks/" : "/pulp/api/tasks/#{uuid}/"
+        end
       end
     end
-  end
 
+    class PackageGroup < PulpResource
+      class << self
+        def all repo_id
+          response = get path(repo_id), self.default_headers
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def path repo_id
+          self.path_with_prefix("/repositories/#{repo_id}/packagegroups/")
+        end
+      end
+    end
+
+    class PackageGroupCategory < PulpResource
+      class << self
+        def all repo_id
+          response = get path(repo_id), self.default_headers
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def path repo_id
+          self.path_with_prefix("/repositories/#{repo_id}/packagegroupcategories/")
+        end
+      end
+    end
+
+    class User < PulpResource
+      class << self
+        def create attrs
+          response = self.post path, attrs.to_json, self.default_headers
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def destroy login
+          self.delete(path(login), self.default_headers).code.to_i
+        end
+
+        def find login
+          response = self.get path(login), self.default_headers
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def path(login=nil)
+          users = self.path_with_prefix("/users/")
+          login.nil? ? users : users + "#{login}/"
+        end
+      end
+    end
+
+    class Roles < PulpResource
+      class << self
+        def add role_name, username
+          added = self.post(path(role_name) + "/add/", {:username => username}.to_json, self.default_headers)
+          added.body == "true"
+        end
+
+        def remove role_name, username
+          removed = self.post(path(role_name) + "/remove/", {:username => username}.to_json, self.default_headers)
+          removed.body == "true"
+        end
+
+        def path(role_name=nil)
+          roles = self.path_with_prefix("/roles/")
+          role_name.nil? ? roles : roles + "#{role_name}/"
+        end
+      end
+    end
+
+    class Filter < PulpResource
+      class << self
+        def create attrs
+          response = self.post path, attrs.to_json, self.default_headers
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def destroy id
+          self.delete(path(id), self.default_headers).code.to_i
+        end
+
+        def find id
+          response = self.get path(id), self.default_headers
+          JSON.parse(response.body).with_indifferent_access
+        end
+
+        def add_packages id, packages
+          response = self.post path(id) + "add_packages/", {:packages => packages}.to_json, self.default_headers
+          return response.body
+        end
+
+        def remove_packages id, packages
+          response = self.post path(id) + "remove_packages/", {:packages => packages}.to_json, self.default_headers
+          return response.body
+        end
+
+        def path(id=nil)
+          filters = self.path_with_prefix("/filters/")
+          id.nil? ? filters : filters + "#{id}/"
+        end
+      end
+    end
+
+  end
 end

--- a/src/lib/tasks/reindex.rake
+++ b/src/lib/tasks/reindex.rake
@@ -15,7 +15,7 @@ task :reindex=>["environment", "clear_search_indices"]  do
 
   print "Re-indexing Repositories\n"
   
-  #pulp_repos = Pulp::Repository.all
+  #pulp_repos = Resources::Pulp::Repository.all
   #repos = Repository.all
   #repos.each{|r| r.populate_from pulp_repos}
 

--- a/src/lib/util/url_matcher.rb
+++ b/src/lib/util/url_matcher.rb
@@ -31,74 +31,77 @@
 
 require 'pathname'
 
-module UrlMatcher
+module Util
 
-  def self.match(path, routes)
-    path     = Path.new(path)
-    patterns = routes.map {|route| Pattern.new(Array(route).first) }
+  module UrlMatcher
 
-    patterns.each do |pattern|
-      return [pattern.to_s] + pattern.vars if pattern == path
-    end
+    def self.match(path, routes)
+      path     = Path.new(path)
+      patterns = routes.map {|route| Pattern.new(Array(route).first) }
 
-    [nil]
-  end
-
-  class Path
-    attr_accessor :parts, :ext
-
-    def initialize(path)
-      self.parts, self.ext = split_path(path)
-    end
-
-    def to_s
-      '/' + self.parts.join('/') + self.ext
-    end
-
-    private
-    def split_path(path)
-      path  = path.to_s
-      ext   = Pathname(path).extname
-      path  = path.sub(/#{ext}$/,'')
-      parts = path.split('/').reject {|part| part.empty? }
-      [parts, ext]
-    end
-  end
-
-  class Pattern < Path
-
-    def variables
-      return [] unless @match
-
-      a = []
-      self.parts.each_with_index do |part,i|
-        a << @match.parts[i] if part[0] == ?:
+      patterns.each do |pattern|
+        return [pattern.to_s] + pattern.vars if pattern == path
       end
-      a << @match.ext[1..-1] if self.ext[1] == ?:
-      a
-    end
-    alias :vars :variables
 
-    def ==(path)
-      is_match = size_match?(path) && ext_match?(path) && static_match?(path)
-      @match = path if is_match
-      is_match
+      [nil]
     end
 
-    private
-    def size_match?(path)
-      self.parts.size == path.parts.size
-    end
+    class Path
+      attr_accessor :parts, :ext
 
-    def ext_match?(path)
-      (self.ext == path.ext) || (self.ext[1] == ?: && !path.ext.empty?)
-    end
-
-    def static_match?(path)
-      self.parts.each_with_index do |part,i|
-        return false unless part[0] == ?: || path.parts[i] == part
+      def initialize(path)
+        self.parts, self.ext = split_path(path)
       end
-      true
+
+      def to_s
+        '/' + self.parts.join('/') + self.ext
+      end
+
+      private
+      def split_path(path)
+        path  = path.to_s
+        ext   = Pathname(path).extname
+        path  = path.sub(/#{ext}$/,'')
+        parts = path.split('/').reject {|part| part.empty? }
+        [parts, ext]
+      end
+    end
+
+    class Pattern < Path
+
+      def variables
+        return [] unless @match
+
+        a = []
+        self.parts.each_with_index do |part,i|
+          a << @match.parts[i] if part[0] == ?:
+        end
+        a << @match.ext[1..-1] if self.ext[1] == ?:
+        a
+      end
+      alias :vars :variables
+
+      def ==(path)
+        is_match = size_match?(path) && ext_match?(path) && static_match?(path)
+        @match = path if is_match
+        is_match
+      end
+
+      private
+      def size_match?(path)
+        self.parts.size == path.parts.size
+      end
+
+      def ext_match?(path)
+        (self.ext == path.ext) || (self.ext[1] == ?: && !path.ext.empty?)
+      end
+
+      def static_match?(path)
+        self.parts.each_with_index do |part,i|
+          return false unless part[0] == ?: || path.parts[i] == part
+        end
+        true
+      end
     end
   end
 end

--- a/src/spec/controllers/api/packages_controller_spec.rb
+++ b/src/spec/controllers/api/packages_controller_spec.rb
@@ -47,7 +47,7 @@ describe Api::PackagesController, :katello => true do
 
     @repo.stub(:packages).and_return([])
     package = { 'repoids' => [ repo_id ] }
-    Pulp::Package.stub(:find).and_return(package)
+    Resources::Pulp::Package.stub(:find).and_return(package)
 
     @request.env["HTTP_ACCEPT"] = "application/json"
     login_user_api
@@ -102,7 +102,7 @@ describe Api::PackagesController, :katello => true do
 
     describe "show a package" do
       it "should call pulp find package api" do
-        Pulp::Package.should_receive(:find).once.with(1)
+        Resources::Pulp::Package.should_receive(:find).once.with(1)
         get 'show', :id => 1, :repository_id => repo_id
       end
     end

--- a/src/spec/controllers/api/products_controller_spec.rb
+++ b/src/spec/controllers/api/products_controller_spec.rb
@@ -27,8 +27,8 @@ describe Api::ProductsController, :katello => true do
     disable_product_orchestration
     disable_user_orchestration
 
-    Pulp::Repository.stub(:packages).and_return([])
-    Pulp::Repository.stub(:errata).and_return([])
+    Resources::Pulp::Repository.stub(:packages).and_return([])
+    Resources::Pulp::Repository.stub(:errata).and_return([])
 
     @organization = new_test_org
     @environment = KTEnvironment.create!(:name=> "foo123", :organization => @organization, :prior =>@organization.library)
@@ -61,7 +61,7 @@ describe Api::ProductsController, :katello => true do
     Product.stub!(:select).and_return(@products)
     @product.stub(:repos).and_return(@repositories)
     @product.stub(:sync_state => ::PulpSyncStatus::Status::NOT_SYNCED)
-    Pulp::Repository.stub(:sync_history => [])
+    Resources::Pulp::Repository.stub(:sync_history => [])
 
 
     @request.env["HTTP_ACCEPT"] = "application/json"
@@ -70,7 +70,7 @@ describe Api::ProductsController, :katello => true do
 
   describe "show product" do
     before do
-      Pulp::Repository.stub(:find).and_return(RepoTestData::REPO_PROPERTIES)
+      Resources::Pulp::Repository.stub(:find).and_return(RepoTestData::REPO_PROPERTIES)
     end
 
     let(:action) { :show }
@@ -90,7 +90,7 @@ describe Api::ProductsController, :katello => true do
     let(:gpg_key) { GpgKey.create!(:name => "Gpg key", :content => "100", :organization => @organization) }
 
     before do
-      Pulp::Repository.stub(:find).and_return(RepoTestData::REPO_PROPERTIES)
+      Resources::Pulp::Repository.stub(:find).and_return(RepoTestData::REPO_PROPERTIES)
       Product.stub(:find_by_cp_id).with(@product.cp_id).and_return(@product)
       @product.stub(:update_attributes! => true)
     end

--- a/src/spec/controllers/api/puppetclasses_controller_spec.rb
+++ b/src/spec/controllers/api/puppetclasses_controller_spec.rb
@@ -22,8 +22,8 @@ describe Api::PuppetclassesController, :katello => true do
   # TODO disabled until Foreman is integrated
   #describe "GET 'index'" do
     #it "should be successful" do
-      #puppet_class = Foreman::Puppetclass.new
-      #Foreman::Puppetclass.should_receive(:new).once.and_return(puppet_class)
+      #puppet_class = Resources::Foreman::Puppetclass.new
+      #Resources::Foreman::Puppetclass.should_receive(:new).once.and_return(puppet_class)
       #puppet_class.should_receive(:list).once.and_return([])
       #get 'index', :format => :json
       #response.should be_success

--- a/src/spec/controllers/api/repositories_controller_spec.rb
+++ b/src/spec/controllers/api/repositories_controller_spec.rb
@@ -38,10 +38,10 @@ describe Api::RepositoriesController, :katello => true do
       ep = EnvironmentProduct.find_or_create(@organization.library, @product)
       @repository = Repository.create!(:environment_product => ep, :name=> "repo_1", :pulp_id=>"1")
       Repository.stub(:find).and_return(@repository)
-      Pulp::Repository.stub(:start_discovery).and_return({})
+      Resources::Pulp::Repository.stub(:start_discovery).and_return({})
       PulpSyncStatus.stub(:using_pulp_task).and_return(task_stub)
-      Pulp::PackageGroup.stub(:all => {})
-      Pulp::PackageGroupCategory.stub(:all => {})
+      Resources::Pulp::PackageGroup.stub(:all => {})
+      Resources::Pulp::PackageGroupCategory.stub(:all => {})
     end
     describe "for create" do
       let(:action) {:create}
@@ -273,7 +273,7 @@ describe Api::RepositoriesController, :katello => true do
     end
 
     describe "repository discovery" do
-      it "should call Pulp::Proxy.post" do
+      it "should call Resources::Pulp::Proxy.post" do
         url  = "http://url.org"
         type = "yum"
 
@@ -304,8 +304,8 @@ describe Api::RepositoriesController, :katello => true do
     end
 
     describe "repository discovery" do
-      it "should call Pulp::Proxy.post" do
-        Pulp::Repository.should_receive(:start_discovery).with(url, type).once.and_return({})
+      it "should call Resources::Pulp::Proxy.post" do
+        Resources::Pulp::Repository.should_receive(:start_discovery).with(url, type).once.and_return({})
         PulpSyncStatus.should_receive(:using_pulp_task).with({}).and_return(task_stub)
         Organization.stub!(:first).and_return(@organization)
 
@@ -361,10 +361,10 @@ describe Api::RepositoriesController, :katello => true do
       before do
           @repo = Repository.new(:pulp_id=>"123", :id=>"123")
           Repository.stub(:find).and_return(@repo)
-          Pulp::PackageGroup.stub(:all => {})
+          Resources::Pulp::PackageGroup.stub(:all => {})
       end
       it "should call Pulp layer" do
-        Pulp::PackageGroup.should_receive(:all).with("123")
+        Resources::Pulp::PackageGroup.should_receive(:all).with("123")
         subject
       end
       it { should be_success }
@@ -376,10 +376,10 @@ describe Api::RepositoriesController, :katello => true do
       before do
           @repo = Repository.new(:pulp_id=>"123", :id=>"123")
           Repository.stub(:find).and_return(@repo)
-          Pulp::PackageGroupCategory.stub(:all => {})
+          Resources::Pulp::PackageGroupCategory.stub(:all => {})
       end
       it "should call Pulp layer" do
-        Pulp::PackageGroupCategory.should_receive(:all).with("123")
+        Resources::Pulp::PackageGroupCategory.should_receive(:all).with("123")
         subject
       end
       it { should be_success }

--- a/src/spec/controllers/api/subscriptions_controller_spec.rb
+++ b/src/spec/controllers/api/subscriptions_controller_spec.rb
@@ -32,11 +32,11 @@ describe Api::SubscriptionsController do
     set_default_locale
     disable_org_orchestration
 
-    Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Candlepin::Consumer.stub!(:update).and_return(true)
+    Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-    Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Pulp::Consumer.stub!(:update).and_return(true)
+    Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Pulp::Consumer.stub!(:update).and_return(true)
 
     @organization = Organization.create!(:name => 'test_org', :cp_key => 'test_org')
     @environment_1 = KTEnvironment.create!(:name => 'test_1', :prior => @organization.library.id, :organization => @organization)
@@ -58,24 +58,24 @@ describe Api::SubscriptionsController do
 
     context "subscribes" do
       it "to one pool" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).once.with(@system.uuid, "poolidXYZ", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).once.with(@system.uuid, "poolidXYZ", 1)
         post :create, :system_id => @system.id, :pool => "poolidXYZ", :quantity => 1
       end
     end
 
     context "unsubscribes" do
       it "from one pool" do
-        Candlepin::Consumer.should_receive(:remove_entitlement).once.with(@system.uuid, "poolidXYZ")
+        Resources::Candlepin::Consumer.should_receive(:remove_entitlement).once.with(@system.uuid, "poolidXYZ")
         post :destroy, :system_id => @system.id, :id => "poolidXYZ"
       end
 
       it "from one pool by serial" do
-        Candlepin::Consumer.should_receive(:remove_certificate).once.with(@system.uuid, "serialidXYZ")
+        Resources::Candlepin::Consumer.should_receive(:remove_certificate).once.with(@system.uuid, "serialidXYZ")
         post :destroy_by_serial, :system_id => @system.id, :serial_id => "serialidXYZ"
       end
 
       it "from all pools" do
-        Candlepin::Consumer.should_receive(:remove_entitlements).once.with(@system.uuid)
+        Resources::Candlepin::Consumer.should_receive(:remove_entitlements).once.with(@system.uuid)
         post :destroy_all, :system_id => @system.id
       end
     end
@@ -93,7 +93,7 @@ describe Api::SubscriptionsController do
       end
 
       it "should retrieve Consumer's errata from pulp" do
-        Candlepin::Consumer.should_receive(:entitlements).once.with(uuid).and_return([])
+        Resources::Candlepin::Consumer.should_receive(:entitlements).once.with(uuid).and_return([])
         get :index, :system_id => @system.uuid
       end
     end

--- a/src/spec/controllers/api/sync_controller_spec.rb
+++ b/src/spec/controllers/api/sync_controller_spec.rb
@@ -156,8 +156,8 @@ describe Api::SyncController, :katello => true do
       before(:each) do
         #@organization = Organization.create!(:name => "organization", :cp_key => "123")
         
-        Pulp::Repository.stub(:sync).with("1").and_return(async_task_1)
-        Pulp::Repository.stub(:sync).with("2").and_return(async_task_2)
+        Resources::Pulp::Repository.stub(:sync).with("1").and_return(async_task_1)
+        Resources::Pulp::Repository.stub(:sync).with("2").and_return(async_task_2)
         #@syncable = mock()
         #@syncable.stub!(:organization).and_return(@organization)
 

--- a/src/spec/controllers/api/systems_controller_spec.rb
+++ b/src/spec/controllers/api/systems_controller_spec.rb
@@ -51,11 +51,11 @@ describe Api::SystemsController do
     set_default_locale
     disable_org_orchestration
 
-    Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Candlepin::Consumer.stub!(:update).and_return(true)
+    Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-    Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Pulp::Consumer.stub!(:update).and_return(true)
+    Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Pulp::Consumer.stub!(:update).and_return(true)
 
     @organization = Organization.create!(:name => 'test_org', :cp_key => 'test_org')
     @environment_1 = KTEnvironment.create!(:name => 'test_1', :prior => @organization.library.id, :organization => @organization)
@@ -164,7 +164,7 @@ describe Api::SystemsController do
   end
 
   it "returns 410 for deleted systems" do
-    Candlepin::Consumer.should_receive(:get).and_return do
+    Resources::Candlepin::Consumer.should_receive(:get).and_return do
       raise RestClient::Gone.new(
                 mock(:response, :code => 410, :body =>
                     '{"displayMessage":"Consumer 83705a61-8968-444f-9253-caefbc0e9995 has been deleted",' +
@@ -216,7 +216,7 @@ describe Api::SystemsController do
       @system_1 = create_system(:name => 'test', :environment => @environment_1, :cp_type => 'system', :facts => facts, :uuid => uuid_1)
       @system_2 = create_system(:name => 'test2', :environment => @environment_2, :cp_type => 'system', :facts => facts, :uuid => uuid_2)
 
-      Candlepin::Consumer.stub(:get => SystemTestData.host)
+      Resources::Candlepin::Consumer.stub(:get => SystemTestData.host)
     end
 
     let(:action) { :index }
@@ -253,10 +253,10 @@ describe Api::SystemsController do
       let(:pool_id) {"POOL_ID_123456"}
 
       before :each do
-        Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid_3})
+        Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid_3})
         @system_3 = System.create!(:name => 'test3', :environment => @environment_2, :cp_type => 'system', :facts => facts)
 
-        Candlepin::Entitlement.stub(:get).and_return([
+        Resources::Candlepin::Entitlement.stub(:get).and_return([
           {"pool" => {"id" => pool_id}, "consumer" => {"uuid" => @system_1.uuid}},
           {"pool" => {"id" => pool_id}, "consumer" => {"uuid" => @system_3.uuid}}
         ])
@@ -299,7 +299,7 @@ describe Api::SystemsController do
       it_should_behave_like "protected action"
 
       it "successfully with update permissions" do
-        Pulp::Consumer.should_receive(:upload_package_profile).once.with(uuid, package_profile).and_return(true)
+        Resources::Pulp::Consumer.should_receive(:upload_package_profile).once.with(uuid, package_profile).and_return(true)
         put :upload_package_profile, :id => uuid, :_json => package_profile
         response.body.should == @sys.to_json
       end
@@ -311,7 +311,7 @@ describe Api::SystemsController do
       it_should_behave_like "protected action"
 
       it "successfully with register permissions" do
-        Pulp::Consumer.should_receive(:upload_package_profile).once.with(uuid, package_profile).and_return(true)
+        Resources::Pulp::Consumer.should_receive(:upload_package_profile).once.with(uuid, package_profile).and_return(true)
         put :upload_package_profile, :id => uuid, :_json => package_profile
         response.body.should == @sys.to_json
       end
@@ -342,7 +342,7 @@ describe Api::SystemsController do
   describe "update a system" do
     before(:each) do
       @sys = System.create!(:name => 'test', :environment => @environment_1, :cp_type => 'system', :facts => facts, :uuid => uuid, :description => "fake description")
-      Candlepin::Consumer.stub!(:get).and_return({:uuid => uuid})
+      Resources::Candlepin::Consumer.stub!(:get).and_return({:uuid => uuid})
       System.stub!(:first).and_return(@sys)
     end
 
@@ -353,21 +353,21 @@ describe Api::SystemsController do
     it_should_behave_like "protected action"
 
     it "should change the name" do
-      Pulp::Consumer.should_receive(:update).once.with(@organization.cp_key, uuid, @sys.description).and_return(true) if AppConfig.katello?
+      Resources::Pulp::Consumer.should_receive(:update).once.with(@organization.cp_key, uuid, @sys.description).and_return(true) if AppConfig.katello?
       post :update, :id => uuid, :name => "foo_name"
       response.body.should == @sys.to_json
       response.should be_success
     end
 
     it "should change the description" do
-      Pulp::Consumer.should_receive(:update).once.with(@organization.cp_key, uuid, "redkin is awesome.").and_return(true) if AppConfig.katello?
+      Resources::Pulp::Consumer.should_receive(:update).once.with(@organization.cp_key, uuid, "redkin is awesome.").and_return(true) if AppConfig.katello?
       post :update, :id => uuid, :description => "redkin is awesome."
       response.body.should == @sys.to_json
       response.should be_success
     end
 
     it "should change the location" do
-      Pulp::Consumer.should_receive(:update).once.with(@organization.cp_key, uuid, @sys.description).and_return(true) if AppConfig.katello?
+      Resources::Pulp::Consumer.should_receive(:update).once.with(@organization.cp_key, uuid, @sys.description).and_return(true) if AppConfig.katello?
       post :update, :id => uuid, :location => "never-neverland"
       response.body.should == @sys.to_json
       response.should be_success
@@ -376,7 +376,7 @@ describe Api::SystemsController do
     it "should update installed products" do
       @sys.facts = nil
       @sys.stub(:guest => 'false', :guests => [])
-      Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, installed_products, nil, nil, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, installed_products, nil, nil, nil).and_return(true)
       post :update, :id => uuid, :installedProducts => installed_products
       response.body.should == @sys.to_json
       response.should be_success
@@ -385,7 +385,7 @@ describe Api::SystemsController do
     it "should update releaseVer" do
       @sys.facts = nil
       @sys.stub(:guest => 'false', :guests => [])
-      Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, nil, nil, "1.1", nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, nil, nil, "1.1", nil).and_return(true)
       post :update, :id => uuid, :releaseVer => "1.1"
       response.body.should == @sys.to_json
       response.should be_success
@@ -394,7 +394,7 @@ describe Api::SystemsController do
     it "should update service level agreement" do
       @sys.facts = nil
       @sys.stub(:guest => 'false', :guests => [])
-      Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, nil, nil, nil, "SLA").and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, nil, nil, nil, "SLA").and_return(true)
       post :update, :id => uuid, :serviceLevel => "SLA"
       response.body.should == @sys.to_json
       response.should be_success
@@ -420,7 +420,7 @@ describe Api::SystemsController do
     end
 
     it "should retrieve Consumer's errata from pulp" do
-      Pulp::Consumer.should_receive(:errata).once.with(uuid).and_return([])
+      Resources::Pulp::Consumer.should_receive(:errata).once.with(uuid).and_return([])
       get :errata, :id => @system.uuid
     end
   end
@@ -444,13 +444,13 @@ describe Api::SystemsController do
 
     it "should retrieve avaialble pools from Candlepin" do
       #@system.should_receive(:available_pools_full).once.and_return([])
-      Candlepin::Consumer.should_receive(:available_pools).once.with(uuid, false).and_return([])
+      Resources::Candlepin::Consumer.should_receive(:available_pools).once.with(uuid, false).and_return([])
       get :pools, :id => @system.uuid
     end
 
     it "should retrieve available pools from Candlepin" do
       #@system.should_receive(:available_pools_full).once.and_return([])
-      Candlepin::Consumer.should_receive(:available_pools).once.with(uuid, true).and_return([])
+      Resources::Candlepin::Consumer.should_receive(:available_pools).once.with(uuid, true).and_return([])
       get :pools, :id => @system.uuid, :listall => true
     end
   end
@@ -497,44 +497,44 @@ describe Api::SystemsController do
     let(:enabled_repos_empty) { { "repos" => [] } }
 
     it "should not bind any" do
-      Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'a' => '', 'b' => ''})
+      Resources::Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'a' => '', 'b' => ''})
       put :enabled_repos, :id => @system.uuid, :enabled_repos => enabled_repos
       response.status.should == 200
     end
 
     it "should bind one" do
-      Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'a' => ''})
-      Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'b').once
+      Resources::Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'a' => ''})
+      Resources::Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'b').once
       put :enabled_repos, :id => @system.uuid, :enabled_repos => enabled_repos
       response.status.should == 200
     end
 
     it "should bind two" do
-      Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({})
-      Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'a').once
-      Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'b').once
+      Resources::Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({})
+      Resources::Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'a').once
+      Resources::Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'b').once
       put :enabled_repos, :id => @system.uuid, :enabled_repos => enabled_repos
       response.status.should == 200
     end
 
     it "should bind one and unbind one" do
-      Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'b' => '', 'c' => ''})
-      Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'a').once
-      Pulp::Consumer.should_receive(:unbind).with(@system.uuid, 'c').once
+      Resources::Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'b' => '', 'c' => ''})
+      Resources::Pulp::Consumer.should_receive(:bind).with(@system.uuid, 'a').once
+      Resources::Pulp::Consumer.should_receive(:unbind).with(@system.uuid, 'c').once
       put :enabled_repos, :id => @system.uuid, :enabled_repos => enabled_repos
       response.status.should == 200
     end
 
     it "should unbind two" do
-      Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'a' => '', 'b' => ''})
-      Pulp::Consumer.should_receive(:unbind).with(@system.uuid, 'a').once
-      Pulp::Consumer.should_receive(:unbind).with(@system.uuid, 'b').once
+      Resources::Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({'a' => '', 'b' => ''})
+      Resources::Pulp::Consumer.should_receive(:unbind).with(@system.uuid, 'a').once
+      Resources::Pulp::Consumer.should_receive(:unbind).with(@system.uuid, 'b').once
       put :enabled_repos, :id => @system.uuid, :enabled_repos => enabled_repos_empty
       response.status.should == 200
     end
 
     it "should do nothing" do
-      Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({})
+      Resources::Pulp::Consumer.should_receive(:repoids).with(@system.uuid).once.and_return({})
       put :enabled_repos, :id => @system.uuid, :enabled_repos => enabled_repos_empty
       response.status.should == 200
     end

--- a/src/spec/controllers/api/systems_packages_controller_spec.rb
+++ b/src/spec/controllers/api/systems_packages_controller_spec.rb
@@ -33,11 +33,11 @@ describe Api::SystemPackagesController do
     set_default_locale
     disable_org_orchestration
     User.current = @user
-    Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Candlepin::Consumer.stub!(:update).and_return(true)
+    Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-    Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Pulp::Consumer.stub!(:update).and_return(true)
+    Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Pulp::Consumer.stub!(:update).and_return(true)
 
     @organization = Organization.create!(:name => 'test_org', :cp_key => 'test_org')
     @environment_1 = KTEnvironment.create!(:name => 'test_1', :prior => @organization.library.id, :organization => @organization)

--- a/src/spec/controllers/api/uebercerts_controller_spec.rb
+++ b/src/spec/controllers/api/uebercerts_controller_spec.rb
@@ -41,7 +41,7 @@ describe Api::UebercertsController do
 
   context "show" do
     before do
-      Candlepin::Owner.stub!(:get_ueber_cert).and_return({})
+      Resources::Candlepin::Owner.stub!(:get_ueber_cert).and_return({})
       disable_authorization_rules
     end
 

--- a/src/spec/controllers/environments_controller_spec.rb
+++ b/src/spec/controllers/environments_controller_spec.rb
@@ -88,7 +88,7 @@ describe EnvironmentsController do
       set_default_locale
       controller.stub!(:notice)
 
-      #Candlepin::Owner.stub!(:merge_to).and_return @org
+      #Resources::Candlepin::Owner.stub!(:merge_to).and_return @org
       @env = mock(KTEnvironment, EnvControllerTest::ENVIRONMENT)
       @env.stub!(:successor).and_return("")
 

--- a/src/spec/controllers/organizations_controller_spec.rb
+++ b/src/spec/controllers/organizations_controller_spec.rb
@@ -283,7 +283,7 @@ describe OrganizationsController do
       new_test_org
     end
     it "should download" do
-      Candlepin::Owner.should_receive(:get_ueber_cert).once.and_return(:cert => "uber",:key=>"ueber")
+      Resources::Candlepin::Owner.should_receive(:get_ueber_cert).once.and_return(:cert => "uber",:key=>"ueber")
       get :download_debug_certificate, :id => @organization.id.to_s
       response.should be_success
     end

--- a/src/spec/controllers/providers_controller_spec.rb
+++ b/src/spec/controllers/providers_controller_spec.rb
@@ -43,7 +43,7 @@ describe ProvidersController do
       @provider.stub(:name).and_return("RH_Provider")
       @provider.stub(:owner_imports).and_return([])
 
-      Candlepin::Owner.stub!(:pools).and_return({})
+      Resources::Candlepin::Owner.stub!(:pools).and_return({})
     end
 
     it "should update a provider subscription" do

--- a/src/spec/controllers/repositories_controller_spec.rb
+++ b/src/spec/controllers/repositories_controller_spec.rb
@@ -40,7 +40,7 @@ describe RepositoriesController, :katello => true do
     describe "GET Edit" do
       before do
         Product.stub!(:find).and_return(@product)
-        Pulp::Repository.stub!(:find).and_return(@repository)
+        Resources::Pulp::Repository.stub!(:find).and_return(@repository)
       end
       let(:action) {:edit}
       let(:req) { get :edit, :provider_id => @provider.id, :product_id => @product.id, :id => @repository.id}
@@ -63,7 +63,7 @@ describe RepositoriesController, :katello => true do
       @gpg = GpgKey.create!(:name => "foo", :organization => @organization, :content => "222")
       @ep = EnvironmentProduct.find_or_create(@organization.library, @product)
       controller.stub!(:current_organization).and_return(@org)
-      Candlepin::Content.stub(:create => {:id => "123"})
+      Resources::Candlepin::Content.stub(:create => {:id => "123"})
     end
       let(:invalidrepo) do
         {

--- a/src/spec/controllers/subscriptions_controller_spec.rb
+++ b/src/spec/controllers/subscriptions_controller_spec.rb
@@ -30,8 +30,8 @@ describe SubscriptionsController do
       login_user
       set_default_locale
       setup_current_organization(new_test_org)
-      Candlepin::Owner.stub!(:pools).and_return([ProductTestData::POOLS])
-      Candlepin::Owner.stub!(:statistics).and_return([])
+      Resources::Candlepin::Owner.stub!(:pools).and_return([ProductTestData::POOLS])
+      Resources::Candlepin::Owner.stub!(:statistics).and_return([])
 
 
       @product = MemoStruct.new

--- a/src/spec/controllers/sync_management_controller_spec.rb
+++ b/src/spec/controllers/sync_management_controller_spec.rb
@@ -28,7 +28,7 @@ describe SyncManagementController, :katello => true do
 
   describe "GET 'index'" do
     before (:each) do
-      Pulp::Repository.stub(:all).and_return([])
+      Resources::Pulp::Repository.stub(:all).and_return([])
       setup_current_organization
       @library = KTEnvironment.new
       @mock_org.stub!(:library).and_return(@library)

--- a/src/spec/controllers/system_errata_controller_spec.rb
+++ b/src/spec/controllers/system_errata_controller_spec.rb
@@ -32,11 +32,11 @@ describe SystemErrataController, :katello => true do
       controller.stub!(:errors)
       controller.stub!(:notice)
 
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Candlepin::Consumer.stub!(:update).and_return(true)
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-      Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Pulp::Consumer.stub!(:update).and_return(true)
+      Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Pulp::Consumer.stub!(:update).and_return(true)
     end
 
     describe "viewing systems" do
@@ -60,7 +60,7 @@ describe SystemErrataController, :katello => true do
             to_ret << errata
           }
 
-          Pulp::Consumer.stub!(:errata).and_return(to_ret)
+          Resources::Pulp::Consumer.stub!(:errata).and_return(to_ret)
         end
         
         describe 'on initial load' do

--- a/src/spec/controllers/system_events_controller_spec.rb
+++ b/src/spec/controllers/system_events_controller_spec.rb
@@ -29,12 +29,12 @@ describe SystemEventsController do
       #controller.stub!(:errors)
       #controller.stub!(:notice)
 
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Candlepin::Consumer.stub!(:update).and_return(true)
-      Candlepin::Consumer.stub!(:events).and_return([])
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Candlepin::Consumer.stub!(:update).and_return(true)
+      Resources::Candlepin::Consumer.stub!(:events).and_return([])
 
-      Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Pulp::Consumer.stub!(:update).and_return(true)
+      Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Pulp::Consumer.stub!(:update).and_return(true)
     end
 
     describe "system tasks", :katello => true do

--- a/src/spec/controllers/system_packages_controller_spec.rb
+++ b/src/spec/controllers/system_packages_controller_spec.rb
@@ -31,11 +31,11 @@ describe SystemPackagesController, :katello => true do
 
       controller.stub!(:notice)
 
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Candlepin::Consumer.stub!(:update).and_return(true)
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-      Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Pulp::Consumer.stub!(:update).and_return(true)
+      Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Pulp::Consumer.stub!(:update).and_return(true)
     end
 
     describe "viewing packages" do
@@ -48,8 +48,8 @@ describe SystemPackagesController, :katello => true do
         before (:each) do
           @system = System.create!(:name=>"verbose", :environment => @environment, :cp_type=>"system", :facts=>{"Test1"=>1, "verbose_facts" => "Test facts"})
 
-          Pulp::Consumer.stub!(:installed_packages).and_return([])
-          Candlepin::Consumer.stub!(:events).and_return([])
+          Resources::Pulp::Consumer.stub!(:installed_packages).and_return([])
+          Resources::Candlepin::Consumer.stub!(:events).and_return([])
         end
 
         it "should show packages" do

--- a/src/spec/controllers/system_templates_controller_spec.rb
+++ b/src/spec/controllers/system_templates_controller_spec.rb
@@ -48,10 +48,10 @@ describe SystemTemplatesController, :katello => true do
 
     describe "GET download" do
       describe "with valid template id" do
-        before { ::Candlepin::Owner.stub!(:get_ueber_cert).and_return({ :cert => "", :key => "" }) }
+        before { ::Resources::Candlepin::Owner.stub!(:get_ueber_cert).and_return({ :cert => "", :key => "" }) }
         it "sends xml export of template" do
           @system_template_1.stub(:repositories).and_return([Repository.new(:name=>"FOOREPO", :pulp_id=>"anid")])
-          Pulp::Distribution.stub(:find).and_return({})
+          Resources::Pulp::Distribution.stub(:find).and_return({})
           @system_template_1.stub(:distributions).and_return([SystemTemplateDistribution.new({:distribution_pulp_id=>"FOO"})])
           SystemTemplate.stub(:find).and_return(@system_template_1)
           SystemTemplate.stub(:where).and_return([@system_template_1])

--- a/src/spec/controllers/systems_controller_spec.rb
+++ b/src/spec/controllers/systems_controller_spec.rb
@@ -25,8 +25,8 @@ describe SystemsController do
       setup_system_creation
       @environment = KTEnvironment.new(:name => 'test', :prior => @organization.library.id, :organization => @organization)
       @environment.save!
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Candlepin::Consumer.stub!(:update).and_return(true)
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Candlepin::Consumer.stub!(:update).and_return(true)
       @system = System.create!(:name=>"bar1", :environment => @environment, :cp_type=>"system", :facts=>{"Test" => ""})
       @run_auth_action = lambda do |resource, perm|
             if :organization == resource
@@ -144,12 +144,12 @@ describe SystemsController do
       controller.stub!(:notice)
       controller.stub(:search_validate).and_return(false)
 
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Candlepin::Consumer.stub!(:get).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Candlepin::Consumer.stub!(:update).and_return(true)
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Candlepin::Consumer.stub!(:get).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-      Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Pulp::Consumer.stub!(:update).and_return(true)
+      Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Pulp::Consumer.stub!(:update).and_return(true)
     end
 
     describe "viewing systems" do
@@ -195,7 +195,7 @@ describe SystemsController do
         before (:each) do
           @system = System.create!(:name=>"verbose", :environment => @environment, :cp_type=>"system", :facts=>{"Test1"=>1, "verbose_facts" => "Test facts"})
 
-          Pulp::Consumer.stub!(:installed_packages).and_return([])
+          Resources::Pulp::Consumer.stub!(:installed_packages).and_return([])
         end
 
         it "it should show facts" do

--- a/src/spec/helpers/product_helper_methods.rb
+++ b/src/spec/helpers/product_helper_methods.rb
@@ -38,7 +38,7 @@ module ProductHelperMethods
   def promote repo, environment
     disable_product_orchestration
     repo.stub!(:pulp_repo_facts).and_return({:clone_ids => []})
-    Pulp::Repository.stub!(:clone_repo).and_return({})
+    Resources::Pulp::Repository.stub!(:clone_repo).and_return({})
     Glue::Pulp::Repos.stub!(:groupid).and_return([])
     repo.stub(:content => {:id => "123"})
     repo.promote(environment.prior, environment)

--- a/src/spec/helpers/system_helper_methods.rb
+++ b/src/spec/helpers/system_helper_methods.rb
@@ -2,23 +2,23 @@ include OrganizationHelperMethods
 
 module SystemHelperMethods
   def setup_system_creation
-    Candlepin::Consumer.stub(:create).and_return({:owner=> { :key=> 'test_organization'}})
-    Candlepin::Consumer.stub(:update).and_return({})
-    Candlepin::Consumer.stub(:entitlements).and_return({})
-    Candlepin::Consumer.stub(:compliance).and_return({:compliance=>true, :partiallyCompliantProducts=>[], :nonCompliantProducts=>[]}.with_indifferent_access)
-    Candlepin::Consumer.stub(:available_pools).and_return([])
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Candlepin::Consumer.stub!(:update).and_return(true)
+    Resources::Candlepin::Consumer.stub(:create).and_return({:owner=> { :key=> 'test_organization'}})
+    Resources::Candlepin::Consumer.stub(:update).and_return({})
+    Resources::Candlepin::Consumer.stub(:entitlements).and_return({})
+    Resources::Candlepin::Consumer.stub(:compliance).and_return({:compliance=>true, :partiallyCompliantProducts=>[], :nonCompliantProducts=>[]}.with_indifferent_access)
+    Resources::Candlepin::Consumer.stub(:available_pools).and_return([])
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-      Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-      Pulp::Consumer.stub!(:update).and_return(true)
+      Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+      Resources::Pulp::Consumer.stub!(:update).and_return(true)
     new_test_org
   end
 
   def create_system attrs
     if attrs.with_indifferent_access[:uuid]
       required_uuid = attrs.with_indifferent_access[:uuid]
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => required_uuid, :owner => {:key => required_uuid}})
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => required_uuid, :owner => {:key => required_uuid}})
     end
     System.create!(attrs)
   end
@@ -57,8 +57,8 @@ module SystemHelperMethods
 
   def stub_consumer_packages_install(expected_response, refresh_response = nil)
     refresh_response ||= expected_response
-    Pulp::Consumer.stub!(:install_packages).and_return(expected_response)
-    Pulp::Task.stub!(:find).and_return([refresh_response])
+    Resources::Pulp::Consumer.stub!(:install_packages).and_return(expected_response)
+    Resources::Pulp::Task.stub!(:find).and_return([refresh_response])
   end
 
 end

--- a/src/spec/lib/cdn_spec.rb
+++ b/src/spec/lib/cdn_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
-require 'resources/cdn'
 
-describe CDN::CdnVarSubstitutor do
+describe Resources::CDN::CdnVarSubstitutor do
 
   let(:provider_url) { "https://cdn.redhat.com" }
   let(:path_with_variables) { "/content/dist/rhel/server/5/$releasever/$basearch/os" }
@@ -11,7 +10,7 @@ describe CDN::CdnVarSubstitutor do
   end
 
   subject do
-    CDN::CdnVarSubstitutor.new(provider_url, connect_options)
+    Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options)
   end
 
   it "should substitute all variables with values in listings" do
@@ -64,7 +63,7 @@ describe CDN::CdnVarSubstitutor do
   end
 
 
-  it "should handle error codes from CDN" do
+  it "should handle error codes from Resources::CDN" do
     stub_forbidden_cdn_requests
     lambda { subject.substitute_vars(path_with_variables) }.should raise_error Errors::SecurityViolation
   end
@@ -73,9 +72,9 @@ describe CDN::CdnVarSubstitutor do
     stub_successful_cdn_requests(["6","61"],["i386", "x86_64"])
 
     @net_mock.should_receive(:start).exactly(3).times
-    CDN::CdnVarSubstitutor.with_cache do
-      CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
-      CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
+    Resources::CDN::CdnVarSubstitutor.with_cache do
+      Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
+      Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
     end
   end
 
@@ -83,10 +82,10 @@ describe CDN::CdnVarSubstitutor do
     stub_successful_cdn_requests(["6","61"],["i386", "x86_64"])
 
     @net_mock.should_receive(:start).exactly(6).times
-    CDN::CdnVarSubstitutor.with_cache do
-      CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
+    Resources::CDN::CdnVarSubstitutor.with_cache do
+      Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
     end
-    CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
+    Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
   end
 
 

--- a/src/spec/lib/url_matcher_spec.rb
+++ b/src/spec/lib/url_matcher_spec.rb
@@ -12,30 +12,28 @@
 
 require 'spec_helper'
 
-require 'util/url_matcher'
-
-describe UrlMatcher do
+describe Util::UrlMatcher do
 
   it "should accept empty string and array" do
-    m = UrlMatcher.match('', [])
+    m = Util::UrlMatcher.match('', [])
     m[0].should be_nil
     m.size.should equal(1)
   end
 
   it "should not match different paths" do
-    m = UrlMatcher.match('/asdf', ['/abcd'])
+    m = Util::UrlMatcher.match('/asdf', ['/abcd'])
     m[0].should be_nil
     m.size.should equal(1)
   end
 
   it "should accept /" do
-    m = UrlMatcher.match('/', ['/'])
+    m = Util::UrlMatcher.match('/', ['/'])
     m[0].should match('/')
     m.size.should equal(1)
   end
 
   it "should accept /x/y/z" do
-    m = UrlMatcher.match('/80/01/15', ['/:year/:month/:day'])
+    m = Util::UrlMatcher.match('/80/01/15', ['/:year/:month/:day'])
     m[0].should match('/:year/:month/:day')
     m[1].should match('80')
     m[2].should match('01')
@@ -43,7 +41,7 @@ describe UrlMatcher do
   end
 
   it "should match fist always" do
-    m = UrlMatcher.match('/80/01/15', ['/:a/:b/:c', '/:year/:month/:day'])
+    m = Util::UrlMatcher.match('/80/01/15', ['/:a/:b/:c', '/:year/:month/:day'])
     m[0].should match('/:a/:b/:c')
     m[1].should match('80')
     m[2].should match('01')

--- a/src/spec/models/activation_key_spec.rb
+++ b/src/spec/models/activation_key_spec.rb
@@ -145,8 +145,8 @@ describe ActivationKey do
   describe "#apply_to_system" do
 
     before(:each) do
-      Pulp::Consumer.stub!(:create).and_return({:uuid => "1234", :owner => {:key => "1234"}})
-      Candlepin::Consumer.stub!(:create).and_return({:uuid => "1234", :owner => {:key => "1234"}})
+      Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => "1234", :owner => {:key => "1234"}})
+      Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => "1234", :owner => {:key => "1234"}})
       @system = System.new(:name => "test", :cp_type => "system", :facts => {"distribution.name"=>"Fedora"})
     end
 
@@ -171,7 +171,7 @@ describe ActivationKey do
   describe "#subscribe_system" do
 
     before(:each) do
-      Candlepin::Pool.stub!(:find) do |x|
+      Resources::Candlepin::Pool.stub!(:find) do |x|
         {
           :productName => "Blah Server OS",
           :productId => dates[x][:productId],
@@ -213,7 +213,7 @@ describe ActivationKey do
       let(:sockets) { 1 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "a", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "a", 1)
         @akey.pools.size.should == 1
         @akey.subscribe_system(@system)
       end
@@ -239,7 +239,7 @@ describe ActivationKey do
       let(:sockets) { 1 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "b", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "b", 1)
         @akey.pools.size.should == 2
         @akey.subscribe_system(@system)
       end
@@ -271,7 +271,7 @@ describe ActivationKey do
       let(:sockets) { 1 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "a", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "a", 1)
         @akey.pools.size.should == 3
         @akey.subscribe_system(@system)
       end
@@ -298,8 +298,8 @@ describe ActivationKey do
       let(:sockets) { 1 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
         @akey.subscribe_system(@system)
       end
     end
@@ -325,8 +325,8 @@ describe ActivationKey do
       let(:sockets) { 8 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 5)
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 3)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 5)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 3)
         @akey.subscribe_system(@system)
       end
     end
@@ -352,7 +352,7 @@ describe ActivationKey do
       let(:sockets) { 1 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
         @akey.subscribe_system(@system)
       end
     end
@@ -378,7 +378,7 @@ describe ActivationKey do
       let(:sockets) { 1 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
         @akey.subscribe_system(@system)
       end
     end
@@ -454,7 +454,7 @@ describe ActivationKey do
       let(:sockets) { 2 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 2)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 2)
         @akey.subscribe_system(@system)
       end
     end
@@ -505,8 +505,8 @@ describe ActivationKey do
       let(:sockets) { 2 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 2).and_return([ { "id" => "ent1" } ])
-        Candlepin::Consumer.should_receive(:remove_entitlement).with(@system.uuid, "ent1")
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 2).and_return([ { "id" => "ent1" } ])
+        Resources::Candlepin::Consumer.should_receive(:remove_entitlement).with(@system.uuid, "ent1")
         lambda { @akey.subscribe_system(@system) }.should raise_error(RuntimeError, /^Not enough entitlements/)
       end
     end
@@ -532,8 +532,8 @@ describe ActivationKey do
       let(:sockets) { 2 }
 
       it "consumes the correct entitlement" do
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
-        Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
+        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
         @akey.subscribe_system(@system)
       end
     end

--- a/src/spec/models/changeset_spec.rb
+++ b/src/spec/models/changeset_spec.rb
@@ -422,7 +422,7 @@ describe Changeset, :katello => true do
             :nvrea      => 'some_nvrea')
         @changeset.state = Changeset::REVIEW
 
-        Pulp::Package.stub(:dep_solve).and_return({ })
+        Resources::Pulp::Package.stub(:dep_solve).and_return({ })
 
         @clone.should_receive(:add_packages).once.with([@pack.id])
 

--- a/src/spec/models/distribution_spec.rb
+++ b/src/spec/models/distribution_spec.rb
@@ -21,7 +21,7 @@ describe Glue::Pulp::Distribution do
   context "Find distribution" do
     it "should call pulp find distribution api" do
       
-      Pulp::Distribution.should_receive(:find).once.with('1')
+      Resources::Pulp::Distribution.should_receive(:find).once.with('1')
       Glue::Pulp::Distribution.find('1')
     end
     
@@ -36,5 +36,5 @@ end
 
 
 def disable_distribution_orchestration
-  Pulp::Distribution.stub(:find).and_return({})
+  Resources::Pulp::Distribution.stub(:find).and_return({})
 end

--- a/src/spec/models/environment_spec.rb
+++ b/src/spec/models/environment_spec.rb
@@ -241,13 +241,13 @@ describe KTEnvironment do
       it "should add content not already promoted" do
         already_promoted_content("123", "456")
         newly_promoted_content("123", "456", "789", "10")
-        Candlepin::Environment.should_receive(:add_content).with(@environment.id, Set.new(["789", "10"]))
+        Resources::Candlepin::Environment.should_receive(:add_content).with(@environment.id, Set.new(["789", "10"]))
         @environment.update_cp_content
       end
 
       def already_promoted_content(*content_ids)
         @already_promoted_content_ids = content_ids
-        Candlepin::Environment.stub(:find).and_return(
+        Resources::Candlepin::Environment.stub(:find).and_return(
           {:environmentContent => @already_promoted_content_ids.map {|id| {:contentId => id}}})
       end
 

--- a/src/spec/models/errata_spec.rb
+++ b/src/spec/models/errata_spec.rb
@@ -29,7 +29,7 @@ describe Glue::Pulp::Errata, :katello => true do
   context "Find errata" do
     it "should call pulp find errata api" do
       
-      Pulp::Errata.should_receive(:find).once.with('1')
+      Resources::Pulp::Errata.should_receive(:find).once.with('1')
       Glue::Pulp::Errata.find('1')
     end
     
@@ -47,15 +47,15 @@ describe Glue::Pulp::Errata, :katello => true do
       KTEnvironment.stub(:find => @env)
 
       filter = { :type => "security", :environment_id => @env.id }
-      Pulp::Repository.should_receive(:errata).once.with(@repo.pulp_id, filter.except(:environment_id)).and_return(RepoTestData::REPO_ERRATA[0..0])
-      Pulp::Repository.should_receive(:errata).once.with(@repo2.pulp_id, filter.except(:environment_id)).and_return(RepoTestData::REPO_ERRATA[1..1])
+      Resources::Pulp::Repository.should_receive(:errata).once.with(@repo.pulp_id, filter.except(:environment_id)).and_return(RepoTestData::REPO_ERRATA[0..0])
+      Resources::Pulp::Repository.should_receive(:errata).once.with(@repo2.pulp_id, filter.except(:environment_id)).and_return(RepoTestData::REPO_ERRATA[1..1])
 
       Glue::Pulp::Errata.filter(filter).should == RepoTestData::REPO_ERRATA
     end
 
     it "should be able to search all errata of given type and repo" do
       filter = { :type => "security", :repoid => "repo-123" }
-      Pulp::Repository.should_receive(:errata).once.with(@repo.pulp_id, filter.except(:repoid)).and_return(RepoTestData::REPO_ERRATA[0..0])
+      Resources::Pulp::Repository.should_receive(:errata).once.with(@repo.pulp_id, filter.except(:repoid)).and_return(RepoTestData::REPO_ERRATA[0..0])
       Repository.should_receive(:find).once.with(filter[:repoid]).and_return(@repo)
       Glue::Pulp::Errata.filter(filter).should == RepoTestData::REPO_ERRATA[0..0]
     end
@@ -65,8 +65,8 @@ describe Glue::Pulp::Errata, :katello => true do
       product_with_repo = mock(Product, :repos => [@repo, @repo2])
 
       ::Product.should_receive(:find_by_cp_id!).with("product-123").and_return(product_with_repo)
-      Pulp::Repository.should_receive(:errata).once.with(@repo.pulp_id, filter.slice(:type)).and_return(RepoTestData::REPO_ERRATA[0..0])
-      Pulp::Repository.should_receive(:errata).once.with(@repo2.pulp_id, filter.slice(:type)).and_return(RepoTestData::REPO_ERRATA[1..1])
+      Resources::Pulp::Repository.should_receive(:errata).once.with(@repo.pulp_id, filter.slice(:type)).and_return(RepoTestData::REPO_ERRATA[0..0])
+      Resources::Pulp::Repository.should_receive(:errata).once.with(@repo2.pulp_id, filter.slice(:type)).and_return(RepoTestData::REPO_ERRATA[1..1])
 
       Glue::Pulp::Errata.filter(filter).should == RepoTestData::REPO_ERRATA
     end
@@ -76,5 +76,5 @@ end
 
 
 def disable_errata_orchestration
-  Pulp::Errata.stub(:find).and_return({})
+  Resources::Pulp::Errata.stub(:find).and_return({})
 end

--- a/src/spec/models/hypervisor_spec.rb
+++ b/src/spec/models/hypervisor_spec.rb
@@ -19,11 +19,11 @@ describe Hypervisor do
     let(:hypervisor_record) { Hypervisor.find_by_uuid(new_hypervisor_attrs[:uuid]) }
 
     before do
-      Candlepin::Consumer.stub(:register_hypervisors).with(virt_who_params).and_return({"created" => [new_hypervisor_attrs]}.with_indifferent_access)
+      Resources::Candlepin::Consumer.stub(:register_hypervisors).with(virt_who_params).and_return({"created" => [new_hypervisor_attrs]}.with_indifferent_access)
     end
 
     it "should call cp" do
-      Candlepin::Consumer.should_receive(:register_hypervisors).with(virt_who_params)
+      Resources::Candlepin::Consumer.should_receive(:register_hypervisors).with(virt_who_params)
       System.register_hypervisors(@environment, virt_who_params)
     end
 
@@ -33,7 +33,7 @@ describe Hypervisor do
     end
 
     it "should not create candlepin consumer" do
-      Candlepin::Consumer.should_not_receive(:create)
+      Resources::Candlepin::Consumer.should_not_receive(:create)
       System.register_hypervisors(@environment, virt_who_params)
     end
 

--- a/src/spec/models/model_spec_helper.rb
+++ b/src/spec/models/model_spec_helper.rb
@@ -83,64 +83,64 @@ EOKEY
 
 
   def disable_product_orchestration
-    Candlepin::Product.stub!(:get).and_return([{:productContent => []}])
-    Candlepin::Product.stub!(:add_content).and_return(true)
-    Candlepin::Product.stub!(:create).and_return({:id => 1})
-    Candlepin::Product.stub!(:create_unlimited_subscription).and_return(true)
+    Resources::Candlepin::Product.stub!(:get).and_return([{:productContent => []}])
+    Resources::Candlepin::Product.stub!(:add_content).and_return(true)
+    Resources::Candlepin::Product.stub!(:create).and_return({:id => 1})
+    Resources::Candlepin::Product.stub!(:create_unlimited_subscription).and_return(true)
 
-    Candlepin::Content.stub!(:create).and_return(true)
+    Resources::Candlepin::Content.stub!(:create).and_return(true)
 
     # pulp orchestration
-    Candlepin::Product.stub!(:certificate).and_return("")
-    Candlepin::Product.stub!(:key).and_return("")
-    Pulp::Repository.stub!(:create).and_return([])
-    Pulp::Repository.stub!(:update_schedule).and_return(true)
-    Pulp::Repository.stub!(:delete_schedule).and_return(true)
-    Pulp::Repository.stub!(:all).and_return([])
-    Pulp::Repository.stub!(:update).and_return([])
+    Resources::Candlepin::Product.stub!(:certificate).and_return("")
+    Resources::Candlepin::Product.stub!(:key).and_return("")
+    Resources::Pulp::Repository.stub!(:create).and_return([])
+    Resources::Pulp::Repository.stub!(:update_schedule).and_return(true)
+    Resources::Pulp::Repository.stub!(:delete_schedule).and_return(true)
+    Resources::Pulp::Repository.stub!(:all).and_return([])
+    Resources::Pulp::Repository.stub!(:update).and_return([])
   end
 
   def disable_org_orchestration
-    Candlepin::Owner.stub!(:create).and_return({})
-    Candlepin::Owner.stub!(:create_user).and_return(true)
-    Candlepin::Owner.stub!(:destroy)
-    Candlepin::Owner.stub!(:get_ueber_cert).and_return({ :cert => CERT, :key => KEY })
+    Resources::Candlepin::Owner.stub!(:create).and_return({})
+    Resources::Candlepin::Owner.stub!(:create_user).and_return(true)
+    Resources::Candlepin::Owner.stub!(:destroy)
+    Resources::Candlepin::Owner.stub!(:get_ueber_cert).and_return({ :cert => CERT, :key => KEY })
     disable_env_orchestration # env is orchestrated with org - we disable this as well
   end
 
   def disable_env_orchestration
-    Candlepin::Environment.stub!(:create).and_return({})
-    Candlepin::Environment.stub!(:destroy).and_return({})
-    Candlepin::Environment.stub!(:find).and_return({:environmentContent => []})
-    Candlepin::Environment.stub!(:add_content).and_return({})
+    Resources::Candlepin::Environment.stub!(:create).and_return({})
+    Resources::Candlepin::Environment.stub!(:destroy).and_return({})
+    Resources::Candlepin::Environment.stub!(:find).and_return({:environmentContent => []})
+    Resources::Candlepin::Environment.stub!(:add_content).and_return({})
   end
 
   def disable_user_orchestration
-    Pulp::User.stub!(:create).and_return({})
-    Pulp::User.stub!(:destroy).and_return(200)
-    Pulp::Roles.stub!(:add).and_return(true)
-    Pulp::Roles.stub!(:remove).and_return(true)
+    Resources::Pulp::User.stub!(:create).and_return({})
+    Resources::Pulp::User.stub!(:destroy).and_return(200)
+    Resources::Pulp::Roles.stub!(:add).and_return(true)
+    Resources::Pulp::Roles.stub!(:remove).and_return(true)
   end
 
   def disable_filter_orchestration
-    Pulp::Filter.stub!(:create).and_return({})
-    Pulp::Filter.stub!(:destroy).and_return(200)
-    Pulp::Filter.stub(:find).and_return({})
+    Resources::Pulp::Filter.stub!(:create).and_return({})
+    Resources::Pulp::Filter.stub!(:destroy).and_return(200)
+    Resources::Pulp::Filter.stub(:find).and_return({})
   end
 
   def disable_repo_orchestration
-    Pulp::Repository.stub(:sync_history).and_return([])
-    Pulp::Task.stub!(:destroy).and_return({})
+    Resources::Pulp::Repository.stub(:sync_history).and_return([])
+    Resources::Pulp::Task.stub!(:destroy).and_return({})
 
-    Pulp::Repository.stub(:packages).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_PACKAGES)
-    Pulp::Repository.stub(:errata).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_ERRATA)
-    Pulp::Repository.stub(:distributions).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_DISTRIBUTIONS)
-    Pulp::Repository.stub(:find).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_PROPERTIES)
-    Pulp::Repository.stub(:find).with(RepoTestData::CLONED_REPO_ID).and_return(RepoTestData::CLONED_PROPERTIES)
+    Resources::Pulp::Repository.stub(:packages).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_PACKAGES)
+    Resources::Pulp::Repository.stub(:errata).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_ERRATA)
+    Resources::Pulp::Repository.stub(:distributions).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_DISTRIBUTIONS)
+    Resources::Pulp::Repository.stub(:find).with(RepoTestData::REPO_ID).and_return(RepoTestData::REPO_PROPERTIES)
+    Resources::Pulp::Repository.stub(:find).with(RepoTestData::CLONED_REPO_ID).and_return(RepoTestData::CLONED_PROPERTIES)
   end
 
   def disable_cdn
-    CDN::CdnResource.stub(:ca_file => "#{Rails.root}/config/candlepin-ca.crt")
+    Resources::CDN::CdnResource.stub(:ca_file => "#{Rails.root}/config/candlepin-ca.crt")
     OpenSSL::X509::Certificate.stub(:new).and_return(&:to_s)
     OpenSSL::PKey::RSA.stub(:new).and_return(&:to_s)
   end

--- a/src/spec/models/organization_spec.rb
+++ b/src/spec/models/organization_spec.rb
@@ -16,8 +16,8 @@ require 'models/model_spec_helper'
 describe Organization do
 
   before(:each) do
-    Candlepin::Owner.stub!(:create_user).and_return(true)
-    Candlepin::Owner.should_receive(:create).at_least(:once).and_return({})
+    Resources::Candlepin::Owner.stub!(:create_user).and_return(true)
+    Resources::Candlepin::Owner.should_receive(:create).at_least(:once).and_return({})
     disable_env_orchestration
     @organization = Organization.create(:name => 'test_organization', :cp_key => 'test_organization')
   end
@@ -59,7 +59,7 @@ describe Organization do
 
   context "delete an organization" do
     before do
-      Candlepin::Owner.should_receive(:destroy).at_least(:once).and_return({})
+      Resources::Candlepin::Owner.should_receive(:destroy).at_least(:once).and_return({})
     end
 
     it "can delete the org" do

--- a/src/spec/models/pool_spec.rb
+++ b/src/spec/models/pool_spec.rb
@@ -17,7 +17,7 @@ describe KTPool do
   context "Find pool by organization and id" do
     let(:pool_id) { ProductTestData::POOLS[:id] }
     before do
-      Candlepin::Pool.should_receive(:find).with(pool_id).and_return(ProductTestData::POOLS)
+      Resources::Candlepin::Pool.should_receive(:find).with(pool_id).and_return(ProductTestData::POOLS)
     end
     it "should return pool that is in the organization" do
       create_org_from_cp_owner(ProductTestData::POOLS[:owner])

--- a/src/spec/models/provider_spec.rb
+++ b/src/spec/models/provider_spec.rb
@@ -47,7 +47,7 @@ describe Provider do
     before(:each) do
       Glue::Candlepin::ProductContent.stub(:create)
       Glue::Candlepin::ProductContent.stub(:new)
-      Candlepin::Product.stub!(:create).and_return({:id => "product_id"})
+      Resources::Candlepin::Product.stub!(:create).and_return({:id => "product_id"})
       @provider = Provider.new({
         :name => 'test_provider',
         :repository_url => 'https://something.net',
@@ -92,8 +92,8 @@ describe Provider do
           product
       end
       before do
-        Candlepin::Owner.stub(:pools).and_return([ProductTestData::POOLS])
-        Candlepin::Product.stub(:get).and_return do |id|
+        Resources::Candlepin::Owner.stub(:pools).and_return([ProductTestData::POOLS])
+        Resources::Candlepin::Product.stub(:get).and_return do |id|
           case id
                  when "rhel6-server" then [marketing_product_attrs]
                  when "20" then [eng_product_attrs]
@@ -142,7 +142,7 @@ describe Provider do
       product.productContent = [product_content(product_name)]
       product.productContent.each do |product_content|
         releases.each do |release|
-          version = CDN::Utils.parse_version(release)
+          version = Resources::CDN::Utils.parse_version(release)
           repo_name = "#{product_content.content.name} #{release}"
           Repository.create!(:environment_product => EnvironmentProduct.find_or_create(product.organization.library, product),
                              :cp_label => product_content.content.label,

--- a/src/spec/models/pulp_task_status_spec.rb
+++ b/src/spec/models/pulp_task_status_spec.rb
@@ -72,11 +72,11 @@ describe PulpTaskStatus do
         end
         @t.save!
 
-        Pulp::Task.stub(:find).and_return([updated_pulp_task])
+        Resources::Pulp::Task.stub(:find).and_return([updated_pulp_task])
       end
 
       it "should fetch data from pulp" do
-        Pulp::Task.should_receive(:find).once.with([@t.uuid]).and_return([updated_pulp_task])
+        Resources::Pulp::Task.should_receive(:find).once.with([@t.uuid]).and_return([updated_pulp_task])
         @t.refresh
       end
 

--- a/src/spec/models/repo_spec.rb
+++ b/src/spec/models/repo_spec.rb
@@ -52,7 +52,7 @@ describe Glue::Pulp::Repo, :katello => true do
 
   context "Create & destroy a repo" do
     it "should create the repo with correct properties" do
-      Pulp::Repository.should_receive(:create).with do |props|
+      Resources::Pulp::Repository.should_receive(:create).with do |props|
         props[:id].should == RepoTestData::REPO_PROPERTIES[:pulp_id]
         props[:name].should == RepoTestData::REPO_PROPERTIES[:name]
         props[:groupid].should == RepoTestData::REPO_PROPERTIES[:groupid]
@@ -67,9 +67,9 @@ describe Glue::Pulp::Repo, :katello => true do
       @repo.stub(:update_packages_index).and_return
       @repo.stub(:update_errata_index).and_return
       @repo.stub(:content_id).and_return("124321323")
-      Candlepin::Product.should_receive(:remove_content)
-      Candlepin::Content.should_receive(:destroy)
-      Pulp::Repository.should_receive(:destroy).with(RepoTestData::REPO_ID)
+      Resources::Candlepin::Product.should_receive(:remove_content)
+      Resources::Candlepin::Content.should_receive(:destroy)
+      Resources::Pulp::Repository.should_receive(:destroy).with(RepoTestData::REPO_ID)
       @repo.destroy
     end
 
@@ -77,17 +77,17 @@ describe Glue::Pulp::Repo, :katello => true do
       @rh_repo.stub(:update_packages_index).and_return
       @rh_repo.stub(:update_errata_index).and_return
       @rh_repo.stub(:content_id).and_return("124321323")
-      Pulp::Repository.stub(:find).and_return({:groupid=>["product:123", "env:123", "org:123"]})
-      Candlepin::Product.should_receive(:remove_content)
-      Candlepin::Content.should_not_receive(:destroy)
-      Pulp::Repository.should_receive(:destroy).with(@rh_repo.pulp_id)
+      Resources::Pulp::Repository.stub(:find).and_return({:groupid=>["product:123", "env:123", "org:123"]})
+      Resources::Candlepin::Product.should_receive(:remove_content)
+      Resources::Candlepin::Content.should_not_receive(:destroy)
+      Resources::Pulp::Repository.should_receive(:destroy).with(@rh_repo.pulp_id)
       @rh_repo.destroy
     end
   end
 
   context "Finding a repo" do
     it "should call Pulp's find api'" do
-      Pulp::Repository.should_receive(:find).with(RepoTestData::REPO_ID)
+      Resources::Pulp::Repository.should_receive(:find).with(RepoTestData::REPO_ID)
       Repository.find_by_pulp_id(RepoTestData::REPO_ID).feed
     end
 
@@ -101,14 +101,14 @@ describe Glue::Pulp::Repo, :katello => true do
 
   context "Find packages" do
     it "should find all packages in the repo" do
-      Pulp::Repository.should_receive(:packages).once.with(RepoTestData::REPO_ID)
+      Resources::Pulp::Repository.should_receive(:packages).once.with(RepoTestData::REPO_ID)
       packs = @repo.packages
       packs.length.should == RepoTestData::REPO_PACKAGES.length
     end
 
     it "called for second time should use the cached values" do
       @repo.packages
-      Pulp::Repository.should_not_receive(:packages).with(RepoTestData::REPO_ID, {})
+      Resources::Pulp::Repository.should_not_receive(:packages).with(RepoTestData::REPO_ID, {})
       @repo.packages
     end
 
@@ -120,14 +120,14 @@ describe Glue::Pulp::Repo, :katello => true do
 
   context "Find errata" do
     it "should find all errata in the repo" do
-      Pulp::Repository.should_receive(:errata).once.with(RepoTestData::REPO_ID)
+      Resources::Pulp::Repository.should_receive(:errata).once.with(RepoTestData::REPO_ID)
       errata = @repo.errata
       errata.length.should == RepoTestData::REPO_ERRATA.length
     end
 
     it "called for second time should use the cached values" do
       @repo.errata
-      Pulp::Repository.should_not_receive(:errata).with(RepoTestData::REPO_ID)
+      Resources::Pulp::Repository.should_not_receive(:errata).with(RepoTestData::REPO_ID)
       @repo.errata
     end
 
@@ -139,14 +139,14 @@ describe Glue::Pulp::Repo, :katello => true do
 
   context "Find distributions" do
     it "should find all distributions in the repo" do
-      Pulp::Repository.should_receive(:distributions).once.with(RepoTestData::REPO_ID)
+      Resources::Pulp::Repository.should_receive(:distributions).once.with(RepoTestData::REPO_ID)
       dists = @repo.distributions
       dists.length.should == RepoTestData::REPO_DISTRIBUTIONS.length
     end
 
     it "called for second time should use the cached values" do
       @repo.distributions
-      Pulp::Repository.should_not_receive(:distributions).with(RepoTestData::REPO_ID)
+      Resources::Pulp::Repository.should_not_receive(:distributions).with(RepoTestData::REPO_ID)
       @repo.distributions
     end
 
@@ -160,7 +160,7 @@ describe Glue::Pulp::Repo, :katello => true do
 
     it "should call pulp synchronization api" do
       @repo.stub(:async).and_return(@repo)
-      Pulp::Repository.should_receive(:sync).with(RepoTestData::REPO_ID).and_return({})
+      Resources::Pulp::Repository.should_receive(:sync).with(RepoTestData::REPO_ID).and_return({})
       task = mock()
       task.stub(:save!)
       PulpSyncStatus.should_receive(:using_pulp_task).and_return(task)
@@ -170,17 +170,17 @@ describe Glue::Pulp::Repo, :katello => true do
     context "status returned by synced?" do
 
       it "should be false for repos that have never been synced" do
-        Pulp::Repository.stub(:sync_history).and_return([])
+        Resources::Pulp::Repository.stub(:sync_history).and_return([])
         @repo.synced?.should == false
       end
 
       it "should be false for repos whose last sync failed" do
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::UNSUCCESSFULL_SYNC_HISTORY)
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::UNSUCCESSFULL_SYNC_HISTORY)
         @repo.synced?.should == false
       end
 
       it "should be true for repos with last successfull sync in sync history" do
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
         @repo.synced?.should == true
       end
     end
@@ -188,7 +188,7 @@ describe Glue::Pulp::Repo, :katello => true do
     context "status returned by sync_status" do
 
       it "should be status of the last synchronization" do
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
         returned_status = @repo.sync_status
 
         last_status = ::PulpSyncStatus.using_pulp_task(RepoTestData::SUCCESSFULL_SYNC_HISTORY[0])
@@ -202,7 +202,7 @@ describe Glue::Pulp::Repo, :katello => true do
     context "state returned by sync_state" do
 
       it "should be the same as state of the last synchronization status" do
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
         @repo.sync_state.should == RepoTestData::SUCCESSFULL_SYNC_HISTORY[0][:state]
       end
     end
@@ -210,13 +210,13 @@ describe Glue::Pulp::Repo, :katello => true do
     context "should return correct synchronization times" do
 
       it "for already synced repo" do
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
         @repo.sync_start.to_s.should == RepoTestData::LAST_SUCC_SYNC_START
         @repo.sync_finish.to_s.should == RepoTestData::LAST_SUCC_SYNC_FINISH
       end
 
       it "for repo that has never been synced" do
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return([])
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return([])
         @repo.sync_start.should == nil
         @repo.sync_finish.should == nil
       end
@@ -288,20 +288,20 @@ describe Glue::Pulp::Repo, :katello => true do
     context "cancelling" do
 
       it "should call Pulp's cancel api if the sync history is not empty" do
-        Pulp::Repository.stub(:sync_status) do
+        Resources::Pulp::Repository.stub(:sync_status) do
           raise
         end
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
-        Pulp::Task.should_receive(:cancel).with(RepoTestData::SUCCESSFULL_SYNC_HISTORY[0]["id"])
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return(RepoTestData::SUCCESSFULL_SYNC_HISTORY)
+        Resources::Pulp::Task.should_receive(:cancel).with(RepoTestData::SUCCESSFULL_SYNC_HISTORY[0]["id"])
         @repo.cancel_sync
       end
 
       it "should not call Pulp's cancel api if the sync history is empty" do
-        Pulp::Repository.stub(:sync_status) do
+        Resources::Pulp::Repository.stub(:sync_status) do
           raise
         end
-        Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return([])
-        Pulp::Task.should_not_receive(:cancel)
+        Resources::Pulp::Repository.stub(:sync_history).with(RepoTestData::REPO_ID).and_return([])
+        Resources::Pulp::Task.should_not_receive(:cancel)
         @repo.cancel_sync
       end
 
@@ -338,8 +338,8 @@ describe Glue::Pulp::Repo, :katello => true do
   context "Repo promote" do
 
     before :each do
-      Pulp::Repository.stub(:packages).and_return([])
-      Pulp::Repository.stub(:errata).and_return([])
+      Resources::Pulp::Repository.stub(:packages).and_return([])
+      Resources::Pulp::Repository.stub(:errata).and_return([])
 
       @to_env = KTEnvironment.create!(:organization =>@organization, :name=>"Prod", :prior=>@organization.library)
       @from_env = @to_env.prior
@@ -379,7 +379,7 @@ describe Glue::Pulp::Repo, :katello => true do
     end
 
     it "should clone the repo" do
-      Pulp::Repository.should_receive(:clone_repo).with do |repo, cloned|
+      Resources::Pulp::Repository.should_receive(:clone_repo).with do |repo, cloned|
         repo.should == @repo
         cloned.name.should == RepoTestData::CLONED_PROPERTIES[:name]
 
@@ -413,7 +413,7 @@ describe Glue::Pulp::Repo, :katello => true do
     end
 
     it "should set relative path correctly" do
-      Pulp::Repository.should_receive(:clone_repo).with do |repo, cloned|
+      Resources::Pulp::Repository.should_receive(:clone_repo).with do |repo, cloned|
         cloned.relative_path.should == "#{@repo.organization.name}/#{@to_env.name}#{@content_path}"
         true
       end
@@ -422,9 +422,9 @@ describe Glue::Pulp::Repo, :katello => true do
   end
 
   describe "#package_groups" do
-    before { Pulp::PackageGroup.stub(:all => RepoTestData.repo_package_groups) }
+    before { Resources::Pulp::PackageGroup.stub(:all => RepoTestData.repo_package_groups) }
     it "should call pulp layer" do
-      Pulp::PackageGroup.should_receive(:all).with(RepoTestData::REPO_PROPERTIES[:pulp_id])
+      Resources::Pulp::PackageGroup.should_receive(:all).with(RepoTestData::REPO_PROPERTIES[:pulp_id])
       @repo.package_groups
     end
 
@@ -435,9 +435,9 @@ describe Glue::Pulp::Repo, :katello => true do
   end
 
   describe "#package_group_categories" do
-    before { Pulp::PackageGroupCategory.stub(:all => RepoTestData.repo_package_group_categories) }
+    before { Resources::Pulp::PackageGroupCategory.stub(:all => RepoTestData.repo_package_group_categories) }
     it "should call pulp layer" do
-      Pulp::PackageGroupCategory.should_receive(:all).with(RepoTestData::REPO_PROPERTIES[:pulp_id])
+      Resources::Pulp::PackageGroupCategory.should_receive(:all).with(RepoTestData::REPO_PROPERTIES[:pulp_id])
       @repo.package_group_categories
     end
 

--- a/src/spec/models/system_spec.rb
+++ b/src/spec/models/system_spec.rb
@@ -54,10 +54,10 @@ describe System do
                          :installedProducts => installed_products,
                          :serviceLevel => nil)
 
-    Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Candlepin::Consumer.stub!(:update).and_return(true)
+    Resources::Candlepin::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Candlepin::Consumer.stub!(:update).and_return(true)
 
-    Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Pulp::Consumer.stub!(:create).and_return({:uuid => uuid, :owner => {:key => uuid}})
   end
 
   context "system in invalid state should not be valid" do
@@ -69,8 +69,8 @@ describe System do
   end
 
   it "registers system in candlepin and pulp on create" do
-    Candlepin::Consumer.should_receive(:create).once.with(@environment.id, @organization.name, system_name, cp_type, facts, installed_products, nil, nil, nil).and_return({:uuid => uuid, :owner => {:key => uuid}})
-    Pulp::Consumer.should_receive(:create).once.with(@organization.cp_key, uuid, description).and_return({:uuid => uuid, :owner => {:key => uuid}}) if AppConfig.katello?
+    Resources::Candlepin::Consumer.should_receive(:create).once.with(@environment.id, @organization.name, system_name, cp_type, facts, installed_products, nil, nil, nil).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Pulp::Consumer.should_receive(:create).once.with(@organization.cp_key, uuid, description).and_return({:uuid => uuid, :owner => {:key => uuid}}) if AppConfig.katello?
     @system.save!
   end
 
@@ -80,8 +80,8 @@ describe System do
     }
 
     it "should delete consumer in candlepin and pulp" do
-      Candlepin::Consumer.should_receive(:destroy).once.with(uuid).and_return(true)
-      Pulp::Consumer.should_receive(:destroy).once.with(uuid).and_return(true) if AppConfig.katello?
+      Resources::Candlepin::Consumer.should_receive(:destroy).once.with(uuid).and_return(true)
+      Resources::Pulp::Consumer.should_receive(:destroy).once.with(uuid).and_return(true) if AppConfig.katello?
       @system.destroy
     end
   end
@@ -89,8 +89,8 @@ describe System do
   context "regenerate identity certificates" do
     before { @system.uuid = uuid }
 
-    it "should call Candlepin::Consumer.regenerate_identity_certificates" do
-      Candlepin::Consumer.should_receive(:regenerate_identity_certificates).once.with(uuid).and_return(true)
+    it "should call Resources::Candlepin::Consumer.regenerate_identity_certificates" do
+      Resources::Candlepin::Consumer.should_receive(:regenerate_identity_certificates).once.with(uuid).and_return(true)
       @system.regenerate_identity_certificates
     end
   end
@@ -98,9 +98,9 @@ describe System do
   context "subscribe an entitlement" do
     before { @system.uuid = uuid }
 
-    it "should call Candlepin::Consumer.consume_entitlement" do
+    it "should call Resources::Candlepin::Consumer.consume_entitlement" do
       pool_id = "foo"
-      Candlepin::Consumer.should_receive(:consume_entitlement).once.with(uuid,pool_id,nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:consume_entitlement).once.with(uuid,pool_id,nil).and_return(true)
       @system.subscribe pool_id
     end
   end
@@ -108,8 +108,8 @@ describe System do
   context "unsubscribe an entitlement" do
     before { @system.uuid = uuid }
     entitlement_id = "foo"
-    it "should call Candlepin::Consumer.remove_entitlement" do
-      Candlepin::Consumer.should_receive(:remove_entitlement).once.with(uuid, entitlement_id).and_return(true)
+    it "should call Resources::Candlepin::Consumer.remove_entitlement" do
+      Resources::Candlepin::Consumer.should_receive(:remove_entitlement).once.with(uuid, entitlement_id).and_return(true)
       @system.unsubscribe entitlement_id
     end
   end
@@ -117,9 +117,9 @@ describe System do
   context "unsubscribe an certificate by serial" do
     before { @system.uuid = uuid }
 
-    it "should call Candlepin::Consumer.remove_certificate" do
+    it "should call Resources::Candlepin::Consumer.remove_certificate" do
       serial_id = "foo"
-      Candlepin::Consumer.should_receive(:remove_certificate).once.with(uuid,serial_id).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:remove_certificate).once.with(uuid,serial_id).and_return(true)
       @system.unsubscribe_by_serial serial_id
     end
   end
@@ -127,8 +127,8 @@ describe System do
   context "unsubscribe all entitlements" do
     before { @system.uuid = uuid }
 
-    it "should call Candlepin::Consumer.remove_entitlements" do
-      Candlepin::Consumer.should_receive(:remove_entitlements).once.with(uuid).and_return(true)
+    it "should call Resources::Candlepin::Consumer.remove_entitlements" do
+      Resources::Candlepin::Consumer.should_receive(:remove_entitlements).once.with(uuid).and_return(true)
       @system.unsubscribe_all
     end
   end
@@ -138,17 +138,17 @@ describe System do
       @system.save!
     end
 
-    it "should give facts to Candlepin::Consumer" do
+    it "should give facts to Resources::Candlepin::Consumer" do
       @system.facts = facts
       @system.installedProducts = nil # simulate it's not loaded in memory
-      Candlepin::Consumer.should_receive(:update).once.with(uuid, facts, nil, nil, nil, nil, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, facts, nil, nil, nil, nil, nil).and_return(true)
       @system.save!
     end
 
-    it "should give installeProducts to Candlepin::Consumer" do
+    it "should give installeProducts to Resources::Candlepin::Consumer" do
       @system.installedProducts = installed_products
       @system.facts = nil # simulate it's not loaded in memory
-      Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, installed_products, nil, nil, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, installed_products, nil, nil, nil).and_return(true)
       @system.save!
     end
 s  end
@@ -167,13 +167,13 @@ s  end
       before(:each) do
         @system.uuid = uuid
         @system.save
-        Candlepin::Consumer.stub!(:get).and_return({:href => href, :uuid => uuid})
-        Candlepin::Consumer.stub!(:entitlements).and_return({})
-        Candlepin::Consumer.stub!(:available_pools).and_return([])
+        Resources::Candlepin::Consumer.stub!(:get).and_return({:href => href, :uuid => uuid})
+        Resources::Candlepin::Consumer.stub!(:entitlements).and_return({})
+        Resources::Candlepin::Consumer.stub!(:available_pools).and_return([])
       end
 
       it "should access candlepin if uninialized" do
-        Candlepin::Consumer.should_receive(:get).once.with(uuid).and_return({:href => href, :uuid => uuid})
+        Resources::Candlepin::Consumer.should_receive(:get).once.with(uuid).and_return({:href => href, :uuid => uuid})
         @system.href
       end
 
@@ -182,7 +182,7 @@ s  end
       specify { @system.cp_type.should == cp_type }
 
       it "should access candlepin if entitlements is uninialized" do
-        Candlepin::Consumer.should_receive(:entitlements).once.with(uuid).and_return({})
+        Resources::Candlepin::Consumer.should_receive(:entitlements).once.with(uuid).and_return({})
         @system.entitlements
       end
 
@@ -192,8 +192,8 @@ s  end
           @system.entitlements = entitlements
           @system.save
 
-          Candlepin::Consumer.should_not_receive(:get)
-          Candlepin::Consumer.should_not_receive(:entitlements)
+          Resources::Candlepin::Consumer.should_not_receive(:get)
+          Resources::Candlepin::Consumer.should_not_receive(:entitlements)
         end
 
         specify { @system.href.should == href; }
@@ -201,8 +201,8 @@ s  end
       end
 
       it "should access candlepin if pools is uninialized" do
-        Candlepin::Consumer.should_receive(:entitlements).once.with(uuid).and_return([{"pool" => {"id" => 100}}])
-        Candlepin::Pool.should_receive(:find).once.and_return({})
+        Resources::Candlepin::Consumer.should_receive(:entitlements).once.with(uuid).and_return([{"pool" => {"id" => 100}}])
+        Resources::Candlepin::Pool.should_receive(:find).once.and_return({})
         @system.pools
       end
 
@@ -210,9 +210,9 @@ s  end
         before(:each) do
           @system.href = href
           @system.pools = {}
-          Candlepin::Consumer.should_not_receive(:get)
-          Candlepin::Consumer.should_not_receive(:entitlements)
-          Candlepin::Pool.should_not_receive(:find)
+          Resources::Candlepin::Consumer.should_not_receive(:get)
+          Resources::Candlepin::Consumer.should_not_receive(:entitlements)
+          Resources::Candlepin::Pool.should_not_receive(:find)
         end
 
         specify { @system.href.should == href }
@@ -220,15 +220,15 @@ s  end
       end
 
       it "should access candlepin if available_pools is uninitialized" do
-        Candlepin::Consumer.should_receive(:available_pools).once.with(uuid, false).and_return([])
+        Resources::Candlepin::Consumer.should_receive(:available_pools).once.with(uuid, false).and_return([])
         @system.available_pools
       end
 
       context "shouldn't access candlepin available_pools if initialized" do
         before(:each) do
           @system.available_pools = available_pools
-          Candlepin::Consumer.should_not_receive(:get)
-          Candlepin::Consumer.should_not_receive(:available_pools)
+          Resources::Candlepin::Consumer.should_not_receive(:get)
+          Resources::Candlepin::Consumer.should_not_receive(:available_pools)
         end
         specify { @system.available_pools.should == available_pools }
       end
@@ -236,14 +236,14 @@ s  end
     end
 
     context "shouldn't access candlepin if new record" do
-      before(:each) { Candlepin::Consumer.should_not_receive(:get) }
+      before(:each) { Resources::Candlepin::Consumer.should_not_receive(:get) }
       specify { @system.href.should be_nil }
     end
   end
 
   context "pulp attributes", :katello => true do
     it "should update package-profile" do
-      Pulp::Consumer.should_receive(:upload_package_profile).once.with(uuid, package_profile).and_return(true)
+      Resources::Pulp::Consumer.should_receive(:upload_package_profile).once.with(uuid, package_profile).and_return(true)
       @system.upload_package_profile(package_profile)
     end
   end
@@ -304,7 +304,7 @@ s  end
       @system_2 = create_system(common_attrs.merge(:name => "sys_2", :uuid => "sys_2_uuid"))
       @system_3 = create_system(common_attrs.merge(:name => "sys_3", :uuid => "sys_3_uuid"))
 
-      Candlepin::Entitlement.stub(:get).and_return([
+      Resources::Candlepin::Entitlement.stub(:get).and_return([
         {"pool" => {"id" => pool_id_1}, "consumer" => {"uuid" => @system_1.uuid}},
         {"pool" => {"id" => pool_id_1}, "consumer" => {"uuid" => @system_2.uuid}},
         {"pool" => {"id" => pool_id_2}, "consumer" => {"uuid" => @system_2.uuid}},
@@ -327,20 +327,20 @@ s  end
 
     # TODO: Unsure how to test this after making :host, :guests use lazy_accessor
     pending "guest system" do
-      before { Candlepin::Consumer.stub(:host => nil, :guests => []) }
+      before { Resources::Candlepin::Consumer.stub(:host => nil, :guests => []) }
 
       it "should get host system" do
-        Candlepin::Consumer.should_receive(:host).with(@system.uuid).and_return(SystemTestData.host)
+        Resources::Candlepin::Consumer.should_receive(:host).with(@system.uuid).and_return(SystemTestData.host)
         @system.host.name.should == SystemTestData.host["name"]
       end
     end
 
     # TODO: Unsure how to test this after making :host, :guests use lazy_accessor
     pending "host system" do
-      before { Candlepin::Consumer.stub(:host => nil, :guests => []) }
+      before { Resources::Candlepin::Consumer.stub(:host => nil, :guests => []) }
 
       it "should get guest systems" do
-        Candlepin::Consumer.should_receive(:guests).with(@system.uuid).and_return(SystemTestData.guests)
+        Resources::Candlepin::Consumer.should_receive(:guests).with(@system.uuid).and_return(SystemTestData.guests)
         guests = @system.guests
         guests.should have(1).system
         guests.first.name.should == SystemTestData.guests.first["name"]
@@ -349,7 +349,7 @@ s  end
 
     context "guest without host (before running virt-who)" do
       it "should return no host" do
-        Candlepin::CandlepinResource.stub(:default_headers => {}, :get => MemoStruct.new(:code => 204, :body => ""))
+        Resources::Candlepin::CandlepinResource.stub(:default_headers => {}, :get => MemoStruct.new(:code => 204, :body => ""))
         @system.host.should_not be
       end
     end

--- a/src/spec/models/system_template_revision_spec.rb
+++ b/src/spec/models/system_template_revision_spec.rb
@@ -76,9 +76,9 @@ describe SystemTemplate, :katello => true do
     before :each do
 
       stub_repos([repo])
-      Pulp::Repository.stub(:packages_by_name => [pack1])
-      Pulp::PackageGroup.stub(:all => pack_groups.clone)
-      Pulp::PackageGroupCategory.stub(:all => pack_group_categories.clone)
+      Resources::Pulp::Repository.stub(:packages_by_name => [pack1])
+      Resources::Pulp::PackageGroup.stub(:all => pack_groups.clone)
+      Resources::Pulp::PackageGroupCategory.stub(:all => pack_group_categories.clone)
 
 
 
@@ -89,8 +89,8 @@ describe SystemTemplate, :katello => true do
       @tpl1.add_pg_category("pg_category1")
       @tpl1.save!
 
-      Pulp::PackageGroup.stub(:all => pack_groups.clone)
-      Pulp::PackageGroupCategory.stub(:all => pack_group_categories.clone)
+      Resources::Pulp::PackageGroup.stub(:all => pack_groups.clone)
+      Resources::Pulp::PackageGroupCategory.stub(:all => pack_group_categories.clone)
     end
 
 

--- a/src/spec/models/system_template_spec.rb
+++ b/src/spec/models/system_template_spec.rb
@@ -413,7 +413,7 @@ describe SystemTemplate, :katello => true do
     })}
 
     before :each do
-      Pulp::PackageGroup.stub(:all => RepoTestData.repo_package_groups)
+      Resources::Pulp::PackageGroup.stub(:all => RepoTestData.repo_package_groups)
       stub_repos([repo])
     end
 
@@ -468,7 +468,7 @@ describe SystemTemplate, :katello => true do
     })}
 
     before :each do
-      Pulp::PackageGroupCategory.stub(:all => RepoTestData.repo_package_group_categories)
+      Resources::Pulp::PackageGroupCategory.stub(:all => RepoTestData.repo_package_group_categories)
       stub_repos([repo])
     end
 
@@ -519,7 +519,7 @@ describe SystemTemplate, :katello => true do
     })}
 
     before :each do
-      Pulp::Repository.stub(:distributions => [RepoTestData.repo_distributions])
+      Resources::Pulp::Repository.stub(:distributions => [RepoTestData.repo_distributions])
       stub_repos([repo])
     end
 
@@ -561,8 +561,8 @@ describe SystemTemplate, :katello => true do
     describe "repositories and distributions", :katello => true do
       before do
         disable_repo_orchestration
-        Pulp::Repository.stub(:distributions => [RepoTestData.repo_distributions])
-        Pulp::Distribution.stub(:find => RepoTestData.repo_distributions)
+        Resources::Pulp::Repository.stub(:distributions => [RepoTestData.repo_distributions])
+        Resources::Pulp::Distribution.stub(:find => RepoTestData.repo_distributions)
         stub_repos([Repository.new(RepoTestData::REPO_PROPERTIES)])
         @prod1.stub(:repos => [Repository.new(RepoTestData::REPO_PROPERTIES)])
 

--- a/src/spec/models/user_spec.rb
+++ b/src/spec/models/user_spec.rb
@@ -75,12 +75,12 @@ describe User do
       before(:each) { disable_user_orchestration }
 
       it "should call pulp user create api during user creation" do
-        Pulp::User.should_receive(:create).once.with(hash_including(:login => USERNAME, :name => USERNAME)).and_return({})
+        Resources::Pulp::User.should_receive(:create).once.with(hash_including(:login => USERNAME, :name => USERNAME)).and_return({})
         User.create!(to_create_simple)
       end
 
       it "should call pulp role api during user creation" do
-        Pulp::Roles.should_receive(:add).once.with("super-users", USERNAME).and_return(true)
+        Resources::Pulp::Roles.should_receive(:add).once.with("super-users", USERNAME).and_return(true)
         User.create!(to_create_simple)
       end
     end
@@ -96,12 +96,12 @@ describe User do
       end
 
       it "should call pulp user delete api during user deletion" do
-        Pulp::User.should_receive(:destroy).once.with(USERNAME).and_return(200)
+        Resources::Pulp::User.should_receive(:destroy).once.with(USERNAME).and_return(200)
         @user.destroy
       end
 
       it "should call pulp role api during user deletion" do
-        Pulp::Roles.should_receive(:remove).once.with("super-users", USERNAME).and_return(true)
+        Resources::Pulp::Roles.should_receive(:remove).once.with("super-users", USERNAME).and_return(true)
         @user.destroy
       end
     end


### PR DESCRIPTION
Code loaded with require is not reloaded in development mode after each
request and therefore it's needed to restart the whole server. Using
require_dependency instead might lead to memory leaks when some
constants are not marked for reload.

Since we have `lib` dir already in autoload paths we can let Rails to load
and unload the code automatically when following convetions. Therefore
modules under `lib/resources` dir were moved to `Resources` module so
that Rails knows where to find them. This change should also improve the
code readability: e.g. it's clearer where the Candlepin module is defined
now.

Since this commit it's almost never needed to require code from `lib` dir explicitly. Just use the Class/Module and Rails will do the job for you.
