### PR TITLE
822069 - Making candlepin proxy DELETE return a body for sub-man consume...

### DIFF
--- a/src/app/controllers/api/candlepin_proxies_controller.rb
+++ b/src/app/controllers/api/candlepin_proxies_controller.rb
@@ -21,7 +21,9 @@ class Api::CandlepinProxiesController < Api::ProxiesController
   end
 
   def delete
-    head ::Resources::Candlepin::Proxy.delete(@request_path).code.to_i
+    r = ::Resources::Candlepin::Proxy.delete(@request_path).code.to_i
+    Rails.logger.debug r if AppConfig.debug_cp_proxy
+    render :text => r, :content_type => :json
   end
 
   def post


### PR DESCRIPTION
...r delete methods

Subscription manager needs info back from the DELETE method for certain requests, like consumer deletion
