### PR TITLE
Add exit_with to reconfigure attempt.

### DIFF
--- a/puppet/bin/katello-configure
+++ b/puppet/bin/katello-configure
@@ -388,6 +388,7 @@ Dir.chdir '/root'
 # check if puppet was already executed
 if File.exists? '/var/lib/katello/db_seed_done'
   $stderr.puts "WARNING: Katello was already configured, reconfiguration is NOT supported yet"
+  exit_with :general
 end
 
 # perform check-up


### PR DESCRIPTION
Prevents katello-configure from attempting to reconfigure if already configured.  
