### PR TITLE
Refactoring: adding members to katello system group more puppet friendly way

### DIFF
--- a/puppet/modules/apache2/manifests/config.pp
+++ b/puppet/modules/apache2/manifests/config.pp
@@ -1,8 +1,8 @@
 class apache2::config {
 
-  exec { "add-apache-user-to-katello-group":
-        command => "usermod -a -G katello apache",
-        path => "/usr/sbin"
+  user { 'apache':
+        ensure => present,
+        groups => ['katello']
   }
 
   # support RHEL5/RHEL6 only

--- a/puppet/modules/candlepin/manifests/config.pp
+++ b/puppet/modules/candlepin/manifests/config.pp
@@ -1,8 +1,8 @@
 class candlepin::config {
 
-  exec { "add-tomcat-user-to-katello-group":
-        command => "usermod -a -G katello tomcat",
-        path => "/usr/sbin",
+  user { 'tomcat':
+        ensure => present,
+        groups => ['katello'],
         before => Exec["cpsetup"]
   }
 

--- a/puppet/modules/qpid/manifests/config.pp
+++ b/puppet/modules/qpid/manifests/config.pp
@@ -1,9 +1,8 @@
 class qpid::config {
 
-  exec { "add-qpidd-user-to-katello-group":
-        command => "usermod -a -G katello qpidd",
-        path => "/usr/sbin",
-        before => [Class["qpid::service"]],
+  user { 'qpidd':
+        ensure => present,
+        groups => ['katello']
   }
 
   file { "/etc/qpidd.conf":

--- a/puppet/modules/thumbslug/manifests/config.pp
+++ b/puppet/modules/thumbslug/manifests/config.pp
@@ -1,8 +1,8 @@
 class thumbslug::config {
 
-  exec { "add-thumbslug-user-to-katello-group":
-        command => "usermod -a -G katello thumbslug",
-        path => "/usr/sbin"
+  user { 'thumbslug':
+        ensure => present,
+        groups => ['katello']
   }
 
   file { "/etc/thumbslug/thumbslug.conf":


### PR DESCRIPTION
Tested with katello. Was unable install headpin to test the thumbslug user, but it follows the same pattern as other users.
