### PR TITLE
805956 - daily cron script for checking for new content on CDN

### DIFF
--- a/src/config/initializers/delayed_job.rb
+++ b/src/config/initializers/delayed_job.rb
@@ -3,7 +3,8 @@ require 'katello_logger'
 # Models have to use logger.info instead of Rails.logger.info in order for the desired log file to be used.
 # When running under Rails last caller is "/usr/share/katello/config.ru:1" but when running standalone
 # last caller is "script/delayed_job:3".
-if caller.last =~ /script\/delayed_job:\d+$/ || caller.last =~ /\/rake/
+
+if caller.last =~ /script\/delayed_job:\d+$/ || (caller.last =~ /\/rake/ && ARGV.include?("jobs:work"))
   level = (ENV['KATELLO_LOGGING'] || "warn").dup
   level_sql = (ENV['KATELLO_LOGGING_SQL'] || "fatal").dup
   Delayed::Worker.logger = KatelloLogger.new("#{Rails.root}/log/#{Rails.env}_delayed_jobs.log", level)

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -209,6 +209,10 @@ cp -R .bundle * %{buildroot}%{homedir}
 install -m 600 config/%{name}.yml %{buildroot}%{_sysconfdir}/%{name}/%{name}.yml
 install -m 644 config/environments/production.rb %{buildroot}%{_sysconfdir}/%{name}/environment.rb
 
+#copy cron scripts to be scheduled daily
+install -d -m0755 %{buildroot}%{_sysconfdir}/cron.daily
+install -m 755 script/katello-refresh-cdn %{buildroot}%{_sysconfdir}/cron.daily/katello-refresh-cdn
+
 #copy init scripts and sysconfigs
 install -Dp -m0644 %{confdir}/%{name}.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}
 install -Dp -m0755 %{confdir}/%{name}.init %{buildroot}%{_initddir}/%{name}
@@ -351,6 +355,7 @@ fi
 %files glue-pulp
 %{homedir}/app/models/glue/pulp
 %{homedir}/lib/resources/pulp.rb
+%config(missingok) %{_sysconfdir}/cron.daily/katello-refresh-cdn
 
 %files glue-candlepin
 %{homedir}/app/models/glue/candlepin

--- a/src/lib/tasks/cdn_refresh.rake
+++ b/src/lib/tasks/cdn_refresh.rake
@@ -1,0 +1,12 @@
+namespace :katello do
+  desc "Check for new repositories on CDN and create repositories if needed for all the organizations"
+  task :refresh_cdn => [:environment] do
+    Rails.logger.info("Refreshing CDN products")
+    User.current = User.hidden.first
+    Organization.all.each do |org|
+      Rails.logger.debug("CDN refresh for org #{org.name}")
+      org.redhat_provider.refresh_products
+    end
+    Rails.logger.info("Refreshing CDN products finished")
+  end
+end

--- a/src/script/katello-refresh-cdn
+++ b/src/script/katello-refresh-cdn
@@ -1,0 +1,11 @@
+#!/bin/env bash
+# script for refreshing the newest content from CDN. It doesn't synchronize the
+# repositories but lets Katello know there is new content available.
+
+# running the script from rails root
+RAILS_DIR=/usr/share/katello
+pushd $RAILS_DIR &> /dev/null
+
+rake katello:refresh_cdn RAILS_ENV=production
+
+popd &> /dev/null


### PR DESCRIPTION
This script goes through all the organizations and checks whether there is no
new content available. It there is new content it updates Katello to be aware
of that.

It's equivalent to calling:

```
katello provider refresh_products --name "Red Hat" --org OrgName
```

for every organization in Katello.

@mccun934 Could you review this?
