### PR TITLE
system groups - errata - show systems each errata is associated with

### DIFF
--- a/src/app/stylesheets/widgets/tipsy_custom.scss
+++ b/src/app/stylesheets/widgets/tipsy_custom.scss
@@ -1,25 +1,6 @@
-.errata_tooltip { 
+.tooltip {
   .tipsy-inner {
-    max-width: 800px;
-    width: 440px; 
-    background: #F5FAFA;
-    max-height: 500px;
-    overflow: hidden;
-    padding: 0;
-    
-    label { color: black; margin-right: 5px; }
-    p,li,pre { font-size: 110%; text-align: left; color: black; }
-    pre { text-indent: 0; }
-    .item-container { margin: 5px 10px 5px 6px; word-wrap: break-word; }
-    .jspVerticalBar{ padding: 0 4px 0 0; }
-    .details_container{ max-height: inherit; }
-  }
-}
-
-.table_tooltip {
-  .tipsy-inner {
-    max-width: 800px;
-    width: 440px;
+    max-width: 440px;
     background: #F5FAFA;
     max-height: 500px;
     overflow: hidden;
@@ -59,4 +40,29 @@
     .jspVerticalBar{ padding: 0 4px 0 0; }
     .details_container{ max-height: inherit; }
   }
+}
+
+.tipsy-icon {
+  background-color: #BBBBBB;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  border-radius: 8px;
+  font-weight: bold;
+  color: #FFFFFF;
+  text-align: center;
+  padding: 0px 5px;
+  text-decoration: none;
+
+  .hover, &:hover {
+    background-color: #000000;
+  }
+}
+.info:after {
+  content: "i"
+}
+.tipsy-hover {
+  background-color: #000000;
+}
+.tipsy-nohover {
+  background-color: #BBBBBB;
 }

--- a/src/app/views/dashboard/_errata.haml
+++ b/src/app/views/dashboard/_errata.haml
@@ -28,7 +28,7 @@
                 .col_3.one-line-ellipsis
                   #{errata_product_names(errata, repos)}
                 .col_4
-                  %span.details-icon.errata-info{ "data-title" => errata.title, "data-issued" => errata.issued, "data-description" => errata.description, "data-id" => errata.id, "data-packages" => errata.pkglist.to_json, "data-reference_url" => (errata.references[0] ? errata.references[0]["href"] : "") }
+                  %span.tipsy-icon.info.errata-info{ "data-title" => errata.title, "data-issued" => errata.issued, "data-description" => errata.description, "data-id" => errata.id, "data-packages" => errata.pkglist.to_json, "data-reference_url" => (errata.references[0] ? errata.references[0]["href"] : "") }
               %div.system_list
                 .subheader
                   .col_1

--- a/src/app/views/system_groups/errata/_index.html.haml
+++ b/src/app/views/system_groups/errata/_index.html.haml
@@ -50,7 +50,9 @@
         %th
           #{_("TITLE")}
         %th
-          #{_("INFO")}
+          #{_("DETAILS")}
+        %th
+          #{_("SYSTEMS")}
       %tbody
         -#= render :partial => "system_groups/errata/items", :locals => { :errata => errata, :editable => editable }
     #list-spinner

--- a/src/app/views/systems/errata/_index.html.haml
+++ b/src/app/views/systems/errata/_index.html.haml
@@ -43,7 +43,7 @@
         %th
           #{_("TITLE")}
         %th
-          #{_("INFO")}
+          #{_("DETAILS")}
       %tbody
         -#= render :partial => "systems/errata/items", :locals => { :errata => errata, :editable => editable }
     #list-spinner

--- a/src/app/views/systems/errata/_items.html.haml
+++ b/src/app/views/systems/errata/_items.html.haml
@@ -14,5 +14,9 @@
         = image_tag('spinner.gif', :alt => _('Loading'))
         %span.errata_status_text
           #{_('Installing')}
-    %td      
-      %span.details-icon.errata-info{ "data-title" => e.title, "data-issued" => e.issued, "data-description" => e.description, "data-id" => e.id, "data-packages" => e.pkglist.to_json, "data-reference_url" => (e.references[0] ? e.references[0]["href"] : "") }
+    %td
+      %span.tipsy-icon.info.errata-info{ "data-title" => e.title, "data-issued" => e.issued, "data-description" => e.description, "data-id" => e.id, "data-packages" => e.pkglist.to_json, "data-reference_url" => (e.references[0] ? e.references[0]["href"] : "") }
+    -if defined?(errata_systems) and !errata_systems.blank?
+      %td{:style => "text-align:center;"}
+        %span.tipsy-icon.systems{"data-list" => errata_systems[e.id].to_json}
+          = errata_systems[e.id].length

--- a/src/public/javascripts/dashboard.js
+++ b/src/public/javascripts/dashboard.js
@@ -172,5 +172,5 @@ $(window).load(function() {
     $(".loading").each(function(){
        KT.dashboard.widgetReload($(this))
     });
-    KT.tipsy.custom.errata_tooltip();
+    KT.tipsy.custom.tooltip($('.tipsy-icon.errata-info'));
 });

--- a/src/public/javascripts/system_errata.js
+++ b/src/public/javascripts/system_errata.js
@@ -39,12 +39,14 @@ KT.system.errata = function() {
                 install_url = KT.routes.install_system_errata_path(id);
                 status_url = KT.routes.status_system_errata_path(id);
                 update_function = update_status_for_system;
+                KT.tipsy.custom.tooltip($('.tipsy-icon.errata-info'));
             } else {
                 // errata_for === 'system_group'
                 items_url = KT.routes.items_system_group_errata_path(id);
                 install_url = KT.routes.install_system_group_errata_path(id);
                 status_url = KT.routes.status_system_group_errata_path(id);
                 update_function = update_status_for_group;
+                KT.tipsy.custom.tooltip($('.tipsy-icon.systems, .tipsy-icon.errata-info'));
             }
 
             register_events();
@@ -64,7 +66,6 @@ KT.system.errata = function() {
     		$('#errata_state_radio_outstanding').bind('change', fetch_errata);
             $('#run_errata_button').bind('click', add_errata);
     		load_more.bind('click', { clear_items : false }, fetch_errata);
-            KT.tipsy.custom.errata_tooltip();
     	},
         init_status_check = function(){
             var timeout = 8000;
@@ -98,7 +99,6 @@ KT.system.errata = function() {
     		}).success(function(data){
     			insert_data(data, !clear_items);
     			show_spinner(false);
-
     		});
     	},
     	get_current_filter = function(){

--- a/src/public/javascripts/widgets/tipsy.custom.js
+++ b/src/public/javascripts/widgets/tipsy.custom.js
@@ -1,21 +1,21 @@
 KT.tipsy = KT.tipsy || {};
 
 KT.tipsy.custom = (function(){
-    var errata_tooltip = function(){
-         $('.errata-info').tipsy({ 
-            gravity: 'e', live : true, html : true, title : KT.tipsy.templates.errata, 
-            hoverable : true, delayOut : 250, opacity : 1, delayIn : 300, className : 'errata_tooltip',
-            stickyClick : function(element, state){ 
-                if (state === 'on'){
-                    $(element).addClass('details-icon-hover').removeClass('details-icon');
-                } else {
-                    $(element).addClass('details-icon').removeClass('details-icon-hover');
-                }
-            },
-            afterShow : function(){
-                $('.details_container').addClass('scroll-pane');
-                KT.common.jscroll_init($('.scroll-pane'));
-            }});
+    var tooltip = function(element) {
+        element.tipsy({
+           gravity: 'e', live : true, html : true, title : KT.tipsy.templates.dynamic,
+           hoverable : true, delayOut : 250, opacity : 1, delayIn : 300, className : 'tooltip',
+           stickyClick : function(element, state){
+               if (state === 'on'){
+                   $(element).addClass('tipsy-hover').removeClass('tipsy-nohover');
+               } else {
+                   $(element).addClass('tipsy-nohover').removeClass('tipsy-hover');
+               }
+           },
+           afterShow : function(){
+               $('.details_container').addClass('scroll-pane');
+               KT.common.jscroll_init($('.scroll-pane'));
+           }});
     },
     disable_details_tooltip = function(element) {
         element.replaceWith('<span class="details-icon-nohover"></span>');
@@ -34,7 +34,7 @@ KT.tipsy.custom = (function(){
 
         $('.system_content_action').tipsy({
            gravity: 'e', live : true, html : true, title : KT.tipsy.templates.table_template,
-           hoverable : true, delayOut : 250, opacity : 1, delayIn : 300, className : 'table_tooltip',
+           hoverable : true, delayOut : 250, opacity : 1, delayIn : 300, className : 'tooltip',
            afterShow : function(){
                $('.details_container').addClass('scroll-pane');
                KT.common.jscroll_init($('.scroll-pane'));
@@ -49,7 +49,7 @@ KT.tipsy.custom = (function(){
            }});
     };
     return {
-        errata_tooltip           : errata_tooltip,
+        tooltip                  : tooltip,
         disable_details_tooltip  : disable_details_tooltip,
         promotion_filter_tooltip : promotion_filter_tooltip,
         system_packages_tooltips : system_packages_tooltip
@@ -57,9 +57,43 @@ KT.tipsy.custom = (function(){
 })();
 
 KT.tipsy.templates = (function(){
-    var errata = function(){
+    var dynamic = function() {
+      // The dynamic function will determine the template to use for rendering the tipsy based on the type of element.
+      // Currently, this is assumed to be either errata-info or a simple list.
+      var html, element = $(this);
+      if (element.hasClass('errata-info')) {
+          html = errata(element);
+      } else {
+          html = list(element);
+      }
+      return html;
+    },
+    list = function(element) {
+        // The list template assumes that the data shown in the template is essentially a simple list of items.
+        // The items are pulled from the data-list attribute associated with the tipsy element.
         var html = '<div class="details_container">',
-            element = $(this),
+            items_list = [],
+            generate_list = function(){
+                var items_list = element.data('list'),
+                    i = 0,
+                    length = items_list.length,
+                    html = "";
+
+                for(i; i < length; i += 1){
+                    html += "<li>" + items_list[i] + '</li>';
+                }
+                return html;
+            };
+
+        items_list = generate_list();
+
+        html += '<div class="item-container"><ul style="margin:0 0 0 4px;" class="la">' + items_list + '</ul></div>';
+        html += '</div>';
+
+        return html;
+    },
+    errata = function(element){
+        var html = '<div class="details_container">',
             packages_list = [],
             generate_packages = function(){
                 var packages = element.data('packages')[0]["packages"],
@@ -146,7 +180,7 @@ KT.tipsy.templates = (function(){
     };
 
     return {
-        errata            : errata,
+        dynamic           : dynamic,
         promotion_filters : promotion_filters,
         table_template    : table_template
     };


### PR DESCRIPTION
This commit contains a few changes:
1. Changes to the SystemGroups -> Errata pane to show the user
   the number of systems a given errata is associated with.
   The number is a tipsy that when hovered over will show
   the list of system names.
2. Changes to enable both the errata 'details' and system list
   to both be handled using tipsy with the 'sticky' option.
3. Changes to refactor logic to reduce some of the duplication
   in the tipsy logic.
