### PR TITLE
826249 - accessing Systems By Environment is generating an error

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -150,6 +150,8 @@ class SystemsController < ApplicationController
     accesible_envs = KTEnvironment.systems_readable(current_organization)
 
     begin
+      @system_groups = SystemGroup.where(:organization_id => current_organization).where(:locked=>false).order(:name)
+
       @systems = []
       setup_environment_selector(current_organization, accesible_envs)
       if @environment


### PR DESCRIPTION
When adding the bulk system group add/remove to the System's page, missed that there was a separate action for the By Environment page.  This commit addresses the error user's will see when accessing the page.
