### PR TITLE
cli - new option types - url and list

### DIFF
--- a/cli/src/katello/client/core/environment.py
+++ b/cli/src/katello/client/core/environment.py
@@ -36,9 +36,7 @@ class EnvironmentAction(Action):
 
     def get_prior_id(self, orgName, priorName):
         prior = get_environment(orgName, priorName)
-        if prior != None:
-            return prior["id"]
-        return None
+        return prior["id"]
 
 # environment actions ------------------------------------------------------------
 

--- a/cli/src/katello/client/core/permission.py
+++ b/cli/src/katello/client/core/permission.py
@@ -61,8 +61,8 @@ class Create(PermissionAction):
         parser.add_option('--description', dest='desc', help=_("permission description"))
         parser.add_option('--org', dest='org', help=_("organization name"))
         parser.add_option('--scope', dest='scope', help=_("scope of the permisson (required)"))
-        parser.add_option('--verbs', dest='verbs', help=_("verbs for the permission"), default="")
-        parser.add_option('--tags', dest='tags', help=_("tags for the permission"), default="")
+        parser.add_option('--verbs', dest='verbs', type="list", help=_("verbs for the permission"), default="")
+        parser.add_option('--tags', dest='tags', type="list", help=_("tags for the permission"), default="")
 
     def check_options(self, validator):
         validator.require(('user_role', 'name', 'scope'))
@@ -85,12 +85,6 @@ class Create(PermissionAction):
         except KeyError, e:
             system_exit(os.EX_DATAERR, _("Could not find tag [ %s ] in scope of [ %s ]") % (e[0], scope))
 
-    def split_options(self, opts):
-        if opts == "":
-            return []
-        else:
-            return opts.split(",")
-
 
     def run(self):
         role_name = self.get_option('user_role')
@@ -98,8 +92,8 @@ class Create(PermissionAction):
         desc = self.get_option('desc')
         org_name = self.get_option('org')
         scope = self.get_option('scope')
-        verbs = self.split_options(self.get_option('verbs'))
-        tags = self.split_options(self.get_option('tags'))
+        verbs = self.get_option('verbs')
+        tags = self.get_option('tags')
 
         tag_ids = self.tags_to_ids(tags, org_name, scope)
 

--- a/cli/src/katello/client/core/product.py
+++ b/cli/src/katello/client/core/product.py
@@ -308,7 +308,7 @@ class Create(ProductAction):
                                help=_("product name (required)"))
         parser.add_option("--description", dest="description",
                                help=_("product description"))
-        parser.add_option("--url", dest="url",
+        parser.add_option("--url", dest="url", type="url",
                                help=_("repository url eg: http://download.fedoraproject.org/pub/fedora/linux/releases/"))
         parser.add_option("--nodisc", action="store_true", dest="nodiscovery",
                                help=_("skip repository discovery"))

--- a/cli/src/katello/client/core/provider.py
+++ b/cli/src/katello/client/core/provider.py
@@ -129,7 +129,7 @@ class Update(ProviderAction):
                                help=_("provider name (required)"))
         parser.add_option("--description", dest="description",
                                help=_("provider description"))
-        parser.add_option("--url", dest="url",
+        parser.add_option("--url", dest="url", type="url",
                                help=_("repository url eg: http://download.fedoraproject.org/pub/fedora/linux/releases/"))
         parser.add_option('--org', dest='org',
                                help=_("name of organization (required)"))
@@ -140,16 +140,7 @@ class Update(ProviderAction):
 
 
     def check_options(self, validator):
-
         validator.require(('name', 'org'))
-
-        if validator.exists('url'):
-            url = self.get_option('url')
-            url_parsed = urlparse(url)
-            if not url_parsed.scheme in ["http","https"]:                       # pylint: disable=E1101
-                validator.add_option_error(_('Option --url has to start with http:// or https://'))
-            elif not url_parsed.netloc:                                         # pylint: disable=E1101
-                validator.add_option_error(_('Option --url is not in a valid format'))
 
 
     def create(self, name, orgName, description, url):

--- a/cli/src/katello/client/core/repo.py
+++ b/cli/src/katello/client/core/repo.py
@@ -118,7 +118,7 @@ class Create(RepoAction):
                                help=_("organization name eg: foo.example.com (required)"))
         parser.add_option('--name', dest='name',
                                help=_("repository name to assign (required)"))
-        parser.add_option("--url", dest="url",
+        parser.add_option("--url", dest="url", type="url",
                                help=_("url path to the repository (required)"))
         parser.add_option('--product', dest='prod',
                                help=_("product name (required)"))
@@ -153,7 +153,7 @@ class Discovery(RepoAction):
                                help=_("organization name eg: foo.example.com (required)"))
         parser.add_option('--name', dest='name',
                                help=_("repository name prefix to add to all the discovered repositories (required)"))
-        parser.add_option("--url", dest="url",
+        parser.add_option("--url", dest="url", type="url",
                                help=_("root url to perform discovery of repositories eg: http://porkchop.devel.redhat.com/ (required)"))
         parser.add_option("--assumeyes", action="store_true", dest="assumeyes",
                                help=_("assume yes; automatically create candidate repositories for discovered urls (optional)"))
@@ -175,8 +175,7 @@ class Discovery(RepoAction):
         selectedurls = self.select_repositories(repourls, assumeyes)
 
         prod = get_product(orgName, prodName)
-        if prod != None:
-            self.create_repositories(orgName, prod["id"], name, selectedurls)
+        self.create_repositories(orgName, prod["id"], name, selectedurls)
 
         return os.EX_OK
 

--- a/cli/src/katello/client/core/system.py
+++ b/cli/src/katello/client/core/system.py
@@ -152,15 +152,15 @@ class InstalledPackages(SystemAction):
                        help=_("system name (required)"))
         parser.add_option('--environment', dest='environment',
                        help=_("environment name"))
-        parser.add_option('--install', dest='install',
+        parser.add_option('--install', dest='install', type="list",
                        help=_("packages to be installed remotely on the system, package names are separated with comma"))
-        parser.add_option('--remove', dest='remove',
+        parser.add_option('--remove', dest='remove', type="list",
                        help=_("packages to be removed remotely from the system, package names are separated with comma"))
-        parser.add_option('--update', dest='update',
+        parser.add_option('--update', dest='update', type="list",
                        help=_("packages to be updated on the system, use --all to update all packages, package names are separated with comma"))
-        parser.add_option('--install_groups', dest='install_groups',
+        parser.add_option('--install_groups', dest='install_groups', type="list",
                        help=_("package groups to be installed remotely on the system, group names are separated with comma"))
-        parser.add_option('--remove_groups', dest='remove_groups',
+        parser.add_option('--remove_groups', dest='remove_groups', type="list",
                        help=_("package groups to be removed remotely from the system, group names are separated with comma"))
 
     def check_options(self, validator):
@@ -182,7 +182,6 @@ class InstalledPackages(SystemAction):
         update = self.get_option('update')
         install_groups = self.get_option('install_groups')
         remove_groups = self.get_option('remove_groups')
-        packages_separator = ","
 
         task = None
 
@@ -195,19 +194,19 @@ class InstalledPackages(SystemAction):
         system_id = system['uuid']
 
         if install:
-            task = self.api.install_packages(system_id, install.split(packages_separator))
+            task = self.api.install_packages(system_id, install)
         if remove:
-            task = self.api.remove_packages(system_id, remove.split(packages_separator))
+            task = self.api.remove_packages(system_id, remove)
         if update:
             if update == '--all':
                 update_packages = []
             else:
-                update_packages = update.split(packages_separator)
+                update_packages = update
             task = self.api.update_packages(system_id, update_packages)
         if install_groups:
-            task = self.api.install_package_groups(system_id, install_groups.split(packages_separator))
+            task = self.api.install_package_groups(system_id, install_groups)
         if remove_groups:
-            task = self.api.remove_package_groups(system_id, remove_groups.split(packages_separator))
+            task = self.api.remove_package_groups(system_id, remove_groups)
 
         if task:
             uuid = task["uuid"]
@@ -743,7 +742,7 @@ class AddSystemGroups(SystemAction):
             return os.EX_DATAERR
 
         system_group_ids = [group["id"] for group in system_groups]
-        
+
         system = self.api.add_system_groups(system["uuid"], system_group_ids)
 
         if system != None:
@@ -786,7 +785,7 @@ class RemoveSystemGroups(SystemAction):
             return os.EX_DATAERR
 
         system_group_ids = [group["id"] for group in system_groups]
-        
+
         system = self.api.remove_system_groups(system["uuid"], system_group_ids)
 
         if system != None:

--- a/cli/src/katello/client/core/system_group.py
+++ b/cli/src/katello/client/core/system_group.py
@@ -320,7 +320,7 @@ class AddSystems(SystemGroupAction):
                                help=_("system group name (required)"))
         parser.add_option('--org', dest='org',
                                help=_("name of organization (required)"))
-        parser.add_option('--system_uuids', dest='system_uuids',
+        parser.add_option('--system_uuids', dest='system_uuids', type="list",
                               help=_("comma separated list of system uuids (required)"))
 
     def check_options(self, validator):
@@ -335,8 +335,6 @@ class AddSystems(SystemGroupAction):
 
         if system_group is None:
             return os.EX_DATAERR
-
-        system_ids = [uuid for uuid in system_ids.split(',')]
 
         systems = self.api.add_systems(org_name, system_group["id"], system_ids)
 
@@ -356,7 +354,7 @@ class RemoveSystems(SystemGroupAction):
                                help=_("system group name (required)"))
         parser.add_option('--org', dest='org',
                                help=_("name of organization (required)"))
-        parser.add_option('--system_uuids', dest='system_uuids',
+        parser.add_option('--system_uuids', dest='system_uuids', type="list",
                               help=_("comma separated list of system uuids (required)"))
 
     def check_options(self, validator):
@@ -371,8 +369,6 @@ class RemoveSystems(SystemGroupAction):
 
         if system_group is None:
             return os.EX_DATAERR
-
-        system_ids = [uuid for uuid in system_ids.split(',')]
 
         systems = self.api.remove_systems(org_name, system_group["id"], system_ids)
 

--- a/cli/src/katello/client/core/template.py
+++ b/cli/src/katello/client/core/template.py
@@ -429,10 +429,7 @@ class Update(TemplateAction):
         ids = []
         for rec in repos:
             repo = get_repo(orgName, rec['product'], rec['name'])
-            if repo != None:
-                ids.append(repo['id'])
-            else:
-                system_exit(os.EX_DATAERR)
+            ids.append(repo['id'])
         return ids
 
 

--- a/cli/test/katello_option_test.py
+++ b/cli/test/katello_option_test.py
@@ -1,0 +1,113 @@
+from unittest import TestCase
+from mock import Mock
+
+from katello.client.i18n_optparse import OptionParser, OptionParserExitError
+from katello.client.core.base import KatelloOption
+from cli_test_utils import ColoredAssertionError
+
+class KatelloOptionTestCase(TestCase):
+
+    failureException = ColoredAssertionError
+
+    def setup_parser(self):
+        self.parser = OptionParser(option_class=KatelloOption)
+        self.parser.error = Mock()
+        self.parser.error.side_effect = OptionParserExitError()
+        return self.parser
+
+    def assert_args_valid(self, cli_arguments):
+        cli_arguments = self.__ensure_iterable(cli_arguments)
+        try:
+            self.opts, self.args = self.parser.parse_args(cli_arguments)
+        except OptionParserExitError, opee:
+            self.fail("The option parser should accept arguments [ %s ]" % ", ".join(cli_arguments) )
+
+    def assert_args_invalid(self, cli_arguments):
+        cli_arguments = self.__ensure_iterable(cli_arguments)
+        try:
+            self.opts, self.args = self.parser.parse_args(cli_arguments)
+            self.fail("The option parser should NOT accept arguments [ %s ]" % ", ".join(cli_arguments) )
+        except OptionParserExitError, opee:
+            pass
+
+    def get_option(self, dest):
+        return getattr(self.opts, dest)
+
+
+    def __ensure_iterable(self, var):
+        if not isinstance(var, (tuple, list)):
+            return [var]
+        else:
+            return var
+
+
+class BoolOptionTest(KatelloOptionTestCase):
+
+    def setUp(self):
+        self.setup_parser()
+        self.parser.add_option("--opt", type="bool", dest="opt")
+
+    def test_it_accepts_true(self):
+        for arg in ["True", "true", "TRUE"]:
+            self.assert_args_valid("--opt="+arg)
+            self.assertTrue(self.get_option("opt"))
+
+    def test_it_accepts_false(self):
+        for arg in ["False", "false", "FALSE"]:
+            self.assert_args_valid("--opt="+arg)
+            self.assertFalse(self.get_option("opt"))
+
+    def test_it_does_not_accept_empty_value(self):
+        self.assert_args_invalid("--opt=")
+
+
+class ListOptionTest(KatelloOptionTestCase):
+
+    def __test_with_args(self, args, expected_len, delim=None):
+        self.setup_parser()
+        self.parser.add_option("--opt", type="list", dest="opt", delimiter=delim)
+
+        self.assert_args_valid(args)
+        self.assertTrue(isinstance(self.get_option("opt"), list))
+        self.assertEquals(len(self.get_option("opt")), expected_len)
+
+    def test_it_accepts_list(self):
+        self.__test_with_args("--opt=item1,item2,item3", 3)
+
+    def test_it_accepts_single_item(self):
+        self.__test_with_args("--opt=item1", 1)
+
+    def test_it_accepts_empty_value(self):
+        self.__test_with_args("--opt=", 0)
+
+    def test_it_accepts_list_with_given_delimiter(self):
+        self.__test_with_args("--opt=item1#item2#item3", 3, delim="#")
+
+    def test_it_accepts_single_item_with_given_delimiter(self):
+        self.__test_with_args("--opt=item1", 1, delim="#")
+
+    def test_it_accepts_empty_value_with_given_delimiter(self):
+        self.__test_with_args("--opt=", 0, delim="#")
+
+
+class UrlOptionTest(KatelloOptionTestCase):
+
+    def setUp(self):
+        self.setup_parser()
+        self.parser.add_option("--opt", type="url", dest="opt")
+        self.parser.add_option("--opt2", type="url", dest="opt2", schemes=["abc"])
+
+    def test_it_accepts_http_by_default(self):
+        self.assert_args_valid("--opt=http://walrus.org/a/b/c/")
+
+    def test_it_accepts_https_by_default(self):
+        self.assert_args_valid("--opt=https://walrus.org/a/b/c/")
+
+    def test_it_does_not_accept_non_urls(self):
+        self.assert_args_invalid("--opt2=some_string")
+
+    def test_it_accepts_custom_schemes(self):
+        self.assert_args_valid("--opt2=abc://walrus.org/a/b/c/")
+
+    def test_it_does_not_accept_disabled_schemes(self):
+        self.assert_args_invalid("--opt2=http://walrus.org/a/b/c/")


### PR DESCRIPTION
Two new types of options

list
- allows to insert more values in one option
- separator can be defined, ',' is used by default
- result stored in a list
- eg. --packages=walrus,dolphin

url
- checks values if they are in correct url format
- accepted schemes can be defined, ['http', 'https'] is default
