### PR TITLE
katello, unit tests - track creation line of mocks

### DIFF
--- a/src/spec/spec_helper.rb
+++ b/src/spec/spec_helper.rb
@@ -27,7 +27,9 @@ require "helpers/user_helper_methods"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+Dir[Rails.root.join("spec/support/**/*.rb")].each do |f|
+  require f unless f =~ /monkey/
+end
 
 RSpec.configure do |config|
   # == Mock Framework
@@ -61,3 +63,5 @@ end
 Webrat.configure do |config|
   config.mode = :rails
 end
+
+require 'spec/support/monkey_rspec_trac_creation_line_of_mocks' # has to be loaded after RSpec

--- a/src/spec/support/monkey_rspec_trac_creation_line_of_mocks.rb
+++ b/src/spec/support/monkey_rspec_trac_creation_line_of_mocks.rb
@@ -1,0 +1,40 @@
+# when mock receives unexpected message
+# it adds line where mock was created to a message error
+#    RSpec::Mocks::MockExpectationError: Mock "syncable" created on:
+#     /.../spec/controllers/api/sync_controller_spec.rb:200 received unexpected message :sync with (no args)
+
+require 'rspec/version'
+
+unless RSpec::Version::STRING =~ /^2\.10\.0$/ # change if it works for other versions
+  warn "monkey eats only a banana! (this monkey needs rspec 2.10.0)\n#{__FILE__}:#{__LINE__}"
+else
+  module RSpec::Mocks
+    module TestDouble
+      def initialize(name=nil, stubs_and_options={ })
+        __initialize_as_test_double(name, stubs_and_options)
+        @__created_on_line = caller.find { |line| line =~ %r(/spec/) }
+      end
+    end
+
+    class ErrorGenerator
+      def intro
+        intro = if @name
+                  "#{@declared_as} #{@name.inspect}"
+                elsif TestDouble === @target
+                  @declared_as
+                elsif Class === @target
+                  "<#{@target.inspect} (class)>"
+                elsif @target
+                  @target
+                else
+                  "nil"
+                end
+        if created_on_line = @target.instance_eval { @__created_on_line }
+          "#{intro} created on: \n#{created_on_line}"
+        else
+          intro
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
when mock receives unexpected message it adds line where mock was created to a message 

```
RSpec::Mocks::MockExpectationError: Mock "syncable" created on:
/.../spec/controllers/api/sync_controller_spec.rb:200 received unexpected message :sync with (no args)
```
