### PR TITLE
815308 - traceback on package search

### DIFF
--- a/src/app/controllers/packages_controller.rb
+++ b/src/app/controllers/packages_controller.rb
@@ -38,33 +38,37 @@ class PackagesController < ApplicationController
 	def show
 		render :partial=>"show", :layout => "tupane_layout"
 	end
-	
+
 	def filelist
         render :partial=>"filelist", :layout => "tupane_layout"
 	end
-	
+
 	def changelog
         render :partial=>"changelog", :layout => "tupane_layout"
-	end 
-	
+	end
+
   def dependencies
       render :partial=>"dependencies", :layout => "tupane_layout"
-  end 	
+  end
 
   def auto_complete_library
-    name = params[:term]
-    render :json=>Glue::Pulp::Package.name_search(name)
+    begin
+        packages = Glue::Pulp::Package.name_search(params[:term])
+    rescue Tire::Search::SearchRequestFailed
+        packages = []
+    end
+    render :json => packages
   end
 
   def validate_name_library
     name = params[:term]
-    render :json=>Glue::Pulp::Package.search("name:#{name}", 0, 1).count 
+    render :json=>Glue::Pulp::Package.search("name:#{name}", 0, 1).count
   end
 
   private
 
   def lookup_package
-    @package_id = params[:id] 
+    @package_id = params[:id]
     @package = Glue::Pulp::Package.find @package_id
     raise(_("Unable to find package %s" % @package_id)) if @package.nil?
   end

--- a/src/app/models/glue/pulp/package.rb
+++ b/src/app/models/glue/pulp/package.rb
@@ -64,7 +64,7 @@ class Glue::Pulp::Package < Glue::Pulp::SimplePackage
 
     query = Katello::Search::filter_input query
     query = "*" if query == ""
-    query = "name_autocomplete:#{query}"
+    query = "name_autocomplete:(#{query})"
 
     search = Tire.search self.index do
       fields [:name]

--- a/src/lib/util/search.rb
+++ b/src/lib/util/search.rb
@@ -13,6 +13,8 @@
 module Katello
   module Search
 
+    DISABLED_LUCENE_SPECIAL_CHARS = ['-', ':']
+
     def self.custom_analyzers
       {
         "kt_name_analyzer" => {
@@ -39,15 +41,13 @@ module Katello
       }
     end
 
-
     # Filter the search input, escaping unsupported lucene syntax (e.g. usage of - operator)
     def self.filter_input search
-      unless search.nil?
-        search = search.gsub('^', "\\^")
-        search = search.gsub('-', "\\-")
-        search = search.gsub(':', "\\:")
+      return nil if search.nil?
+      DISABLED_LUCENE_SPECIAL_CHARS.each do |chr|
+        search = search.gsub(chr, '\\'+chr)
       end
-      search
+      return search
     end
 
   end


### PR DESCRIPTION
Package search was raising exceptions when the query syntax was not correct.
See [1] for details.

[1] http://lucene.apache.org/core/old_versioned_docs/versions/3_0_0/queryparsersyntax.html

Please ping me when you merge.
