### PR TITLE
827540 - system template - add description to promotions view

### DIFF
--- a/src/app/views/system_templates/_promotion_details.html.haml
+++ b/src/app/views/system_templates/_promotion_details.html.haml
@@ -5,9 +5,20 @@
 
 = content_for :content do
   .clear
-  %fieldset.grid_5
-    %label #{_("Name")}:
-    = template.name
+
+  %fieldset
+    .grid_2.ra
+      %label #{_("Name")}:
+    .grid_5.la
+      = template.name
+
+  %fieldset
+    .grid_2.ra
+      %label #{_("Description")}:
+    .grid_5.la
+      = template.description
+
+
   #system_template_promotion_tabs
     .grid_5
       %h5 #{_("Contents:")}


### PR DESCRIPTION
This is a small commit to add the template's description to the system template's view on the promotions page.
