### PR TITLE
cdn - Allow CDN URLs to handle "file://"

### DIFF
--- a/src/lib/resources/cdn.rb
+++ b/src/lib/resources/cdn.rb
@@ -64,6 +64,14 @@ module Resources
       end
 
       def get(path, headers={})
+        # emulate what happens for an HTTP get, but with file://
+        if @uri.scheme == "file"
+          fs_path = @uri.path + path
+          Rails.logger.debug "CDN: Requesting local path #{fs_path}"
+          # if this fails, let the error bubble up so the user sees it
+          return File.read(fs_path)
+        end
+        
         path = File.join(@uri.request_uri,path)
         Rails.logger.debug "CDN: Requesting path #{path}"
         req = Net::HTTP::Get.new(path)


### PR DESCRIPTION
In order for a disconnected katello instance to create pulp repos without
access to the CDN, it needs to pull data from a local copy of the relevant CDN
data.

Allow users to specify "file:///path/to/local/copy", so manifest imports create
pulp repos pointed to local copies of CDN data.
