### PR TITLE
Make sure to reference ::Pool when using the model class

### DIFF
--- a/src/app/controllers/activation_keys_controller.rb
+++ b/src/app/controllers/activation_keys_controller.rb
@@ -98,10 +98,10 @@ class ActivationKeysController < ApplicationController
     begin
       if params.has_key? :subscription_id
         params[:subscription_id].keys.each do |pool|
-          kt_pool = Pool.where(:cp_id => pool)[0]
+          kt_pool = ::Pool.where(:cp_id => pool)[0]
 
           if kt_pool.nil?
-            Pool.create!(:cp_id => pool, :key_pools => [KeyPool.create!(:activation_key => @activation_key)])
+            ::Pool.create!(:cp_id => pool, :key_pools => [KeyPool.create!(:activation_key => @activation_key)])
           else
             key_sub = KeyPool.where(:activation_key_id => @activation_key.id, :pool_id => kt_pool.id)[0]
 

--- a/src/app/controllers/api/activation_keys_controller.rb
+++ b/src/app/controllers/api/activation_keys_controller.rb
@@ -125,7 +125,7 @@ class Api::ActivationKeysController < Api::ApiController
   end
 
   def find_pool
-    @pool = Pool.find_by_organization_and_id(@activation_key.organization, params[:poolid])
+    @pool = ::Pool.find_by_organization_and_id(@activation_key.organization, params[:poolid])
   end
 
   def verify_presence_of_organization_or_environment

--- a/src/app/controllers/subscriptions_controller.rb
+++ b/src/app/controllers/subscriptions_controller.rb
@@ -24,9 +24,9 @@ class SubscriptionsController < ApplicationController
     cp_pools = Resources::Candlepin::Owner.pools(current_organization.cp_key)
     if cp_pools
       # Pool objects
-      @subscriptions = cp_pools.collect {|cp_pool| Pool.find_pool(cp_pool['id'], cp_pool)}
+      @subscriptions = cp_pools.collect {|cp_pool| ::Pool.find_pool(cp_pool['id'], cp_pool)}
       # Index pools
-      Pool.index_pools(@subscriptions) if @subscriptions.length > 0
+      ::Pool.index_pools(@subscriptions) if @subscriptions.length > 0
     else
       @subscriptions = []
     end

--- a/src/app/models/activation_key.rb
+++ b/src/app/models/activation_key.rb
@@ -27,7 +27,7 @@ class ActivationKey < ActiveRecord::Base
   belongs_to :system_template
 
   has_many :key_pools
-  has_many :pools, :class_name => "Pool", :through => :key_pools
+  has_many :pools, :class_name => "::Pool", :through => :key_pools
 
   has_many :key_system_groups, :dependent => :destroy
   has_many :system_groups, :through => :key_system_groups

--- a/src/app/models/glue/candlepin/owner.rb
+++ b/src/app/models/glue/candlepin/owner.rb
@@ -114,7 +114,7 @@ module Glue::Candlepin::Owner
       else
         pools = Resources::Candlepin::Owner.pools self.cp_key
       end
-      pools.collect { |p| Pool.new p }
+      pools.collect { |p| ::Pool.new p }
     end
 
     def generate_debug_cert

--- a/src/app/models/glue/candlepin/pool.rb
+++ b/src/app/models/glue/candlepin/pool.rb
@@ -33,7 +33,7 @@ module Glue::Candlepin::Pool
 
   module ClassMethods
     def find_by_organization_and_id(organization, pool_id)
-      pool = Pool.find_by_cp_id(pool_id) || Pool.new(Resources::Candlepin::Pool.find(pool_id))
+      pool = ::Pool.find_by_cp_id(pool_id) || Pool.new(Resources::Candlepin::Pool.find(pool_id))
       if pool.organization == organization
         return pool
       end

--- a/src/app/models/glue/candlepin/product.rb
+++ b/src/app/models/glue/candlepin/product.rb
@@ -249,7 +249,7 @@ module Glue::Candlepin::Product
     def del_pools
       Rails.logger.debug "Deleting pools for product #{name} in candlepin"
       Resources::Candlepin::Product.pools(organization.cp_key, self.cp_id).each do |pool|
-        Pool.find_all_by_cp_id(pool['id']).each(&:destroy)
+        ::Pool.find_all_by_cp_id(pool['id']).each(&:destroy)
         Resources::Candlepin::Pool.destroy(pool['id'])
       end
       true

--- a/src/app/models/key_pool.rb
+++ b/src/app/models/key_pool.rb
@@ -15,5 +15,5 @@ class KeyPool < ActiveRecord::Base
   include Authorization
 
   belongs_to :activation_key
-  belongs_to :pool, :class_name => "Pool"
+  belongs_to :pool, :class_name => "::Pool"
 end

--- a/src/app/models/pool.rb
+++ b/src/app/models/pool.rb
@@ -84,7 +84,7 @@ class Pool < ActiveRecord::Base
   # prior to this call the pool was already fetched.
   def self.find_pool(cp_id, pool_json=nil)
     pool_json = Resources::Candlepin::Pool.find(cp_id) if !pool_json
-    Pool.new(pool_json) if not pool_json.nil?
+    ::Pool.new(pool_json) if not pool_json.nil?
   end
 
   def self.index_pools pools
@@ -92,7 +92,7 @@ class Pool < ActiveRecord::Base
       pool.as_json.merge(pool.index_options)
     }
     Tire.index self.index do
-      create :settings => Pool.index_settings, :mappings => Pool.index_mapping
+      create :settings => ::Pool.index_settings, :mappings => ::Pool.index_mapping
       import json_pools
     end if !json_pools.empty?
   end

--- a/src/spec/controllers/activation_keys_controller_spec.rb
+++ b/src/spec/controllers/activation_keys_controller_spec.rb
@@ -37,7 +37,7 @@ describe ActivationKeysController do
     @system_template_1 = AppConfig.katello? ? SystemTemplate.create!(:name => 'template1', :environment => @environment_1) : nil
     @system_template_2 = AppConfig.katello? ? SystemTemplate.create!(:name => 'template2', :environment => @environment_1) : nil
     @a_key = ActivationKey.create!(:name => "another test key", :organization => @organization, :environment => @environment_1)
-    @subscription = Pool.create!(:cp_id => "Test Subscription",
+    @subscription = ::Pool.create!(:cp_id => "Test Subscription",
                                           :key_pools => [KeyPool.create!(:activation_key => @a_key)])
 
     @akey_params = {:activation_key => { :name => "test key", :description => "this is the test key", :environment_id => @environment_1.id,

--- a/src/spec/controllers/api/activation_keys_controller_spec.rb
+++ b/src/spec/controllers/api/activation_keys_controller_spec.rb
@@ -188,12 +188,12 @@ describe Api::ActivationKeysController do
     before(:each) do
       @environment = KTEnvironment.create!(:organization => @organization, :name => "Dev", :prior => @organization.library)
       @activation_key = ActivationKey.create!(:name => 'activation key', :organization => @organization, :environment => @environment)
-      @pool_in_activation_key = Pool.create!(:cp_id => "pool-123")
-      @pool_not_in_activation_key = Pool.create!(:cp_id => "pool-456")
+      @pool_in_activation_key = ::Pool.create!(:cp_id => "pool-123")
+      @pool_not_in_activation_key = ::Pool.create!(:cp_id => "pool-456")
 
       KeyPool.create!(:activation_key_id => @activation_key.id, :pool_id => @pool_in_activation_key.id)
       ActivationKey.stub!(:find).and_return(@activation_key)
-      Pool.stub(:find_by_organization_and_id).and_return do |org,poolid|
+      ::Pool.stub(:find_by_organization_and_id).and_return do |org,poolid|
        case poolid
        when "pool-123" then @pool_in_activation_key
        when "pool-456" then @pool_not_in_activation_key
@@ -218,7 +218,7 @@ describe Api::ActivationKeysController do
       end
 
       it "should not add a pool that is already in the activation key" do
-        Pool.stub(:find_by_organization_and_id => @pool_in_activation_key)
+        ::Pool.stub(:find_by_organization_and_id => @pool_in_activation_key)
         req
         @activation_key.pools.should include(@pool_in_activation_key)
         @activation_key.pools.should have(1).pool

--- a/src/spec/models/activation_key_spec.rb
+++ b/src/spec/models/activation_key_spec.rb
@@ -145,21 +145,21 @@ describe ActivationKey do
   describe "pools in a activation key" do
 
     it "should map 2way pool to keys" do
-      s = Pool.create!(:cp_id  => 'abc123')
+      s = ::Pool.create!(:cp_id  => 'abc123')
       @akey.pools = [s]
       @akey.pools.first.cp_id.should == 'abc123'
       s.activation_keys.first.name.should == aname
     end
 
     it "should assign multiple pools to keys" do
-      s = Pool.create!(:cp_id  => 'abc123')
-      s2 = Pool.create!(:cp_id  => 'def123')
+      s = ::Pool.create!(:cp_id  => 'abc123')
+      s2 = ::Pool.create!(:cp_id  => 'def123')
       @akey.pools = [s,s2]
       @akey.pools.last.cp_id.should == 'def123'
     end
 
     it "should include pools details in json output" do
-      pool = Pool.create!(:cp_id  => 'abc123')
+      pool = ::Pool.create!(:cp_id  => 'abc123')
       @akey.pools << pool
       pool.reload
       @akey.as_json[:pools].should == [ { :cp_id => pool.cp_id } ]
@@ -207,7 +207,7 @@ describe ActivationKey do
       @system = System.new(:name => "test", :cp_type => "system", :facts => {"distribution.name"=>"Fedora"}, :uuid => "uuid-uuid")
       @system.should_receive(:sockets).and_return(sockets)
       dates.each_pair do |k,v|
-        pool = Pool.create!(:cp_id => k)
+        pool = ::Pool.create!(:cp_id => k)
         @akey.key_pools.create!(:pool_id  => pool.id)
       end
     end

--- a/src/spec/models/pool_spec.rb
+++ b/src/spec/models/pool_spec.rb
@@ -12,7 +12,7 @@
 
 require 'spec_helper'
 
-describe Pool do
+describe ::Pool do
 
   context "Find pool by organization and id" do
     let(:pool_id) { ProductTestData::POOLS[:id] }
@@ -21,12 +21,12 @@ describe Pool do
     end
     it "should return pool that is in the organization" do
       create_org_from_cp_owner(ProductTestData::POOLS[:owner])
-      Pool.find_by_organization_and_id(@organization, pool_id).cp_id.should == ProductTestData::POOLS[:id]
+      ::Pool.find_by_organization_and_id(@organization, pool_id).cp_id.should == ProductTestData::POOLS[:id]
     end
 
     it "should return nil if the pool doesn't belong to the organization" do
       create_org_from_cp_owner(:displayName => "Another Org", :key => "another_org")
-      Pool.find_by_organization_and_id(@organization, pool_id).should be_nil
+      ::Pool.find_by_organization_and_id(@organization, pool_id).should be_nil
     end
   end
 


### PR DESCRIPTION
There are also Glue::Candlepin::Pool and Resources::Candlepin::Pool classes.
When using without 'absolute' path (::), it might lead to using wrong class.

@thomasmckay would you mind review this patch, since it's related to 1a24bb47207e96c996335805694456b290bc7b2f ?
