### PR TITLE
835152 - creating logs in advanced during installation

### DIFF
--- a/puppet/modules/katello/manifests/config.pp
+++ b/puppet/modules/katello/manifests/config.pp
@@ -145,6 +145,8 @@ class katello::config {
                   Class["candlepin::service"], 
                   Class["pulp::service"], 
                   File["${katello::params::log_base}"], 
+                  File["${katello::params::log_base}/production.log"], 
+                  File["${katello::params::log_base}/production_sql.log"], 
                   File["${katello::params::config_dir}/katello.yml"],
                   Postgres::Createdb[$katello::params::db_name],
                   Common::Simple_replace["org_name"],


### PR DESCRIPTION
Ok, this precreates log files created by Rails in advance with correct owner and permissions. It prevents all errors like those. We are mangling with log directory permissions, I am going to remove this in the upstream later on this week. But this fixes the bug.

Fixing bug https://bugzilla.redhat.com/show_bug.cgi?id=835152
