### PR TITLE
Added server side bindings for cs  repo compare packages and errata calls

### DIFF
--- a/src/app/controllers/content_search_controller.rb
+++ b/src/app/controllers/content_search_controller.rb
@@ -12,6 +12,7 @@
 
 class ContentSearchController < ApplicationController
   before_filter :find_repo, :only => [:repo_packages, :repo_errata]
+  before_filter :find_repos, :only => [:repo_compare_packages, :repo_compare_errata]
 
   def rules
     contents_test = lambda{true}
@@ -23,7 +24,9 @@ class ContentSearchController < ApplicationController
         :my_environments => contents_test,
         :packages=>contents_test,
         :repo_packages => contents_test,
-        :repo_errata => contents_test
+        :repo_errata => contents_test,
+        :repo_compare_errata =>contents_test,
+        :repo_compare_packages =>contents_test
     }
   end
 
@@ -131,13 +134,53 @@ class ContentSearchController < ApplicationController
                                               :description => {:display => e[:description]}}}
     end
     render :json => rows
+  end
 
+
+  def repo_compare_packages
+    repo_compare_content true
+  end
+
+
+  def repo_compare_errata
+    repo_compare_content false
   end
 
 
   private
+
+  def repo_compare_content is_package
+    repo_map = {}
+    @repos.each do |r|
+      repo_map[r.pulp_id] = r
+    end
+    if is_package
+      packages = Glue::Pulp::Package.search('', params[:offset], current_user.page_size, repo_map.keys)
+    else
+      packages = Glue::Pulp::Errata.search('', params[:offset], current_user.page_size, :repoids =>  repo_map.keys)
+    end
+    rows = packages.collect do |pack|
+      cols = {}
+      (pack.repoids & repo_map.keys).each do |r|
+        cols[repo_map[r].id] = {}
+      end
+      name = pack.id
+      if is_package
+        name = pack.nvrea
+      end
+      {:name => name, :id => pack.id, :cols => cols}
+    end
+    render :json => rows
+
+
+  end
+
+  def find_repos
+    @repos = Repository.readable_in_org(current_organization).where(:id => params[:repos])
+  end
+
   def find_repo
-    @repo = Repository.find(params[:repo])
+    @repo = Repository.readable_in_org(current_organization).find(params[:repo])
   end
 
   def repo_rows repos

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -45,6 +45,8 @@ Src::Application.routes.draw do
         post :repos
         get :repo_packages
         get :repo_errata
+        get :repo_compare_packages
+        get :repo_compare_errata
       end
   end
 


### PR DESCRIPTION
2 routes got added

 http://<fqdn>:3000/katello/content_search/repo_compare_packages?repos=1&repos=3
 http://<fqdn>:3000/katello/content_search/repo_compare_errata?repos=1&repos=3

they return json showing a list of packages or errata and columns showing an empty hash for existence in that repo .
