### PR TITLE
cli - fix for url options not allowing file://

### DIFF
--- a/cli/src/katello/client/core/base.py
+++ b/cli/src/katello/client/core/base.py
@@ -404,7 +404,7 @@ def check_url(option, opt, value):
     if not url_parsed.scheme in schemes:                                 # pylint: disable=E1101
         formatted_schemes = " or ".join([s+"://" for s in schemes])
         raise OptionValueError(_('option %s: has to start with %s') % (opt, formatted_schemes))
-    elif not url_parsed.netloc:                                          # pylint: disable=E1101
+    elif not url_parsed.netloc and not url_parsed.path:                  # pylint: disable=E1101
         raise OptionValueError(_('option %s: invalid format') % (opt))
     return value
 

--- a/cli/src/katello/client/core/product.py
+++ b/cli/src/katello/client/core/product.py
@@ -21,7 +21,7 @@ import datetime
 from katello.client.core import repo
 from katello.client.api.product import ProductAPI
 from katello.client.api.repo import RepoAPI
-from katello.client.core.repo import format_sync_state, format_sync_time
+from katello.client.core.repo import format_sync_state, format_sync_time, ALLOWED_REPO_URL_SCHEMES
 from katello.client.api.changeset import ChangesetAPI
 from katello.client.config import Config
 from katello.client.core.base import BaseAction, Command
@@ -308,7 +308,7 @@ class Create(ProductAction):
                                help=_("product name (required)"))
         parser.add_option("--description", dest="description",
                                help=_("product description"))
-        parser.add_option("--url", dest="url", type="url",
+        parser.add_option("--url", dest="url", type="url", schemes=ALLOWED_REPO_URL_SCHEMES,
                                help=_("repository url eg: http://download.fedoraproject.org/pub/fedora/linux/releases/"))
         parser.add_option("--nodisc", action="store_true", dest="nodiscovery",
                                help=_("skip repository discovery"))

--- a/cli/src/katello/client/core/repo.py
+++ b/cli/src/katello/client/core/repo.py
@@ -31,6 +31,8 @@ from katello.client.utils import printer
 
 Config()
 
+ALLOWED_REPO_URL_SCHEMES = ("http", "https", "ftp", "file") 
+
 SYNC_STATES = { 'waiting':     _("Waiting"),
                 'running':     _("Running"),
                 'error':       _("Error"),
@@ -118,7 +120,7 @@ class Create(RepoAction):
                                help=_("organization name eg: foo.example.com (required)"))
         parser.add_option('--name', dest='name',
                                help=_("repository name to assign (required)"))
-        parser.add_option("--url", dest="url", type="url",
+        parser.add_option("--url", dest="url", type="url", schemes=ALLOWED_REPO_URL_SCHEMES, 
                                help=_("url path to the repository (required)"))
         parser.add_option('--product', dest='prod',
                                help=_("product name (required)"))
@@ -153,7 +155,7 @@ class Discovery(RepoAction):
                                help=_("organization name eg: foo.example.com (required)"))
         parser.add_option('--name', dest='name',
                                help=_("repository name prefix to add to all the discovered repositories (required)"))
-        parser.add_option("--url", dest="url", type="url",
+        parser.add_option("--url", dest="url", type="url", schemes=ALLOWED_REPO_URL_SCHEMES, 
                                help=_("root url to perform discovery of repositories eg: http://porkchop.devel.redhat.com/ (required)"))
         parser.add_option("--assumeyes", action="store_true", dest="assumeyes",
                                help=_("assume yes; automatically create candidate repositories for discovered urls (optional)"))

--- a/cli/test/katello/tests/core/product/product_create_test.py
+++ b/cli/test/katello/tests/core/product/product_create_test.py
@@ -16,7 +16,11 @@ class RequiredCLIOptionsTests(CLIOptionTestCase):
     ]
 
     allowed_options = [
-        ('--org=ACME', '--provider=porkchop', '--name=product1')
+        ('--org=ACME', '--provider=porkchop', '--name=product1'),
+        ('--org=ACME', '--provider=porkchop', '--name=product1', '--url=http://localhost'),
+        ('--org=ACME', '--provider=porkchop', '--name=product1', '--url=https://localhost'),
+        ('--org=ACME', '--provider=porkchop', '--name=product1', '--url=ftp://localhost'),
+        ('--org=ACME', '--provider=porkchop', '--name=product1', '--url=file://localhost')
     ]
 
 

--- a/cli/test/katello/tests/core/repo/repo_create_test.py
+++ b/cli/test/katello/tests/core/repo/repo_create_test.py
@@ -1,14 +1,9 @@
-import unittest
-from mock import Mock
-import urlparse
-from katello.tests.core.action_test_utils import CLIOptionTestCase, CLIActionTestCase
-
-import katello.client.core.repo
-from katello.client.core.repo import Discovery
+from katello.tests.core.action_test_utils import CLIOptionTestCase
+from katello.client.core.repo import Create
 
 class RequiredCLIOptionsTests(CLIOptionTestCase):
 
-    action = Discovery()
+    action = Create()
 
     disallowed_options = [
         ('--name=repo1', '--url=http://localhost', '--product=product1'),
@@ -18,118 +13,10 @@ class RequiredCLIOptionsTests(CLIOptionTestCase):
     ]
 
     allowed_options = [
-        ('--org=ACME', '--name=repo1', '--url=http://localhost', '--product=product1')
+        ('--org=ACME', '--name=repo1', '--url=http://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--url=https://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--url=ftp://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--url=file:///a/b/c/', '--product=product1')
     ]
 
 
-class RepoDiscoveryTest(CLIActionTestCase):
-    RESULT = {'result':[]}
-    DISCOVERY_TASK = {}
-    URL = 'http://localhost'
-    ORG = 'ACME'
-
-    def setUp(self):
-        self.set_action(Discovery())
-        self.set_module(katello.client.core.repo)
-
-        self.mock(self.module, 'run_spinner_in_bg', [self.RESULT])
-        self.mock(self.module, 'system_exit')
-
-        self.mock(self.action.api, 'repo_discovery', self.DISCOVERY_TASK)
-
-    def tearDown(self):
-        self.restore_mocks()
-
-    def test_performs_pulp_repo_discovery(self):
-        self.action.discover_repositories(self.ORG, self.URL)
-        self.action.api.repo_discovery.assert_called_once_with(self.ORG, self.URL, 'yum')
-
-    def test_polls_pulp(self):
-        self.action.discover_repositories(self.ORG, self.URL)
-        self.module.run_spinner_in_bg.assert_called_once_with(self.module.wait_for_async_task, [self.DISCOVERY_TASK])
-
-    def test_exit_when_no_repos_were_discovered(self):
-        self.module.run_spinner_in_bg.return_value = [self.RESULT]
-        self.action.discover_repositories(self.ORG, self.URL)
-        self.module.system_exit.assert_called_once
-
-
-class RepositorySelectionTest(unittest.TestCase):
-    DISCOVERED_URLS = ['http://localhost/a/b/', 'http://localhost/a/c/']
-
-    def setUp(self):
-        self.create_action = Discovery()
-        self.original_system_exit = katello.client.core.repo.system_exit
-        katello.client.core.repo.system_exit = Mock()
-
-
-    def tearDown(self):
-        katello.client.core.repo.system_exit = self.original_system_exit
-
-    def test_q_forces_exit(self):
-        raw_input_stub = RawInputStub(['q'])
-        self.create_action.select_repositories(self.DISCOVERED_URLS, False, raw_input_stub.raw_input)
-
-        katello.client.core.repo.system_exit.assert_called_once
-
-    def test_a_y_adds_all_discovered_repos(self):
-        raw_input_stub = RawInputStub(['a', 'y'])
-        selected_repos = self.create_action.select_repositories(self.DISCOVERED_URLS, False, raw_input_stub.raw_input)
-
-        self.assertEqual(selected_repos, self.DISCOVERED_URLS)
-
-    def test_1_y_adds_first_discovered_repo(self):
-        raw_input_stub = RawInputStub(['1', 'y'])
-        selected_repos = self.create_action.select_repositories(self.DISCOVERED_URLS, False, raw_input_stub.raw_input)
-
-        self.assertEqual(selected_repos, [self.DISCOVERED_URLS[0]])
-
-    def test_assumeyes_adds_all_discovered_repos(self):
-        selected_repos = self.create_action.select_repositories(self.DISCOVERED_URLS, True)
-        self.assertEqual(selected_repos, self.DISCOVERED_URLS)
-
-
-class RepositoryNameTest(unittest.TestCase):
-    NAME = 'REPO'
-    URL = 'http://localhost/a/b/'
-
-    def setUp(self):
-        self.create_action = Discovery()
-        self.parsedUrl = urlparse.urlparse(self.URL)
-
-    def test_replaces_slashes_with_underscores(self):
-        self.assertEqual(self.create_action.repository_name(self.NAME, self.parsedUrl.path), "REPO_a_b_")
-
-
-class CreateRepositoryTest(unittest.TestCase):
-    ORGANIZATION = 'ACME_Corporation'
-    PRODUCT_ID = '123'
-    NAME = 'REPO'
-    URL = 'http://localhost/a/b/'
-    URL2 = 'http://localhost/a/c/'
-
-    def setUp(self):
-        self.create_action = Discovery()
-        self.create_action.api.create = Mock()
-
-    def test_create_repo_in_pulp(self):
-        self.create_action.create_repositories(self.ORGANIZATION, self.PRODUCT_ID, self.NAME, [self.URL])
-        parsedUrl = urlparse.urlparse(self.URL)
-        self.create_action.api.create.assert_called_once_with(self.ORGANIZATION, self.PRODUCT_ID, self.create_action.repository_name(self.NAME, parsedUrl.path), self.URL, None, None)
-
-    def test_creates_repos_in_pulp_for_all_urls(self):
-        self.create_action.create_repositories(self.ORGANIZATION, self.PRODUCT_ID, self.NAME, [self.URL, self.URL2])
-        self.create_action.api.create.assert_called_twice
-
-
-class RawInputStub:
-
-    def __init__(self, input):
-        self.invocation = 0
-        self.input = input
-
-    def raw_input(self, prompt):
-        to_return = self.input[self.invocation]
-        self.invocation = self.invocation + 1
-
-        return to_return

--- a/cli/test/katello/tests/core/repo/repo_discovery_test.py
+++ b/cli/test/katello/tests/core/repo/repo_discovery_test.py
@@ -1,0 +1,138 @@
+import unittest
+from mock import Mock
+import urlparse
+from katello.tests.core.action_test_utils import CLIOptionTestCase, CLIActionTestCase
+
+import katello.client.core.repo
+from katello.client.core.repo import Discovery
+
+class RequiredCLIOptionsTests(CLIOptionTestCase):
+
+    action = Discovery()
+
+    disallowed_options = [
+        ('--name=repo1', '--url=http://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--url=http://localhost'),
+        ('--org=ACME', '--url=http://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--product=product1')
+    ]
+
+    allowed_options = [
+        ('--org=ACME', '--name=repo1', '--url=http://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--url=https://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--url=ftp://localhost', '--product=product1'),
+        ('--org=ACME', '--name=repo1', '--url=file:///a/b/c/', '--product=product1')
+    ]
+
+
+class RepoDiscoveryTest(CLIActionTestCase):
+    RESULT = {'result':[]}
+    DISCOVERY_TASK = {}
+    URL = 'http://localhost'
+    ORG = 'ACME'
+
+    def setUp(self):
+        self.set_action(Discovery())
+        self.set_module(katello.client.core.repo)
+
+        self.mock(self.module, 'run_spinner_in_bg', [self.RESULT])
+        self.mock(self.module, 'system_exit')
+
+        self.mock(self.action.api, 'repo_discovery', self.DISCOVERY_TASK)
+
+    def tearDown(self):
+        self.restore_mocks()
+
+    def test_performs_pulp_repo_discovery(self):
+        self.action.discover_repositories(self.ORG, self.URL)
+        self.action.api.repo_discovery.assert_called_once_with(self.ORG, self.URL, 'yum')
+
+    def test_polls_pulp(self):
+        self.action.discover_repositories(self.ORG, self.URL)
+        self.module.run_spinner_in_bg.assert_called_once_with(self.module.wait_for_async_task, [self.DISCOVERY_TASK])
+
+    def test_exit_when_no_repos_were_discovered(self):
+        self.module.run_spinner_in_bg.return_value = [self.RESULT]
+        self.action.discover_repositories(self.ORG, self.URL)
+        self.module.system_exit.assert_called_once
+
+
+class RepositorySelectionTest(unittest.TestCase):
+    DISCOVERED_URLS = ['http://localhost/a/b/', 'http://localhost/a/c/']
+
+    def setUp(self):
+        self.create_action = Discovery()
+        self.original_system_exit = katello.client.core.repo.system_exit
+        katello.client.core.repo.system_exit = Mock()
+
+
+    def tearDown(self):
+        katello.client.core.repo.system_exit = self.original_system_exit
+
+    def test_q_forces_exit(self):
+        raw_input_stub = RawInputStub(['q'])
+        self.create_action.select_repositories(self.DISCOVERED_URLS, False, raw_input_stub.raw_input)
+
+        katello.client.core.repo.system_exit.assert_called_once
+
+    def test_a_y_adds_all_discovered_repos(self):
+        raw_input_stub = RawInputStub(['a', 'y'])
+        selected_repos = self.create_action.select_repositories(self.DISCOVERED_URLS, False, raw_input_stub.raw_input)
+
+        self.assertEqual(selected_repos, self.DISCOVERED_URLS)
+
+    def test_1_y_adds_first_discovered_repo(self):
+        raw_input_stub = RawInputStub(['1', 'y'])
+        selected_repos = self.create_action.select_repositories(self.DISCOVERED_URLS, False, raw_input_stub.raw_input)
+
+        self.assertEqual(selected_repos, [self.DISCOVERED_URLS[0]])
+
+    def test_assumeyes_adds_all_discovered_repos(self):
+        selected_repos = self.create_action.select_repositories(self.DISCOVERED_URLS, True)
+        self.assertEqual(selected_repos, self.DISCOVERED_URLS)
+
+
+class RepositoryNameTest(unittest.TestCase):
+    NAME = 'REPO'
+    URL = 'http://localhost/a/b/'
+
+    def setUp(self):
+        self.create_action = Discovery()
+        self.parsedUrl = urlparse.urlparse(self.URL)
+
+    def test_replaces_slashes_with_underscores(self):
+        self.assertEqual(self.create_action.repository_name(self.NAME, self.parsedUrl.path), "REPO_a_b_")
+
+
+class CreateRepositoryTest(unittest.TestCase):
+    ORGANIZATION = 'ACME_Corporation'
+    PRODUCT_ID = '123'
+    NAME = 'REPO'
+    URL = 'http://localhost/a/b/'
+    URL2 = 'http://localhost/a/c/'
+
+    def setUp(self):
+        self.create_action = Discovery()
+        self.create_action.api.create = Mock()
+
+    def test_create_repo_in_pulp(self):
+        self.create_action.create_repositories(self.ORGANIZATION, self.PRODUCT_ID, self.NAME, [self.URL])
+        parsedUrl = urlparse.urlparse(self.URL)
+        self.create_action.api.create.assert_called_once_with(self.ORGANIZATION, self.PRODUCT_ID, self.create_action.repository_name(self.NAME, parsedUrl.path), self.URL, None, None)
+
+    def test_creates_repos_in_pulp_for_all_urls(self):
+        self.create_action.create_repositories(self.ORGANIZATION, self.PRODUCT_ID, self.NAME, [self.URL, self.URL2])
+        self.create_action.api.create.assert_called_twice
+
+
+class RawInputStub:
+
+    def __init__(self, input):
+        self.invocation = 0
+        self.input = input
+
+    def raw_input(self, prompt):
+        to_return = self.input[self.invocation]
+        self.invocation = self.invocation + 1
+
+        return to_return


### PR DESCRIPTION
Scheme file:// is not in default values for option type 'url'.
I listed all allowed schemes explicitly where it was necessary and created unit tests for the modified commands. This concerns repo creation, repo discovery and product creation.
