### PR TITLE
we should own log files

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -352,6 +352,10 @@ fi
 %defattr(-, katello, katello)
 %{_localstatedir}/log/%{name}
 %{datadir}
+%ghost %attr(640, katello, katello) %{_localstatedir}/log/%{name}/production.log
+%ghost %attr(640, katello, katello) %{_localstatedir}/log/%{name}/production_sql.log
+%ghost %attr(640, katello, katello) %{_localstatedir}/log/%{name}/production_delayed_jobs.log
+%ghost %attr(640, katello, katello) %{_localstatedir}/log/%{name}/production_delayed_jobs_sql.log
 
 %files glue-pulp
 %{homedir}/app/models/glue/pulp


### PR DESCRIPTION
addressing:
# rpm -qf /var/log/katello/production_delayed_jobs_sql.log

file /var/log/katello/production_delayed_jobs_sql.log is not owned by any package
