### PR TITLE
%defattr is not needed since rpm 4.4

### DIFF
--- a/agent/katello-agent.spec
+++ b/agent/katello-agent.spec
@@ -39,7 +39,6 @@ cp src/katello/agent/katelloplugin.py %{buildroot}/%{_libdir}/gofer/plugins
 rm -rf %{buildroot}
 
 %files
-%defattr(-,root,root,-)
 %config(noreplace) %{_sysconfdir}/gofer/plugins/katelloplugin.conf
 %{_libdir}/gofer/plugins/katelloplugin.*
 %doc LICENSE

--- a/certs-tools/gen-rpm.sh
+++ b/certs-tools/gen-rpm.sh
@@ -326,7 +326,6 @@ rm -rf \$RPM_BUILD_ROOT
 `generate_section "$PREUN" preun`
 
 %files
-%defattr(-,root,root)
 `echo -e $filesect`
 EOF
 

--- a/puppet/katello-configure.spec
+++ b/puppet/katello-configure.spec
@@ -73,7 +73,6 @@ cp -Rp upgrade-scripts/* %{buildroot}%{homedir}/upgrade-scripts
 rm -rf %{buildroot}
 
 %files
-%defattr(-,root,root)
 %{homedir}/
 %{_sbindir}/katello-configure
 %{_sbindir}/katello-upgrade

--- a/repos/katello-repos.spec
+++ b/repos/katello-repos.spec
@@ -54,14 +54,12 @@ install -m 644 rhel-thumbslug.repo %{buildroot}%{_sysconfdir}/yum.repos.d/thumbs
 rm -rf %{buildroot}
 
 %files
-%defattr(-,root,root)
 %{_sysconfdir}/yum.repos.d/candlepin.repo
 %{_sysconfdir}/yum.repos.d/katello.repo
 %{_sysconfdir}/yum.repos.d/pulp.repo
 %{_sysconfdir}/yum.repos.d/thumbslug.repo
 
 %files testing
-%defattr(-,root,root)
 %{_sysconfdir}/yum.repos.d/katello-testing.repo
 %{_sysconfdir}/yum.repos.d/pulp-testing.repo
 

--- a/selinux/katello-selinux/katello-selinux.spec
+++ b/selinux/katello-selinux/katello-selinux.spec
@@ -130,7 +130,6 @@ fi
 /sbin/restorecon -rvvi /var/lib/katello /var/log/katello /usr/share/katello /etc/katello /usr/sbin/katello-*
 
 %files
-%defattr(-,root,root,0755)
 %doc %{modulename}.fc %{modulename}.if %{modulename}.te
 %attr(0600,root,root) %{_datadir}/selinux/*/%{modulename}.pp.bz2
 %{_datadir}/selinux/devel/include/%{moduletype}/%{modulename}.if

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -298,7 +298,6 @@ fi
 
 %files
 %attr(600, katello, katello)
-%defattr(-,root,root)
 %{_bindir}/katello-*
 %{homedir}/app/controllers
 %{homedir}/app/helpers
@@ -333,7 +332,6 @@ fi
 %{homedir}/Rakefile
 
 %files common
-%defattr(-,root,root)
 %doc README LICENSE doc/
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.yml
 %config(noreplace) %{_sysconfdir}/%{name}/thin.yml


### PR DESCRIPTION
which means rhel5+ and we do not support rhel4 anymore
http://fedoraproject.org/wiki/Packaging:Guidelines#File_Permissions
