### PR TITLE
system groups - cli - fix broken test

### DIFF
--- a/cli/src/katello/client/api/system_group.py
+++ b/cli/src/katello/client/api/system_group.py
@@ -29,9 +29,13 @@ class SystemGroupAPI(KatelloAPI):
         path = "/api/organizations/%s/system_groups/%s" % (org_id, system_group_id)
         return self.server.GET(path, query)[1]
 
-    def system_group_history(self, org_id, system_group_id, query={}):
-        path = "/api/organizations/%s/system_groups/%s/history" % (org_id, system_group_id)
-        return self.server.GET(path, query)[1]
+    def system_group_history(self, org_id, system_group_id, job_id=None):
+        if job_id == None:
+            path = "/api/organizations/%s/system_groups/%s/history" % (org_id, system_group_id)
+        else:
+            path = "/api/organizations/%s/system_groups/%s/history/%s" % (org_id, system_group_id, job_id)
+
+        return self.server.GET(path)[1]
 
     def system_group_by_name(self, org_id, system_group_name, query={}):
         path = "/api/organizations/%s/system_groups/" % org_id

--- a/cli/src/katello/client/core/system_group.py
+++ b/cli/src/katello/client/core/system_group.py
@@ -197,7 +197,7 @@ class HistoryTasks(SystemGroupAction):
         system_group = get_system_group(org_name, system_group_name)
 
         # get list of jobs
-        history = self.api.system_group_history(org_name, system_group['id'], {'job_id':job_id})
+        history = self.api.system_group_history(org_name, system_group['id'], job_id)
         if history == None:
             print >> sys.stderr, _("Could not find job [ %s ] for system group [ %s ]") % (job_id, system_group_name)
             return os.EX_DATAERR

--- a/cli/test/katello/tests/core/system/system_group_history_tasks_test.py
+++ b/cli/test/katello/tests/core/system/system_group_history_tasks_test.py
@@ -41,11 +41,11 @@ class SystemGroupHistoryTasksTest(CLIActionTestCase):
 
         self.mock_options(self.OPTIONS)
         self.mock(self.module, 'get_system_group', self.SYSTEM_GROUP)
-        self.mock(self.action.api, 'system_group_history', system_data.SYSTEM_GROUP_HISTORY)
+        self.mock(self.action.api, 'system_group_history', system_data.SYSTEM_GROUP_HISTORY[0])
 
     def test_it_calls_system_groups_api(self):
         self.action.run()
-        self.action.api.system_group_history.assert_called_once_with(self.OPTIONS['org'], system_data.SYSTEM_GROUPS[0]['id'], {'job_id':'1'})
+        self.action.api.system_group_history.assert_called_once_with(self.OPTIONS['org'], system_data.SYSTEM_GROUPS[0]['id'], self.OPTIONS['job_id'])
 
     def test_it_prints_the_system_groups(self):
         self.action.run()


### PR DESCRIPTION
While working on adding the pkg actions, updated separated out
the API for retrieving the list of jobs and retrieving a job
in to 2 separate APIs.  With this, missed a test that needed to
be updated.
