### PR TITLE
JSHint - Adds support for running JSHint in development via a rake task.

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -78,6 +78,12 @@ group :test, :development do
   gem "js-routes", :require => 'js_routes'
 
   #needed for unit tests
+  #
+  #needed for syntax checking
+  gem 'libv8'
+  gem 'therubyracer'
+  gem 'jshintrb', '0.1.1'
+
 end
 
 group :development do

--- a/src/lib/tasks/jshint.rake
+++ b/src/lib/tasks/jshint.rake
@@ -1,0 +1,30 @@
+require "jshintrb/jshinttask"
+
+Jshintrb::JshintTask.new :jshint do |t|
+  t.pattern = '{public/javascripts, public/javscripts/widgets}/*.js'
+  t.exclude_pattern = '{public/javascripts/converge-ui/**/*,public/javascripts/tests/**/*,public/javascripts/routes}.js'
+  t.options = {
+    :bitwise => true,
+    :curly => true,
+    :eqeqeq => true,
+    :forin => true,
+    :immed => true,
+    :latedef => true,
+    :newcap => false,
+    :noarg => true,
+    :noempty => true,
+    :nonew => true,
+    :plusplus => true,
+    :regexp => true,
+    :undef => true,
+    :strict => false,
+    :trailing => true,
+    :browser => true,
+    :jquery => true,
+    :passfail => false,
+    :white => false,
+    :sub => true,
+    :lastsemic => true,
+    :smarttabs => true
+  }
+end


### PR DESCRIPTION
JSHint is a code style checker for the JavaScript language based on the original JSLint by Douglas Crockford.  The JSHintrb gem (https://github.com/stereobooster/jshintrb) provides a convient wrapper around JSHint that can easily be configured via a rake task.  

This request adds the necessary dependencies and adds a rake task that developers can run before checking code in to ensure Javascript meets project standards.  Follow-up work will be needed to clean-up the current Javascript.

The options applied thus far reflect the common code conventions that Katello has adopted up to this point.  The full list of available options can be found here:
http://www.jshint.com/options/

This pull request is dependent upon the development gems showing up in the Katello repository.

ACKs:
@knowncitizen
@mccun934
