### PR TITLE
837136 - fixing promotions packages sometimes not loading

### DIFF
--- a/src/public/javascripts/slidingtree.js
+++ b/src/public/javascripts/slidingtree.js
@@ -395,7 +395,7 @@ KT.sliding_tree.list = function(parent, bcs, sliding_tree){
     var current_items = 0,
     replace_list = function(html, args){
         if (!args || args === sliding_tree.get_current_crumb()){
-            parent.children('.has_content').html(html);
+            parent.children('.will_have_content').html(html);
         }
     },
     append = function(html, args) {


### PR DESCRIPTION
Previously we were using ".has_content" to insert the new data, but while the slide is transitioning .has_content is still on the old container, and once completed is moved to the new container (and the old one's html is cleared).  By using '.will_hav_content'  we ensure that we are getting the container that is to be displayed.
