### PR TITLE
fixes an incompatibility with newer puppet versions

### DIFF
--- a/puppet/katello-configure.spec
+++ b/puppet/katello-configure.spec
@@ -31,7 +31,11 @@ katello-upgrade which handles upgrades between versions.
 
 %build
 #check syntax for all puppet scripts
+%if 0%{?rhel} || 0%{?fedora} < 17
 find -name '*.pp' | xargs -n 1 -t puppet --parseonly
+%else
+find -name '*.pp' | xargs -n 1 -t puppet parser validate
+%endif
 
 #check for puppet erb syntax errors
 find modules/ -name \*erb | xargs aux/check_erb


### PR DESCRIPTION
addressing:
Could not parse options: wrong number of arguments (1 for 0)

This happen in puppet 2.7, which is in Fedora 17
