### PR TITLE
839005 - removed 'force' from upload manifest in UI

### DIFF
--- a/src/app/controllers/subscriptions_controller.rb
+++ b/src/app/controllers/subscriptions_controller.rb
@@ -192,7 +192,7 @@ class SubscriptionsController < ApplicationController
           display_message = ""
         end
 
-        notice @provider.import_error_message(display_message, force_update), {:level => :error, :details => pp_exception(error)}
+        notice @provider.import_error_message(display_message), {:level => :error, :details => pp_exception(error)}
 
         Rails.logger.error "error uploading subscriptions."
         Rails.logger.error error

--- a/src/app/models/glue/provider.rb
+++ b/src/app/models/glue/provider.rb
@@ -202,7 +202,7 @@ module Glue::Provider
         display_message = ApplicationController.parse_display_message(display_message)
 
         if options[:notify]
-          notice import_error_message(display_message, options[:force]),  :level => :error, :details => error.backtrace.join("\n"),
+          notice import_error_message(display_message),  :level => :error, :details => error.backtrace.join("\n"),
                  :synchronous_request => false, :request_type => 'providers__update_redhat_provider'
         end
 
@@ -253,12 +253,10 @@ module Glue::Provider
       pre_queue.create(:name => "delete products for provider: #{self.name}", :priority => 1, :action => [self, :del_products])
     end
 
-    def import_error_message display_message, force_update
+    def import_error_message display_message
       error_texts = [
           _("Subscription manifest upload for provider '%s' failed.") % self.name,
-          (_("Reason: %s") % display_message unless display_message.blank?),
-          (_("If you are uploading an older manifest, you can use the Force checkbox to overwrite " +
-                 "existing data.") if force_update == "false")
+          (_("Reason: %s") % display_message unless display_message.blank?)
       ].compact
       error_texts.join('<br />')
     end

--- a/src/app/views/subscriptions/_new.html.haml
+++ b/src/app/views/subscriptions/_new.html.haml
@@ -47,12 +47,6 @@
             %fieldset
               .grid_2.ra.fieldset
                 &nbsp;
-              .grid_8.la#force_checkbox
-                = check_box_tag :force_import
-                = label_tag :force, _('Force Override of Previous Import')
-            %fieldset
-              .grid_2.ra.fieldset
-                &nbsp;
               .grid_8.la#upload_button
                 = f.submit _("Upload")
 


### PR DESCRIPTION
Per discussion, the "force" option has been removed from the UI; it remains on the command line for advanced usage and work-around problems.

https://bugzilla.redhat.com/show_bug.cgi?id=839005
