### PR TITLE
811564_subs_match - change default user preference to 'false' for 'match subscriptions to system'

### DIFF
--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -478,7 +478,7 @@ class User < ActiveRecord::Base
   end
 
   def subscriptions_match_system_preference
-    self.preferences[:user][:subscriptions_match_system] rescue true
+    self.preferences[:user][:subscriptions_match_system] rescue false
   end
 
   def subscriptions_match_system_preference= flag


### PR DESCRIPTION
Feedback was to make default _not_ to match shown subscriptions to the system.
