### PR TITLE
Added server side code for Repo Compare Shared/Unique

### DIFF
--- a/src/app/models/glue/pulp/errata.rb
+++ b/src/app/models/glue/pulp/errata.rb
@@ -12,7 +12,7 @@
 
 require 'set'
 require 'util/search'
-
+require 'util/package_util'
 class Glue::Pulp::Errata
 
   SECURITY = "security"
@@ -115,8 +115,8 @@ class Glue::Pulp::Errata
   def self.search query, start, page_size, filters={}, sort=[:id_sort, "DESC"]
     return [] if !Tire.index(self.index).exists?
     all_rows = query.blank?
-
-    search = Tire.search self.index do
+    search = Tire::Search::Search.new(self.index)
+    search.instance_eval do
       query do
         if all_rows
           all
@@ -129,9 +129,6 @@ class Glue::Pulp::Errata
        size page_size
        from start
       end
-      if filters.has_key?(:repoids)
-        filter :terms, :repoids => filters[:repoids]
-      end
       if filters.has_key?(:type)
         filter :term, :type => filters[:type]
       end
@@ -141,7 +138,14 @@ class Glue::Pulp::Errata
 
       sort { by sort[0], sort[1] } unless !all_rows
     end
-    return search.results
+
+    if filters.has_key?(:repoids)
+      search_mode = filters[:search_mode] || :all
+      repoids = filters[:repoids]
+      Katello::PackageUtils.setup_shared_unique_filter(repoids, search_mode, search)
+    end
+
+    return search.perform.results
   rescue
     return []
   end

--- a/src/lib/util/package_util.rb
+++ b/src/lib/util/package_util.rb
@@ -138,5 +138,19 @@ module Katello
       /[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\-\.\_\+\,]+/
     end
 
+    def self.setup_shared_unique_filter(repoids, search_mode, search_results)
+      repo_filter_ids = repoids.collect do |repo|
+            {:term => {:repoids => [repo]}}
+      end
+      case search_mode
+        when :shared
+          search_results.filter :and, repo_filter_ids
+        when :unique
+          search_results.filter :or, repo_filter_ids
+          search_results.filter :not, :filter => {:and => repo_filter_ids}
+        else
+          search_results.filter :or, repo_filter_ids
+      end
+    end
   end
 end


### PR DESCRIPTION
The following URLs will now accept a "mode" parameter

```
http://<FQDN>/katello/content_search/repo_compare_errata?mode=shared&type=compare_errata&repos%5B0%5D%5Benv_id%5D=1&repos%5B0%5D%5Brepo_id%5D=12&repos%5B1%5D%5Benv_id%5D=1&repos%5B1%5D%5Brepo_id%5D=11
```

```
http://<FQDN>/katello/content_search/repo_compare_errata?mode=unique&type=compare_errata&repos%5B0%5D%5Benv_id%5D=1&repos%5B0%5D%5Brepo_id%5D=12&repos%5B1%5D%5Benv_id%5D=1&repos%5B1%5D%5Brepo_id%5D=11
```
