### PR TITLE
katello - make jshintrb optional

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -5,7 +5,7 @@ source 'http://repos.fedorapeople.org/repos/katello/gems/'
 gem 'rails', '3.0.10'
 gem 'thin', '>=1.2.11'
 
-gem 'tire' , '>= 0.3.0', '< 0.4'
+gem 'tire', '>= 0.3.0', '< 0.4'
 gem 'json'
 gem 'rest-client', :require => 'rest_client'
 gem 'jammit'
@@ -69,22 +69,23 @@ group :test, :development do
 
   #needed  for documentation
   gem 'yard', '>= 0.5.3'
-  
+
   #needed by hudson
-  gem 'ci_reporter','>= 1.6.3'
+  gem 'ci_reporter', '>= 1.6.3'
   gem 'gettext', '>= 1.9.3', :require => false
   gem 'ruby_parser'
-  
+
   #needed to generate routes in javascript
   gem "js-routes", :require => 'js_routes'
+end
 
+group :jshintrb do
   #needed for unit tests
   #
   #needed for syntax checking
   gem 'libv8'
   gem 'therubyracer'
   gem 'jshintrb', '0.1.1'
-
 end
 
 group :development do

--- a/src/lib/tasks/jshint.rake
+++ b/src/lib/tasks/jshint.rake
@@ -1,32 +1,37 @@
 if Rails.env = 'development'
-  require "jshintrb/jshinttask"
+  begin
+    require "jshintrb/jshinttask"
 
-  Jshintrb::JshintTask.new :jshint do |t|
-    t.pattern = '{public/javascripts, public/javscripts/widgets}/*.js'
-    t.exclude_pattern = '{public/javascripts/converge-ui/**/*,public/javascripts/tests/**/*,public/javascripts/routes}.js'
-    t.options = {
-      :bitwise => true,
-      :curly => true,
-      :eqeqeq => true,
-      :forin => true,
-      :immed => true,
-      :latedef => true,
-      :newcap => false,
-      :noarg => true,
-      :noempty => true,
-      :nonew => true,
-      :plusplus => true,
-      :regexp => true,
-      :undef => true,
-      :strict => false,
-      :trailing => true,
-      :browser => true,
-      :jquery => true,
-      :passfail => false,
-      :white => false,
-      :sub => true,
-      :lastsemic => true,
-      :smarttabs => true
-    }
+    Jshintrb::JshintTask.new :jshint do |t|
+      t.pattern         = '{public/javascripts, public/javscripts/widgets}/*.js'
+      t.exclude_pattern = '{public/javascripts/converge-ui/**/*,public/javascripts/tests/**/*,public/javascripts/routes}.js'
+      t.options         = {
+          :bitwise   => true,
+          :curly     => true,
+          :eqeqeq    => true,
+          :forin     => true,
+          :immed     => true,
+          :latedef   => true,
+          :newcap    => false,
+          :noarg     => true,
+          :noempty   => true,
+          :nonew     => true,
+          :plusplus  => true,
+          :regexp    => true,
+          :undef     => true,
+          :strict    => false,
+          :trailing  => true,
+          :browser   => true,
+          :jquery    => true,
+          :passfail  => false,
+          :white     => false,
+          :sub       => true,
+          :lastsemic => true,
+          :smarttabs => true
+      }
+
+    end
+  rescue LoadError
+    warn "install jshintrb gem"
   end
 end


### PR DESCRIPTION
extract jshintrb gem and its dependencies into group
allow to run katello without jshintrb
