### PR TITLE
add rubygem-activesupport to rhel6 repo

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -43,6 +43,7 @@
        <packagereq type="default">rubygem-activemodel</packagereq>
        <packagereq type="default">rubygem-activerecord</packagereq>
        <packagereq type="default">rubygem-activeresource</packagereq>
+       <packagereq type="default">rubygem-activesupport</packagereq>
        <packagereq type="default">rubygem-acts_as_reportable</packagereq>
        <packagereq type="default">rubygem-arel</packagereq>
        <packagereq type="default">rubygem-builder</packagereq>


### PR DESCRIPTION
addressing:
Error: Package: rubygem-delayed_job-2.1.4-2.el6.noarch (katello)
           Requires: rubygem(activesupport) >= 3.0
           Installing: 1:rubygem-activesupport-2.3.8-2.el6.noarch (epel)
               rubygem(activesupport) = 2.3.8
