### PR TITLE
Changing katello-upgrade to start pulp/candlepin/ES prior to db:migrate

### DIFF
--- a/puppet/upgrade-scripts/default/0004_migrate_katello_db.sh
+++ b/puppet/upgrade-scripts/default/0004_migrate_katello_db.sh
@@ -11,9 +11,22 @@ KATELLO_HOME=${KATELLO_HOME:-/usr/share/katello}
 KATELLO_ENV=${KATELLO_ENV:-production}
 KATELLO_PREFIX=${KATELLO_PREFIX:-/katello}
 
+SERVICES = ["tomcat6",  "elasticsearch", "pulp-server"]
+if [ "$KATELLO_PREFIX" = "/headpin" -o "$KATELLO_PREFIX" = "/sam" ]; then
+    SERVICES = ["tomcat6",  "elasticsearch"]
+fi
+for SERVICE in $SERVICES; do 
+    service $SERVICE start
+done
+
+
 pushd $KATELLO_HOME >/dev/null
 RAILS_RELATIVE_URL_ROOT=$KATELLO_PREFIX RAILS_ENV=$KATELLO_ENV rake db:migrate --trace 2>&1
 ret_code=$?
 popd >/dev/null
+
+for SERVICE in $SERVICES; do
+    service $SERVICE stop
+done
 
 exit $ret_code


### PR DESCRIPTION
We currently have a migration file that requires that pulp & ES be running.  This change starts pulp, cp, and ES prior to running db:migrate.   Since pulp and Candlepin need to be stopped prior to their respective db migration, we still need to make sure these services are stopped prior to their migrations running, hence I did not change the katello-upgrade script itself
