### PR TITLE
gemfile - decreasing thin 1.2.11 requirement to 1.2.8

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,8 +1,10 @@
 #source "http://rubygems.org"
 source 'http://repos.fedorapeople.org/repos/katello/gems/'
 
+# When adding new version requirement check out EPEL6 repository first
+# and use this version if possible. Also check Fedora version (usually higher).
 gem 'rails', '3.0.10'
-gem 'thin', '>=1.2.11'
+gem 'thin', '>=1.2.8'
 
 gem 'tire', '>= 0.3.0', '< 0.4'
 gem 'json'


### PR DESCRIPTION
All smoke tests are working, there is no reason to have this version there
and we save one dependency for Katello as this is distributed via EPEL6.
