### PR TITLE
change default password for katello and candlepin

### DIFF
--- a/puppet/default-answer-file
+++ b/puppet/default-answer-file
@@ -5,8 +5,8 @@ answer_file =
 # Katello administrative user (default: admin)
 user_name = admin
 
-# Katello user's password (default: admin)
-user_pass = admin
+# Katello user's password (default: nimda)
+user_pass = nimda
 
 # Katello user's email (default: root@localhost)
 user_email = root@localhost
@@ -41,7 +41,7 @@ db_password = katellopw
 candlepin_db_user = candlepin
 
 # Candlepin databse password
-candlepin_db_password = candlepin
+candlepin_db_password = nipeldnac
 
 # Candlepin database name
 candlepin_db_name = candlepin


### PR DESCRIPTION
use reverse of username
this way we can catch in tests potential errors where we accidentally use password for username or vice versa.
