### PR TITLE
rake - make rake compatible with 0.8.7

### DIFF
--- a/src/Rakefile
+++ b/src/Rakefile
@@ -12,8 +12,6 @@ rescue Exception
   require 'rake'
 end
 
-include Rake::DSL
-
 task :default => [:spec]
 
 Src::Application.load_tasks


### PR DESCRIPTION
Because EL6 uses 0.8.7 wile Fedoras are now on 0.9.1+
