### PR TITLE
allow to run jammit on Fedora 17

### DIFF
--- a/src/katello-headpin.spec
+++ b/src/katello-headpin.spec
@@ -102,7 +102,7 @@ compass compile
 
 #generate Rails JS/CSS/... assets
 echo Generating Rails assets...
-jammit --config config/assets.yml -f
+LC_ALL="en_US.UTF-8" jammit --config config/assets.yml -f
 
 # remove glue-specific files
 rm -rf app/models/glue/*


### PR DESCRIPTION
addressing:
- jammit --config config/assets.yml -f
  /usr/share/gems/gems/jammit-0.6.5/lib/jammit/compressor.rb:155:in `gsub': invalid byte sequence in US-ASCII (ArgumentError)
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit/compressor.rb:155:in`with_data_uris'
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit/compressor.rb:86:in `compress_css'
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit/packager.rb:76:in`pack_stylesheets'
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit/packager.rb:41:in `block in precache_all'
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit/packager.rb:38:in`each'
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit/packager.rb:38:in `precache_all'
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit.rb:137:in`package!'
      from /usr/share/gems/gems/jammit-0.6.5/lib/jammit/command_line.rb:29:in `initialize'
      from /usr/share/gems/gems/jammit-0.6.5/bin/jammit:5:in`new'
      from /usr/share/gems/gems/jammit-0.6.5/bin/jammit:5:in `<top (required)>'
      from /usr/bin/jammit:23:in`load'
      from /usr/bin/jammit:23:in `<main>'
  error: Bad exit status from /var/tmp/rpm-tmp.Vz9TXI (%build)
