### PR TITLE
add notification dir

### DIFF
--- a/src/katello-headpin.spec
+++ b/src/katello-headpin.spec
@@ -203,6 +203,7 @@ and then run katello-configure to configure everything.
 %{homedir}/lib/*.rb
 %{homedir}/lib/monkeys
 %{homedir}/lib/navigation
+%{homedir}/lib/notifications
 %{homedir}/lib/resources
 %{homedir}/lib/tasks
 %{homedir}/lib/util


### PR DESCRIPTION
addressing:
error: Installed (but unpackaged) file(s) found:
   /usr/share/katello/lib/notifications/controller_helper.rb
   /usr/share/katello/lib/notifications/notifier.rb
    Installed (but unpackaged) file(s) found:
   /usr/share/katello/lib/notifications/controller_helper.rb
   /usr/share/katello/lib/notifications/notifier.rb
Child return code was: 1
