### PR TITLE
require recent converge-ui

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -111,7 +111,7 @@ BuildRequires:  rubygem(fssm) >= 0.2.7
 BuildRequires:  rubygem(compass) >= 0.11.5
 BuildRequires:  rubygem(compass-960-plugin) >= 0.10.4
 BuildRequires:  java >= 0:1.6.0
-BuildRequires:  converge-ui-devel >= 0.7
+BuildRequires:  converge-ui-devel >= 0.8.3
 
 %description common
 Common bits for all Katello instances


### PR DESCRIPTION
addressing build errors:
- echo Compiling SASS files...
- compass cc/stylesheets/compiled/c/stylesheets/compiled/widgets/c/stylesheets/compiled/sections/

ompilr
rpp/stylesheets/widgets/path_selector.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)

lc/stylesheets/compiled/widgets/tipsy_custom.css
ease enter the commit message for your changes. Lines starting
rpp/stylesheets/sections/tabs.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)

ith '#r will be ignored, and an empty message aborts the commit.
rpp/stylesheets/sections/loginpage.scss (Line 9: File to import not found or unreadable: converge-ui/composites/login.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)

n brancr master
rpp/stylesheets/sections/generic.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)

hanger to be committed:
rpp/stylesheets/sections/systems.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)

use rgit reset HEAD <file>..." to unstage)
rpp/stylesheets/sections/orgs.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)

odifier:   katello.spec
rpp/stylesheets/sections/contents.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
c/stylesheets/compiled/sections/contents.css

r
rpp/stylesheets/sections/notifications.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load :
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
tc/stylesheets/compiled/sections/notifications.css
r
rpp/stylesheets/sections/subscriptions.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
tc/stylesheets/compiled/sections/subscriptions.css
r
rpp/stylesheets/sections/operations.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
tc/stylesheets/compiled/sections/operations.css
r
rpp/stylesheets/sections/dashboard.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
tc/stylesheets/compiled/sections/dashboard.css
r
rpp/stylesheets/sections/content_search.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
tc/stylesheets/compiled/sections/content_search.css
ec/stylesheets/compiled/ie.css
tr
rpp/stylesheets/katello.scss (Line 2: File to import not found or unreadable: converge-ui/composites/shell.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
tc/stylesheets/compiled/katello.css
r
rpp/stylesheets/fancyqueries.scss (Line 1: File to import not found or unreadable: converge-ui/partials/base.
Load paths:
  /builddir/build/BUILD/katello-0.2.51/app/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/blueprint/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-0.11.5/frameworks/compass/stylesheets
  /usr/lib/ruby/gems/1.8/gems/compass-960-plugin-0.10.4/stylesheets
  Compass::SpriteImporter)
tc/stylesheets/compiled/fancyqueries.css
RPM build errors:
error: Bad exit status from /var/tmp/rpm-tmp.hvMiGk (%build)
    Bad exit status from /var/tmp/rpm-tmp.hvMiGk (%build)e
