### PR TITLE
puppet - nss generation ordering issue

### DIFF
--- a/puppet/modules/certs/manifests/config.pp
+++ b/puppet/modules/certs/manifests/config.pp
@@ -232,7 +232,12 @@ class certs::config {
       exec { "create-nss-db":
         command => "certutil -N -d '${nss_db_dir}' -f '${certs::params::nss_db_password_file}' 2>>${katello::params::configure_log_base}/certificates.log",
         path    => "/usr/bin",
-        require => [File["${certs::params::nss_db_password_file}"], File[$nss_db_dir], File["${katello::params::configure_log_base}"]],
+        require => [
+          File["${certs::params::nss_db_password_file}"],
+          File[$nss_db_dir],
+          Exec["deploy-ssl-qpid-broker-certificate"],
+          File["${katello::params::configure_log_base}"]
+          ],
         before  => Class["qpid::service"],
         creates => ["$nss_db_dir/cert8.db", "$nss_db_dir/key3.db", "$nss_db_dir/secmod.db"],
         notify => [


### PR DESCRIPTION
Resolves:

The top-level log file is [/var/log/katello/katello-configure-20120730-134859/main.log]
[1;35merr: /Stage[main]/Certs::Config/Exec[generate-pfx-for-nss-db]: Failed to call refresh: openssl pkcs12 -in /root/ssl-build/kvm-guest-04.rhts.eng.bos.redhat.com/qpid-broker.crt -inkey /root/ssl-build/kvm-guest-04.rhts.eng.bos.redhat.com/qpid-broker.key -export -out '/root/ssl-build/kvm-guest-04.rhts.eng.bos.redhat.com/qpid-broker.pfx' -password 'file:/etc/katello/pk12_password-file' 2>>/var/log/katello/katello-configure/certificates.log returned 1 instead of one of [0] at /usr/share/katello/install/puppet/modules/certs/manifests/config.pp:269[0m
[1;35merr: /Stage[main]/Certs::Config/Exec[add-private-key-to-nss-db]: Failed to call refresh: pk12util -i '/root/ssl-build/kvm-guest-04.rhts.eng.bos.redhat.com/qpid-broker.pfx' -d '/etc/pki/katello/nssdb/' -w '/etc/katello/pk12_password-file' -k '/etc/katello/nss_db_password-file' 2>>/var/log/katello/katello-configure/certificates.log returned 10 instead of one of [0] at /usr/share/katello/install/puppet/modules/certs/manifests/config.pp:277[0m

Error opening input file /root/ssl-build/katello-ci-rhel62.xxx.com/qpid-broker.crt
/root/ssl-build/katello-ci-rhel62.xxx.com/qpid-broker.crt: No such file or directory
pk12util: File Open failed: /root/ssl-build/katello-ci-rhel62.xxx.com/qpid-broker.pfx: File not found.
