### PR TITLE
spec - fixing invalid perms for /var/log/katello

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -360,7 +360,7 @@ fi
 %{homedir}/db/schema.rb
 
 %defattr(-, katello, katello)
-%attr(640, katello, katello) %{_localstatedir}/log/%{name}
+%attr(750, katello, katello) %{_localstatedir}/log/%{name}
 %{datadir}
 %ghost %attr(640, katello, katello) %{_localstatedir}/log/%{name}/production.log
 %ghost %attr(640, katello, katello) %{_localstatedir}/log/%{name}/production_sql.log


### PR DESCRIPTION
Resolving:

```
Starting katello-jobs: bash: /var/log/katello/jobs-startup.log: Permission denied
```
