### PR TITLE
spec - fixing invalid perms for /var/log/katello in puppet

### DIFF
--- a/puppet/modules/katello/manifests/config.pp
+++ b/puppet/modules/katello/manifests/config.pp
@@ -22,7 +22,7 @@ class katello::config {
       group   => $katello::params::group,
       content => "",
       replace => false,
-      mode    => 640,
+      mode    => 750,
       require => [ File["${katello::params::log_base}"] ];
   }
 


### PR DESCRIPTION
Complementary fix for the latest pull request - forgot to change perms also in the puppet.
