### PR TITLE
puppet - moving lib/util into common subpackage

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -327,7 +327,6 @@ fi
 %{homedir}/lib/notifications
 %{homedir}/lib/resources/cdn.rb
 %{homedir}/lib/tasks
-%{homedir}/lib/util
 %{homedir}/locale
 %{homedir}/public
 %{homedir}/script
@@ -358,6 +357,7 @@ fi
 %{_sysconfdir}/bash_completion.d/%{name}
 %{homedir}/log
 %{homedir}/db/schema.rb
+%{homedir}/lib/util
 
 %defattr(-, katello, katello)
 %attr(750, katello, katello) %{_localstatedir}/log/%{name}


### PR DESCRIPTION
Resolves headping installation error:

[root@aa ~]# katello-configure --deployment=headpin -b
Starting Katello configuration
The top-level log file is [/var/log/katello/katello-configure-20120731-090948/main.log]
Could not autoload katello_config_value: Katello was not installed on this host - configuration cannot continue at /usr/share/katello/install/puppet/modules/katello/manifests/params.pp:3 on node aa.lan
