### PR TITLE
puppet - better wait code for mongod

### DIFF
--- a/src/script/service-wait
+++ b/src/script/service-wait
@@ -53,8 +53,8 @@ after_start() {
       /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- http://localhost:$TOMCAT_PORT
       ;;
     mongod)
-      # RHBZ 824405 - wait until data port is avaiable
-      for i in {1..$WAIT_MAX}; do netstat -ln | grep -q ":$MONGO_PORT\s" && break; sleep 1; done
+      # RHBZ 824405 - wait until service is avaiable
+      for i in {1..$WAIT_MAX}; do mongo --eval "printjson(db.getCollectionNames())" 2>/dev/null 1>&2 && break; sleep 1; done
       ;;
     postgresql)
       # RHBZ 800534 for RHEL 6.x - pg sysvinit script return non-zero when PID is not created in 2 seconds


### PR DESCRIPTION
Resolving

err: /Stage[main]/Pulp::Config/Exec[migrate_pulp_db]/returns: change from notrun to 0 failed: pulp-migrate >/var/log/katello/katello-configure/pulp_migrate.log 2>&1 && touch /var/lib/pulp/init.flag returned 1 instead of one of [0] at /usr/share/katello/install/puppet/modules/pulp/manifests/config.pp:60

Migrate was executed while mongodb was still starting up. I was waiting for port, now we really try to connect using "mongo" command for 30 seconds.
