### PR TITLE
844796 - Async import now properly checking progress

### DIFF
--- a/src/app/controllers/providers_controller.rb
+++ b/src/app/controllers/providers_controller.rb
@@ -69,9 +69,6 @@ class ProvidersController < ApplicationController
     if @provider.import_task.nil?
       to_ret = {'state' => 'finished'}
     else
-      # user didn't provide a manifest to upload
-      notify.error _("Subscription manifest must be specified on upload.")
-      render :nothing => true
       to_ret = @provider.import_task.to_json
     end
 
@@ -86,36 +83,6 @@ class ProvidersController < ApplicationController
   end
 
   def redhat_provider
-=begin
-    # We default to none imported until we can properly poll Candlepin for status of the import
-    @grouped_subscriptions = []
-    begin
-      find_subscriptions
-    rescue Exception => error
-      display_message = parse_display_message(error.response)
-      error_text = _("Unable to retrieve subscription manifest for provider '%s'.") % @provider.name
-      error_text += "<br />" + _("Reason: %s") % display_message unless display_message.blank?
-      notify.exception error_text, error, :asynchronous => true
-      Rails.logger.error "Error fetching subscriptions from Candlepin"
-      Rails.logger.error error
-      Rails.logger.error error.backtrace.join("\n")
-      render :template =>"providers/redhat/show", :status => :bad_request and return
-    end
-
-    begin
-      @statuses = @provider.owner_imports
-    rescue Exception => error
-      @statuses = []
-      display_message = parse_display_message(error.response)
-      error_text = _("Unable to retrieve subscription history for provider '%s'.") % @provider.name
-      error_text += "<br />" + _("Reason: %s") % display_message unless display_message.blank?
-      notify.exception error_text, error, :asynchronous => true
-      Rails.logger.error "Error fetching subscription history from Candlepin"
-      Rails.logger.error error
-      Rails.logger.error error.backtrace.join("\n")
-      render :template =>"providers/redhat/show", :status => :bad_request and return
-    end
-=end
     render :template =>"providers/redhat/show"
   end
 

--- a/src/public/javascripts/subscription.js
+++ b/src/public/javascripts/subscription.js
@@ -17,8 +17,6 @@ KT.subscription = (function() {
 
     // Data that is unchanged from previous will come in as ""
     updateStatus = function(data) {
-        console.log("XYZ: updateStatus() " + data)
-
         if (data !== "" && $('.import_progress_message')) {
             $(".import_progress_message").html(i18n.import_in_progress(data["state"]));
         }
@@ -54,6 +52,7 @@ KT.subscription = (function() {
             }, updateStatus);
         }
 
+        notices.checkNotices();
     },
     initSubscription = function initSubscription() {
         startUpdater();


### PR DESCRIPTION
For async manifest import, there were double-render errors while the progress was being checked from javascript. In addition, notices were not being displayed after a very quick manifest import.
