### PR TITLE
803757 - Systems: Users should not be able to enter anything other than ...

### DIFF
--- a/src/app/models/system.rb
+++ b/src/app/models/system.rb
@@ -67,6 +67,7 @@ class System < ActiveRecord::Base
   validates_uniqueness_of :name, :scope => :environment_id
   validates :description, :katello_description_format => true
   validates_length_of :location, :maximum => 255
+  validates :sockets, :presence => true, :numericality => { :only_integer => true, :greater_than => 0 }
   before_create  :fill_defaults
 
   scope :by_env, lambda { |env| where('environment_id = ?', env) unless env.nil?}


### PR DESCRIPTION
...positive integers for sockets

the user is now required to input a socket number. only integers greater than zero will validate correctly.
