### PR TITLE
828369 - katello.conf owned by katello:katello

### DIFF
--- a/puppet/modules/katello/manifests/config.pp
+++ b/puppet/modules/katello/manifests/config.pp
@@ -68,9 +68,9 @@ class katello::config {
 
     "/etc/httpd/conf.d/katello.conf":
       content => template("katello/etc/httpd/conf.d/katello.conf.erb"),
-      owner   => $katello::params::user,
-      group   => $katello::params::group,
-      mode    => "600",
+      owner   => "root",
+      group   => "root",
+      mode    => "644",
       notify  => Exec["reload-apache2"];
 
     "/etc/ldap_fluff.yml":


### PR DESCRIPTION
/etc/httpd/conf.d/katello.conf is owned by katello:katello - Does it have to be this way? 

Having an application own the http config file is not best security practice and will create security audit alerts with enterprise customers.
