### PR TITLE
Introduce +load_remote_data+ method to lazy_attributes

### DIFF
--- a/src/app/models/glue/candlepin/pool.rb
+++ b/src/app/models/glue/candlepin/pool.rb
@@ -44,69 +44,8 @@ module Glue::Candlepin::Pool
 
     def initialize(attrs = nil)
       if not attrs.nil? and attrs.member? 'id'
-        # initializing from candlepin json
-        @product_name = attrs["productName"]
-        @start_date = Date.parse(attrs["startDate"])
-        @end_date = Date.parse(attrs["endDate"])
-        @consumed = attrs["consumed"]
-        @quantity = attrs["quantity"]
-        @attrs = attrs["attributes"]
-        @owner = attrs["owner"]
-        @product_id = attrs["productId"]
-        @cp_id = attrs['id']
-        @account_number = attrs['accountNumber']
-        @contract_number = attrs['contractNumber']
-        @provided_products = attrs['providedProducts']
-
-        @source_pool_id = nil
-        @host_id = nil
-        @virt_only = false
-        @pool_derived = false
-        attrs['attributes'].each do |attr|
-          case attr['name']
-            when 'source_pool_id'
-              @source_pool_id = attr['value']
-            when 'requires_host'
-              @host_id = attr['value']
-            when 'virt_only'
-              @virt_only = attr['value'] == 'true' ? true : false
-            when 'pool_derived'
-              @pool_derived = attr['value'] == 'true' ? true : false
-          end
-        end if attrs['attributes']
-
-        @virt_limit = 0
-        @support_type = ""
-        @arch = ""
-        @support_level = ""
-        @sockets = 0
-        @description = ""
-        @product_family = ""
-        @variant = ""
-        @multi_entitlement = false
-        attrs['productAttributes'].each do |attr|
-          case attr['name']
-            when 'virt_limit'
-              @virt_limit = attr['value'].to_i
-            when 'support_type'
-              @support_type = attr['value']
-            when 'arch'
-              @arch = attr['value']
-            when 'support_level'
-              @support_level = attr['value']
-            when 'sockets'
-              @sockets = attr['value'].to_i
-            when 'description'
-              @description = attr['value']
-            when 'product_family'
-              @product_family = attr['value']
-            when 'variant'
-              @variant = attr['value']
-            when 'multi-entitlement'
-              @multi_entitlement = (attr['value'] == 'true' || attr['value'] == 'yes') ? true : false
-          end
-        end if attrs['productAttributes']
-
+        # initializing from cadlepin json
+        load_remote_data(attrs)
         super(:cp_id => attrs['id'])
       else
         super
@@ -115,6 +54,70 @@ module Glue::Candlepin::Pool
 
     def organization
       Organization.find_by_name(owner["key"])
+    end
+
+    # if defined +load_remote_data+ will be used by +lazy_accessors+
+    # to define instance variables
+    def load_remote_data(attrs)
+      @product_name = attrs["productName"]
+      @start_date = Date.parse(attrs["startDate"]) if attrs["startDate"]
+      @end_date = Date.parse(attrs["endDate"]) if attrs["endDate"]
+      @consumed = attrs["consumed"]
+      @quantity = attrs["quantity"]
+      @attrs = attrs["attributes"]
+      @owner = attrs["owner"]
+      @product_id = attrs["productId"]
+      @cp_id = attrs['id']
+      @account_number = attrs['accountNumber']
+      @contract_number = attrs['contractNumber']
+      @provided_products = attrs['providedProducts']
+      @source_pool_id = nil
+      @host_id = nil
+      @virt_only = false
+      @pool_derived = false
+      attrs['attributes'].each do |attr|
+        case attr['name']
+          when 'source_pool_id'
+            @source_pool_id = attr['value']
+          when 'requires_host'
+            @host_id = attr['value']
+          when 'virt_only'
+            @virt_only = attr['value'] == 'true' ? true : false
+          when 'pool_derived'
+            @pool_derived = attr['value'] == 'true' ? true : false
+        end
+      end if attrs['attributes']
+      @virt_limit = 0
+      @support_type = ""
+      @arch = ""
+      @support_level = ""
+      @sockets = 0
+      @description = ""
+      @product_family = ""
+      @variant = ""
+      @multi_entitlement = false
+      attrs['productAttributes'].each do |attr|
+        case attr['name']
+          when 'virt_limit'
+            @virt_limit = attr['value'].to_i
+          when 'support_type'
+            @support_type = attr['value']
+          when 'arch'
+            @arch = attr['value']
+          when 'support_level'
+            @support_level = attr['value']
+          when 'sockets'
+            @sockets = attr['value'].to_i
+          when 'description'
+            @description = attr['value']
+          when 'product_family'
+            @product_family = attr['value']
+          when 'variant'
+            @variant = attr['value']
+          when 'multi-entitlement'
+            @multi_entitlement = (attr['value'] == 'true' || attr['value'] == 'yes') ? true : false
+        end
+      end if attrs['productAttributes']
     end
 
   end

--- a/src/app/models/lazy_accessor.rb
+++ b/src/app/models/lazy_accessor.rb
@@ -141,7 +141,12 @@ module LazyAccessor
 
     def prepopulate(remote_values)
       attrs = self.lazy_attributes
-      remote_values.each_pair {|k,v| instance_variable_set("@#{k.to_s}", v) if (attrs and attrs.include?(k.to_sym) and respond_to?("#{k.to_s}="))}
+      # if +load_remote_data+ is defined, use it to populate the instance variables
+      if self.respond_to?(:load_remote_data)
+        load_remote_data(remote_values)
+      else
+        remote_values.each_pair {|k,v| instance_variable_set("@#{k.to_s}", v) if (attrs and attrs.include?(k.to_sym) and respond_to?("#{k.to_s}="))}
+      end
     end
   end
 end

--- a/src/spec/models/activation_key_spec.rb
+++ b/src/spec/models/activation_key_spec.rb
@@ -214,12 +214,12 @@ describe ActivationKey do
     before(:each) do
       Resources::Candlepin::Pool.stub!(:find) do |x|
         {
-          :product_name => "Blah Server OS",
-          :product_id => dates[x][:product_id],
-          :start_date => dates[x][:start_date],
+          :productName => "Blah Server OS",
+          :productId => dates[x][:productId],
+          :startDate => dates[x][:startDate],
           :quantity => dates[x][:quantity],
           :consumed => dates[x][:consumed],
-        }
+        }.with_indifferent_access
       end
       @system = System.new(:name => "test", :cp_type => "system", :facts => {"distribution.name"=>"Fedora"}, :uuid => "uuid-uuid")
       @system.should_receive(:sockets).and_return(sockets)
@@ -244,8 +244,8 @@ describe ActivationKey do
       let(:dates) do
         {
           "a" => {
-            :product_id => "A",
-            :start_date => Date.parse("2011-02-11T11:11:11.111+0000"),
+            :productId => "A",
+            :startDate => "2011-02-11T11:11:11.111+0000",
             :quantity => 10,
             :consumed => 0,
           }
@@ -264,14 +264,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "a" => {
-            :product_id => "A",
-            :start_date => Date.parse("2011-01-02T11:11:11.111+0000"),
+            :productId => "A",
+            :startDate => "2011-01-02T11:11:11.111+0000",
             :quantity => 10,
             :consumed => 0,
           },
           "b" => {
-            :product_id => "A",
-            :start_date => Date.parse("2011-01-01T11:11:11.111+0000"), # older
+            :productId => "A",
+            :startDate => "2011-01-01T11:11:11.111+0000", # older
             :quantity => 10,
             :consumed => 0,
           }
@@ -290,20 +290,20 @@ describe ActivationKey do
       let(:dates) do
         {
           "b" => {
-            :product_id => "A",
-            :start_date => Date.parse("2011-01-11T11:11:11.111+0000"),
+            :productId => "A",
+            :startDate => "2011-01-11T11:11:11.111+0000",
             :quantity => 10,
             :consumed => 0,
           },
           "c" => {
-            :product_id => "A",
-            :start_date => Date.parse("2011-01-11T11:11:11.111+0000"),
+            :productId => "A",
+            :startDate => "2011-01-11T11:11:11.111+0000",
             :quantity => 10,
             :consumed => 0,
           },
           "a" => {
-            :product_id => "A",
-            :start_date => Date.parse("2011-01-11T11:11:11.111+0000"),
+            :productId => "A",
+            :startDate => "2011-01-11T11:11:11.111+0000",
             :quantity => 10,
             :consumed => 0,
           }
@@ -323,14 +323,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-11T11:11:11.111+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-11T11:11:11.111+0000",
             :quantity => 5,
             :consumed => 0,
           },
           "pool 2" => {
-            :product_id => "product 2",
-            :start_date => Date.parse("2011-01-11T11:11:11.111+0000"),
+            :productId => "product 2",
+            :startDate => "2011-01-11T11:11:11.111+0000",
             :quantity => 5,
             :consumed => 0,
           },
@@ -350,14 +350,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-02T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-02T00:00:00.000+0000",
             :quantity => 5,
             :consumed => 0,
           },
           "pool 2" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"), # older
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000", # older
             :quantity => 5,
             :consumed => 0,
           },
@@ -377,14 +377,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-02T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-02T00:00:00.000+0000",
             :quantity => 5,
             :consumed => 0,
           },
           "pool 2" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"), # older
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000", # older
             :quantity => 5,
             :consumed => 0,
           },
@@ -403,14 +403,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 5,
             :consumed => 0,
           },
           "pool 2" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 5,
             :consumed => 0,
           },
@@ -429,14 +429,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 0,
             :consumed => 0,
           },
           "pool 2" => {
-            :product_id => "product 2",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 2",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 2,
             :consumed => 0,
           },
@@ -454,14 +454,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 99,
             :consumed => 99,
           },
           "pool 2" => {
-            :product_id => "product 2",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 2",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 2,
             :consumed => 0,
           },
@@ -479,14 +479,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 5, # 0 remaining
             :consumed => 5,
           },
           "pool 2" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"),
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000",
             :quantity => 5, # 2 remaining
             :consumed => 3,
           },
@@ -505,14 +505,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"), # older
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000", # older
             :quantity => 1,
             :consumed => 0,
           },
           "pool 2" => {
-            :product_id => "product 2",
-            :start_date => Date.parse("2011-01-02T00:00:00.000+0000"),
+            :productId => "product 2",
+            :startDate => "2011-01-02T00:00:00.000+0000",
             :quantity => 2, # 1 remaining
             :consumed => 1,
           },
@@ -530,14 +530,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"), # older
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000", # older
             :quantity => 2,
             :consumed => 0,
           },
           "pool 2" => {
-            :product_id => "product 2",
-            :start_date => Date.parse("2011-01-02T00:00:00.000+0000"),
+            :productId => "product 2",
+            :startDate => "2011-01-02T00:00:00.000+0000",
             :quantity => 2, # 1 remaining
             :consumed => 1,
           },
@@ -557,14 +557,14 @@ describe ActivationKey do
       let(:dates) do
         {
           "pool 1" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"), # same date
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000", # same date
             :quantity => 5, # 1 remaining
             :consumed => 4,
           },
           "pool 2" => {
-            :product_id => "product 1",
-            :start_date => Date.parse("2011-01-01T00:00:00.000+0000"), # same date
+            :productId => "product 1",
+            :startDate => "2011-01-01T00:00:00.000+0000", # same date
             :quantity => 5, # 1 remaining
             :consumed => 4,
           },


### PR DESCRIPTION
When defined in your model, this method is used to transfer data from remote
source to instance variables when using lazy attributes.

It can be also used in the +initialize+ method to reduce the code duplicity.

This also allows having different names for the variables and keys in hash.

You can see the usage in +glue/candlepin/pool.rb+, where the problem with
different names occurred, causing:

```
Product has no product associated
```

when using activation key for registering and subscribing system to some
product.

Note:

This commit improved the system tests, so that they use subscriptions with activation keys. There is also another issue, displaying

```
 Multi-entitlement not supported for pool with id {POOLID}
```

This is different issue and will be solved with anohter pull request (after finding out what's wrong)

@thomasmckay
