### PR TITLE
Fixes for some API issues

### DIFF
--- a/src/app/controllers/api/activation_keys_controller.rb
+++ b/src/app/controllers/api/activation_keys_controller.rb
@@ -101,6 +101,7 @@ class Api::ActivationKeysController < Api::ApiController
     render :json => @activation_key.to_json
   end
 
+  private
 
   def find_organization
     return unless params.has_key?(:organization_id)

--- a/src/app/controllers/api/api_controller.rb
+++ b/src/app/controllers/api/api_controller.rb
@@ -83,7 +83,7 @@ class Api::ApiController < ActionController::Base
     return @query_params
   end
 
-
+  private
 
   def find_organization
     raise HttpErrors::NotFound, _("organization_id required but not specified.") if params[:organization_id].nil?
@@ -98,9 +98,7 @@ class Api::ApiController < ActionController::Base
     end
   end
 
-  private
-
-   def verify_ldap
+  def verify_ldap
     u = current_user
     u.verify_ldap_roles if (AppConfig.ldap_roles && u != nil)
   end

--- a/src/app/controllers/api/changesets_content_controller.rb
+++ b/src/app/controllers/api/changesets_content_controller.rb
@@ -123,7 +123,7 @@ class Api::ChangesetsContentController < Api::ApiController
     render(unless removed_objects.blank?
              { :text => (options[:success] or raise ArgumentError), :status => 200 }
            else
-             { :text => (options[:not_found] or raise ArgumentError), :status => 200 }
+             { :text => (options[:not_found] or raise ArgumentError), :status => 404 }
            end)
   end
 

--- a/src/app/controllers/api/changesets_controller.rb
+++ b/src/app/controllers/api/changesets_controller.rb
@@ -73,6 +73,8 @@ class Api::ChangesetsController < Api::ApiController
     render :text => _("Deleted changeset '#{params[:id]}'"), :status => 200
   end
 
+  private
+
   def find_changeset
     @changeset = Changeset.find(params[:id])
     raise HttpErrors::NotFound, _("Couldn't find changeset '#{params[:id]}'") if @changeset.nil?

--- a/src/app/controllers/api/filters_controller.rb
+++ b/src/app/controllers/api/filters_controller.rb
@@ -108,6 +108,8 @@ class Api::FiltersController < Api::ApiController
     render :json => @repository.filters.to_json
   end
 
+  private
+
   def find_organization
     if not find_optional_organization
       @organization = @repository.organization

--- a/src/app/controllers/api/organizations_controller.rb
+++ b/src/app/controllers/api/organizations_controller.rb
@@ -37,6 +37,7 @@ class Api::OrganizationsController < Api::ApiController
   end
   def param_rules
     {
+      :create => [:name, :description],
       :update => {:organization  => [:name, :description]}
     }
   end

--- a/src/app/controllers/api/roles_controller.rb
+++ b/src/app/controllers/api/roles_controller.rb
@@ -81,6 +81,7 @@ class Api::RolesController < Api::ApiController
     render :json => details
   end
 
+  private
 
   def find_role
     @role = Role.find(params[:id])

--- a/src/app/controllers/api/uebercerts_controller.rb
+++ b/src/app/controllers/api/uebercerts_controller.rb
@@ -21,7 +21,7 @@ class Api::UebercertsController < Api::ApiController
   end
 
   def show
-    @organization.generate_debug_cert if params[:regenerate] == 'True'
+    @organization.generate_debug_cert if (params[:regenerate]||'').downcase == 'true'
     render :json => @organization.debug_cert
   end
 end

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -642,7 +642,7 @@ Src::Application.routes.draw do
     resources :users do
       get :report, :on => :collection
       get :sync_ldap_roles, :on => :collection
-      resources :roles, :controller => :users do
+      resources :roles, :controller => :users, :only =>[] do
        post   :index, :on => :collection, :action => :add_role
        delete :destroy, :on => :member, :action => :remove_role
        get    :index, :on => :collection, :action => :list_roles


### PR DESCRIPTION
Addressing https://fedorahosted.org/katello/wiki/APIDocumentationEfforts

organizations#create  parameters not in params_match
route post,put,delete /users/:user_id/roles/\*   apart from get the routes are redundant. Actions are also accessible from /roles/*
activation_key#find_  find methods should be protected or something
uebercert   uebercert#show  method should also accept 'true' as well as 'True'
changeset_content_controller#render_after_removal not found should return 404 or some other error code.
