### PR TITLE
move service-wait to katello-common

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -328,7 +328,6 @@ fi
 %files
 %attr(600, katello, katello)
 %{_bindir}/katello-*
-%{_sbindir}/service-wait
 %{homedir}/app/controllers
 %{homedir}/app/helpers
 %{homedir}/app/mailers
@@ -365,6 +364,7 @@ fi
 
 %files common
 %doc README LICENSE doc/
+%{_sbindir}/service-wait
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.yml
 %config(noreplace) %{_sysconfdir}/%{name}/thin.yml
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/%{name}.conf


### PR DESCRIPTION
package katello is not installed when you install headpin, therefore
katello-configure --deployment=headpin fails with:

err: /Stage[main]/Postgres::Service/Service[postgresql]/ensure: change from stopped to running failed: Could not start Service[postgresql]: Execution of '/usr/sbin/service-wait postgresql start' returned 1:  at /usr/share/katello/install/puppet/modules/postgres/manifests/service.pp:15
err: /Stage[main]/Postgres::Service/Exec[wait-for-postgresql]: Failed to call refresh: Command exceeded timeout at /usr/share/katello/install/puppet/modules/postgres/manifests/service.pp:25
