### PR TITLE
Content search - make positioning more custom

### DIFF
--- a/src/public/javascripts/content_search.js
+++ b/src/public/javascripts/content_search.js
@@ -98,7 +98,7 @@ KT.content_search = function(paths_in){
 
         env_select = KT.path_select('column_selector', 'env', paths,
             {select_mode:'multi', link_first: true, footer: footer });
-
+        env_select.reposition_left(); 
         init_tipsy();
 
         comparison_grid = KT.comparison_grid();
@@ -172,7 +172,6 @@ KT.content_search = function(paths_in){
             env_select.select(env.id)
         });
         comparison_grid.show_columns(env_obj);
-        env_select.reposition();
     },
     bind_load_more_event = function(){
       $(document).bind('load_more.comparison_grid', function(event){
@@ -360,7 +359,6 @@ KT.content_search = function(paths_in){
 
             comparison_grid.show_columns(environments);
             $.bbq.pushState({envs:env_ids});
-            env_select.reposition();
             envs_changed = true;
         });
     },

--- a/src/public/javascripts/widgets/path_selector.js
+++ b/src/public/javascripts/widgets/path_selector.js
@@ -83,7 +83,6 @@ KT.path_select = function(div_id, name, environments, options_in){
             }
             scroll_obj = KT.env_select_scroll({});
             recalc_scroll();
-            reposition_left();
         },
         reposition_left = function(){
             var selector_width, pos;
@@ -252,7 +251,7 @@ KT.path_select = function(div_id, name, environments, options_in){
         get_select_event : get_select_event,
         clear_selected: clear_selected,
         select:select,
-        reposition: reposition_left
+        reposition_left: reposition_left
     };
 };
 


### PR DESCRIPTION
currently with path selector it was always calling reposition_left
which meant the selector would also be pushed to the left of the screen
This is not something that is always desired, so this was made optional

Also, previously content search would have to reposition the env selector
whenever a new environment was added.  This is no longer the case, so 
the reposition call only needs to be called once. 
