### PR TITLE
allow to build nightly from HEAD

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -10,3 +10,8 @@ branches = se-rhel-6
 [koji]
 releaser = tito.release.KojiReleaser
 autobuild_tags = katello-nightly-rhel6 katello-nightly-fedora16 katello-nightly-fedora17
+
+[koji-head]
+releaser = tito.release.KojiReleaser
+autobuild_tags = katello-nightly-rhel6 katello-nightly-fedora16 katello-nightly-fedora17
+builder.test = 1


### PR DESCRIPTION
created new release target koji-head, which build from HEAD

and modify build-missing-builds-in-koji.sh to build packages from HEAD
unless tagged package in Koji is latest greatest
