### PR TITLE
Redcarpet needs to be installed, not just a buildrequires

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -76,6 +76,7 @@ Requires:       rubygem(tire) >= 0.3.0
 Requires:       rubygem(tire) < 0.4
 Requires:       rubygem(ldap_fluff)
 Requires:       rubygem(apipie-rails)
+Requires:       rubygem(redcarpet)
 
 %if 0%{?rhel} == 6
 Requires:       redhat-logos >= 60.0.14


### PR DESCRIPTION
I'm not sure how much redcarpet is used for, might just be install dep of katello-configure instead of katello-common
