### PR TITLE
package rubygem-hashr is in Fedora now

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -42,7 +42,6 @@
        <packagereq type="default">rubygem-fast_gettext</packagereq>
        <packagereq type="default">rubygem-gettext_i18n_rails</packagereq>
        <packagereq type="default">rubygem-haml-rails</packagereq>
-       <packagereq type="default">rubygem-hashr</packagereq>
        <packagereq type="default">rubygem-i18n_data</packagereq>
        <packagereq type="default">rubygem-jammit</packagereq>
        <packagereq type="default">rubygem-ldap_fluff</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-server-fedora17.xml
@@ -40,7 +40,6 @@
        <packagereq type="default">rubygem-color</packagereq>
        <packagereq type="default">rubygem-daemons</packagereq>
        <packagereq type="default">rubygem-fastercsv</packagereq>
-       <packagereq type="default">rubygem-hashr</packagereq>
        <packagereq type="default">rubygem-jammit</packagereq>
        <packagereq type="default">rubygem-ldap_fluff</packagereq>
        <packagereq type="default">rubygem-pdf-writer</packagereq>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=845799
