### PR TITLE
apidoc - removed duplicite api doc entry

### DIFF
--- a/src/app/controllers/api/environments_controller.rb
+++ b/src/app/controllers/api/environments_controller.rb
@@ -108,7 +108,6 @@ identifier of an environment that is prior the new environment in the chain, it 
 either library or an envrionment at the end of the chain
     DESC
   end
-  api :POST, "/organizations/:organization_id/environments", "Create an environment in an organization"
   def create
     environment = KTEnvironment.new(params[:environment])
     @organization.environments << environment


### PR DESCRIPTION
Environments create had two identical doc strings causing doubled entries in api docs
