### PR TITLE
configure - workaround for puppet bug 16006

### DIFF
--- a/puppet/katello-configure.spec
+++ b/puppet/katello-configure.spec
@@ -38,9 +38,11 @@ ruby -c bin/katello-configure lib/puppet/parser/functions/*rb
 
 #check syntax for all puppet scripts
 %if 0%{?rhel} || 0%{?fedora} < 17
+# Puppet 2.6 parseonly mode does not handle multiple files correctly
 find -name '*.pp' | xargs -n 1 -t puppet --parseonly
 %else
-find -name '*.pp' | xargs -n 1 -t puppet parser validate
+# Puppet Bug #16006 (puppet 2.7 not working without a hostname)
+find -name '*.pp' | FACTER_hostname=builder xargs -t puppet parser validate
 %endif
 
 #check for puppet erb syntax errors


### PR DESCRIPTION
We set a fake hostname for koji environment in this case. It is fixed in upstream version already.
