### PR TITLE
811556 - Displaced 'save' button while editing the changeset description...

### DIFF
--- a/src/app/views/changesets/_edit.html.haml
+++ b/src/app/views/changesets/_edit.html.haml
@@ -17,7 +17,7 @@
       .grid_3.ra
         %label #{_("Description:")}
       .grid_5.la{:name=>"description", :class=>("editable edit_description" if editable),
-          "data-id"=>@changeset.id,"data-url"=>changeset_path(@changeset.id)}
+          "data-id"=>@changeset.id,"data-url"=>changeset_path(@changeset.id)}<
         = @changeset.description.blank? ? _("None") : @changeset.description
     .fieldset
       .grid_3.ra


### PR DESCRIPTION
... under "changeset history" tab

Another way would be to expand those inputs little bit but grid_5 is used on most edit forms so I suggest to use it here too. 
