### PR TITLE
850745 - secret_token is not generated properly (CVE-2012-3503)

### DIFF
--- a/src/config/initializers/secret_token.rb
+++ b/src/config/initializers/secret_token.rb
@@ -1,7 +1,14 @@
-# Be sure to restart your server when you modify this file.
+require 'active_support/secure_random'
 
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Src::Application.config.secret_token = 'f466b184ef680822293d7130f57593a7087a34b5de0607c64d1ceb66fcac4dce6810a6f176feba3fbbf2489de93c0918397c0c275996eb476b2fa6079ab849c1'
+begin
+  # Read token string from the file.
+  token = IO.read('/etc/katello/secret_token')
+  raise RuntimeError, 'Size is too small' if token.length < 9
+  Src::Application.config.secret_token = token.chomp
+rescue Exception => e
+  # If anything is wrong make sure the token is random. This is safe even when
+  # Katello is not configured correctly for any reason (but session is lost
+  # after each restart).
+  Rails.logger.warn "Using randomly generated secure token: #{e.message}"
+  Src::Application.config.secret_token = ActiveSupport::SecureRandom.hex(80)
+end


### PR DESCRIPTION
We have found a flaw in the generation of the
Application.config.secret_token value. This value is used in the file
/usr/share/katello/config/initializers/secret_token.rb to provide a secret
token when session cookies are generated for user sessions within Katello.

Specifically a static key with a value of:

f466b184ef680822293d7130f57593a7087a34b5de0607c64d1ceb66fcac4dce\
6810a6f176feba3fbbf2489de93c0918397c0c275996eb476b2fa6079ab849c1

is included by default. The spec file for Katello includes commands to
generate a new key:

NEWKEY=$(</dev/urandom tr -dc A-Za-z0-9 | head -c128) sed -i
"s/^Src::Application.config.secret_token =
'.*'/Src::Application.config.secret_token = '$NEWKEY'/" \
/usr/share/katello/config/initializers/secret_token.rb

however this was erroneously placed in the "postuninstall" section, which is
run when removing Katello from the system). Thus a new secret token is not
created and all affected Katello installations have the same secret token
value.

https://access.redhat.com/security/cve/CVE-2012-3503
