### PR TITLE
850790 - Content promotion from CLI no longer works

### DIFF
--- a/cli/src/katello/client/core/changeset.py
+++ b/cli/src/katello/client/core/changeset.py
@@ -460,7 +460,7 @@ class Promote(Apply):
 
         # Block attempts to call this on deletion changesets, otherwise continue
         cset = get_changeset(orgName, envName, csName)
-        if cset['type'] == constants.DELETION:
+        if 'type' in cset and cset['type'] == constants.DELETION:
             print _("This is a deletion changeset and does not support promotion")
             return os.EX_DATAERR
 


### PR DESCRIPTION
Addressing issue:

https://bugzilla.redhat.com/show_bug.cgi?id=850790
