### PR TITLE
846251: Do not specify the attribute name for uniqueness validation

### DIFF
--- a/src/app/models/system_group.rb
+++ b/src/app/models/system_group.rb
@@ -53,8 +53,8 @@ class SystemGroup < ActiveRecord::Base
   validates :pulp_id, :presence => true
   validates :name, :presence => true, :katello_name_format => true
   validates_presence_of :organization_id, :message => N_("Organization cannot be blank.")
-  validates_uniqueness_of :name, :scope => :organization_id, :message => N_("Name must be unique within one organization")
-  validates_uniqueness_of :pulp_id, :message=> N_("Pulp identifier must be unique.")
+  validates_uniqueness_of :name, :scope => :organization_id, :message => N_("must be unique within one organization")
+  validates_uniqueness_of :pulp_id, :message=> N_("must be unique.")
 
   UNLIMITED_SYSTEMS = -1
   validates_numericality_of :max_systems, :only_integer => true, :greater_than_or_equal_to => -1, :message => N_("must be a positive integer value.")


### PR DESCRIPTION
This is not friendly for translators, but this is consistent
