### PR TITLE
850935 - katello-cli-common should own only /etc/katello and not its content

### DIFF
--- a/cli/katello-cli.spec
+++ b/cli/katello-cli.spec
@@ -93,7 +93,7 @@ chmod 755 %{buildroot}%{python_sitelib}/%{base_name}/client/main.py
 %{_mandir}/man1/%{base_name}-debug-certificates.1*
 
 %files common
-%{_sysconfdir}/%{base_name}
+%dir %{_sysconfdir}/%{base_name}
 %{python_sitelib}/%{base_name}/
 
 


### PR DESCRIPTION
client.conf was include in katello-cli-common by mistake. This package should own only directory /etc/katello, but not its content. And one of the reason is that headpin and katello have diferent content of client.conf.
