### PR TITLE
fix runtime errors

### DIFF
--- a/cli/src/katello/client/constants.py
+++ b/cli/src/katello/client/constants.py
@@ -16,6 +16,8 @@
 #
 #
 
+from gettext import gettext as _
+
 STATUS_DETAIL_SUCCESS = """
      Name          \t%-20s
      Result        \t%-20s
@@ -37,3 +39,13 @@ SELECTION_QUERY = """
   'c'   \t : clear selections
   'q'   \t : abort the repo creation
 """
+
+PROMOTION = 'PROMOTION'
+DELETION = 'DELETION'
+
+# Help string for optparser
+OPT_HELP_PROMOTION = _("changeset type promotion: pushes changes to the next environment [DEFAULT]")
+OPT_HELP_DELETION = _("changeset type deletion: deletes items in changeset from current environment")
+OPT_ERR_PROMOTION_OR_DELETE = _("specify either --promotion or --deletion but not both")
+
+

--- a/cli/src/katello/client/core/product.py
+++ b/cli/src/katello/client/core/product.py
@@ -18,6 +18,7 @@ import os
 from gettext import gettext as _
 import datetime
 
+from katello.client import constants
 from katello.client.core import repo
 from katello.client.api.product import ProductAPI
 from katello.client.api.repo import RepoAPI
@@ -263,10 +264,10 @@ class Promote(SingleProductAction):
 
         returnCode = os.EX_OK
 
-        cset = self.csapi.create(orgName, env["id"], self.create_cs_name())
+        cset = self.csapi.create(orgName, env["id"], self.create_cs_name(), constants.PROMOTION)
         try:
             self.csapi.add_content(cset["id"], "products", {'product_id': prod['id']})
-            task = self.csapi.promote(cset["id"])
+            task = self.csapi.apply(cset["id"])
             task = AsyncTask(task)
 
             run_spinner_in_bg(wait_for_async_task, [task], message=_("Promoting the product, please wait... "))


### PR DESCRIPTION
addressing pylint:
E1120:266,15:Promote.run: No value passed for parameter 'type' in function call
E1101:269,19:Promote.run: Instance of 'ChangesetAPI' has no 'promote' member

This was caused by commit 3a3086b14ea6636d8047c4b1e67db41e482fd8f0

changes in changeset.py are really not needid, but it remained there from situation, when I wanted to fix it differently. And since we need to move all this string to constants some time, I left it there.
