### PR TITLE
Moved service-wait link target to katello-common

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -403,6 +403,7 @@ rm -f %{datadir}/Gemfile.lock 2>/dev/null
 %{homedir}/public
 %exclude %{homedir}/public/apipie-cache
 %{homedir}/script
+%exclude %{homedir}/script/service-wait
 %{homedir}/spec
 %{homedir}/tmp
 %{homedir}/vendor
@@ -433,6 +434,7 @@ rm -f %{datadir}/Gemfile.lock 2>/dev/null
 %{homedir}/log
 %{homedir}/db/schema.rb
 %{homedir}/lib/util
+%{homedir}/script/service-wait
 
 %defattr(-, katello, katello)
 %attr(750, katello, katello) %{_localstatedir}/log/%{name}


### PR DESCRIPTION
The service-wait srcipt is a link to /user/share/katello/script/service-wait. When it was moved to katello-common, the target was left in katello. This patch will move the target to katello-common as well.

The test scratch build is in [koji](http://koji-katello.lab.eng.brq.redhat.com/koji/taskinfo?taskID=5372).
