### PR TITLE
848038: Include the translation files with the cli tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ cli/po/build
 cli/po/POTFILES.in
 cli/cover
 cli/doc/build
+cli/man/build
 *.swp

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,4 +1,48 @@
 SRC_DIR     = src/katello
+SHELL := /bin/bash
+PREFIX ?=
+SYSCONF ?= etc
+PYTHON_DIR ?= /usr/lib/python2.7/site-packages
+BASE_NAME ?= katello
+INSTALL_MODULE = katello
+PKGNAME = client
+CODE_DIR = ${PREFIX}${PYTHON_DIR}/${INSTALL_MODULE}/${PKGNAME}
+BIN_DIR = ${PREFIX}/usr/bin
+MAN_DIR = ${PREFIX}/usr/share/man
+VERSION = $(shell echo `grep ^Version: $(PKGNAME).spec | awk '{ print $$2 }'`)
+OS = $(shell lsb_release -i | awk '{ print $$3 }' | awk -F. '{ print $$1}')
+OS_VERSION = $(shell lsb_release -r | awk '{ print $$2 }' | awk -F. '{ print $$1}')
+
+
+clean:
+	rm -rf po/build
+	rm -rf man/build
+
+install: compile-man compile-po
+	install -d ${PREFIX}/usr/share/locale/
+	install -d ${BIN_DIR}
+	install -d ${CODE_DIR}
+	install -d ${PREFIX}/etc/${BASE_NAME}
+	install -d ${CODE_DIR}/api
+	install -d ${CODE_DIR}/cli
+	install -d ${CODE_DIR}/core
+	install -d ${CODE_DIR}/utils
+	install -pm 0644 bin/${BASE_NAME} ${PREFIX}/usr/bin/${BASE_NAME}
+	install -pm 0644 bin/${BASE_NAME}-debug-certificates ${BIN_DIR}/${BASE_NAME}-debug-certificates
+	install -pm 0644 etc/client.conf ${PREFIX}/etc/${BASE_NAME}/client.conf
+	install -pm 0644 src/${BASE_NAME}/client/*.py ${CODE_DIR}
+	install -pm 0644 src/${BASE_NAME}/client/api/*.py ${CODE_DIR}/api/
+	install -pm 0644 src/${BASE_NAME}/client/cli/*.py ${CODE_DIR}/cli/
+	install -pm 0644 src/${BASE_NAME}/client/core/*.py ${CODE_DIR}/core/
+	install -pm 0644 src/${BASE_NAME}/client/utils/*.py ${CODE_DIR}/utils/
+	install -d -m 0755 ${MAN_DIR}/man1
+	install -m 0644 man/build/${BASE_NAME}.1* ${MAN_DIR}/man1
+	install -m 0644 man/build/${BASE_NAME}-debug-certificates.1* ${MAN_DIR}/man1
+
+	cp -R po/build/* ${PREFIX}/usr/share/locale/
+
+	# several scripts are executable
+	chmod 755 ${CODE_DIR}/main.py
 
 po/POTFILES.in:
 	# generate the POTFILES.in file expected by intltool. it wants one
@@ -24,6 +68,25 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
+# Compile translations
+compile-po:
+	for lang in $(basename $(notdir $(wildcard po/*.po))) ; do \
+		echo $$lang ; \
+		mkdir -p po/build/$$lang/LC_MESSAGES/ ; \
+		msgfmt -c --statistics -o po/build/$$lang/LC_MESSAGES/katello.mo po/$$lang.po ; \
+	done
+
+compile-man:
+	PYTHONPATH=src python src/katello/client/utils/usage.py >katello-usage.txt
+	mkdir -p man/build
+	cp man/katello.pod man/build/katello.pod
+	cp man/katello-debug-certificates.pod man/build/katello-debug-certificates.pod
+	sed -e '/^THE_USAGE/{r katello-usage.txt' -e 'd}' man/build/katello.pod |\
+		sed -e 's/THE_VERSION/%{version}/g' |\
+		/usr/bin/pod2man --name=katello -c "Katello Reference" --section=1 --release=%{version} - man/build/katello.1
+	sed -e 's/THE_VERSION/%{version}/g' man/build/katello-debug-certificates.pod |\
+	/usr/bin/pod2man --name=katello -c "Katello Reference" --section=1 --release=%{version} - man/build/katello-debug-certificates.1
+	rm katello-usage.txt
 cover:
 	nosetests --with-coverage --cover-package=katello --cover-html --cover-inclusive .
 

--- a/cli/katello-cli.spec
+++ b/cli/katello-cli.spec
@@ -27,7 +27,7 @@ BuildArch:     noarch
 
 
 %description
-Provides a client package for managing application life-cycle for 
+Provides a client package for managing application life-cycle for
 Linux systems with Katello
 
 %package common
@@ -60,31 +60,11 @@ sed -e 's/THE_VERSION/%{version}/g' katello-debug-certificates.pod |\
 popd
 
 %install
-install -d %{buildroot}%{_bindir}/
-install -d %{buildroot}%{_sysconfdir}/%{base_name}/
-install -d %{buildroot}%{python_sitelib}/%{base_name}
-install -d %{buildroot}%{python_sitelib}/%{base_name}/client
-install -d %{buildroot}%{python_sitelib}/%{base_name}/client/api
-install -d %{buildroot}%{python_sitelib}/%{base_name}/client/cli
-install -d %{buildroot}%{python_sitelib}/%{base_name}/client/core
-install -d %{buildroot}%{python_sitelib}/%{base_name}/client/utils
-install -pm 0644 bin/%{base_name} %{buildroot}%{_bindir}/%{base_name}
-install -pm 0644 bin/%{base_name}-debug-certificates %{buildroot}%{_bindir}/%{base_name}-debug-certificates
-install -pm 0644 etc/client.conf %{buildroot}%{_sysconfdir}/%{base_name}/client.conf
-install -pm 0644 src/%{base_name}/*.py %{buildroot}%{python_sitelib}/%{base_name}/
-install -pm 0644 src/%{base_name}/client/*.py %{buildroot}%{python_sitelib}/%{base_name}/client/
-install -pm 0644 src/%{base_name}/client/api/*.py %{buildroot}%{python_sitelib}/%{base_name}/client/api/
-install -pm 0644 src/%{base_name}/client/cli/*.py %{buildroot}%{python_sitelib}/%{base_name}/client/cli/
-install -pm 0644 src/%{base_name}/client/core/*.py %{buildroot}%{python_sitelib}/%{base_name}/client/core/
-install -pm 0644 src/%{base_name}/client/utils/*.py %{buildroot}%{python_sitelib}/%{base_name}/client/utils/
-install -d -m 0755 %{buildroot}%{_mandir}/man1
-install -m 0644 man/%{base_name}.man1 %{buildroot}%{_mandir}/man1/%{base_name}.1
-install -m 0644 man/%{base_name}-debug-certificates.man1 %{buildroot}%{_mandir}/man1/%{base_name}-debug-certificates.1
+make -f Makefile install VERSION=%{version}-%{release} PREFIX=%{buildroot} MANPATH=%{_mandir} PYTHON_DIR=%{python_sitelib}
 
-# several scripts are executable
-chmod 755 %{buildroot}%{python_sitelib}/%{base_name}/client/main.py
+%find_lang katello
 
-%files 
+%files -f katello.lang
 %attr(755,root,root) %{_bindir}/%{base_name}
 %attr(755,root,root) %{_bindir}/%{base_name}-debug-certificates
 %config(noreplace) %{_sysconfdir}/%{base_name}/client.conf
@@ -413,7 +393,7 @@ chmod 755 %{buildroot}%{python_sitelib}/%{base_name}/client/main.py
 - Fix bug on cli repo info for disabled repository (inecas@redhat.com)
 
 * Wed Dec 14 2011 Shannon Hughes <shughes@redhat.com> 0.1.25-1
-- system engine build 
+- system engine build
 
 * Thu Dec 08 2011 Mike McCune <mmccune@redhat.com> 0.1.23-2
 - periodic rebuild

--- a/cli/po/as.po
+++ b/cli/po/as.po
@@ -3,2805 +3,149 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # ngoswami <ngoswami@fedoraproject.org>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2011-11-14 09:46-0500\n"
-"Last-Translator: ngoswami <ngoswami@fedoraproject.org>\n"
+"PO-Revision-Date: 2012-08-24 02:25-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: as\n"
-"Plural-Forms: \n"
-"X-Generator: Zanata 1.5.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "প্ৰমাণপত্ৰ নথিপত্ৰ %s অস্তিত্ববান নহয় অথবা পঢ়িব নোৱাৰি"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "চাবি নথিপত্ৰ %s অস্তিত্ববান নহয় অথবা পঢ়িব নোৱাৰি"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "kerberos -ৰ সহায়ত প্ৰমাণীত কৰিব নোৱাৰি"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Katello ব্যৱহাৰকাৰী একাওন্ট তথ্যসমূহ"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "একাওন্ট ব্যৱহাৰকাৰীনাম"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "একাওন্ট পাছৱাৰ্ড"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello চাৰ্ভাৰ তথ্য"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "katello চাৰ্ভাৰ হস্ট নাম (অবিকল্পিত: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "অবৈধ কমান্ড; অনুগ্ৰহ কৰি চাওক --help"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "কোনো কমান্ড দিয়া হোৱা নাই; অনুগ্ৰহ কৰি চাওক --help"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "সংঘঠন [ %s ] বিচাৰি পোৱা নগল"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "সংঘঠন [ %s ] -ৰ ভিতৰত পৰিৱেশ [ %s ] বিচাৰি পোৱা নগল"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "সংঘঠন [ %s ] -ৰ ভিতৰত উৎপাদন [ %s ] পোৱা নগল"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "সংঘঠন [%s] -ৰ ভিতৰত প্ৰদানকাৰী [%s] পোৱা নগল"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "পৰিৱেশ [%s] -ৰ ভিতৰত টেমপ্লেইট [%s] পোৱা নগল"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "পৰিৱেশ [%s] -ৰ ভিতৰত সলনিসংহতি [%s] পোৱা নগল"
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "সংঘঠন [%s] -ত চিস্টেম [%s] বিচাৰি পোৱা নগল"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "সকলো জ্ঞাত সংঘঠনসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "সংঘঠন তালিকা"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "সংঘঠন সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "সংঘঠন নাম উদাহৰণস্বৰূপ: foo.example.com (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "উপভোক্তা বিৱৰণ উদাহৰণ: foo -ৰ সংঘঠন"
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "সংঘঠন [%s] সফলতাৰে সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr "সংঘঠন [%s] সৃষ্টি কৰিব পৰা নগল"
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "এটা সংঘঠনৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "সংঘঠনৰ তথ্য"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "এটা সংঘঠন মচি পেলাওক"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "সংঘঠন [%s] সফলতাৰে মচি পেলোৱা হল"
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "এটা সংঘঠন আপডেইট কৰক"
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "সংঘঠন [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "সংঘঠনৰ Uebercert"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত সংঘঠন বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "উৎপাদন নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "জ্ঞাত উৎপাদনসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr "প্ৰদানকাৰী %s -ৰ বাবে উৎপাদন তালিকা"
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "সংঘঠন %s, পৰিৱেশ '%s' -ৰ বাবে উৎপাদন তালিকা"
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "এটা উৎপাদন সংমিহলি কৰক"
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "উৎপাদন [%s] সংমিহলি কৰিবলে ব্যৰ্থ হল: %s"
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "উৎপাদন [%s] সংমিহলিত কৰা হল"
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "উৎপাদনৰ সংমিহলিৰ অৱস্থা"
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "উৎপাদন অৱস্থা"
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "উৎপাদন উন্নত কৰা হৈছে, অপেক্ষা কৰক..."
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "এটা স্বনিৰ্বাচিত প্ৰদানকাৰীলে নতুন উৎপাদন সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "প্ৰদানকাৰী নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "উৎপাদন বিৱৰণ"
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"ভঁৰাল url উদাহৰণ: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-"ধৰি লওক হয়; খোজ কৰা urlসমূহৰ বাবে প্ৰাৰ্থী ভঁৰালসমূহ স্বচালিতভাৱে সৃষ্টি কৰক"
-" (বৈকল্পিক)"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "সফলতাৰে উৎপাদন [%s] সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "[%s] -ত খোজ কৰা ভঁৰাল Urlসমূহ"
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "এটা উৎপাদন আৰু ইয়াৰ সমল মচি পেলাওক"
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত উৎপাদন বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr "এটা সংঘঠনৰ ভিতৰত চিস্টেমসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr "পৰিৱেশ নাম উদাহৰণস্বৰূপ: উন্নয়ন"
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr "সংঘঠনৰ বাবে চিস্টেমসমূহ তালিকা [%s]"
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ৰ বাবে চিস্টেমসমূহৰ তালিকা"
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr "এটা সংঘঠনৰ ভিতৰত এটা চিস্টেম প্ৰদৰ্শন কৰক"
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr "চিস্টেমৰ নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "পৰিৱেশৰ নাম"
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr "সংঘঠন [%s] -ৰ বাবে চিস্টেম তথ্য"
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ৰ বাবে চিস্টেম তথ্য"
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr "সংঘঠন [%s] -ত চিস্টেম [%s] -ৰ বাবে পেকেইজ তথ্য"
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ত চিস্টেম [%s] -ৰ বাবে পেকেইজ তথ্য"
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "সম্পূৰ্ণ"
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr "এটা চিস্টেমৰ হাৰ্ডৱেৰ তথ্যসমূহ প্ৰদৰ্শন কৰক"
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr "সংঘঠন [%s] -ত চিস্টেম [%s] -ৰ বাবে চিস্টেম তথ্যসমূহ"
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ত চিস্টেম [%s] -ৰ বাবে চিস্টেম তথ্যসমূহ"
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "এটা চিস্টেম ৰেজিস্টাৰ কৰক"
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "সংঘঠনৰ নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-"সক্ৰিয়কৰণ চাবি, বহুতো চাবি কমাৰ সৈতে পৃথক কৰা হয় উদাহৰণস্বৰূপ "
-"--activationkey=key1,key2"
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "%s -ৰ সৈতে বিকল্প %s ধাৰ্য্য কৰিব নোৱাৰি"
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr "চিস্টেম [%s] সফলতাৰে ৰেজিস্টাৰ কৰা হল"
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr "চিস্টেম [%s] ৰেজিস্টাৰ কৰিব নোৱাৰি"
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr "এটা চিস্টেম আনৰেজিস্টাৰ কৰক"
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr "চিস্টেম [%s] -ক সফলতাৰে আনৰেজিস্টাৰ কৰা হল"
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr "এটা চিস্টেমক প্ৰমাণপত্ৰলে স্বাক্ষৰ কৰক"
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr "অস্বাক্ষৰ কৰিবলে প্ৰমাণপত্ৰ ক্ৰমিক (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr "পৰিমাণ (অবিকল্পিত: ১)"
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr "চিস্টেম [%s] সফলতাৰে স্বাক্ষৰ কৰা হল"
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr "এটা চিস্টেমৰ বাবে স্বাক্ষৰনসমূহ তালিকাভুক্ত কৰা হল"
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr "প্ৰমাণপত্ৰৰ পৰা এটা চিস্টেম অস্বাক্ষৰ কৰক"
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr "চিস্টেম [%s] সফলতাৰে অস্বাক্ষৰ কৰা হল"
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr "এটা চিস্টেম আপডেইট কৰক"
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr "চিস্টেমৰ বাবে এটা নতুন নাম"
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr "চিস্টেমৰ এটা বিৱৰণ"
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr "চিস্টেমৰ অৱস্থান"
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr "চিস্টেম [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr "চিস্টেম [%s] আপডেইট কৰিব পৰা নগল"
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত চিস্টেম বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "এটা ভঁৰালত বিতৰণসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "ভঁৰাল আইডি"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "ভঁৰালৰ নাম"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "সংঘঠন নাম উদাহৰণ: foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "উৎপাদন নাম উদাহৰণস্বৰূপ: fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "ভঁৰাল %s -ৰ বাবে বিতৰণ তালিকা"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "এটা বিতৰণৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "বিতৰণ আইডি উদাহৰণ: ks-rh-noarch (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "বিতৰণ তথ্য"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত ভঁৰাল বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "katello চাৰ্ভাৰৰ অৱস্থা পাওক"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Katello -ৰ অৱস্থা"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "চাৰ্ভাৰৰ অৱস্থা নিৰীক্ষণ কৰক"
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr "এটা পেকেইজৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr "পেকেইজ আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr "পেকেইজ তথ্য"
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr "এটা ভঁৰালত পেকেইজসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr "ভঁৰাল %s -ৰ বাবে পেকেইজ তালিকা"
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত পেকেইজ বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "কোনো বিৱৰণ উপলব্ধ নাই"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "কোনো কাৰ্য্য প্ৰদান কৰা হোৱা নাই: অনুগ্ৰহ কৰি --help চাওক"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "অবৈধ কাৰ্য্য: অনুগ্ৰহ কৰি --help চাওক"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "grep বন্ধু আউটপুট"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "ভাৰভৌচ, অধিক গঠিত আউটপুট"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "বিকল্প %s -ৰ প্ৰয়োজন; অনুগ্ৰহ কৰি --help চাওক"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "ত্ৰুটি: কাৰ্য্য ব্যৰ্থ হল"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr "ত্ৰুটি: আপুনি /etc/katello/client.conf -ত সংৰূপণ কৰা চাৰ্ভাৰ হস্টনাম"
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-"আপুনি সংযোগ কৰি থকা katello চাৰ্ভাৰৰ পৰা ঘুৰাই পঠোৱা হস্টনামৰ সৈতে মিল "
-"নাখায়।"
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "আপোনাৰ: [%s] সংৰূপীত আছে কিন্তু চাৰ্ভাৰৰ পৰা পোৱা গল: [%s]।"
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "/etc/katello/client.conf নথিপত্ৰত হস্ট শুদ্ধ কৰক"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "অবৈধ তথ্যসমূহ অথবা প্ৰমাণীত কৰিবলে অক্ষম"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "বিকল্প %s: অবৈধ বুলিয়ান মান: %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "সকলো জ্ঞাত ব্যৱহাৰকাৰী তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "ব্যৱহাৰকাৰী তালিকা"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "ব্যৱহাৰকাৰী সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "ব্যৱহাৰকাৰী নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "আৰম্ভণি পাছৱাৰ্ড (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "অসামৰ্থবান কৰা একাওন্ট (অবিকল্পিত হল 'মিছা')"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "সফলতাৰে ব্যৱহাৰকাৰী [%s] সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "ব্যৱহাৰকাৰী [%s] সৃষ্টি কৰিব পৰা নগল"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "ব্যৱহাৰকাৰীৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "ব্যৱহাৰকাৰী তথ্য"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "ব্যৱহাৰকাৰী মচি পেলাওক"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "ব্যৱহাৰকাৰী [%s] সফলাতাৰে মচি পেলোৱা হল"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "এজন ব্যৱহাৰকাৰী আপডেইট কৰক"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "আৰম্ভণি পাছৱাৰ্ড"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "ব্যৱহাৰকাৰী [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত ব্যৱহাৰকাৰী বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "সংঘঠনৰ নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "সক্ৰিয়কৰণ চাবি নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "এটা সক্ৰিয়কৰণ চাবি আপডেইট কৰক"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "নতুন টেমপ্লেইট নাম"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "সকলো সক্ৰিয়কৰণ চাবি তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "সংঘঠন [%s] -ত কোনো চাবি পোৱা নগল"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "সংঘঠন [%s] পৰিৱেশ [%s] -ত কোনো চাবি পোৱা নগল"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "সক্ৰিয়কৰণ চাবি তালিকা"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "এটা সক্ৰিয়কৰণ চাবিৰ বিষয়ে তথ্য দেখুৱাওক"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "সক্ৰিয়কৰণ চাবি তথ্য"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "এটা সক্ৰিয়কৰণ চাবি সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "পৰিৱেশ নাম উদাহৰণস্বৰূপ: dev (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "সক্ৰিয়কৰণ চাবি বিৱৰণ"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "টেমপ্লেইট নাম উদাহৰণ: চাৰ্ভাৰসমূহ"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "টেমপ্লেইট [%s] বিচাৰি পোৱা নগল"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "সক্ৰিয়কৰণ চাবি [%s] সফলতাৰে সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "সক্ৰিকৰণ চাবি [%s] সৃষ্টি কৰিব পৰা নগল"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "নতুন পৰিৱেশ নাম উদাহৰণ: dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "নতুন বিৱৰণ"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "নতুন টেমপ্লেইট নাম উদাহৰণ: চাৰ্ভাৰসমূহ"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "সক্ৰিয়কৰণ চাবি [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "এটা সক্ৰিয়কৰণ চাবি মচি পেলাওক"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "সক্ৰিয়কৰণ চাবি [%s] সফলতাৰে মচি পেলোৱা হল"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত সক্ৰিয়কৰণ চাবি বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "উপলব্ধ পেকেইজ দলসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "ভঁৰাল আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "ভঁৰাল [%s] -ত কোনো পেকেইজ দল পোৱা নগল"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "পেকেইজ দল তথ্য"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "এটা পেকেইজ দলৰ বাবে লুকআপ তথ্য"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "পেকেইজ দল আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "ভঁৰাল [%s] -ত পেকেইজ দল [%s] পোৱা নগল"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "উপলব্ধ পেকেইজ দল বিভাগসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "ভঁৰাল [%s] -ত কোনো পেকেইজ দল বিভাগসমূহ পোৱা নগল"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "পেকেইজ দল বিভাগ তথ্য"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "পেকেইজ দল বিভাগ আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "ভঁৰাল [%s] -ত পেকেইজ দল বিভাগ [%s] পোৱা নগল"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "পেকেইজ দল বিভাগ তথ্য"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত পেকেইজ দল বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "এটা পৰিৱেশৰ নতুন সলনিসংহতিসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "পৰিৱেশ নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "সলনিসংহতি তালিকা"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "এটা সলনিসংহতিৰ বিষয়ে বিৱৰিত তথ্য"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "সলনিসংহতি নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "সলনিসংহতি তথ্য"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "এটা পৰিৱেশৰ বাবে এটা নতুন সলনিসংহতি সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "পৰিৱেশ [%s] -ৰ বাবে সলনিসংহতি [%s] সফলতাৰে সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "পৰিৱেশ [%s] -ৰ বাবে সলনিসংহতি [%s] সৃষ্টি কৰিব নোৱাৰি"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "এটা সলনিসংহতিৰ আপডেইট সমলসমূহ"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s %s -ৰ আগত আহিব লাগিব"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "সলনিসংহতিলে যোগ কৰিব লগিয়া উৎপাদন"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "সলনিসংহতিৰ পৰা আতৰাবলে উৎপাদন"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "সলনিসংহতিলে যোগ কৰিবলে এটা টেমপ্লেইটৰ নাম"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "সলনিসংহতিৰ পৰা আতৰাবলে এটা টেমপ্লেইটৰ নাম"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr "উৎপাদন যৰ পৰা পেকেইজসমূহ/এৰাটা/ভঁৰালসমূহ তুলি লোৱা হয়"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "সলনিসংহতিলে যোগ কৰিবলে"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "সলনিসংহতিৰ পৰা আতৰাবলে"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "সলনিসংহতি [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "এটা সলনিসংহতি মচি পেলায়"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "এটা সলনিসংহতিক পৰৱৰ্তী পৰিৱেশলে উন্নত কৰে"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "সলনিসংহতি উন্নত কৰা হৈছে, অনুগ্ৰহ কৰি অপেক্ষা কৰক..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "সলনিসংহতি [%s] উন্নত কৰা হল"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "সলনিসংহতি [%s] উন্নতকৰণ ব্যৰ্থ হল: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত সলনিসংহতি বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr "সকলো জ্ঞাত প্ৰদানকাৰী তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr "প্ৰদানকাৰী তালিকা"
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr "এজন প্ৰদানকাৰীৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr "প্ৰদানকাৰী তথ্য"
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr "এজন প্ৰদানকাৰী সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr "এজন প্ৰদানকাৰীৰক আপডেইট কৰক"
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr "বিৱৰণ প্ৰদান কৰক"
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr "প্ৰদানকাৰী নাম"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "বিকল্প --url http:// অথবা https:// -ৰ সৈতে আৰম্ভ হব লাগিব"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "বিকল্প --url এটা বৈধ বিন্যাসত নাই"
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr "প্ৰদানকাৰী [%s] সফলতাৰে সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr "প্ৰদানকাৰী [%s] সৃষ্টি কৰিব পৰা নগল"
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr "প্ৰদানকাৰী [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr "এজন প্ৰদানকাৰীক মচি পেলাওক"
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr "এজন প্ৰদানকাৰীক সংমিহলি কৰক"
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr "প্ৰদানকাৰী [%s] সংমিহলি হবলে ব্যৰ্থ: %s"
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr "প্ৰদানকাৰী [%s] সংমিহলি কৰা হল"
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr "প্ৰদানকাৰীৰ সংমিহলিৰ অৱস্থা"
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr "প্ৰদানকাৰীৰ অৱস্থা"
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr "এটা মেনিফেস্ট নথিপত্ৰ ইমপোৰ্ট কৰক"
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr "মেনিফেস্ট নথিপত্ৰলে পথ (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr "নথিপত্ৰ %s অস্তিত্ববান নহয়"
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr "মেনিফেস্ট ইমপোৰ্ট কৰা হৈ আছে, অনুগ্ৰহ কৰি অপেক্ষা কৰক..."
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত প্ৰদানকাৰী বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "জ্ঞাত পৰিৱেশসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "সংঘঠন"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "আগৰ পৰিৱেশ"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "পৰিৱেশ তালিকা"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "পৰিৱেশ নাম উদাহৰণস্বৰূপ: foo.example.com (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "পৰিৱেশ তথ্য"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "এটা পৰিৱেশ সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "পৰিৱেশ বিৱৰণ উদাহৰণস্বৰূপ: foo -ৰ পৰিৱেশ"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "আগৰ পৰিৱেশৰ নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "পৰিৱেশ [%s] সফলতাৰে সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "পৰিৱেশ [%s] সৃষ্টি কৰিব পৰা নগল"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "এটা পৰিৱেশ আপডেইট কৰক"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "আগৰ পৰিৱেশৰ নাম"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "পৰিৱেশ [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "এটা পৰিৱেশ মচি পেলাওক"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "পৰিৱেশ [%s] সফলতাৰে মচি পেলোৱা হল"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত পৰিৱেশ বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "ক্লাএন্ট সংৰূপলে এটা বিকল্প সংৰক্ষণ কৰক"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-"সংৰক্ষণ কৰিবলে বিকল্পৰ নাম (উদাহৰণ সংঘঠন, পৰিৱেশ, প্ৰদানকাৰী, ইত্যাদী) "
-"(প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "নিৰ্ধাৰিত বিকল্পৰ অধিনত সংৰক্ষণ কৰিব লগিয়া মান (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "ক্লাএন্ট সংৰূপৰ পৰা এটা বিকল্প আতৰাওক"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "মচিব লগিয়া বিকল্পৰ নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "ক্লাএন্ট সংৰূপত সংৰক্ষীত বিকল্পসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "সংৰক্ষীত বিকল্পসমূহ"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত ক্লাএন্ট বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "সকলো টেমপ্লেইট তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "সংঘঠনৰ নাম (যদি পৰিৱেশ ধাৰ্য্য কৰা হৈছে প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "পৰিৱেশ [%s] -ত কোনো টেমপ্লেইট পোৱা নগল"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "টেমপ্লেইট তালিকা"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "এটা টেমপ্লেইটৰ বিষয়ে তালিকা তথ্য"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "টেমপ্লেইট নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "টেমপ্লেইট তথ্য"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "এটা টেমপ্লেইট নথিপত্ৰ সৃষ্টি কৰক আৰু তথ্য ইমপোৰ্ট কৰক"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "টেমপ্লেইট নথিপত্ৰলে পথ (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "টেমপ্লেইট ইমপোৰ্ট কৰা হৈছে, অনুগ্ৰহ কৰি অপেক্ষা কৰক..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "এটা ৰিক্ত টেমপ্লেইট নথিপত্ৰ সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "উপধায়ক টেমপ্লেইটৰ নাম"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "টেমপ্লেইট বিৱৰণ"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "টেমপ্লেইট [%s] সফলতাৰে সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "টেমপ্লেই [%s] সৃষ্টি কৰিব পৰা নগল"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "এটা টেমপ্লেইট আপডেইটসমূহৰ নাম আৰু বিৱৰণ"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "প্ৰতিটো %s -ৰ আগত এটা %s আহিব লাগিব"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "প্ৰাচলৰ নাম, %s অনুকৰণ কৰিব লাগিব"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "প্ৰাচলৰ মান"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "প্ৰাচলৰ নাম"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "পেকেইজ দলৰ নাম"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "পেকেইজ দল বিভাগৰ নাম"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "প্ৰাচল '%s' -ৰ বাবে সন্ধানহিন মান"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "টেমপ্লেইট আপডেইট কৰা হৈছে, অনুগ্ৰহ কৰি অপেক্ষা কৰক..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "টেমপ্লেইট [%s] সফলতাৰে আপডেইট কৰা হল"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "এটা টেমপ্লেইট মচি পেলায়"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত টেমপ্লেইট বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "এটা শ্বেল হিচাপে cli চলাওক"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr "এটা ভঁৰালৰ বাবে সকলো এৰাটা তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr "এৰাটা তালিকা"
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr "এটা চিস্টেমৰ বাবে এৰাটা তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr "সংঘঠন %s -ত চিস্টেম %s -ৰ বাবে এৰাটা"
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr "এটা এৰাটাৰ বিষয়ে তথ্য"
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr "এৰাটা আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr "এৰাটা তথ্য"
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr "katello চাৰ্ভাৰত এৰাটা বিশেষ কাৰ্য্যসমূহ"
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "অপেক্ষা কৰি আছে"
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "চলি আছে"
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "ত্ৰুটি"
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "বাতিল কৰা হল"
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "সময় অন্ত"
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr "সংমিহলিত নহয়"
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr "এটা বিশেষ URL -ত এটা ভঁৰাল সৃষ্টি কৰক"
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr "ধাৰ্য্য কৰিবলে ভঁৰাল নাম (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr "ভঁৰাললে url পথ (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr "ভঁৰাল [%s] সফলতাৰে সৃষ্টি কৰা হল"
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr "এটা URL -ত অন্তৰ্ভুক্ত কৰা খোজ ভঁৰালসমূহ"
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr "সকলো খোজ কৰা ভঁৰালসমূহলে যোগ কৰিবলে ভঁৰাল নাম উপসৰ্গ (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-"ভঁৰালসমূহৰ খোজ পৰিৱেশন কৰিবলে ৰুট url উদাহৰণস্বৰূপ: "
-"http://porkchop.devel.redhat.com/ (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr "ভঁৰাল urlসমূহ খোজ কৰা হৈ আছে, ই কিছু সময় লব পাৰে..."
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "ত্ৰুটি: %s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-"\n"
-"urlসমূহ যাৰ বাবে প্ৰাৰ্থী ভঁৰালসমূহ সৃষ্টি কৰিব লাগে নিৰ্বাচন কৰক; সুনিশ্চিত কৰিবলে `y` ব্যৱহাৰ কৰক (সহায়ৰ বাবে h):"
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr "ব্যৱহাৰকাৰী অনুৰোধত কাৰ্য্য বাতিল কৰা হল।"
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr "এটা ভঁৰালৰ বিষয়ে অৱস্থা তথ্য"
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "ভঁৰাল অৱস্থা"
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "এটা ভঁৰালৰ বিষয়ে তথ্য"
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "প্ৰগতি"
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr "ভঁৰাল %s -ৰ বিষয়ে তথ্য"
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr "এটা ভঁৰাল সংমিহলি কৰক"
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr "ভঁৰাল [%s] সংমিহলিত"
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr "ভঁৰাল [%s] সংমিহলি হবলে ব্যৰ্থ: %s"
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr "এটা সংঘঠনৰ ভিতৰত ভঁৰালসমূহ তালিকাভুক্ত কৰক"
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr "সংঘঠন নাম উদাহৰণস্বৰূপ: ACME_Corporation (প্ৰয়োজনীয়)"
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr "সংঘঠন %s পৰিৱেশ %s উৎপাদন %s -ৰ বাবে ভঁৰাল তালিকা"
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr "সংঘঠন %s -ত উৎপাদন %s -ৰ বাবে ভঁৰাল তালিকা"
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr "সংঘঠন %s পৰিৱেশ %s -ৰ বাবে ভঁৰাল তালিকা"
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr "এটা ভঁৰাল মচি পেলাওক"
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
-msgstr "ব্যৱহাৰ: %s"
+msgstr "ব্যৱহাৰ: %s\n"
 
 #: ../src/katello/client/i18n_optparse.py:49
 msgid "Usage"
@@ -2816,6 +160,7 @@ msgid "Options"
 msgstr "বিকল্পসমূহ"
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2868,6 +213,7 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr "বিকল্প %s: অবৈধ পছন্দ: %r (%s -ৰ পৰা বাছক)"
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr "এই সহায় বাৰ্তা দেখুৱাওক আৰু প্ৰস্থান কৰক"
@@ -2875,3 +221,3027 @@ msgstr "এই সহায় বাৰ্তা দেখুৱাওক আৰ�
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
 msgstr "প্ৰগ্ৰামৰ সংস্কৰণ নম্বৰ দেখুৱাওক আৰু প্ৰস্থান কৰক"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "ক্লাএন্ট সংৰূপলে এটা বিকল্প সংৰক্ষণ কৰক"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+"সংৰক্ষণ কৰিবলে বিকল্পৰ নাম (উদাহৰণ সংঘঠন, পৰিৱেশ, প্ৰদানকাৰী, ইত্যাদী) "
+"(প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "নিৰ্ধাৰিত বিকল্পৰ অধিনত সংৰক্ষণ কৰিব লগিয়া মান (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "ক্লাএন্ট সংৰূপৰ পৰা এটা বিকল্প আতৰাওক"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "মচিব লগিয়া বিকল্পৰ নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "ক্লাএন্ট সংৰূপত সংৰক্ষীত বিকল্পসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "সংৰক্ষীত বিকল্পসমূহ"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত ক্লাএন্ট বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "সকলো সক্ৰিয়কৰণ চাবি তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "সংঘঠনৰ নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr "সংঘঠন [%s] -ত কোনো চাবি পোৱা নগল"
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "সংঘঠন [%s] পৰিৱেশ [%s] -ত কোনো চাবি পোৱা নগল"
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "সক্ৰিয়কৰণ চাবি তালিকা"
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "এটা সক্ৰিয়কৰণ চাবিৰ বিষয়ে তথ্য দেখুৱাওক"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "সক্ৰিয়কৰণ চাবি নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "সক্ৰিয়কৰণ চাবি তথ্য"
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "এটা সক্ৰিয়কৰণ চাবি সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "পৰিৱেশ নাম উদাহৰণস্বৰূপ: dev (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "সক্ৰিয়কৰণ চাবি বিৱৰণ"
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "টেমপ্লেইট নাম উদাহৰণ: চাৰ্ভাৰসমূহ"
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "টেমপ্লেইট [%s] বিচাৰি পোৱা নগল"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "সক্ৰিয়কৰণ চাবি [%s] সফলতাৰে সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "সক্ৰিকৰণ চাবি [%s] সৃষ্টি কৰিব পৰা নগল"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "এটা সক্ৰিয়কৰণ চাবি আপডেইট কৰক"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "নতুন পৰিৱেশ নাম উদাহৰণ: dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "নতুন টেমপ্লেইট নাম"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "নতুন বিৱৰণ"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "নতুন টেমপ্লেইট নাম উদাহৰণ: চাৰ্ভাৰসমূহ"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "সক্ৰিয়কৰণ চাবি [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "এটা সক্ৰিয়কৰণ চাবি মচি পেলাওক"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "সক্ৰিয়কৰণ চাবি [%s] সফলতাৰে মচি পেলোৱা হল"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত সক্ৰিয়কৰণ চাবি বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "সংঘঠনৰ নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "এটা ভঁৰালত বিতৰণসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "ভঁৰাল আইডি"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "ভঁৰালৰ নাম"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "সংঘঠন নাম উদাহৰণ: foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "উৎপাদন নাম উদাহৰণস্বৰূপ: fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "ভঁৰাল %s -ৰ বাবে বিতৰণ তালিকা"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "এটা বিতৰণৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "বিতৰণ আইডি উদাহৰণ: ks-rh-noarch (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "বিতৰণ তথ্য"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত ভঁৰাল বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "সংঘঠন নাম উদাহৰণস্বৰূপ: foo.example.com (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "সকলো জ্ঞাত ব্যৱহাৰকাৰী তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "ব্যৱহাৰকাৰী তালিকা"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "ব্যৱহাৰকাৰী সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "ব্যৱহাৰকাৰী নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "আৰম্ভণি পাছৱাৰ্ড (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "অসামৰ্থবান কৰা একাওন্ট (অবিকল্পিত হল 'মিছা')"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "সফলতাৰে ব্যৱহাৰকাৰী [%s] সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "ব্যৱহাৰকাৰী [%s] সৃষ্টি কৰিব পৰা নগল"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "ব্যৱহাৰকাৰীৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "ব্যৱহাৰকাৰী তথ্য"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "ব্যৱহাৰকাৰী মচি পেলাওক"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "ব্যৱহাৰকাৰী [%s] সফলাতাৰে মচি পেলোৱা হল"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "এজন ব্যৱহাৰকাৰী আপডেইট কৰক"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "আৰম্ভণি পাছৱাৰ্ড"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "ব্যৱহাৰকাৰী [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত ব্যৱহাৰকাৰী বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "এটা পৰিৱেশৰ নতুন সলনিসংহতিসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "পৰিৱেশ নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "সলনিসংহতি তালিকা"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "এটা সলনিসংহতিৰ বিষয়ে বিৱৰিত তথ্য"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "সলনিসংহতি নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "সলনিসংহতি তথ্য"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "এটা পৰিৱেশৰ বাবে এটা নতুন সলনিসংহতি সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "পৰিৱেশ [%s] -ৰ বাবে সলনিসংহতি [%s] সফলতাৰে সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "পৰিৱেশ [%s] -ৰ বাবে সলনিসংহতি [%s] সৃষ্টি কৰিব নোৱাৰি"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "এটা সলনিসংহতিৰ আপডেইট সমলসমূহ"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s %s -ৰ আগত আহিব লাগিব"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "সলনিসংহতিলে যোগ কৰিব লগিয়া উৎপাদন"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "সলনিসংহতিৰ পৰা আতৰাবলে উৎপাদন"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "সলনিসংহতিলে যোগ কৰিবলে এটা টেমপ্লেইটৰ নাম"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "সলনিসংহতিৰ পৰা আতৰাবলে এটা টেমপ্লেইটৰ নাম"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr "উৎপাদন যৰ পৰা পেকেইজসমূহ/এৰাটা/ভঁৰালসমূহ তুলি লোৱা হয়"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "সলনিসংহতিলে যোগ কৰিবলে"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "সলনিসংহতিৰ পৰা আতৰাবলে"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "সলনিসংহতি [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "এটা সলনিসংহতি মচি পেলায়"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "সলনিসংহতি [%s] উন্নতকৰণ ব্যৰ্থ হল: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত সলনিসংহতি বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr "এটা সংঘঠনৰ ভিতৰত চিস্টেমসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr "পৰিৱেশ নাম উদাহৰণস্বৰূপ: উন্নয়ন"
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr "সংঘঠনৰ বাবে চিস্টেমসমূহ তালিকা [%s]"
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ৰ বাবে চিস্টেমসমূহৰ তালিকা"
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr "এটা সংঘঠনৰ ভিতৰত এটা চিস্টেম প্ৰদৰ্শন কৰক"
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr "চিস্টেমৰ নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "পৰিৱেশৰ নাম"
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr "সংঘঠন [%s] -ৰ বাবে চিস্টেম তথ্য"
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ৰ বাবে চিস্টেম তথ্য"
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr "সংঘঠন [%s] -ত চিস্টেম [%s] -ৰ বাবে পেকেইজ তথ্য"
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ত চিস্টেম [%s] -ৰ বাবে পেকেইজ তথ্য"
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "সম্পূৰ্ণ"
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr "এটা চিস্টেমৰ হাৰ্ডৱেৰ তথ্যসমূহ প্ৰদৰ্শন কৰক"
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr "সংঘঠন [%s] -ত চিস্টেম [%s] -ৰ বাবে চিস্টেম তথ্যসমূহ"
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr "সংঘঠন [%s] -ত পৰিৱেশ [%s] -ত চিস্টেম [%s] -ৰ বাবে চিস্টেম তথ্যসমূহ"
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "এটা চিস্টেম ৰেজিস্টাৰ কৰক"
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+"সক্ৰিয়কৰণ চাবি, বহুতো চাবি কমাৰ সৈতে পৃথক কৰা হয় উদাহৰণস্বৰূপ "
+"--activationkey=key1,key2"
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr "চিস্টেম [%s] সফলতাৰে ৰেজিস্টাৰ কৰা হল"
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr "চিস্টেম [%s] ৰেজিস্টাৰ কৰিব নোৱাৰি"
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr "এটা চিস্টেম আনৰেজিস্টাৰ কৰক"
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr "চিস্টেম [%s] -ক সফলতাৰে আনৰেজিস্টাৰ কৰা হল"
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr "এটা চিস্টেমক প্ৰমাণপত্ৰলে স্বাক্ষৰ কৰক"
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr "অস্বাক্ষৰ কৰিবলে প্ৰমাণপত্ৰ ক্ৰমিক (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr "পৰিমাণ (অবিকল্পিত: ১)"
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr "চিস্টেম [%s] সফলতাৰে স্বাক্ষৰ কৰা হল"
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr "এটা চিস্টেমৰ বাবে স্বাক্ষৰনসমূহ তালিকাভুক্ত কৰা হল"
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr "প্ৰমাণপত্ৰৰ পৰা এটা চিস্টেম অস্বাক্ষৰ কৰক"
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr "চিস্টেম [%s] সফলতাৰে অস্বাক্ষৰ কৰা হল"
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr "এটা চিস্টেম আপডেইট কৰক"
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr "চিস্টেমৰ বাবে এটা নতুন নাম"
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr "চিস্টেমৰ এটা বিৱৰণ"
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr "চিস্টেমৰ অৱস্থান"
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr "চিস্টেম [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr "চিস্টেম [%s] আপডেইট কৰিব পৰা নগল"
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত চিস্টেম বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr "এটা পেকেইজৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr "পেকেইজ আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr "পেকেইজ তথ্য"
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr "এটা ভঁৰালত পেকেইজসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr "ভঁৰাল %s -ৰ বাবে পেকেইজ তালিকা"
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত পেকেইজ বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "এটা শ্বেল হিচাপে cli চলাওক"
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "প্ৰদানকাৰী নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr "সকলো জ্ঞাত প্ৰদানকাৰী তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr "প্ৰদানকাৰী তালিকা"
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr "এজন প্ৰদানকাৰীৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr "প্ৰদানকাৰী তথ্য"
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr "এজন প্ৰদানকাৰী সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr "এজন প্ৰদানকাৰীৰক আপডেইট কৰক"
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr "বিৱৰণ প্ৰদান কৰক"
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"ভঁৰাল url উদাহৰণ: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr "প্ৰদানকাৰী নাম"
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr "প্ৰদানকাৰী [%s] সফলতাৰে সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr "প্ৰদানকাৰী [%s] সৃষ্টি কৰিব পৰা নগল"
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr "প্ৰদানকাৰী [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr "এজন প্ৰদানকাৰীক মচি পেলাওক"
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr "এজন প্ৰদানকাৰীক সংমিহলি কৰক"
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr "প্ৰদানকাৰী [%s] সংমিহলি হবলে ব্যৰ্থ: %s"
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr "প্ৰদানকাৰী [%s] সংমিহলি কৰা হল"
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr "প্ৰদানকাৰীৰ সংমিহলিৰ অৱস্থা"
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr "প্ৰদানকাৰীৰ অৱস্থা"
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr "এটা মেনিফেস্ট নথিপত্ৰ ইমপোৰ্ট কৰক"
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr "মেনিফেস্ট নথিপত্ৰলে পথ (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr "নথিপত্ৰ %s অস্তিত্ববান নহয়"
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr "মেনিফেস্ট ইমপোৰ্ট কৰা হৈ আছে, অনুগ্ৰহ কৰি অপেক্ষা কৰক..."
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত প্ৰদানকাৰী বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "katello চাৰ্ভাৰৰ অৱস্থা পাওক"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Katello -ৰ অৱস্থা"
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "কোনো বিৱৰণ উপলব্ধ নাই"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "কোনো কাৰ্য্য প্ৰদান কৰা হোৱা নাই: অনুগ্ৰহ কৰি --help চাওক"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "অবৈধ কাৰ্য্য: অনুগ্ৰহ কৰি --help চাওক"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "grep বন্ধু আউটপুট"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "ভাৰভৌচ, অধিক গঠিত আউটপুট"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr "ত্ৰুটি: আপুনি /etc/katello/client.conf -ত সংৰূপণ কৰা চাৰ্ভাৰ হস্টনাম"
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+"আপুনি সংযোগ কৰি থকা katello চাৰ্ভাৰৰ পৰা ঘুৰাই পঠোৱা হস্টনামৰ সৈতে মিল "
+"নাখায়।"
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "আপোনাৰ: [%s] সংৰূপীত আছে কিন্তু চাৰ্ভাৰৰ পৰা পোৱা গল: [%s]।"
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "/etc/katello/client.conf নথিপত্ৰত হস্ট শুদ্ধ কৰক"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "অবৈধ তথ্যসমূহ অথবা প্ৰমাণীত কৰিবলে অক্ষম"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "বিকল্প %s: অবৈধ বুলিয়ান মান: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr "এটা ভঁৰালৰ বাবে সকলো এৰাটা তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr "এৰাটা তালিকা"
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr "এটা চিস্টেমৰ বাবে এৰাটা তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr "সংঘঠন %s -ত চিস্টেম %s -ৰ বাবে এৰাটা"
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr "এটা এৰাটাৰ বিষয়ে তথ্য"
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr "এৰাটা আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr "এৰাটা তথ্য"
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত এৰাটা বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "উপলব্ধ পেকেইজ দলসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "ভঁৰাল আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "ভঁৰাল [%s] -ত কোনো পেকেইজ দল পোৱা নগল"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "পেকেইজ দল তথ্য"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "এটা পেকেইজ দলৰ বাবে লুকআপ তথ্য"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "পেকেইজ দল আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "ভঁৰাল [%s] -ত পেকেইজ দল [%s] পোৱা নগল"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "উপলব্ধ পেকেইজ দল বিভাগসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "ভঁৰাল [%s] -ত কোনো পেকেইজ দল বিভাগসমূহ পোৱা নগল"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "পেকেইজ দল বিভাগ তথ্য"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "পেকেইজ দল বিভাগ আইডি, স্ট্ৰিং মান (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "ভঁৰাল [%s] -ত পেকেইজ দল বিভাগ [%s] পোৱা নগল"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "পেকেইজ দল বিভাগ তথ্য"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত পেকেইজ দল বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "অপেক্ষা কৰি আছে"
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "চলি আছে"
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "ত্ৰুটি"
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "বাতিল কৰা হল"
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "সময় অন্ত"
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr "সংমিহলিত নহয়"
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr "এটা বিশেষ URL -ত এটা ভঁৰাল সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr "ধাৰ্য্য কৰিবলে ভঁৰাল নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr "ভঁৰাললে url পথ (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "উৎপাদন নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr "ভঁৰাল [%s] সফলতাৰে সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr "এটা URL -ত অন্তৰ্ভুক্ত কৰা খোজ ভঁৰালসমূহ"
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr "সকলো খোজ কৰা ভঁৰালসমূহলে যোগ কৰিবলে ভঁৰাল নাম উপসৰ্গ (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+"ভঁৰালসমূহৰ খোজ পৰিৱেশন কৰিবলে ৰুট url উদাহৰণস্বৰূপ: "
+"http://porkchop.devel.redhat.com/ (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+"ধৰি লওক হয়; খোজ কৰা urlসমূহৰ বাবে প্ৰাৰ্থী ভঁৰালসমূহ স্বচালিতভাৱে সৃষ্টি কৰক"
+" (বৈকল্পিক)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "[%s] -ত খোজ কৰা ভঁৰাল Urlসমূহ"
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr "ভঁৰাল urlসমূহ খোজ কৰা হৈ আছে, ই কিছু সময় লব পাৰে..."
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "ত্ৰুটি: %s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+"\n"
+"urlসমূহ যাৰ বাবে প্ৰাৰ্থী ভঁৰালসমূহ সৃষ্টি কৰিব লাগে নিৰ্বাচন কৰক; সুনিশ্চিত কৰিবলে `y` ব্যৱহাৰ কৰক (সহায়ৰ বাবে h):"
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr "ব্যৱহাৰকাৰী অনুৰোধত কাৰ্য্য বাতিল কৰা হল।"
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr "এটা ভঁৰালৰ বিষয়ে অৱস্থা তথ্য"
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "ভঁৰাল অৱস্থা"
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "এটা ভঁৰালৰ বিষয়ে তথ্য"
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "প্ৰগতি"
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr "ভঁৰাল %s -ৰ বিষয়ে তথ্য"
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr "এটা ভঁৰাল সংমিহলি কৰক"
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr "ভঁৰাল [%s] সংমিহলিত"
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr "ভঁৰাল [%s] সংমিহলি হবলে ব্যৰ্থ: %s"
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr "এটা সংঘঠনৰ ভিতৰত ভঁৰালসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr "সংঘঠন নাম উদাহৰণস্বৰূপ: ACME_Corporation (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr "সংঘঠন %s পৰিৱেশ %s উৎপাদন %s -ৰ বাবে ভঁৰাল তালিকা"
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr "সংঘঠন %s -ত উৎপাদন %s -ৰ বাবে ভঁৰাল তালিকা"
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr "সংঘঠন %s পৰিৱেশ %s -ৰ বাবে ভঁৰাল তালিকা"
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr "এটা ভঁৰাল মচি পেলাওক"
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "সকলো জ্ঞাত সংঘঠনসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "সংঘঠন তালিকা"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "সংঘঠন সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "উপভোক্তা বিৱৰণ উদাহৰণ: foo -ৰ সংঘঠন"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "সংঘঠন [%s] সফলতাৰে সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "সংঘঠন [%s] সৃষ্টি কৰিব পৰা নগল"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "এটা সংঘঠনৰ বিষয়ে তথ্য তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "সংঘঠনৰ তথ্য"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "এটা সংঘঠন মচি পেলাওক"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "সংঘঠন [%s] সফলতাৰে মচি পেলোৱা হল"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "এটা সংঘঠন আপডেইট কৰক"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "সংঘঠন [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "সংঘঠনৰ Uebercert"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত সংঘঠন বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "জ্ঞাত উৎপাদনসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "প্ৰদানকাৰী %s -ৰ বাবে উৎপাদন তালিকা"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "সংঘঠন %s, পৰিৱেশ '%s' -ৰ বাবে উৎপাদন তালিকা"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "এটা উৎপাদন সংমিহলি কৰক"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "উৎপাদন [%s] সংমিহলি কৰিবলে ব্যৰ্থ হল: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "উৎপাদন [%s] সংমিহলিত কৰা হল"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "উৎপাদনৰ সংমিহলিৰ অৱস্থা"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "উৎপাদন অৱস্থা"
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "উৎপাদন উন্নত কৰা হৈছে, অপেক্ষা কৰক..."
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "এটা স্বনিৰ্বাচিত প্ৰদানকাৰীলে নতুন উৎপাদন সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "উৎপাদন বিৱৰণ"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr "সফলতাৰে উৎপাদন [%s] সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "এটা উৎপাদন আৰু ইয়াৰ সমল মচি পেলাওক"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত উৎপাদন বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "সকলো টেমপ্লেইট তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "সংঘঠনৰ নাম (যদি পৰিৱেশ ধাৰ্য্য কৰা হৈছে প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "পৰিৱেশ [%s] -ত কোনো টেমপ্লেইট পোৱা নগল"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "টেমপ্লেইট তালিকা"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "এটা টেমপ্লেইটৰ বিষয়ে তালিকা তথ্য"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "টেমপ্লেইট নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "টেমপ্লেইট তথ্য"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "এটা টেমপ্লেইট নথিপত্ৰ সৃষ্টি কৰক আৰু তথ্য ইমপোৰ্ট কৰক"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "টেমপ্লেইট নথিপত্ৰলে পথ (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "টেমপ্লেইট ইমপোৰ্ট কৰা হৈছে, অনুগ্ৰহ কৰি অপেক্ষা কৰক..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "এটা ৰিক্ত টেমপ্লেইট নথিপত্ৰ সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "উপধায়ক টেমপ্লেইটৰ নাম"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "টেমপ্লেইট বিৱৰণ"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "টেমপ্লেইট [%s] সফলতাৰে সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "টেমপ্লেই [%s] সৃষ্টি কৰিব পৰা নগল"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "এটা টেমপ্লেইট আপডেইটসমূহৰ নাম আৰু বিৱৰণ"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "প্ৰতিটো %s -ৰ আগত এটা %s আহিব লাগিব"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "প্ৰাচলৰ নাম, %s অনুকৰণ কৰিব লাগিব"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "প্ৰাচলৰ মান"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "প্ৰাচলৰ নাম"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "পেকেইজ দলৰ নাম"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "পেকেইজ দল বিভাগৰ নাম"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "প্ৰাচল '%s' -ৰ বাবে সন্ধানহিন মান"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "টেমপ্লেইট আপডেইট কৰা হৈছে, অনুগ্ৰহ কৰি অপেক্ষা কৰক..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "টেমপ্লেইট [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "এটা টেমপ্লেইট মচি পেলায়"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত টেমপ্লেইট বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "জ্ঞাত পৰিৱেশসমূহ তালিকাভুক্ত কৰক"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "সংঘঠন"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "আগৰ পৰিৱেশ"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "পৰিৱেশ তালিকা"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "পৰিৱেশ নাম উদাহৰণস্বৰূপ: foo.example.com (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "পৰিৱেশ তথ্য"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "এটা পৰিৱেশ সৃষ্টি কৰক"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "পৰিৱেশ বিৱৰণ উদাহৰণস্বৰূপ: foo -ৰ পৰিৱেশ"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "আগৰ পৰিৱেশৰ নাম (প্ৰয়োজনীয়)"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "পৰিৱেশ [%s] সফলতাৰে সৃষ্টি কৰা হল"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "পৰিৱেশ [%s] সৃষ্টি কৰিব পৰা নগল"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "এটা পৰিৱেশ আপডেইট কৰক"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "আগৰ পৰিৱেশৰ নাম"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "পৰিৱেশ [%s] সফলতাৰে আপডেইট কৰা হল"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "এটা পৰিৱেশ মচি পেলাওক"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "পৰিৱেশ [%s] সফলতাৰে মচি পেলোৱা হল"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "katello চাৰ্ভাৰত পৰিৱেশ বিশেষ কাৰ্য্যসমূহ"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "প্ৰমাণপত্ৰ নথিপত্ৰ %s অস্তিত্ববান নহয় অথবা পঢ়িব নোৱাৰি"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "চাবি নথিপত্ৰ %s অস্তিত্ববান নহয় অথবা পঢ়িব নোৱাৰি"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "kerberos -ৰ সহায়ত প্ৰমাণীত কৰিব নোৱাৰি"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "বিকল্প %s -ৰ প্ৰয়োজন; অনুগ্ৰহ কৰি --help চাওক"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr ""

--- a/cli/po/bn.po
+++ b/cli/po/bn.po
@@ -15,2774 +15,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: bn-IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2801,6 +158,7 @@ msgid "Options"
 msgstr ""
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2853,10 +211,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/de.po
+++ b/cli/po/de.po
@@ -3,89 +3,68 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # hedda <hedda@fedoraproject.org>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 # hedda <hedda@fedoraproject.org>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2012-05-22 09:51-0400\n"
-"Last-Translator: hedda <hedda@fedoraproject.org>\n"
+"PO-Revision-Date: 2012-08-24 02:50-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de-DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "Zertifikatsdatei %s existiert nicht oder kann nicht gelesen werden"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "Schlüsseldatei %s existiert nicht oder kann nicht gelesen werden"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "Konnte nicht über Kerberos authentifizieren"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "Zeigt Versionsinformationen"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Katello Benutzer-Berechtigungsnachweise"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "Account-Benutzername"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "Account-Passwort"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello-Server-Informationen"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "Katello-Server-Hostname (Standard: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "Ungültiger Befehl; siehe --help"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "Kein Befehl angegeben; siehe --help"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "Organisation [ %s ] konnte nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 "Umgebung [ %s ] konnte innerhalb von Organisation [ %s ] nicht gefunden "
 "werden"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 "Produkt [ %s ] konnte innerhalb von Organisation [ %s ] nicht gefunden "
 "werden"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
@@ -94,435 +73,1403 @@ msgstr ""
 "Repository [ %s ] konnte innerhalb von Organisation [ %s ], Produkt [ %s ] "
 "und Umgebung [ %s ] nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 "Provider [ %s ] konnte innerhalb von Organisation [ %s ] nicht gefunden "
 "werden"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 "Vorlage [ %s ] konnte innerhalb von Umgebung [ %s ] nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 "Änderungssatz [ %s ] konnte innerhalb von Umgebung [ %s ] nicht gefunden "
 "werden"
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "Benutzer [ %s ] konnte nicht gefunden werden"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "Benutzerrolle [ %s ] konnte nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "Synchronisationsplan [ %s ] konnte nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 "Berechtigung [ %s ] für Benutzerrolle [ %s ] konnte nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "Filter [ %s ] konnte nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "System [ %s ] konnte in Org [ %s ] nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "Mehrere Systeme [ %s ] in Umgebung [ %s ] in Org [ %s ] gefunden"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "System [ %s ] in Umgebung [ %s ] in Org [ %s ] konnte nicht gefunden werden"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr "Mehrere Systeme [ %s ] in Org [ %s ], Sie müssen die Umgebung angeben"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "Name"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "Alle bekannten Organisationen auflisten"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "Organisationsliste"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "Organisation erstellen"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "Organisationsname z.B.: foo.example.com (erforderlich)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "Verbraucherbeschreibung z.B.: foo's Organisation"
-
-#: ../src/katello/client/core/organization.py:79
+#. These are a bunch of strings that are marked for translation in optparse,
+#. but not actually translated anywhere. Mark them for translation here,
+#. so we get it picked up. for local translation, and then optparse will
+#. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
+#: ../src/katello/client/i18n_optparse.py:48
 #, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "Org [ %s ] erfolgreich erstellt"
+msgid "Usage: %s\n"
+msgstr "Verwendung: %s\n"
 
-#: ../src/katello/client/core/organization.py:80
+#: ../src/katello/client/i18n_optparse.py:49
+msgid "Usage"
+msgstr "Verwendung"
+
+#: ../src/katello/client/i18n_optparse.py:50
+msgid "%prog [options]"
+msgstr "%prog [Optionen]"
+
+#: ../src/katello/client/i18n_optparse.py:51
+msgid "Options"
+msgstr "Optionen"
+
+#. stuff for option value sanity checking
+# stuff for option value sanity checking
+#: ../src/katello/client/i18n_optparse.py:54
 #, python-format
-msgid "Could not create org [ %s ]"
-msgstr "Org [ %s ] konnte nicht erstellt werden"
+msgid "no such option: %s"
+msgstr "keine solche Option: %s"
 
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "Informationen über eine Organisation anzeigen"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "Verfügbare Service-Levels"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "Organisationsinformationen"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "Organisation löschen"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "Organisation wird gelöscht, bitte warten ..."
-
-#: ../src/katello/client/core/organization.py:135
+#: ../src/katello/client/i18n_optparse.py:55
 #, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "Organisation [ %s ] erfolgreich gelöscht"
+msgid "ambiguous option: %s (%s?)"
+msgstr "mehrdeutige Option: %s (%s?)"
 
-#: ../src/katello/client/core/organization.py:138
+#: ../src/katello/client/i18n_optparse.py:56
 #, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "Löschen der Organisation [ %s ] ist fehlgeschlagen: %s"
+msgid "%s option requires an argument"
+msgstr "%s Option erfordert einen Parameter"
 
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "Organisation aktualisieren"
-
-#: ../src/katello/client/core/organization.py:162
+#: ../src/katello/client/i18n_optparse.py:57
 #, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "Org [ %s ] erfolgreich aktualisiert"
+msgid "%s option requires %d arguments"
+msgstr "%s Option erfordert %d Parameter"
 
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "Überzertifikat generieren und anzeigen"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "Zertifikat neu generieren"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "Organisations-Überzertifikat"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "Subskriptionen anzeigen"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "Subskriptionen der Organisation"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "Organisationsspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "Produktname (erforderlich)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "Umgebungsname z.B.: Produktion (Standard: Bibliothek)"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "Synchronisationsplan einrichten"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "Name des Synchronisationsplans (erforderlich)"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "Synchronisationsplan aufheben"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "Bekannte Produkte auflisten"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "Provider-Name, listet Produkt des Providers in Bibliothek"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "GPG-Schlüssel"
-
-#: ../src/katello/client/core/product.py:147
+#: ../src/katello/client/i18n_optparse.py:58
 #, python-format
-msgid "Product List For Provider %s"
-msgstr "Produktliste für Provider %s"
+msgid "%s option does not take a value"
+msgstr "%s Option akzeptiert keinen Wert"
 
-#: ../src/katello/client/core/product.py:153
+#: ../src/katello/client/i18n_optparse.py:59
+msgid "integer"
+msgstr "Integer"
+
+#: ../src/katello/client/i18n_optparse.py:60
+msgid "long integer"
+msgstr "Long Integer"
+
+#: ../src/katello/client/i18n_optparse.py:61
+msgid "floating-point"
+msgstr "Gleitkommazahl"
+
+#: ../src/katello/client/i18n_optparse.py:62
+msgid "complex"
+msgstr "Complex"
+
+#: ../src/katello/client/i18n_optparse.py:63
 #, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "Produktliste für Organisation %s, Umgebung '%s'"
+msgid "option %s: invalid %s value: %r"
+msgstr "Option %s: ungültiger %s Wert: %r"
 
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "Produkt synchronisieren"
-
-#: ../src/katello/client/core/product.py:179
+#: ../src/katello/client/i18n_optparse.py:64
 #, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "Produkt [ %s ] konnte nicht synchronisiert werden: %s"
+msgid "option %s: invalid choice: %r (choose from %s)"
+msgstr "Option %s: ungültige Auswahl: %r (wählen Sie aus %s)"
 
-#: ../src/katello/client/core/product.py:182
+#. default options
+# default options
+#: ../src/katello/client/i18n_optparse.py:67
+msgid "show this help message and exit"
+msgstr "Zeigt diese Hilfenachricht und beendet"
+
+#: ../src/katello/client/i18n_optparse.py:68
+msgid "show program's version number and exit"
+msgstr "Zeigt die Versionsnummer des Programms und beendet"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "Alle bekannten Benutzerrollen auflisten"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "Benutzerrollenliste"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "Benutzerrolle erstellen"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "Rollenname (erforderlich)"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "Rollenbeschreibung"
+
+#: ../src/katello/client/core/user_role.py:75
 #, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "Produkt [ %s ] Synchronisation abgebrochen"
+msgid "Successfully created user role [ %s ]"
+msgstr "Benutzerrolle [ %s ] erfolgreich erstellt"
 
-#: ../src/katello/client/core/product.py:185
+#: ../src/katello/client/core/user_role.py:76
 #, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "Produkt [ %s ] synchronisiert"
+msgid "Could not create user role [ %s ]"
+msgstr "Benutzerrolle [ %s ] konnte nicht erstellt werden"
 
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "Derzeit laufende Synchronisation abbrechen"
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "Informationen über Benutzerrolle anzeigen"
 
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "Status der Produktsynchronisation"
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "Benutzerrollenname (erforderlich)"
 
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "Produktstatus"
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "Details über die Berechtigungen der Rolle anzeigen"
 
-#: ../src/katello/client/core/product.py:242
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
 msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
 msgstr ""
-"Produkt in eine Umgebung übertragen \n"
-"(erstellt temporären Änderungssatz mit dem Produkt und übertragt diesen)"
+"%s\n"
+"\tfür: %s\n"
+"\tVerben: %s\n"
+"\tauf: %s"
 
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "Übertragung des Produkts, bitte warten ..."
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "Benutzerrollen-Informationen"
 
-#: ../src/katello/client/core/product.py:268
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "Benutzerrolle löschen"
+
+#: ../src/katello/client/core/user_role.py:150
 #, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "Produkt [ %s ] an Umgebung [ %s ] übertragen"
+msgid "Successfully deleted user role [ %s ]"
+msgstr "Benutzerrolle [ %s ] erfolgreich gelöscht"
 
-#: ../src/katello/client/core/product.py:271
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "Rolle aktualisieren"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "Neuer Benutzerrollenname"
+
+#: ../src/katello/client/core/user_role.py:177
 #, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "Übertragung des Produkts [ %s ] fehlgeschlagen: %s"
+msgid "Successfully updated user role [ %s ]"
+msgstr "Benutzerrolle [ %s ] erfolgreich aktualisiert"
 
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "Neues Produkt für angepassten Provider erstellen"
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "LDAP-Gruppe einer Rolle zuweisen"
 
-#: ../src/katello/client/core/product.py:297
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "Name der neuen LDAP-Gruppe (erforderlich)"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr "LDAP-Gruppe [ %s ] erfolgreich zur Benutzerrolle [ %s ] hinzugefügt"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "Zugewiesene LDAP-Gruppe von einer Rolle entfernen"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "Name der zu entfernenden LDAP-Gruppe (erforderlich)"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr "LDAP-Gruppe [ %s ] erfolgreich von Benutzerrolle [ %s ] entfernt"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "Benutzerrollenspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "Option in Client-Konfiguration speichern"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+"Name der zu speichernden Option (z.B. Org, Umgebung, Provider, etc) "
+"(erforderlich)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "Unter spezifizierter Option zu speichernder Wert (erforderlich)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "Erfolgreich"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "Option [ %s ] nicht erfolgreich gespeichert"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "Option von Client-Konfiguration entfernen"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "Name der zu löschenden Option (erforderlich)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "Option [ %s ] erfolgreich gelöscht"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "Option [ %s ] nicht erfolgreich gelöscht"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "In Client-Konfiguration gespeicherte Optionen auflisten"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "Gespeicherte Optionen"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "Clientspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "Alle Aktivierungsschlüssel auflisten"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
 #: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "Providername (erforderlich)"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "Produktbeschreibung"
-
-#: ../src/katello/client/core/product.py:303
 #: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"Repository-URL z.B.: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "Name der Organisation (erforderlich)"
 
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "Repository-Suche überspringen"
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "Umgebungsname z.B.: dev (Standard: Bibliothek)"
 
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-"\"Ja\" annehmen; automatisch Kandidaten-Repositorys für gefundene URLs "
-"erstellen (optional)"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-"GPG-Schlüssel zuweisen; dieser Schlüssel wird für jedes neue Repository "
-"verwendet, sofern nicht gpgkey oder nogpgkey für das Repo angegeben ist"
-
-#: ../src/katello/client/core/product.py:334
+#: ../src/katello/client/core/activation_key.py:69
 #, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "Produkt [ %s ] erfolgreich erstellt"
+msgid "No keys found in organization [ %s ]"
+msgstr "Keine Schlüssel in Organisation [ %s ] gefunden"
 
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
+#: ../src/katello/client/core/activation_key.py:71
 #, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "Repository-URLs gefunden @ [%s]"
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "Keine Schlüssel in Organisation [ %s ] Umgebung [ %s ] gefunden"
 
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "Produktattribute aktualisieren"
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "Aktivierungsschlüssel-Liste"
 
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "Beschreibung des Produkts ändern"
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "Informationen über einen Aktivierungsschlüssel anzeigen"
 
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "GPG-Schlüssel zum Produkt zuweisen"
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "Aktivierungsschlüssel-Name (erforderlich)"
 
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "GPG-Schlüssel auch den Repositorys des Produkts zuweisen"
-
-#: ../src/katello/client/core/product.py:378
+#: ../src/katello/client/core/activation_key.py:121
 #, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "Produkt [ %s ] erfolgreich aktualisiert"
+msgid "Could not find activation key [ %s ]"
+msgstr "Aktivierungsschlüssel [ %s ] konnte nicht gefunden werden"
 
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "Produkt und dessen Inhalt löschen"
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "Aktivierungsschlüssel-Info"
 
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "Filter eines Produkts auflisten"
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "Aktivierungsschlüssel erstellen"
 
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "Produktfilter"
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "Umgebungsname z.B.: Entwicklung (erforderlich)"
 
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "Filter zu Produkt hinzufügen"
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "Aktivierungsschlüssel-Beschreibung"
 
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "Filter von Produkt entfernen"
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "Vorlagenname z.B.: Server"
 
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "Vorlage [ %s ] konnte nicht gefunden werden"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "Aktivierungsschlüssel [ %s ] erfolgreich erstellt"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "Aktivierungsschlüssel [ %s ] konnte nicht erstellt werden"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "Aktivierungsschlüssel aktualisieren"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "Neuer Umgebungsname z.B.: Entwicklung"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "Neuer Vorlagenname"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "Neue Beschreibung"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "Neuer Vorlagenname z.B.: Server"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "Pool zum Aktivierungsschlüssel hinzufügen"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "Pool vom Aktivierungsschlüssel entfernen"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "Aktivierungsschlüssel [ %s ] erfolgreich aktualisiert"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "Aktivierungsschlüssel löschen"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "Aktivierungsschlüssel [ %s ] erfolgreich gelöscht"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "Aktivierungsschlüsselspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "Zeitformat ist ungültig. Erfordert: HH:MM:SS[+HH:MM]"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "Datumsformat ist ungültig. Erfordert: YYYY-MM-DD"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "Alle Filter auflisten"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "Organisationsname (erforderlich)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "Filterliste"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "Filter erstellen"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
 msgid "filter name (required)"
 msgstr "Filtername (erforderlich)"
 
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "Filter [ %s ] zu Produkt [ %s ] hinzugefügt"
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "Beschreibung"
 
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "Filter [ %s ] von Produkt [ %s ] entfernt"
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "Kommagetrennte Liste mit Paketnamen/nvres"
 
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "Produktspezifische Aktionen im Katello-Server"
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "Filter [ %s ] erfolgreich erstellt"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "Filter [ %s ] konnte nicht erstellt werden"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "Filter löschen"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "Filter [ %s ] erfolgreich gelöscht"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "Filterinfo"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "Filterinformationen"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "Paket zu Filter hinzufügen"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "Paket-ID (erforderlich)"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "Paket [ %s ] erfolgreich zu Filter [ %s ] hinzugefügt"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "Paket von Filter entfernen"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "Paket [ %s ] erfolgreich von Filter [ %s ] entfernt"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "Filterspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "Distributionen in einem Repository auflisten"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "Repository-ID"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "Repository-Name"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "Organisationsname z.B.: foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "Umgebungsname z.B.: Produktion (Standard: Bibliothek)"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "Produktname z.B.: fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "Distributionsliste für Repo %s"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "Informationen über eine Distribution anzeigen"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "Repository-ID (erforderlich)"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "Distributions-ID z.B.: ks-rh-noarch (erforderlich)"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "Distributionsinformationen"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "Repospezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "Inhalt des GPG-Schlüssels eingeben (Eingabe abschließen mit STRG+D):"
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "Alle GPG-Schlüssel auflisten"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "Repositorys"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+"Datei mit öffentlichem GPG-Schlüssel, falls nicht spezifiziert, wird "
+"Standardeingabe verwendet"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "Datei mit öffentlichem GPG-Schlüssel"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "Neuen Inhalt des Schlüssels abfragen"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "GPG-Schlüsselspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "Organisationsname z.B.: foo.example.com (erforderlich)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "Remote-Aktion wird ausgeführt [ %s ] ..."
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "Remote-Aktion fertiggestellt:"
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "Remote-Aktion fehlgeschlagen:"
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "Alle bekannten Benutzer auflisten"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "Benutzerliste"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "Benutzer erstellen"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "Benutzername (erforderlich)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "Initiales Passwort (erforderlich)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "E-Mail (erforderlich)"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "Deaktivierter Account (Standard ist 'false')"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "Name der Standardorganisation des Benutzers"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "Name der Standardumgebung des Benutzers"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "Benutzer [ %s ] erfolgreich erstellt"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "Benutzer [ %s ] konnte nicht erstellt werden"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "Informationen über Benutzer anzeigen"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "Benutzerinformationen"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "Benutzer löschen"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "Benutzer [ %s ] erfolgreich gelöscht"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "Benutzer aktualisieren"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "Initiales Passwort"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "E-Mail"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "Deaktivierter Account"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "Standardumgebung des Benutzers ist 'Keine'"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "Benutzer [ %s ] erfolgreich aktualisiert"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "Rollen des Benutzers auflisten"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "Rollen mit LDAP-Gruppen synchronisieren "
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "Rolle zu Benutzer zuweisen"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "Rolle von Benutzer entfernen"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "Benutzerrolle (erforderlich)"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "Rolle [ %s ] nicht gefunden"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "Benutzerbericht"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+"Berichtsformat (mögliche Werte: 'html', 'text' (Standard), 'csv', 'pdf')"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "Benutzerspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "Neue Änderungssätze einer Umgebung auflisten"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "Umgebungsname (erforderlich)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "Änderungssatz-Liste"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "Detaillierte Informationen über einen Änderungssatz"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "Name des Änderungssatzes (erforderlich)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "wird abhängige Pakete anzeigen"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "Änderungssatz-Info"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "Neuen Änderungssatz für eine Umgebung erstellen"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "Änderungssatz-Beschreibung"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "Änderungssatz [ %s ] erfolgreich für Umgebung [ %s ] erstellt"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "Änderungssatz [ %s ] konnte nicht für Umgebung [ %s ] erstellt werden"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "Aktualisiert Inhalte eines Änderungssatzes"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s muss %s vorangestellt werden"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "Name des neuen Änderungssatzes"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "Zum Änderungssatz hinzuzufügendes Produkt"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "Vom Änderungssatz zu entfernendes Produkt"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "Name einer zum Änderungssatz hinzuzufügenden Vorlage"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "Name einer vom Änderungssatz zu entfernenden Vorlage"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+"Bestimmt das Produkt, von dem Pakete/Errata/Repositorys ausgewählt werden"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "zum Änderungssatz hinzuzufügen"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "vom Änderungssatz zu entfernen"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "Änderungssatz [ %s ] erfolgreich aktualisiert"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "Löscht einen Änderungssatz"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "Übertragung des Änderungssatzes [ %s ] fehlgeschlagen: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "Änderungssatzspezifische Aktionen im Katello-Server"
 
 #: ../src/katello/client/core/system.py:47
 msgid "list systems within an organization"
 msgstr "Systeme innerhalb einer Organisation auflisten"
 
 #: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
 msgid "environment name eg: development"
 msgstr "Umgebungsname z.B.: Entwicklung"
 
@@ -540,33 +1487,35 @@ msgstr "Systemliste für Org [ %s ]"
 msgid "Systems List For Environment [ %s ] in Org [ %s ]"
 msgstr "Systemliste für Umgebung [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:82
+#: ../src/katello/client/core/system.py:83
 #: ../src/katello/client/core/system.py:134
 msgid "Service Level"
 msgstr "Service-Level"
 
-#: ../src/katello/client/core/system.py:89
+#: ../src/katello/client/core/system.py:90
 msgid "display a system within an organization"
 msgstr "Ein System innerhalb einer Organisation anzeigen"
 
-#: ../src/katello/client/core/system.py:95
+#: ../src/katello/client/core/system.py:96
 #: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
 #: ../src/katello/client/core/errata.py:105
 msgid "system name (required)"
 msgstr "Systemname (erforderlich)"
 
-#: ../src/katello/client/core/system.py:97
+#: ../src/katello/client/core/system.py:98
 #: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
 msgid "environment name"
 msgstr "Umgebungsname"
 
@@ -630,148 +1579,114 @@ msgstr ""
 "Sie können maximal eine Aktion zum Installieren/Entfernen/Aktualisieren pro "
 "Aufruf angeben"
 
-#: ../src/katello/client/core/system.py:189
+#: ../src/katello/client/core/system.py:188
 #, python-format
 msgid "Package Information for System [ %s ] in Org [ %s ]"
 msgstr "Paketinformation für System [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:191
+#: ../src/katello/client/core/system.py:190
 #, python-format
 msgid ""
 "Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "Paketinformationen für System [ %s ] in Umgebung [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "Remote-Aktion wird ausgeführt [ %s ] ..."
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "Remote-Aktion fertiggestellt:"
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "Remote-Aktion fehlgeschlagen:"
-
-#: ../src/katello/client/core/system.py:243
+#: ../src/katello/client/core/system.py:242
 msgid "display status of remote tasks"
 msgstr "Status der Remote-Aktionen anzeigen"
 
-#: ../src/katello/client/core/system.py:249
+#: ../src/katello/client/core/system.py:248
 msgid "system name"
 msgstr "Systemname"
 
-#: ../src/katello/client/core/system.py:261
+#: ../src/katello/client/core/system.py:260
 msgid "Remote tasks"
 msgstr "Remote-Aufgaben"
 
-#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:268
 msgid "Task id"
 msgstr "Aufgaben-ID"
 
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
 msgid "System"
 msgstr "System"
 
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
 msgid "Action"
 msgstr "Aktion"
 
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
 msgid "Started"
 msgstr "Gestartet"
 
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
 #: ../src/katello/client/core/repo.py:37
 msgid "Finished"
 msgstr "Fertig"
 
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
 msgid "Status"
 msgstr "Status"
 
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
 msgid "Result"
 msgstr "Ergebnis"
 
-#: ../src/katello/client/core/system.py:283
+#: ../src/katello/client/core/system.py:282
 msgid "display status of remote task"
 msgstr "Status der Remote-Aktion anzeigen"
 
-#: ../src/katello/client/core/system.py:287
+#: ../src/katello/client/core/system.py:286
 msgid "UUID of the task"
 msgstr "UUID der Aufgabe"
 
-#: ../src/katello/client/core/system.py:295
+#: ../src/katello/client/core/system.py:294
 msgid "Remote task"
 msgstr "Remote-Aufgabe"
 
-#: ../src/katello/client/core/system.py:313
+#: ../src/katello/client/core/system.py:312
 msgid "list releases available for the system"
 msgstr "Verfügbare Releases für dieses System auflisten"
 
-#: ../src/katello/client/core/system.py:319
+#: ../src/katello/client/core/system.py:318
 msgid "system name (if not specified, list all releases in the environment)"
 msgstr ""
 "Systemname (falls nicht angegeben, werden alle Releases in der Umgebung "
 "aufgelistet)"
 
-#: ../src/katello/client/core/system.py:341
+#: ../src/katello/client/core/system.py:340
 msgid "Available releases"
 msgstr "Verfügbare Releases"
 
-#: ../src/katello/client/core/system.py:349
+#: ../src/katello/client/core/system.py:348
 msgid "display a the hardware facts of a system"
 msgstr "Hardwarefakten eines Systems anzeigen"
 
-#: ../src/katello/client/core/system.py:369
+#: ../src/katello/client/core/system.py:367
 #, python-format
 msgid "System Facts For System [ %s ] in Org [ %s ]"
 msgstr "Systemfakten für System [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:371
+#: ../src/katello/client/core/system.py:369
 #, python-format
 msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
 msgstr "Systemfakten für System [ %s ] in Umgebung [ %s]  in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:388
+#: ../src/katello/client/core/system.py:386
 msgid "register a system"
 msgstr "System registrieren"
 
 #: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "Organisationsname (erforderlich)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
+#: ../src/katello/client/core/system.py:641
 msgid "service level agreement"
 msgstr "Service-Level-Vereinbarung"
 
-#: ../src/katello/client/core/system.py:396
+#: ../src/katello/client/core/system.py:394
 msgid ""
 "activation key, more keys are separated with comma e.g. "
 "--activationkey=key1,key2"
@@ -779,110 +1694,105 @@ msgstr ""
 "Aktivierungsschlüssel, mehrere Schlüssel durch Komma getrennt z.B. "
 "--activationkey=key1,key2"
 
-#: ../src/katello/client/core/system.py:397
+#: ../src/katello/client/core/system.py:395
 msgid "values of $releasever for the system"
 msgstr "Werte für $releasever für das System"
 
-#: ../src/katello/client/core/system.py:399
+#: ../src/katello/client/core/system.py:397
 msgid "system facts"
 msgstr "Systemfakten"
 
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "Option %s kann nicht mit %s spezifiziert werden"
-
-#: ../src/katello/client/core/system.py:429
+#: ../src/katello/client/core/system.py:419
 #, python-format
 msgid "Successfully registered system [ %s ]"
 msgstr "System [ %s ] erfolgreich registriert"
 
-#: ../src/katello/client/core/system.py:430
+#: ../src/katello/client/core/system.py:420
 #, python-format
 msgid "Could not register system [ %s ]"
 msgstr "System [ %s ] konnte nicht registriert werden"
 
-#: ../src/katello/client/core/system.py:435
+#: ../src/katello/client/core/system.py:425
 msgid "remove a deletion record for hypervisor"
 msgstr "Löschungseintrag für Hypervisor entfernen"
 
-#: ../src/katello/client/core/system.py:439
+#: ../src/katello/client/core/system.py:429
 msgid "hypervisor uuid (required"
 msgstr "Hypervisor-UUID (erforderlich)"
 
-#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:437
 #, python-format
 msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
 msgstr "Löschungseintrag für Hypervisor mit UUID [ %s ] erfolgreich entfernt"
 
-#: ../src/katello/client/core/system.py:453
+#: ../src/katello/client/core/system.py:443
 msgid "unregister a system"
 msgstr "System abmelden"
 
-#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:470
 #, python-format
 msgid "Successfully unregistered System [ %s ]"
 msgstr "System [ %s ] erfolgreich abgemeldet"
 
-#: ../src/katello/client/core/system.py:486
+#: ../src/katello/client/core/system.py:475
 msgid "subscribe a system to certificate"
 msgstr "Zertifikat für System subskribieren"
 
-#: ../src/katello/client/core/system.py:494
+#: ../src/katello/client/core/system.py:483
 msgid "certificate serial to unsubscribe (required)"
 msgstr "Abzumeldende Zertifikatsseriennummer  (erforderlich)"
 
-#: ../src/katello/client/core/system.py:496
+#: ../src/katello/client/core/system.py:485
 msgid "quantity (default: 1)"
 msgstr "Anzahl (Standard: 1)"
 
-#: ../src/katello/client/core/system.py:512
+#: ../src/katello/client/core/system.py:499
 #, python-format
 msgid "Successfully subscribed System [ %s ]"
 msgstr "System [ %s ] erfolgreich subskribiert"
 
-#: ../src/katello/client/core/system.py:517
+#: ../src/katello/client/core/system.py:504
 msgid "list subscriptions for a system"
 msgstr "Subskriptionen für ein System auflisten"
 
-#: ../src/katello/client/core/system.py:524
+#: ../src/katello/client/core/system.py:511
 msgid "show available subscriptions"
 msgstr "Verfügbare Subskriptionen anzeigen"
 
-#: ../src/katello/client/core/system.py:542
+#: ../src/katello/client/core/system.py:528
 #, python-format
 msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
 msgstr "Keine Subskriptionen gefunden für System [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:554
+#: ../src/katello/client/core/system.py:540
 #, python-format
 msgid "Current Subscriptions for System [ %s ]"
 msgstr "Derzeitige Subskriptionen für System [ %s ]"
 
-#: ../src/katello/client/core/system.py:556
+#: ../src/katello/client/core/system.py:542
 msgid "Serial Id"
 msgstr "Serien-ID"
 
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
 msgid "Provided products"
 msgstr "Bereitgestellte Produkte"
 
-#: ../src/katello/client/core/system.py:570
+#: ../src/katello/client/core/system.py:556
 #, python-format
 msgid "No Pools found for System [ %s ] in Org [ %s ]"
 msgstr "Keine Pools gefunden für System [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:580
+#: ../src/katello/client/core/system.py:566
 #, python-format
 msgid "Available Subscriptions for System [ %s ]"
 msgstr "Verfügbare Subskriptionen für System [ %s ]"
 
-#: ../src/katello/client/core/system.py:595
+#: ../src/katello/client/core/system.py:581
 msgid "unsubscribe a system from certificate"
 msgstr "System von Zertifikat abmelden"
 
-#: ../src/katello/client/core/system.py:603
+#: ../src/katello/client/core/system.py:589
 msgid ""
 "entitlement id to unsubscribe from (either entitlement or serial or all is "
 "required)"
@@ -890,7 +1800,7 @@ msgstr ""
 "Berechtigungs-ID, von der abgemeldet wird (entweder Berechtigungs-ID oder "
 "Serien-ID oder beide sind erforderlich)"
 
-#: ../src/katello/client/core/system.py:605
+#: ../src/katello/client/core/system.py:591
 msgid ""
 "serial id of a certificate to unsubscribe from (either entitlement or serial"
 " or all is required)"
@@ -898,7 +1808,7 @@ msgstr ""
 "Serien-ID des Zertifikats, von dem abgemeldet wird (entweder Berechtigungs-"
 "ID oder Serien-ID oder beide sind erforderlich)"
 
-#: ../src/katello/client/core/system.py:607
+#: ../src/katello/client/core/system.py:593
 msgid ""
 "unsubscribe from all currently subscribed certificates (either entitlement "
 "or serial or all is required)"
@@ -906,1542 +1816,344 @@ msgstr ""
 "Von allen derzeit subskribierten Zertifikaten abmelden (entweder "
 "Berechtigungs-ID oder Serien-ID oder beide sind erforderlich)"
 
-#: ../src/katello/client/core/system.py:629
+#: ../src/katello/client/core/system.py:614
 #, python-format
 msgid "Successfully unsubscribed System [ %s ]"
 msgstr "System [ %s ] erfolgreich abgemeldet"
 
-#: ../src/katello/client/core/system.py:635
+#: ../src/katello/client/core/system.py:620
 msgid "update a system"
 msgstr "System aktualisieren"
 
-#: ../src/katello/client/core/system.py:646
+#: ../src/katello/client/core/system.py:631
 msgid "a new name for the system"
 msgstr "Neuer Name für das System"
 
-#: ../src/katello/client/core/system.py:648
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
 msgid "a description of the system"
 msgstr "Beschreibung des Systems"
 
-#: ../src/katello/client/core/system.py:650
+#: ../src/katello/client/core/system.py:637
 msgid "location of the system"
 msgstr "Standort des Systems"
 
-#: ../src/katello/client/core/system.py:652
+#: ../src/katello/client/core/system.py:639
 msgid "value of $releasever for the system"
 msgstr "Wert für $releasever für das System"
 
-#: ../src/katello/client/core/system.py:683
+#: ../src/katello/client/core/system.py:674
 #, python-format
 msgid "Successfully updated system [ %s ]"
 msgstr "System [ %s ] erfolgreich aktualisiert"
 
-#: ../src/katello/client/core/system.py:684
+#: ../src/katello/client/core/system.py:675
 #, python-format
 msgid "Could not update system [ %s ]"
 msgstr "System [ %s ] konnte nicht gefunden aktualisiert werden"
 
-#: ../src/katello/client/core/system.py:690
+#: ../src/katello/client/core/system.py:681
 msgid "systems report"
 msgstr "Systemberichte"
 
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
 msgstr ""
-"Berichtsformat (mögliche Werte: 'html', 'text' (Standard), 'csv', 'pdf')"
 
-#: ../src/katello/client/core/system.py:724
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
 msgid "system specific actions in the katello server"
 msgstr "Systemspezifische Aktionen im Katello-Server"
 
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "Alle Filter auflisten"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "Filterliste"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "Filter erstellen"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "Beschreibung"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "Kommagetrennte Liste mit Paketnamen/nvres"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "Filter [ %s ] erfolgreich erstellt"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "Filter [ %s ] konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "Filter löschen"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "Filter [ %s ] erfolgreich gelöscht"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "Filterinfo"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "Filterinformationen"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "Paket zu Filter hinzufügen"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "Paket-ID (erforderlich)"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "Paket [ %s ] erfolgreich zu Filter [ %s ] hinzugefügt"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "Paket von Filter entfernen"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "Paket [ %s ] erfolgreich von Filter [ %s ] entfernt"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "Filterspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "Distributionen in einem Repository auflisten"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "Repository-ID"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "Repository-Name"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "Organisationsname z.B.: foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "Produktname z.B.: fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "Distributionsliste für Repo %s"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "Informationen über eine Distribution anzeigen"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "Repository-ID (erforderlich)"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "Distributions-ID z.B.: ks-rh-noarch (erforderlich)"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "Distributionsinformationen"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "Repospezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "Status des Katello-Servers abrufen"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Katello-Status"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "Status des Servers überprüfen"
-
-#: ../src/katello/client/core/package.py:40
+#: ../src/katello/client/core/package.py:38
 msgid "list information about a package"
 msgstr "Informationen über ein Paket anzeigen"
 
-#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:43
 msgid "package id, string value (required)"
 msgstr "Paket-ID, Zeichenkette (erforderlich)"
 
-#: ../src/katello/client/core/package.py:91
+#: ../src/katello/client/core/package.py:87
 msgid "Package Information"
 msgstr "Paketinformationen"
 
-#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/package.py:94
 msgid "list packages in a repository"
 msgstr "Pakete in einem Repository auflisten"
 
-#: ../src/katello/client/core/package.py:123
+#: ../src/katello/client/core/package.py:117
 #, python-format
 msgid "Package List For Repo %s"
 msgstr "Paketliste für Repo %s"
 
-#: ../src/katello/client/core/package.py:154
+#: ../src/katello/client/core/package.py:148
 msgid "search packages in a repository"
 msgstr "Pakete in einem Repository suchen"
 
-#: ../src/katello/client/core/package.py:159
+#: ../src/katello/client/core/package.py:153
 msgid ""
 "query string for searching packages, e.g. "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
 msgstr "String zur Paketsuche, z.B. 'kernel*','kernel-3.3.0-4.el6.x86_64'"
 
-#: ../src/katello/client/core/package.py:170
+#: ../src/katello/client/core/package.py:164
 #, python-format
 msgid "Package List For Repo %s and Query %s"
 msgstr "Paketliste für Repo %s und Abfrage %s"
 
-#: ../src/katello/client/core/package.py:181
+#: ../src/katello/client/core/package.py:175
 msgid "package specific actions in the katello server"
 msgstr "Paketspezifische Aktionen im Katello-Server"
 
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "Keine Beschreibung verfügbar"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "Keine Aktion angegeben: siehe --help"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "Ungültige Aktion: siehe --help"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "Grep-freundliche Ausgabe"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "Ausführliche, strukturiertere Ausgabe"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr "Spaltentrennzeichen in Grep-freundlicher Ausgabe, nur mit Option -g"
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "Option %s ist erforderlich; siehe --help"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "Option %s kollidiert mit %s; siehe --help"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "Eines von %s ist erforderlich; siehe --help"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "Mindestens eines von %s ist erforderlich; siehe --help"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "Fehler: Operation fehlgeschlagen"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
 msgstr ""
-"FEHLER: Der in /etc/katello/client.conf konfigurierte Server-Hostname stimmt"
-" nicht überein mit"
 
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "Hostname zurückgegeben vom Katello Server, mit dem Sie verbinden.  "
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "Sie haben: [%s] konfiguriert, aber haben: [%s] vom Server erhalten."
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "Bitte korrigieren Sie den Host in der /etc/katello/client.conf-Datei"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
 msgstr ""
-"Ungültige Berechtigungsnachweise oder Authentifizierung fehlgeschlagen"
 
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "Option %s: ungültige Boolesche Variable: %r"
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "CLI als Shell ausführen"
 
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "Alle bekannten Benutzer auflisten"
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "Providername (erforderlich)"
 
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "Benutzerliste"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "Benutzer erstellen"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "Benutzername (erforderlich)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "Initiales Passwort (erforderlich)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "E-Mail (erforderlich)"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "Deaktivierter Account (Standard ist 'false')"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "Name der Standardorganisation des Benutzers"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "Name der Standardumgebung des Benutzers"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "Benutzer [ %s ] erfolgreich erstellt"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "Benutzer [ %s ] konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "Informationen über Benutzer anzeigen"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "Benutzerinformationen"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "Benutzer löschen"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "Benutzer [ %s ] erfolgreich gelöscht"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "Benutzer aktualisieren"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "Initiales Passwort"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "E-Mail"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "Deaktivierter Account"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "Standardumgebung des Benutzers ist 'Keine'"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "Benutzer [ %s ] erfolgreich aktualisiert"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "Rollen des Benutzers auflisten"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "Benutzerrollenliste"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "Rollen mit LDAP-Gruppen synchronisieren "
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "Rolle zu Benutzer zuweisen"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "Rolle von Benutzer entfernen"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "Benutzerrolle (erforderlich)"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "Rolle [ %s ] nicht gefunden"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "Benutzerbericht"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "Benutzerspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "Inhalt des GPG-Schlüssels eingeben (Eingabe abschließen mit STRG+D):"
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "Alle GPG-Schlüssel auflisten"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "Name der Organisation (erforderlich)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "Keine GPG-Schlüssel in Organisation [ %s ] gefunden"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "GPG-Schlüsselliste"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "Informationen über GPG-Schlüssel anzeigen"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "Aktivierungsschlüssel-Name (erforderlich)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "GPG-Schlüssel [ %s ] konnte nicht gefunden werden"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "Repositorys"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "GPG-Schlüsselinfo"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "GPG-Schlüssel erstellen"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-"Datei mit öffentlichem GPG-Schlüssel, falls nicht spezifiziert, wird "
-"Standardeingabe verwendet"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "GPG-Schlüssel [ %s ] erfolgreich erstellt"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "GPG-Schlüssel [ %s ] konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "Aktivierungsschlüssel aktualisieren"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "Neuer Vorlagenname"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "Datei mit öffentlichem GPG-Schlüssel"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "Neuen Inhalt des Schlüssels abfragen"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "GPG-Schlüssel [ %s ] erfolgreich aktualisiert"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "GPG-Schlüssel [ %s ] konnte nicht aktualisiert werden"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "GPG-Schlüssel löschen"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "GPG-Schlüssel [ %s ] erfolgreich gelöscht"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "GPG-Schlüsselspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "Alle Aktivierungsschlüssel auflisten"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "Umgebungsname z.B.: dev (Standard: Bibliothek)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "Keine Schlüssel in Organisation [ %s ] gefunden"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "Keine Schlüssel in Organisation [ %s ] Umgebung [ %s ] gefunden"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "Aktivierungsschlüssel-Liste"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "Informationen über einen Aktivierungsschlüssel anzeigen"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "Aktivierungsschlüssel [ %s ] konnte nicht gefunden werden"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "Aktivierungsschlüssel-Info"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "Aktivierungsschlüssel erstellen"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "Umgebungsname z.B.: Entwicklung (erforderlich)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "Aktivierungsschlüssel-Beschreibung"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "Vorlagenname z.B.: Server"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "Vorlage [ %s ] konnte nicht gefunden werden"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "Aktivierungsschlüssel [ %s ] erfolgreich erstellt"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "Aktivierungsschlüssel [ %s ] konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "Neuer Umgebungsname z.B.: Entwicklung"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "Neue Beschreibung"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "Neuer Vorlagenname z.B.: Server"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "Pool zum Aktivierungsschlüssel hinzufügen"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "Pool vom Aktivierungsschlüssel entfernen"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "Aktivierungsschlüssel [ %s ] erfolgreich aktualisiert"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "Aktivierungsschlüssel löschen"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "Aktivierungsschlüssel [ %s ] erfolgreich gelöscht"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "Aktivierungsschlüsselspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "Verfügbare Paketgruppen auflisten"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "Repository-ID, Zeichenkette (erforderlich)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "Keine Paketgruppen in Repo [%s] gefunden"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "Paketgruppeninformationen"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "Suchinformationen für Paketgruppe"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "Paketgruppen-ID, Zeichenkette (erforderlich)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "Paketgruppe [%s] nicht in Repo [%s] gefunden"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "Verfügbare Paketgruppen-Kategorien auflisten"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "Keine Paketgruppen-Kategorien in Repo [%s] gefunden"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "Paketgruppenkategorie-Informationen"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "Paketgruppenkategorie-ID, Zeichenkette (erforderlich)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "Paketgruppen-Kategorie [%s]  nich in Repo [%s] gefunden"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "Paketgruppenkategorie-Informationen"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "Paketgruppenspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "Neue Änderungssätze einer Umgebung auflisten"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "Umgebungsname (erforderlich)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "Änderungssatz-Liste"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "Detaillierte Informationen über einen Änderungssatz"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "Name des Änderungssatzes (erforderlich)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "wird abhängige Pakete anzeigen"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "Änderungssatz-Info"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "Neuen Änderungssatz für eine Umgebung erstellen"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "Änderungssatz-Beschreibung"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "Änderungssatz [ %s ] erfolgreich für Umgebung [ %s ] erstellt"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "Änderungssatz [ %s ] konnte nicht für Umgebung [ %s ] erstellt werden"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "Aktualisiert Inhalte eines Änderungssatzes"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s muss %s vorangestellt werden"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "Name des neuen Änderungssatzes"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "Zum Änderungssatz hinzuzufügendes Produkt"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "Vom Änderungssatz zu entfernendes Produkt"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "Name einer zum Änderungssatz hinzuzufügenden Vorlage"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "Name einer vom Änderungssatz zu entfernenden Vorlage"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-"Bestimmt das Produkt, von dem Pakete/Errata/Repositorys ausgewählt werden"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "zum Änderungssatz hinzuzufügen"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "vom Änderungssatz zu entfernen"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "Änderungssatz [ %s ] erfolgreich aktualisiert"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "Löscht einen Änderungssatz"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "Überträgt einen Änderungssatz an die nächste Umgebung"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "Übertragung des Änderungssatzes, bitte warten ..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "Änderungssatz [ %s ] übertragen"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "Übertragung des Änderungssatzes [ %s ] fehlgeschlagen: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "Änderungssatzspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/provider.py:59
+#: ../src/katello/client/core/provider.py:57
 msgid "list all known providers"
 msgstr "Alle bekannten Provider auflisten"
 
-#: ../src/katello/client/core/provider.py:81
+#: ../src/katello/client/core/provider.py:79
 msgid "Provider List"
 msgstr "Provider-Liste"
 
-#: ../src/katello/client/core/provider.py:89
+#: ../src/katello/client/core/provider.py:87
 msgid "list information about a provider"
 msgstr "Informationen über einen Provider anzeigen"
 
-#: ../src/katello/client/core/provider.py:104
+#: ../src/katello/client/core/provider.py:102
 msgid "Provider Information"
 msgstr "Provider-Informationen"
 
-#: ../src/katello/client/core/provider.py:116
+#: ../src/katello/client/core/provider.py:114
 msgid "create a provider"
 msgstr "Provider erstellen"
 
-#: ../src/katello/client/core/provider.py:118
+#: ../src/katello/client/core/provider.py:116
 msgid "update a provider"
 msgstr "Provider aktualisieren"
 
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
 msgid "provider description"
 msgstr "Provider-Beschreibung"
 
-#: ../src/katello/client/core/provider.py:139
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"Repository-URL z.B.: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
 msgid "provider name"
 msgstr "Provider-Name"
 
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "Option --url muss mit http:// oder https:// beginnen"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "Option --url ist in einem ungültigen Format"
-
-#: ../src/katello/client/core/provider.py:159
+#: ../src/katello/client/core/provider.py:147
 #, python-format
 msgid "Successfully created provider [ %s ]"
 msgstr "Provider [ %s ] erfolgreich erstellt"
 
-#: ../src/katello/client/core/provider.py:160
+#: ../src/katello/client/core/provider.py:148
 #, python-format
 msgid "Could not create provider [ %s ]"
 msgstr "Provider [ %s ] konnte nicht erstellt werden"
 
-#: ../src/katello/client/core/provider.py:167
+#: ../src/katello/client/core/provider.py:155
 #, python-format
 msgid "Successfully updated provider [ %s ]"
 msgstr "Provider [ %s ] erfolgreich aktualisiert"
 
-#: ../src/katello/client/core/provider.py:185
+#: ../src/katello/client/core/provider.py:173
 msgid "delete a provider"
 msgstr "Provider löschen"
 
-#: ../src/katello/client/core/provider.py:201
+#: ../src/katello/client/core/provider.py:189
 msgid "synchronize a provider"
 msgstr "Provider synchronisieren"
 
-#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/provider.py:204
 #, python-format
 msgid "Provider [ %s ] failed to sync: %s"
 msgstr "Provider [ %s ] konnte nicht synchronisiert werden: %s"
 
-#: ../src/katello/client/core/provider.py:219
+#: ../src/katello/client/core/provider.py:207
 #, python-format
 msgid "Provider [ %s ] synchronization cancelled"
 msgstr "Provider [ %s ] Synchronisation abgebrochen"
 
-#: ../src/katello/client/core/provider.py:222
+#: ../src/katello/client/core/provider.py:210
 #, python-format
 msgid "Provider [ %s ] synchronized"
 msgstr "Provider [ %s ] synchronisiert"
 
-#: ../src/katello/client/core/provider.py:245
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "Derzeit laufende Synchronisation abbrechen"
+
+#: ../src/katello/client/core/provider.py:233
 msgid "status of provider's synchronization"
 msgstr "Status der Provider-Synchronisation"
 
-#: ../src/katello/client/core/provider.py:258
+#: ../src/katello/client/core/provider.py:246
 #, python-format
 msgid "%d%% done (%d of %d packages downloaded)"
 msgstr "%d%% fertig (%d von %d Paketen heruntergeladen)"
 
-#: ../src/katello/client/core/provider.py:269
+#: ../src/katello/client/core/provider.py:257
 msgid "Provider Status"
 msgstr "Provider-Status"
 
-#: ../src/katello/client/core/provider.py:277
+#: ../src/katello/client/core/provider.py:265
 msgid "import a manifest file"
 msgstr "Manifestdatei importieren"
 
-#: ../src/katello/client/core/provider.py:283
+#: ../src/katello/client/core/provider.py:271
 msgid "path to the manifest file (required)"
 msgstr "Pfad zur Manifestdatei (erforderlich)"
 
-#: ../src/katello/client/core/provider.py:285
+#: ../src/katello/client/core/provider.py:273
 msgid "force reimporting the manifest"
 msgstr "Neuimport von Manifest erzwingen"
 
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
 #, python-format
 msgid "File %s does not exist"
 msgstr "Datei %s existiert nicht"
 
-#: ../src/katello/client/core/provider.py:307
+#: ../src/katello/client/core/provider.py:295
 msgid "Importing manifest, please wait... "
 msgstr "Manifest wird importiert, bitte warten... "
 
-#: ../src/katello/client/core/provider.py:320
+#: ../src/katello/client/core/provider.py:308
 msgid "refresh provider's products repositories"
 msgstr "Produkt-Repositorys des Anbieters aktualisieren"
 
-#: ../src/katello/client/core/provider.py:329
+#: ../src/katello/client/core/provider.py:317
 #, python-format
 msgid "Provider successfully refreshed [ %s ]"
 msgstr "Provider erfolgreich aktualisiert [ %s ]"
 
-#: ../src/katello/client/core/provider.py:336
+#: ../src/katello/client/core/provider.py:324
 msgid "provider specific actions in the katello server"
 msgstr "Provider-spezifische Aktionen im Katello-Server"
 
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "Bekannte Umgebungen auflisten"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "Org"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "Vorausgehende Umgebung"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "Umgebungsliste"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "Bestimmte Umgebung auflisten"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "Umgebungsname z.B.: foo.example.com (erforderlich)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "Umgebungsinfo"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "Umgebung erstellen"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "Umgebungsbeschreibung z.B.: foo's Umgebung"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "Name vorausgehender Umgebung (erforderlich)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "Umgebung [ %s ] erfolgreich erstellt"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "Umgebung [ %s ] konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "Umgebung aktualisieren"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "Name vorausgehender Umgebung"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "Umgebung [ %s ] erfolgreich aktualisiert"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "Umgebung löschen"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "Umgebung [ %s ] erfolgreich gelöscht"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "Umgebungsspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "Option in Client-Konfiguration speichern"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-"Name der zu speichernden Option (z.B. Org, Umgebung, Provider, etc) "
-"(erforderlich)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "Unter spezifizierter Option zu speichernder Wert (erforderlich)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "Erfolgreich"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "Option [ %s ] nicht erfolgreich gespeichert"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "Option von Client-Konfiguration entfernen"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "Name der zu löschenden Option (erforderlich)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "Option [ %s ] erfolgreich gelöscht"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "Option [ %s ] nicht erfolgreich gelöscht"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "In Client-Konfiguration gespeicherte Optionen auflisten"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "Gespeicherte Optionen"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "Clientspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "Alle Vorlagen auflisten"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "Name der Organisation (erforderlich bei Angabe der Umgebung)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "Keine Vorlagen in Umgebung [ %s ] gefunden"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "Vorlagenliste"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "Informationen über eine Vorlage anzeigen"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "Vorlagenname (erforderlich)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "Vorlageninfo"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "Vorlagendatei erstellen und Daten importieren"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "Pfad zur Vorlagendatei (erforderlich)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "Vorlage wird importiert, bitte warten ... "
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "Vorlage in Datei exportieren"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "Umgebungsname z.B. Entwicklung"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "Format des Exports, mögliche Werte: %s, Standard: json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "Datei %s konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "Vorlage wird exportiert, bitte warten ... "
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "Vorlage wurde erfolgreich in Datei %s exportiert"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "Leere Vorlagendatei erstellen"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "Name der übergeordneten Vorlage"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "Vorlagenbeschreibung"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "Vorlage [ %s ] erfolgreich erstellt"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "Vorlage [ %s ] konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "Name und Beschreibung einer Vorlage aktualisieren"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "%s muss immer %s vorangestellt sein"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "Name oder nvre des Produkts (epoch:name-rel.ease-ver.sio.n)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "Name des Parameters, %s muss folgen"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "Wert des Parameters"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "Name des Parameters"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "Name der Paketgruppe"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "Name der Paketgruppen-Kategorie"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "Distributions-ID"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "Bestimmt das Produkt, von dem Repositorys ausgewählt werden"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "Zur Vorlage hinzuzufügendes Repository "
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "Von Vorlage zu entfernendes Repository "
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "Fehlender Wert für Parameter '%s'"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "Vorlage wird aktualisiert, bitte warten ..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "Vorlage [ %s ] erfolgreich aktualisiert"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "Vorlage löschen"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "Umgebungsname z.B.: foo.example.com (Standard: Bibliothek)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "Vorlagenspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "CLI als Shell ausführen"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "Bekannte Syncpläne auflisten"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "Sync-Planliste"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "Info über Sync-Plan anzeigen"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "Name des Sync-Plans (erforderlich)"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "Sync-Planinfo"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "Synchronisationsplan erstellen"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "Planbeschreibung"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-"Intervall der Synchronisationswiederholungen (Auswahl: [%s], Standard: "
-"keine)"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "Datum der ersten Synchronisation (erfordert, Format: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-"Zeit der ersten Synchronisation (erfordert, Format: HH:MM:SS, Standard: "
-"00:00:00)"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "Synchronisationsplan [ %s ] erfolgreich erstellt"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "Synchronisationsplan [ %s ] konnte nicht erstellt werden"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "Sync-Plan aktualisieren"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "Neuer Sync-Planname"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "Datum der ersten Synchronisation (Format: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "Zeit der ersten Synchronisation (Format: HH:MM:SS)"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "Sie müssen sowohl --date als auch --time angeben"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "Sync-Plan [ %s ] erfolgreich aktualisiert"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "Sync-Plan löschen"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "Sync-Plan [ %s ] erfolgreich gelöscht"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr "Synchronisationsplanspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "Version des Katello-Servers abrufen"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "Version des Servers überprüfen"
-
-#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "Status des Katello-Servers abrufen"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Katello-Status"
+
+#: ../src/katello/client/core/permission.py:53
 msgid "create a permission for a user role"
 msgstr "Berechtigungen für Benutzerrolle erstellen"
 
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "Rollenname (erforderlich)"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
 msgid "permission name (required)"
 msgstr "Berechtigungsname (erforderlich)"
 
-#: ../src/katello/client/core/permission.py:61
+#: ../src/katello/client/core/permission.py:58
 msgid "permission description"
 msgstr "Berechtigungsbeschreibung"
 
-#: ../src/katello/client/core/permission.py:62
+#: ../src/katello/client/core/permission.py:59
 msgid "organization name"
 msgstr "Organisationsname"
 
-#: ../src/katello/client/core/permission.py:63
+#: ../src/katello/client/core/permission.py:60
 msgid "scope of the permisson (required)"
 msgstr "Bereich der Berechtigung (erforderlich)"
 
-#: ../src/katello/client/core/permission.py:64
+#: ../src/katello/client/core/permission.py:61
 msgid "verbs for the permission"
 msgstr "Verben für die Berechtigung"
 
-#: ../src/katello/client/core/permission.py:65
+#: ../src/katello/client/core/permission.py:62
 msgid "tags for the permission"
 msgstr "Tags für die Berechtigung"
 
-#: ../src/katello/client/core/permission.py:81
+#: ../src/katello/client/core/permission.py:76
 #, python-format
 msgid "Invalid scope [ %s ]"
 msgstr "Ungültiger Bereich [ %s ]"
 
-#: ../src/katello/client/core/permission.py:88
+#: ../src/katello/client/core/permission.py:83
 #, python-format
 msgid "Could not find tag [ %s ] in scope of [ %s ]"
 msgstr "Tag [ %s ] konnte in Bereich [ %s ] nicht gefunden werden"
 
-#: ../src/katello/client/core/permission.py:112
+#: ../src/katello/client/core/permission.py:101
 #, python-format
 msgid "Successfully created permission [ %s ] for user role [ %s ]"
 msgstr "Berechtigung [ %s ] erfolgreich für Benutzerrolle [ %s ] erstellt"
 
-#: ../src/katello/client/core/permission.py:113
+#: ../src/katello/client/core/permission.py:102
 #, python-format
 msgid "Could not create permission [ %s ]"
 msgstr "Berechtigung [ %s ] konnte nicht erstellt werden"
 
-#: ../src/katello/client/core/permission.py:119
+#: ../src/katello/client/core/permission.py:108
 msgid "delete a permission"
 msgstr "Berechtigung löschen"
 
-#: ../src/katello/client/core/permission.py:137
+#: ../src/katello/client/core/permission.py:125
 #, python-format
 msgid "Successfully deleted permission [ %s ] for role [ %s ]"
 msgstr "Berechtigung [ %s ] erfolgreich von Benutzerrolle [ %s ] gelöscht"
 
-#: ../src/katello/client/core/permission.py:143
+#: ../src/katello/client/core/permission.py:131
 msgid "list permissions for a user role"
 msgstr "Berechtigungen für Benutzerrolle auflisten"
 
-#: ../src/katello/client/core/permission.py:170
+#: ../src/katello/client/core/permission.py:158
 msgid "Permission List"
 msgstr "Berechtiungsliste"
 
-#: ../src/katello/client/core/permission.py:177
+#: ../src/katello/client/core/permission.py:165
 msgid "list available scopes, verbs and tags that can be set in a permission"
 msgstr ""
 "Verfügbare Bereiche, Verben und Tags auflisten, die in einer Berechtigung "
 "gesetzt werden können"
 
-#: ../src/katello/client/core/permission.py:181
+#: ../src/katello/client/core/permission.py:169
 msgid ""
 "organization name eg: foo.example.com,\n"
 "lists organization specific verbs"
@@ -2449,26 +2161,100 @@ msgstr ""
 "Organisationsname z.B.: foo.example.com,\n"
 "listet organisationsspezifische Verben auf"
 
-#: ../src/katello/client/core/permission.py:182
+#: ../src/katello/client/core/permission.py:170
 msgid "filter listed results by scope"
 msgstr "Aufgelistete Ergebnisse nach Bereich filtern"
 
-#: ../src/katello/client/core/permission.py:200
+#: ../src/katello/client/core/permission.py:188
 #, python-format
 msgid "Available verbs and tags for permission scope %s"
 msgstr "Verfügbare Verben und Tags für Berechtigungsbereich %s"
 
-#: ../src/katello/client/core/permission.py:202
+#: ../src/katello/client/core/permission.py:190
 msgid "Available verbs"
 msgstr "Verfügbare Verben"
 
-#: ../src/katello/client/core/permission.py:221
+#: ../src/katello/client/core/permission.py:209
 msgid "None"
 msgstr "Keine"
 
-#: ../src/katello/client/core/permission.py:259
+#: ../src/katello/client/core/permission.py:247
 msgid "permission pecific actions in the katello server"
 msgstr "Berechtigungsspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "Keine Beschreibung verfügbar"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "Keine Aktion angegeben: siehe --help"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "Ungültige Aktion: siehe --help"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "Grep-freundliche Ausgabe"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "Ausführliche, strukturiertere Ausgabe"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr "Spaltentrennzeichen in Grep-freundlicher Ausgabe, nur mit Option -g"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+"FEHLER: Der in /etc/katello/client.conf konfigurierte Server-Hostname stimmt"
+" nicht überein mit"
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "Hostname zurückgegeben vom Katello Server, mit dem Sie verbinden.  "
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "Sie haben: [%s] konfiguriert, aber haben: [%s] vom Server erhalten."
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "Bitte korrigieren Sie den Host in der /etc/katello/client.conf-Datei"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+"Ungültige Berechtigungsnachweise oder Authentifizierung fehlgeschlagen"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "Option %s: ungültige Boolesche Variable: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
 
 #: ../src/katello/client/core/errata.py:42
 msgid "list all errata for a repo"
@@ -2490,26 +2276,116 @@ msgstr "Errata-Liste"
 msgid "list errata for a system"
 msgstr "Errata für ein System auflisten"
 
-#: ../src/katello/client/core/errata.py:125
+#: ../src/katello/client/core/errata.py:124
 #, python-format
 msgid "Errata for system %s in organization %s"
 msgstr "Errata für System %s in Organisation %s"
 
-#: ../src/katello/client/core/errata.py:132
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
 msgid "information about an errata"
 msgstr "Informationen über ein Errata"
 
-#: ../src/katello/client/core/errata.py:136
+#: ../src/katello/client/core/errata.py:170
 msgid "errata id, string value (required)"
 msgstr "Errata-ID, Zeichenkette (erforderlich)"
 
-#: ../src/katello/client/core/errata.py:185
+#: ../src/katello/client/core/errata.py:217
 msgid "Errata Information"
 msgstr "Errata-Informationen"
 
-#: ../src/katello/client/core/errata.py:194
+#: ../src/katello/client/core/errata.py:226
 msgid "errata specific actions in the katello server"
 msgstr "Errataspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "Version des Katello-Servers abrufen"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "Version des Servers überprüfen"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "Verfügbare Paketgruppen auflisten"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "Repository-ID, Zeichenkette (erforderlich)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "Keine Paketgruppen in Repo [%s] gefunden"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "Paketgruppeninformationen"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "Suchinformationen für Paketgruppe"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "Paketgruppen-ID, Zeichenkette (erforderlich)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "Paketgruppe [%s] nicht in Repo [%s] gefunden"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "Verfügbare Paketgruppen-Kategorien auflisten"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "Keine Paketgruppen-Kategorien in Repo [%s] gefunden"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "Paketgruppenkategorie-Informationen"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "Paketgruppenkategorie-ID, Zeichenkette (erforderlich)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "Paketgruppen-Kategorie [%s]  nich in Repo [%s] gefunden"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "Paketgruppenkategorie-Informationen"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "Paketgruppenspezifische Aktionen im Katello-Server"
 
 #: ../src/katello/client/core/repo.py:34
 msgid "Waiting"
@@ -2539,20 +2415,27 @@ msgstr "Zeitüberschreitung"
 msgid "Not synced"
 msgstr "Nicht synchronisiert"
 
-#: ../src/katello/client/core/repo.py:116
+#: ../src/katello/client/core/repo.py:114
 msgid "create a repository at a specified URL"
 msgstr "Repository unter angegebener URL erstellen"
 
-#: ../src/katello/client/core/repo.py:122
+#: ../src/katello/client/core/repo.py:120
 msgid "repository name to assign (required)"
 msgstr "Zuzuweisender Repository-Name (erforderlich)"
 
-#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:122
 msgid "url path to the repository (required)"
 msgstr "URL-Pfad zum Repository (erforderlich)"
 
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "Produktname (erforderlich)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
 msgid ""
 "GPG key to be assigned to the repository; by default, the product's GPG key "
 "will be used."
@@ -2560,28 +2443,28 @@ msgstr ""
 "Der zum Repository zugewiesene GPG-Schlüssel; standardmäßig wird der GPG-"
 "Schlüssel des Produkts verwendet."
 
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
 msgid "Don't assign a GPG key to the repository."
 msgstr "Kein GPG-Schlüssel zum Repository zuweisen."
 
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
 #, python-format
 msgid "Successfully created repository [ %s ]"
 msgstr "Repository [ %s ] erfolgreich erstellt"
 
-#: ../src/katello/client/core/repo.py:154
+#: ../src/katello/client/core/repo.py:149
 msgid "discovery repositories contained within a URL"
 msgstr "Discovery-Repositorys innerhalb einer URL"
 
-#: ../src/katello/client/core/repo.py:160
+#: ../src/katello/client/core/repo.py:155
 msgid ""
 "repository name prefix to add to all the discovered repositories (required)"
 msgstr ""
 "Repository-Namenspräfix für alle gefundenen Repositorys (erforderlich)"
 
-#: ../src/katello/client/core/repo.py:162
+#: ../src/katello/client/core/repo.py:157
 msgid ""
 "root url to perform discovery of repositories eg: "
 "http://porkchop.devel.redhat.com/ (required)"
@@ -2589,18 +2472,33 @@ msgstr ""
 "Root-URL zur Suche von Repositorys z.B.: http://porkchop.devel.redhat.com/ "
 "(erforderlich)"
 
-#: ../src/katello/client/core/repo.py:192
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+"\"Ja\" annehmen; automatisch Kandidaten-Repositorys für gefundene URLs "
+"erstellen (optional)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "Repository-URLs gefunden @ [%s]"
+
+#: ../src/katello/client/core/repo.py:183
 msgid "Discovering repository urls, this could take some time..."
 msgstr ""
 "Suchen von Repository-URLs, dieser Vorgang kann einige Zeit in Anspruch "
 "nehmen ..."
 
-#: ../src/katello/client/core/repo.py:196
+#: ../src/katello/client/core/repo.py:187
 #, python-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: ../src/katello/client/core/repo.py:216
+#: ../src/katello/client/core/repo.py:207
 msgid ""
 "\n"
 "Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
@@ -2608,332 +2506,802 @@ msgstr ""
 "\n"
 "Wählen Sie URLs, für die Kandidaten-Repos erstellt werden sollen; `j` zur Bestätigung (h für Hilfe):"
 
-#: ../src/katello/client/core/repo.py:226
+#: ../src/katello/client/core/repo.py:217
 msgid "Operation aborted upon user request."
 msgstr "Operation durch Benutzer abgebrochen."
 
-#: ../src/katello/client/core/repo.py:275
+#: ../src/katello/client/core/repo.py:266
 msgid "status information about a repository"
 msgstr "Statusinformation über ein Repository"
 
-#: ../src/katello/client/core/repo.py:298
+#: ../src/katello/client/core/repo.py:289
 msgid "Repository Status"
 msgstr "Repository-Status"
 
-#: ../src/katello/client/core/repo.py:305
+#: ../src/katello/client/core/repo.py:296
 msgid "information about a repository"
 msgstr "Informationen über ein Repository"
 
-#: ../src/katello/client/core/repo.py:319
+#: ../src/katello/client/core/repo.py:310
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: ../src/katello/client/core/repo.py:322
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "GPG-Schlüssel"
+
+#: ../src/katello/client/core/repo.py:313
 #, python-format
 msgid "Information About Repo %s"
 msgstr "Informationen über Repo %s"
 
-#: ../src/katello/client/core/repo.py:329
+#: ../src/katello/client/core/repo.py:320
 msgid "updates repository attributes"
 msgstr "Aktualisiert Repository-Attribute"
 
-#: ../src/katello/client/core/repo.py:345
+#: ../src/katello/client/core/repo.py:336
 #, python-format
 msgid "Successfully updated repository [ %s ]"
 msgstr "Repository [ %s ] erfolgreich aktualisiert"
 
-#: ../src/katello/client/core/repo.py:351
+#: ../src/katello/client/core/repo.py:342
 msgid "synchronize a repository"
 msgstr "Repository synchronisieren"
 
-#: ../src/katello/client/core/repo.py:361
+#: ../src/katello/client/core/repo.py:352
 #, python-format
 msgid "Repo [ %s ] synced"
 msgstr "Repo [ %s ] synchronisiert"
 
-#: ../src/katello/client/core/repo.py:364
+#: ../src/katello/client/core/repo.py:355
 #, python-format
 msgid "Repo [ %s ] synchronization cancelled"
 msgstr "Repo [ %s ] Synchronisation abgebrochen"
 
-#: ../src/katello/client/core/repo.py:367
+#: ../src/katello/client/core/repo.py:358
 #, python-format
 msgid "Repo [ %s ] failed to sync: %s"
 msgstr "Repo [ %s ] konnte nicht synchronisiert werden: %s"
 
-#: ../src/katello/client/core/repo.py:373
+#: ../src/katello/client/core/repo.py:364
 msgid "cancel currently running synchronization of a repository"
 msgstr "Derzeit laufende Synchronisation eines Repositorys abbrechen"
 
-#: ../src/katello/client/core/repo.py:388
+#: ../src/katello/client/core/repo.py:379
 msgid "enable a repository"
 msgstr "Repository aktivieren"
 
-#: ../src/katello/client/core/repo.py:390
+#: ../src/katello/client/core/repo.py:381
 msgid "disable a repository"
 msgstr "Repository deaktivieren"
 
-#: ../src/katello/client/core/repo.py:409
+#: ../src/katello/client/core/repo.py:400
 msgid "list repos within an organization"
 msgstr "Repos innerhalb einer Organisation auflisten"
 
-#: ../src/katello/client/core/repo.py:413
+#: ../src/katello/client/core/repo.py:404
 msgid "organization name eg: ACME_Corporation (required)"
 msgstr "Organisationsname z.B.: ACME_Corporation (erforderlich)"
 
-#: ../src/katello/client/core/repo.py:419
+#: ../src/katello/client/core/repo.py:410
 msgid "list also disabled repositories"
 msgstr "Ebenfalls deaktivierte Repositorys anzeigen"
 
-#: ../src/katello/client/core/repo.py:439
+#: ../src/katello/client/core/repo.py:430
 #, python-format
 msgid "Repo List For Org %s Environment %s Product %s"
 msgstr "Repo-Liste für Org %s Umgebung %s Produkt %s"
 
-#: ../src/katello/client/core/repo.py:446
+#: ../src/katello/client/core/repo.py:437
 #, python-format
 msgid "Repo List for Product %s in Org %s "
 msgstr "Repo-Liste für Produkt %s in Org %s "
 
-#: ../src/katello/client/core/repo.py:453
+#: ../src/katello/client/core/repo.py:444
 #, python-format
 msgid "Repo List For Org %s Environment %s"
 msgstr "Repo-Liste für Org %s Umgebung %s "
 
-#: ../src/katello/client/core/repo.py:463
+#: ../src/katello/client/core/repo.py:454
 msgid "delete a repository"
 msgstr "Repository löschen"
 
-#: ../src/katello/client/core/repo.py:476
+#: ../src/katello/client/core/repo.py:467
 msgid "list filters of a repository"
 msgstr "Filter eines Repositorys auflisten"
 
-#: ../src/katello/client/core/repo.py:482
+#: ../src/katello/client/core/repo.py:473
 msgid "prints also filters assigned to repository's product."
 msgstr "Ebenfalls Filter von Produkten des Repositorys anzeigen."
 
-#: ../src/katello/client/core/repo.py:492
+#: ../src/katello/client/core/repo.py:483
 msgid "Repository Filters"
 msgstr "Repository-Filter"
 
-#: ../src/katello/client/core/repo.py:506
+#: ../src/katello/client/core/repo.py:497
 msgid "add a filter to a repository"
 msgstr "Filter zu Repository hinzufügen"
 
-#: ../src/katello/client/core/repo.py:508
+#: ../src/katello/client/core/repo.py:499
 msgid "remove a filter from a repository"
 msgstr "Filter von Repository entfernen"
 
-#: ../src/katello/client/core/repo.py:538
+#: ../src/katello/client/core/repo.py:529
 #, python-format
 msgid "Added filter [ %s ] to repository [ %s ]"
 msgstr "Filter [ %s ] zu Repository [ %s ] hinzugefügt"
 
-#: ../src/katello/client/core/repo.py:541
+#: ../src/katello/client/core/repo.py:532
 #, python-format
 msgid "Removed filter [ %s ] to repository [ %s ]"
 msgstr "Filter [ %s ] von Repository [ %s ] entfernt"
 
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "Alle bekannten Benutzerrollen auflisten"
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "Bekannte Syncpläne auflisten"
 
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "Benutzerrolle erstellen"
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
 
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "Rollenbeschreibung"
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "Sync-Planliste"
 
-#: ../src/katello/client/core/user_role.py:77
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "Info über Sync-Plan anzeigen"
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "Name des Sync-Plans (erforderlich)"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "Sync-Planinfo"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "Synchronisationsplan erstellen"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "Planbeschreibung"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
 #, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "Benutzerrolle [ %s ] erfolgreich erstellt"
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+"Intervall der Synchronisationswiederholungen (Auswahl: [%s], Standard: "
+"keine)"
 
-#: ../src/katello/client/core/user_role.py:78
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "Datum der ersten Synchronisation (erfordert, Format: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+"Zeit der ersten Synchronisation (erfordert, Format: HH:MM:SS, Standard: "
+"00:00:00)"
+
+#: ../src/katello/client/core/sync_plan.py:135
 #, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "Benutzerrolle [ %s ] konnte nicht erstellt werden"
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "Synchronisationsplan [ %s ] erfolgreich erstellt"
 
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "Informationen über Benutzerrolle anzeigen"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "Benutzerrollenname (erforderlich)"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "Details über die Berechtigungen der Rolle anzeigen\n"
-
-#: ../src/katello/client/core/user_role.py:109
+#: ../src/katello/client/core/sync_plan.py:136
 #, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "Synchronisationsplan [ %s ] konnte nicht erstellt werden"
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "Sync-Plan aktualisieren"
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "Neuer Sync-Planname"
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "Datum der ersten Synchronisation (Format: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "Zeit der ersten Synchronisation (Format: HH:MM:SS)"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "Sync-Plan [ %s ] erfolgreich aktualisiert"
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "Sync-Plan löschen"
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "Sync-Plan [ %s ] erfolgreich gelöscht"
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr "Synchronisationsplanspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "Alle bekannten Organisationen auflisten"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "Organisationsliste"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "Organisation erstellen"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "Verbraucherbeschreibung z.B.: foo's Organisation"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "Org [ %s ] erfolgreich erstellt"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "Org [ %s ] konnte nicht erstellt werden"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "Informationen über eine Organisation anzeigen"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "Verfügbare Service-Levels"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "Organisationsinformationen"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "Organisation löschen"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "Organisation wird gelöscht, bitte warten ..."
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "Organisation [ %s ] erfolgreich gelöscht"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "Löschen der Organisation [ %s ] ist fehlgeschlagen: %s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "Organisation aktualisieren"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "Org [ %s ] erfolgreich aktualisiert"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "Überzertifikat generieren und anzeigen"
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "Zertifikat neu generieren"
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "Organisations-Überzertifikat"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "Subskriptionen anzeigen"
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "Subskriptionen der Organisation"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "Organisationsspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "Synchronisationsplan einrichten"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "Name des Synchronisationsplans (erforderlich)"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "Synchronisationsplan aufheben"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "Bekannte Produkte auflisten"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "Provider-Name, listet Produkt des Providers in Bibliothek"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "Produktliste für Provider %s"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "Produktliste für Organisation %s, Umgebung '%s'"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "Produkt synchronisieren"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "Produkt [ %s ] konnte nicht synchronisiert werden: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "Produkt [ %s ] Synchronisation abgebrochen"
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "Produkt [ %s ] synchronisiert"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "Status der Produktsynchronisation"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "Produktstatus"
+
+#: ../src/katello/client/core/product.py:249
 msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
 msgstr ""
-"%s\n"
-"\tfür: %s\n"
-"\tVerben: %s\n"
-"\tauf: %s"
+"Produkt in eine Umgebung übertragen \n"
+"(erstellt temporären Änderungssatz mit dem Produkt und übertragt diesen)"
 
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "Benutzerrollen-Informationen"
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "Übertragung des Produkts, bitte warten ..."
 
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "Benutzerrolle löschen"
-
-#: ../src/katello/client/core/user_role.py:152
+#: ../src/katello/client/core/product.py:275
 #, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "Benutzerrolle [ %s ] erfolgreich gelöscht"
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "Produkt [ %s ] an Umgebung [ %s ] übertragen"
 
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "Rolle aktualisieren"
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "Übertragung des Produkts [ %s ] fehlgeschlagen: %s"
 
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "Neuer Benutzerrollenname"
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "Neues Produkt für angepassten Provider erstellen"
 
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "Produktbeschreibung"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "Repository-Suche überspringen"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
 msgstr ""
-"Geben Sie mindestens einen Parameter an, um die Benutzerrolle zu "
-"aktualisieren"
+"GPG-Schlüssel zuweisen; dieser Schlüssel wird für jedes neue Repository "
+"verwendet, sofern nicht gpgkey oder nogpgkey für das Repo angegeben ist"
 
-#: ../src/katello/client/core/user_role.py:180
+#: ../src/katello/client/core/product.py:339
 #, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "Benutzerrolle [ %s ] erfolgreich aktualisiert"
+msgid "Successfully created product [ %s ]"
+msgstr "Produkt [ %s ] erfolgreich erstellt"
 
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "LDAP-Gruppe einer Rolle zuweisen"
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "Produktattribute aktualisieren"
 
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "Name der neuen LDAP-Gruppe (erforderlich)"
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "Beschreibung des Produkts ändern"
 
-#: ../src/katello/client/core/user_role.py:204
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "GPG-Schlüssel zum Produkt zuweisen"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "GPG-Schlüssel auch den Repositorys des Produkts zuweisen"
+
+#: ../src/katello/client/core/product.py:383
 #, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr "LDAP-Gruppe [ %s ] erfolgreich zur Benutzerrolle [ %s ] hinzugefügt"
+msgid "Successfully updated product [ %s ]"
+msgstr "Produkt [ %s ] erfolgreich aktualisiert"
 
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "Zugewiesene LDAP-Gruppe von einer Rolle entfernen"
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "Produkt und dessen Inhalt löschen"
 
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "Name der zu entfernenden LDAP-Gruppe (erforderlich)"
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "Filter eines Produkts auflisten"
 
-#: ../src/katello/client/core/user_role.py:228
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "Produktfilter"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "Filter zu Produkt hinzufügen"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "Filter von Produkt entfernen"
+
+#: ../src/katello/client/core/product.py:463
 #, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr "LDAP-Gruppe [ %s ] erfolgreich von Benutzerrolle [ %s ] entfernt"
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "Filter [ %s ] zu Produkt [ %s ] hinzugefügt"
 
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "Benutzerrollenspezifische Aktionen im Katello-Server"
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "Zeitformat ist ungültig. Erfordert: HH:MM:SS[+HH:MM]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "Datumsformat ist ungültig. Erfordert: YYYY-MM-DD"
-
-#. These are a bunch of strings that are marked for translation in optparse,
-#. but not actually translated anywhere. Mark them for translation here,
-#. so we get it picked up. for local translation, and then optparse will
-#. use them.
-#: ../src/katello/client/i18n_optparse.py:48
+#: ../src/katello/client/core/product.py:466
 #, python-format
-msgid "Usage: %s\n"
-msgstr "Verwendung: %s\n"
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "Filter [ %s ] von Produkt [ %s ] entfernt"
 
-#: ../src/katello/client/i18n_optparse.py:49
-msgid "Usage"
-msgstr "Verwendung"
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "Produktspezifische Aktionen im Katello-Server"
 
-#: ../src/katello/client/i18n_optparse.py:50
-msgid "%prog [options]"
-msgstr "%prog [Optionen]"
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "Alle Vorlagen auflisten"
 
-#: ../src/katello/client/i18n_optparse.py:51
-msgid "Options"
-msgstr "Optionen"
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "Name der Organisation (erforderlich bei Angabe der Umgebung)"
 
-#. stuff for option value sanity checking
-#: ../src/katello/client/i18n_optparse.py:54
+#: ../src/katello/client/core/template.py:67
 #, python-format
-msgid "no such option: %s"
-msgstr "keine solche Option: %s"
+msgid "No templates found in environment [ %s ]"
+msgstr "Keine Vorlagen in Umgebung [ %s ] gefunden"
 
-#: ../src/katello/client/i18n_optparse.py:55
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "Vorlagenliste"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "Informationen über eine Vorlage anzeigen"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "Vorlagenname (erforderlich)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "Vorlageninfo"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "Vorlagendatei erstellen und Daten importieren"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "Pfad zur Vorlagendatei (erforderlich)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "Vorlage wird importiert, bitte warten ... "
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "Vorlage in Datei exportieren"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "Umgebungsname z.B. Entwicklung"
+
+#: ../src/katello/client/core/template.py:200
 #, python-format
-msgid "ambiguous option: %s (%s?)"
-msgstr "mehrdeutige Option: %s (%s?)"
+msgid "format of the export, possible values: %s, default: json"
+msgstr "Format des Exports, mögliche Werte: %s, Standard: json"
 
-#: ../src/katello/client/i18n_optparse.py:56
+#: ../src/katello/client/core/template.py:218
 #, python-format
-msgid "%s option requires an argument"
-msgstr "%s Option erfordert einen Parameter"
+msgid "Could not create file %s"
+msgstr "Datei %s konnte nicht erstellt werden"
 
-#: ../src/katello/client/i18n_optparse.py:57
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "Vorlage wird exportiert, bitte warten ... "
+
+#: ../src/katello/client/core/template.py:225
 #, python-format
-msgid "%s option requires %d arguments"
-msgstr "%s Option erfordert %d Parameter"
+msgid "Template was exported successfully to file %s"
+msgstr "Vorlage wurde erfolgreich in Datei %s exportiert"
 
-#: ../src/katello/client/i18n_optparse.py:58
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "Leere Vorlagendatei erstellen"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "Name der übergeordneten Vorlage"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "Vorlagenbeschreibung"
+
+#: ../src/katello/client/core/template.py:268
 #, python-format
-msgid "%s option does not take a value"
-msgstr "%s Option akzeptiert keinen Wert"
+msgid "Successfully created template [ %s ]"
+msgstr "Vorlage [ %s ] erfolgreich erstellt"
 
-#: ../src/katello/client/i18n_optparse.py:59
-msgid "integer"
-msgstr "Integer"
-
-#: ../src/katello/client/i18n_optparse.py:60
-msgid "long integer"
-msgstr "Long Integer"
-
-#: ../src/katello/client/i18n_optparse.py:61
-msgid "floating-point"
-msgstr "Gleitkommazahl"
-
-#: ../src/katello/client/i18n_optparse.py:62
-msgid "complex"
-msgstr "Complex"
-
-#: ../src/katello/client/i18n_optparse.py:63
+#: ../src/katello/client/core/template.py:269
 #, python-format
-msgid "option %s: invalid %s value: %r"
-msgstr "Option %s: ungültiger %s Wert: %r"
+msgid "Could not create template [ %s ]"
+msgstr "Vorlage [ %s ] konnte nicht erstellt werden"
 
-#: ../src/katello/client/i18n_optparse.py:64
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "Name und Beschreibung einer Vorlage aktualisieren"
+
+#: ../src/katello/client/core/template.py:291
 #, python-format
-msgid "option %s: invalid choice: %r (choose from %s)"
-msgstr "Option %s: ungültige Auswahl: %r (wählen Sie aus %s)"
+msgid "each %s must be preceeded by %s"
+msgstr "%s muss immer %s vorangestellt sein"
 
-#. default options
-#: ../src/katello/client/i18n_optparse.py:67
-msgid "show this help message and exit"
-msgstr "Zeigt diese Hilfenachricht und beendet"
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:68
-msgid "show program's version number and exit"
-msgstr "Zeigt die Versionsnummer des Programms und beendet"
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "Name des Parameters, %s muss folgen"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "Wert des Parameters"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "Name des Parameters"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "Name der Paketgruppe"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "Name der Paketgruppen-Kategorie"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "Distributions-ID"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "Bestimmt das Produkt, von dem Repositorys ausgewählt werden"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "Zur Vorlage hinzuzufügendes Repository "
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "Von Vorlage zu entfernendes Repository "
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "Fehlender Wert für Parameter '%s'"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "Vorlage wird aktualisiert, bitte warten ..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "Vorlage [ %s ] erfolgreich aktualisiert"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "Vorlage löschen"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "Umgebungsname z.B.: foo.example.com (Standard: Bibliothek)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "Vorlagenspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "Bekannte Umgebungen auflisten"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "Org"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "Vorausgehende Umgebung"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "Umgebungsliste"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "Bestimmte Umgebung auflisten"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "Umgebungsname z.B.: foo.example.com (erforderlich)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "Umgebungsinfo"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "Umgebung erstellen"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "Umgebungsbeschreibung z.B.: foo's Umgebung"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "Name vorausgehender Umgebung (erforderlich)"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "Umgebung [ %s ] erfolgreich erstellt"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "Umgebung [ %s ] konnte nicht erstellt werden"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "Umgebung aktualisieren"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "Name vorausgehender Umgebung"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "Umgebung [ %s ] erfolgreich aktualisiert"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "Umgebung löschen"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "Umgebung [ %s ] erfolgreich gelöscht"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "Umgebungsspezifische Aktionen im Katello-Server"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "Zertifikatsdatei %s existiert nicht oder kann nicht gelesen werden"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "Schlüsseldatei %s existiert nicht oder kann nicht gelesen werden"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "Konnte nicht über Kerberos authentifizieren"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "Option %s ist erforderlich; siehe --help"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "Option %s kollidiert mit %s; siehe --help"
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "Mindestens eines von %s ist erforderlich; siehe --help"

--- a/cli/po/es.po
+++ b/cli/po/es.po
@@ -3,85 +3,64 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # gguerrer <gguerrer@fedoraproject.org>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 # gguerrer <gguerrer@fedoraproject.org>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2012-05-24 07:50-0400\n"
-"Last-Translator: gguerrer <gguerrer@fedoraproject.org>\n"
+"PO-Revision-Date: 2012-08-24 02:46-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: es-ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "Archivo de certificado [ %s ] no existe o no se puede leer"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "Archivo de clave %s no existe o no se puede leer"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "No se pudo autenticar a través de kerberos"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "Imprime información de versión"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Credenciales de cuenta de usuario de Katello"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "Nombre de usuario de cuenta"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "Contraseña de cuenta"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Información de servidor de Katello"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "Nombre de host de servidor de Katello (predeterminado: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "Comando inválido; por favor ver --help"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "No se especificó ningún comando; por favor ver --help"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "No se pudo encontrar organización [ %s ]"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
-msgstr "No se pudo encontrar entorno dentro de la organización [ %s ]"
+msgstr "No se pudo encontrar entorno [ %s ] dentro de la organización [ %s ]"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
-msgstr "No se pudo encontrar producto dentro de la organización [ %s ]"
+msgstr "No se pudo encontrar producto [%s] dentro de la organización [ %s ]"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
@@ -90,66 +69,71 @@ msgstr ""
 "No se pudo encontrar repositorio [ %s ] dentro de la organización  [ %s ], "
 "producto  [ %s ] y entorno [ %s ]"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
-msgstr "No se pudo encontrar organización [ %s ]"
+msgstr "No se pudo encontrar [ %s ] organización [ %s ]"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "No se pudo encontrar plantilla [ %s ] dentro del entorno  [ %s ]"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "No se pudo encontrar Changeset [ %s ] dentro del entorno  [ %s ],"
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "No se pudo encontrar  [ %s ]"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "No se pudo encontrar rol  [ %s ]"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "No se pudo encontrar sincronización de plan  [ %s ]"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr "No se pudo encontrar permiso [ %s ] para rol de usuario [ %s ]"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "No se pudo encontrar filtro [ %s ]"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "No se pudo hallar sistema [ %s ] en Organización [ %s ]"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Se hallaron sistemas ambiguos [ %s ] en entorno [ %s ] en Organización [ %s "
 "]"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "No se pudo hallar sistema [ %s ] en entorno [ %s ] en Organización [ %s ]"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
@@ -158,365 +142,1332 @@ msgstr ""
 "Se hallaron sistemas ambiguos [ %s ] en Org [ %s ], debe especificar el "
 "entorno"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "nombre"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "Listar todas las organizaciones conocidas"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "Lista de organizaciones"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "Crear una organización"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "Nombrar organización. Por ejemplo, foo.example.com (requerido)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "Descripción de usuario. Por ejemplo: organización de foo"
-
-#: ../src/katello/client/core/organization.py:79
+#. These are a bunch of strings that are marked for translation in optparse,
+#. but not actually translated anywhere. Mark them for translation here,
+#. so we get it picked up. for local translation, and then optparse will
+#. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
+#: ../src/katello/client/i18n_optparse.py:48
 #, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "Organización creada con [ %s ]"
+msgid "Usage: %s\n"
+msgstr "Uso: %s\n"
 
-#: ../src/katello/client/core/organization.py:80
+#: ../src/katello/client/i18n_optparse.py:49
+msgid "Usage"
+msgstr "Uso"
+
+#: ../src/katello/client/i18n_optparse.py:50
+msgid "%prog [options]"
+msgstr "%prog [opciones]"
+
+#: ../src/katello/client/i18n_optparse.py:51
+msgid "Options"
+msgstr "Opciones"
+
+#. stuff for option value sanity checking
+# stuff for option value sanity checking
+#: ../src/katello/client/i18n_optparse.py:54
 #, python-format
-msgid "Could not create org [ %s ]"
-msgstr "No se pudo crear organización [ %s ]"
+msgid "no such option: %s"
+msgstr "No hay tal opción: %s"
 
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "Listar información sobre una organización"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "Niveles de servicio disponibles"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "Información de organización"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "Borrar una organización"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "Borrar la organización, por favor espere..."
-
-#: ../src/katello/client/core/organization.py:135
+#: ../src/katello/client/i18n_optparse.py:55
 #, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "Organización borrada con éxito [ %s ]"
+msgid "ambiguous option: %s (%s?)"
+msgstr "Opción ambigua: %s (%s?)"
 
-#: ../src/katello/client/core/organization.py:138
+#: ../src/katello/client/i18n_optparse.py:56
 #, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "Borrado de organización [ %s ] falló: %s"
+msgid "%s option requires an argument"
+msgstr "%s opción requiere un argumento"
 
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "Actualizar una organización"
-
-#: ../src/katello/client/core/organization.py:162
+#: ../src/katello/client/i18n_optparse.py:57
 #, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "Organización actualizada con éxito[ %s ]"
+msgid "%s option requires %d arguments"
+msgstr "%s opción requiere %d argumentos"
 
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "Generar y mostrar el certificado Ueber\n"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "Regenerar el certificado"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "Organización Uebercert"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "Mostrar suscripciones"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "Suscripciones de organización"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "Acciones específicas de organización en el servidor de Katello"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "Nombre de producto (requerido)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "Nombre de entorno por ejemplo: producción (predeterminado: Library)"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "Establecer un plan de sincronización"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "Nombre de plan de sincronización (requerido)"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "Des-configurar un plan de sincronización"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "Lista de productos conocidos"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "Nombre de provedor, lista producto de proveedor en la biblioteca"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "Llave GPG"
-
-#: ../src/katello/client/core/product.py:147
+#: ../src/katello/client/i18n_optparse.py:58
 #, python-format
-msgid "Product List For Provider %s"
-msgstr "Lista de productos para proveedor %s"
+msgid "%s option does not take a value"
+msgstr "%s opción no lleva un valor"
 
-#: ../src/katello/client/core/product.py:153
+#: ../src/katello/client/i18n_optparse.py:59
+msgid "integer"
+msgstr "Entero"
+
+#: ../src/katello/client/i18n_optparse.py:60
+msgid "long integer"
+msgstr "Entero largo"
+
+#: ../src/katello/client/i18n_optparse.py:61
+msgid "floating-point"
+msgstr "Punto flotante"
+
+#: ../src/katello/client/i18n_optparse.py:62
+msgid "complex"
+msgstr "Complejo"
+
+#: ../src/katello/client/i18n_optparse.py:63
 #, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "Lista de productos para Organización %s, entorno '%s'"
+msgid "option %s: invalid %s value: %r"
+msgstr "opción %s: inválido %s valor: %r"
 
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "Sincronizar un producto"
-
-#: ../src/katello/client/core/product.py:179
+#: ../src/katello/client/i18n_optparse.py:64
 #, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "Falló la sincronización de producto [ %s ]: %s"
+msgid "option %s: invalid choice: %r (choose from %s)"
+msgstr "opción %s: selección inválida: %r (elegir de %s)"
 
-#: ../src/katello/client/core/product.py:182
+#. default options
+# default options
+#: ../src/katello/client/i18n_optparse.py:67
+msgid "show this help message and exit"
+msgstr "Mostrar este mensaje de ejemplo y salir"
+
+#: ../src/katello/client/i18n_optparse.py:68
+msgid "show program's version number and exit"
+msgstr "Mostrar número de versión de programa y salir"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "Listar todos los roles conocidos"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "Lista de roles de usuario"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "Crear rol de usuario"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "Nombre de rol (requerido)"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "Descripción de rol"
+
+#: ../src/katello/client/core/user_role.py:75
 #, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "Sincronización de producto [ %s ] cancelada"
+msgid "Successfully created user role [ %s ]"
+msgstr "Creado correctamente el rol de usuario [ %s ]"
 
-#: ../src/katello/client/core/product.py:185
+#: ../src/katello/client/core/user_role.py:76
 #, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "Producto [ %s ]  sincronizado"
+msgid "Could not create user role [ %s ]"
+msgstr "No se pudo crear rol de usuario [ %s ]"
 
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "Cancelar sincronización actualmente en ejecución"
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "Lista de información sobre rol de usuario"
 
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "Estatus de sincronización de producto"
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "Nombre de rol de usuario (requerido)"
 
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "Estatus de producto"
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
 msgstr ""
-"Promover un producto a un entorno\n"
-"(crea un Changeset temporal con el producto y lo promueve) "
+"Imprimir en pantalla la información de cada uno de los permisos del rol"
 
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "Promoviendo el producto, por favor espere.."
-
-#: ../src/katello/client/core/product.py:268
+#: ../src/katello/client/core/user_role.py:107
 #, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "Producto [ %s ] promovido al entorno [ %s ] "
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
 
-#: ../src/katello/client/core/product.py:271
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "Información de rol de usuario"
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "Borrar rol de usuario"
+
+#: ../src/katello/client/core/user_role.py:150
 #, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "Promoción del producto [ %s ] falló: %s"
+msgid "Successfully deleted user role [ %s ]"
+msgstr "Rol de usuario borrado correctamente [ %s ]"
 
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "Crear un nuevo producto para un proveedor personal"
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "Actualizar un rol"
 
-#: ../src/katello/client/core/product.py:297
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "Nombre de rol del nuevo usuario"
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr "Actualizado correctamente rol de usuario [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "Asignar grupo LDAP a un rol"
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "Nuevo nombre de grupo LDAP (requerido)"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+"Ha sido añadido con éxito el grupo LDAP [ %s ] al rol de usuario [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "Retirar el grupo LDAP asignado al rol"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "Nombre de grupo LDAP ha sido retirado (requerido)"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+"Ha sido retirado con éxito el grupo LDAP [ %s ] del rol de usuario [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "Acciones específicas de rol de usuario en el servidor Katello"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "Guardar una opción para la configuración de cliente"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+"Nombre de la opción a guardar (por ejemplo, entorno, proveedor, etc) "
+"(requerido)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "Valor a ser guardado bajo una opción específica (requerido)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "Exitosamente"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "No ha recordado la opción [ %s ]"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "Retirar una opción de la configuración de cliente"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "Nombre de la opción que va a ser borrada (requerido)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "Olvidó con éxito la opción  [ %s ]"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "No olvidó la opción  [ %s ]"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "Listar opciones guardadas en la configuración de cliente"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "Opciones guardadas"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "Acciones específicas de cliente en el servidor de Katello"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "Listar todas las llaves de activación"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
 #: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "Nombre de proveedor (requerido)"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "Descripción de producto"
-
-#: ../src/katello/client/core/product.py:303
 #: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"URL de repositorio. Por ejemplo, "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "Nombre de organización (requerido)"
 
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "Saltar descubrimiento de repositorio"
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "Nombre de entorno por ejemplo: dev (predeterminado:library)"
 
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-"Suponga que Sí; automáticamente crea repositorios de candidatos para URL "
-"descubiertas (opcional)"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-"Asignar una llave GPG ; esta llave será utilizada para cada nuevo "
-"repositorio a menos que gpgkey o nogpgkey se especifique."
-
-#: ../src/katello/client/core/product.py:334
+#: ../src/katello/client/core/activation_key.py:69
 #, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "Producto creado con éxito [ %s ] "
+msgid "No keys found in organization [ %s ]"
+msgstr "No se encontraron las llaves en organización [ %s ]"
 
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
+#: ../src/katello/client/core/activation_key.py:71
 #, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "URL de repositorio descubiertas @ [ %s ]"
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "No se encontraron las llaves en organización [ %s ] entorno [ %s ]"
 
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "Actualizar atributos de un producto"
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "Lista de llaves de activación"
 
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "Cambiar descripción del producto"
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "Mostrar información sobre llave de activación"
 
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "Asignar una gpgkey al producto"
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "Nombre de llave de activación (requerida)"
 
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "Asignar también la gpgkey a los repositorios del producto"
-
-#: ../src/katello/client/core/product.py:378
+#: ../src/katello/client/core/activation_key.py:121
 #, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "Producto [ %s ] actualizado correctamente"
+msgid "Could not find activation key [ %s ]"
+msgstr "No se encontró llave de activación [ %s ]"
 
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "Borrar un producto y su contenido"
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "Información de llave de activación"
 
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "Listar filtros de un producto"
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "Crear una llave de activación"
 
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "Filtros del producto"
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "Nombre de entorno. Por ejemplo, dev (requerido)"
 
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "Añadir un filtro a un producto"
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "Descripción de llave de activación"
 
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "Retirar un filtro de un producto"
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "Nombre de plantilla. Por ejemplo, servidores"
 
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "No se pudo hallar plantilla [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "Llave de activación creada con éxito [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "No se pudo crear llave [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "Actualizar una llave de activación"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "Nuevo nombre de entorno. Por ejemplo, dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "Nuevo nombre de plantilla"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "Nueva descripción"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "Nuevo nombre de plantilla. Por ejemplo, servidores"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "Añadir un grupo a una llave de activación"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "Retirar un grupo de la llave de activación"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "Llave de activación actualizada con éxito [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "Borrar una llave de activación"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "Llave de activación borrada con éxito [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "Acciones específicas de llave de activación en el servidor de Katello"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "Formato de tiempo es inválido. Debe ser: HH:MM:SS[+HH:MM]"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "El formato de fecha es inválido. Debe ser: AAAA-MM-DD"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "Listar todos los filtros"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "Nombre de organización (requerida)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "Listar filtro"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "Crear un filtro"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
 msgid "filter name (required)"
 msgstr "Nombre de filtro (requerido)"
 
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "Se añadió filtro [ %s ] al producto [ %s ]"
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "Descripción"
 
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "Se retiró filtro [ %s ] al producto [ %s ] "
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "Lista de nombres de paquetes/nvres separados por coma"
 
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "Acciones específicas de producto en el servidor de Katello"
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "Filtro creado correctamente [ %s ]"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "No se pudo crear filtro [ %s ]"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "Borrar un filtro"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "Filtro borrado correctamente  [ %s ]"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "Información sobre el filtro"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "Información de filtro"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "Añadir un paquete al filtro"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "Id de paquete (requerido)"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "Añadido correctamente paquete [ %s ] al filtro [ %s ]"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "Retirar un paquete del filtro"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "Retirado correctamente el paquete [ %s ] del filtro [ %s ]"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "Acciones específicas de filtraje en el servidor de Katello"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "Listar distribuciones en un repositorio"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "ID de repositorio"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "Nombre de repositorio"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "Nombre de organización. Por ejemplo, foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "Nombre de entorno por ejemplo: producción (predeterminado: Library)"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "Nombre de producto. Por ejemplo, Fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "Lista de distribución para repositorio %s"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "Listar información sobre una distribución"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "ID de repositorio (requerido)"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "ID de distribución. Por ejemplo, ks-rh-noarch (requerido)"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "Información de distribución"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "Acciones especificas de repositorios en el servidor de Katello"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "Ingresar contenido de la llave GPG (terminar entrada con CTRL+D):"
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "Listar todas las llaves GPG"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "Repositorios"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+"Archivo con llave GPG pública. Si no se especifica se utilizará la entrada "
+"estándar"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "Archivo con llave GPG pública"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "Solicita el nuevo contenido de la llave"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "Acciones específicas de llave GPG en el servidor de Katello"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "Nombrar organización. Por ejemplo, foo.example.com (requerido)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "Realizando acción remota [ %s ]... "
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "Acción remota completa:"
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "Acción remota falló:"
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "Listar todos los usuarios conocidos"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "Lista de usuarios"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "Crear usuario"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "Nombre de usuario (requerido)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "Contraseña inicial (requerida)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "correo-e (requerido)"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "Cuenta inactiva (predeterminada es 'falsa')"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "nombre de organización predeterminada de usuario"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "nombre de entorno predeterminado de usuario"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "Usuario creado con éxito [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "No se pudo crear usuario [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "Listar información acerca del usuario"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "Información de usuarios"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "Borrar usuario"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "Usuario borrado con éxito [ %s ]"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "Actualizar un usuario"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "Contraseña inicial"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "correo-e "
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "Cuenta  desactivada"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "Entorno de usuario predeterminado es Ninguno"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "Usuario actualizado con éxito [ %s ]"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "Listar roles de usuario"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "Sincronizar roles con grupos LDAP"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "Asignar rol a un usuario "
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "Retirar rol a un usuario"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "Rol de usuario (requerido)"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "Rol [ %s ] no se encontró"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "Reporte de usuario"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+"Formato de reporte (valores posibles: 'html', 'text' (default), 'csv', "
+"'pdf')"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "Acciones específicas de usuarios en el servidor Katello"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "Listar nuevos Changesets de un entorno"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "Nombre de entorno (requerido)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "Lista de Changeset"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "Información detallada sobre un Changeset"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "Nombre de Changeset (requerido)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "Desplegará paquetes dependientes"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "Información de Changeset"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "Crear un nuevo Changeset de un entorno"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "Descripción de changeset"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "Changeset creado con éxito [ %s ] para entorno [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "No se pudo crear Changeset [ %s ] para entorno [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "Actualizaciones de contenido de un Changeset"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s de estar precedido por %s"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "Nuevo nombre de changeset"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "Producto para añadir un Changeset"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "Producto para retirar un Changeset"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "Nombre de una plantilla a ser añadido al Changeset"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "Nombre de una plantilla a ser retirada del Changeset"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+"Determina el producto del cual se elige paquetes/erratas/repositorios."
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "Para añadir al changeset"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "Para retirar del Changeset"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "Actualizado Changeset con éxito [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "Borra un Changeset"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "Falló la promoción de Changeset [ %s ]: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "Acciones específicas de Changeset en el servidor de Katello"
 
 #: ../src/katello/client/core/system.py:47
 msgid "list systems within an organization"
 msgstr "Listar sistemas dentro de una organización"
 
 #: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
 msgid "environment name eg: development"
 msgstr "Nombre de entorno.  Por ejemplo, desarrollo"
 
@@ -534,33 +1485,35 @@ msgstr "Lista de sistemas para organización [ %s ]"
 msgid "Systems List For Environment [ %s ] in Org [ %s ]"
 msgstr "Lista de sistemas para entorno [ %s ] en Organización [ %s ]"
 
-#: ../src/katello/client/core/system.py:82
+#: ../src/katello/client/core/system.py:83
 #: ../src/katello/client/core/system.py:134
 msgid "Service Level"
 msgstr "Nivel de servicio"
 
-#: ../src/katello/client/core/system.py:89
+#: ../src/katello/client/core/system.py:90
 msgid "display a system within an organization"
 msgstr "Mostrar un sistema dentro de una organización"
 
-#: ../src/katello/client/core/system.py:95
+#: ../src/katello/client/core/system.py:96
 #: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
 #: ../src/katello/client/core/errata.py:105
 msgid "system name (required)"
 msgstr "Nombre de sistema (requerido)"
 
-#: ../src/katello/client/core/system.py:97
+#: ../src/katello/client/core/system.py:98
 #: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
 msgid "environment name"
 msgstr "Nombre de entorno"
 
@@ -624,150 +1577,116 @@ msgstr ""
 "Puede especificar máximo una acción /instalar/retirar/actualizar por llamada"
 " "
 
-#: ../src/katello/client/core/system.py:189
+#: ../src/katello/client/core/system.py:188
 #, python-format
 msgid "Package Information for System [ %s ] in Org [ %s ]"
 msgstr "Información de paquetes para sistema [ %s ] en Organización [ %s ]"
 
-#: ../src/katello/client/core/system.py:191
+#: ../src/katello/client/core/system.py:190
 #, python-format
 msgid ""
 "Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr "Información de paquetes para sistema [ %s ] en entorno [ %s ] "
+msgstr ""
 
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "Realizando acción remota [ %s ]... "
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "Acción remota completa:"
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "Acción remota falló:"
-
-#: ../src/katello/client/core/system.py:243
+#: ../src/katello/client/core/system.py:242
 msgid "display status of remote tasks"
 msgstr "Mostrar estatus de tareas remotas"
 
-#: ../src/katello/client/core/system.py:249
+#: ../src/katello/client/core/system.py:248
 msgid "system name"
 msgstr "Nombre de sistema"
 
-#: ../src/katello/client/core/system.py:261
+#: ../src/katello/client/core/system.py:260
 msgid "Remote tasks"
 msgstr "Tareas remotas"
 
-#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:268
 msgid "Task id"
 msgstr "Id de tareas"
 
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
 msgid "System"
 msgstr "Sistema"
 
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
 msgid "Action"
 msgstr "Acción"
 
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
 msgid "Started"
 msgstr "Comenzó"
 
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
 #: ../src/katello/client/core/repo.py:37
 msgid "Finished"
 msgstr "Finalizó"
 
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
 msgid "Status"
 msgstr "Estatus"
 
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
 msgid "Result"
 msgstr "Resultado:"
 
-#: ../src/katello/client/core/system.py:283
+#: ../src/katello/client/core/system.py:282
 msgid "display status of remote task"
 msgstr "Mostrar estatus de tareas remotas"
 
-#: ../src/katello/client/core/system.py:287
+#: ../src/katello/client/core/system.py:286
 msgid "UUID of the task"
 msgstr "UUID de la tarea"
 
-#: ../src/katello/client/core/system.py:295
+#: ../src/katello/client/core/system.py:294
 msgid "Remote task"
 msgstr "Tarea remota"
 
-#: ../src/katello/client/core/system.py:313
+#: ../src/katello/client/core/system.py:312
 msgid "list releases available for the system"
 msgstr "lista lanzamientos disponibles para el sistema"
 
-#: ../src/katello/client/core/system.py:319
+#: ../src/katello/client/core/system.py:318
 msgid "system name (if not specified, list all releases in the environment)"
 msgstr ""
 "nombre del sistema (si no se especifica, lista todos los lanzamientos en el "
 "entorno)"
 
-#: ../src/katello/client/core/system.py:341
+#: ../src/katello/client/core/system.py:340
 msgid "Available releases"
 msgstr "Lanzamientos disponibles"
 
-#: ../src/katello/client/core/system.py:349
+#: ../src/katello/client/core/system.py:348
 msgid "display a the hardware facts of a system"
 msgstr "Mostrar eventos de hardware de un sistema"
 
-#: ../src/katello/client/core/system.py:369
+#: ../src/katello/client/core/system.py:367
 #, python-format
 msgid "System Facts For System [ %s ] in Org [ %s ]"
 msgstr "Eventos de sistema para sistema [ %s ] en Organización [ %s ]"
 
-#: ../src/katello/client/core/system.py:371
+#: ../src/katello/client/core/system.py:369
 #, python-format
 msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
 msgstr ""
 "Eventos de sistema para sistema [ %s ] en entorno [ %s ] en Organización [ "
 "%s ]"
 
-#: ../src/katello/client/core/system.py:388
+#: ../src/katello/client/core/system.py:386
 msgid "register a system"
 msgstr "Registrar un sistema"
 
 #: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "Nombre de organización (requerida)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
+#: ../src/katello/client/core/system.py:641
 msgid "service level agreement"
 msgstr "acuerdo de nivel de servicios"
 
-#: ../src/katello/client/core/system.py:396
+#: ../src/katello/client/core/system.py:394
 msgid ""
 "activation key, more keys are separated with comma e.g. "
 "--activationkey=key1,key2"
@@ -775,113 +1694,108 @@ msgstr ""
 "Clave de activación, más claves están separadas por coma, por ejemplo, "
 "--activationkey=key1,key2"
 
-#: ../src/katello/client/core/system.py:397
+#: ../src/katello/client/core/system.py:395
 msgid "values of $releasever for the system"
 msgstr "valores de $releasever para el sistema"
 
-#: ../src/katello/client/core/system.py:399
+#: ../src/katello/client/core/system.py:397
 msgid "system facts"
 msgstr "eventos del sistema"
 
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "Opción %s no se puede especificar con %s"
-
-#: ../src/katello/client/core/system.py:429
+#: ../src/katello/client/core/system.py:419
 #, python-format
 msgid "Successfully registered system [ %s ]"
 msgstr "Sistema registrado con éxito [ %s ]"
 
-#: ../src/katello/client/core/system.py:430
+#: ../src/katello/client/core/system.py:420
 #, python-format
 msgid "Could not register system [ %s ]"
 msgstr "No se pudo registrar el sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:435
+#: ../src/katello/client/core/system.py:425
 msgid "remove a deletion record for hypervisor"
 msgstr "Retirar un registro de eliminación para hipervisor"
 
-#: ../src/katello/client/core/system.py:439
+#: ../src/katello/client/core/system.py:429
 msgid "hypervisor uuid (required"
 msgstr "UUID de hipervisor (requerido)"
 
-#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:437
 #, python-format
 msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
 msgstr ""
 "Ha sido retirado registro de eliminación para hipervisor con UUID [ %s ]"
 
-#: ../src/katello/client/core/system.py:453
+#: ../src/katello/client/core/system.py:443
 msgid "unregister a system"
 msgstr "Cancelar registro de un sistema"
 
-#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:470
 #, python-format
 msgid "Successfully unregistered System [ %s ]"
 msgstr "Registro de sistema ha sido cancelado con éxito [ %s ]"
 
-#: ../src/katello/client/core/system.py:486
+#: ../src/katello/client/core/system.py:475
 msgid "subscribe a system to certificate"
 msgstr "Suscribir un sistema a certificado"
 
-#: ../src/katello/client/core/system.py:494
+#: ../src/katello/client/core/system.py:483
 msgid "certificate serial to unsubscribe (required)"
 msgstr "Serial de certificado para cancelar suscripción (requerido)"
 
-#: ../src/katello/client/core/system.py:496
+#: ../src/katello/client/core/system.py:485
 msgid "quantity (default: 1)"
 msgstr "Cantidad (predeterminada: 1)"
 
-#: ../src/katello/client/core/system.py:512
+#: ../src/katello/client/core/system.py:499
 #, python-format
 msgid "Successfully subscribed System [ %s ]"
 msgstr "Sistema suscrito con éxito [ %s ]"
 
-#: ../src/katello/client/core/system.py:517
+#: ../src/katello/client/core/system.py:504
 msgid "list subscriptions for a system"
 msgstr "Listar suscripciones para un sistema"
 
-#: ../src/katello/client/core/system.py:524
+#: ../src/katello/client/core/system.py:511
 msgid "show available subscriptions"
 msgstr "Mostrar suscripciones disponibles"
 
-#: ../src/katello/client/core/system.py:542
+#: ../src/katello/client/core/system.py:528
 #, python-format
 msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
 msgstr ""
 "No se encontraron suscripciones para el sistema [ %s ] en Organización [ %s "
 "]"
 
-#: ../src/katello/client/core/system.py:554
+#: ../src/katello/client/core/system.py:540
 #, python-format
 msgid "Current Subscriptions for System [ %s ]"
 msgstr "Suscripciones actuales para el sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:556
+#: ../src/katello/client/core/system.py:542
 msgid "Serial Id"
 msgstr "ID de serial"
 
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
 msgid "Provided products"
 msgstr "Productos suministrados"
 
-#: ../src/katello/client/core/system.py:570
+#: ../src/katello/client/core/system.py:556
 #, python-format
 msgid "No Pools found for System [ %s ] in Org [ %s ]"
 msgstr "No hay grupos para sistema [ %s ] en Organización [ %s ]"
 
-#: ../src/katello/client/core/system.py:580
+#: ../src/katello/client/core/system.py:566
 #, python-format
 msgid "Available Subscriptions for System [ %s ]"
 msgstr "Suscripciones disponibles para el sistema [ %s ] "
 
-#: ../src/katello/client/core/system.py:595
+#: ../src/katello/client/core/system.py:581
 msgid "unsubscribe a system from certificate"
 msgstr "Cancelar suscripción de sistema del certificado"
 
-#: ../src/katello/client/core/system.py:603
+#: ../src/katello/client/core/system.py:589
 msgid ""
 "entitlement id to unsubscribe from (either entitlement or serial or all is "
 "required)"
@@ -889,7 +1803,7 @@ msgstr ""
 "ID de derechos para cancelar suscripción desde (derechos, seriales o todos "
 "requeridos)"
 
-#: ../src/katello/client/core/system.py:605
+#: ../src/katello/client/core/system.py:591
 msgid ""
 "serial id of a certificate to unsubscribe from (either entitlement or serial"
 " or all is required)"
@@ -897,7 +1811,7 @@ msgstr ""
 "Id de serial de un certificado para cancelar desde (derechos, seriales o "
 "todos requeridos)"
 
-#: ../src/katello/client/core/system.py:607
+#: ../src/katello/client/core/system.py:593
 msgid ""
 "unsubscribe from all currently subscribed certificates (either entitlement "
 "or serial or all is required)"
@@ -905,236 +1819,98 @@ msgstr ""
 "Cancelar la suscripción de todos los certificados actualmente suscritos "
 "(derechos, seriales o todos requeridos)"
 
-#: ../src/katello/client/core/system.py:629
+#: ../src/katello/client/core/system.py:614
 #, python-format
 msgid "Successfully unsubscribed System [ %s ]"
 msgstr "Cancelación exitosa de suscripción de Sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:635
+#: ../src/katello/client/core/system.py:620
 msgid "update a system"
 msgstr "Actualizar un sistema"
 
-#: ../src/katello/client/core/system.py:646
+#: ../src/katello/client/core/system.py:631
 msgid "a new name for the system"
 msgstr "Un nuevo nombre para el sistema"
 
-#: ../src/katello/client/core/system.py:648
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
 msgid "a description of the system"
 msgstr "Una descripción del sistema"
 
-#: ../src/katello/client/core/system.py:650
+#: ../src/katello/client/core/system.py:637
 msgid "location of the system"
 msgstr "Lugar del sistema"
 
-#: ../src/katello/client/core/system.py:652
+#: ../src/katello/client/core/system.py:639
 msgid "value of $releasever for the system"
 msgstr "valor de $releasever para el sistema"
 
-#: ../src/katello/client/core/system.py:683
+#: ../src/katello/client/core/system.py:674
 #, python-format
 msgid "Successfully updated system [ %s ]"
 msgstr "Sistema actualizado con éxito [ %s ]"
 
-#: ../src/katello/client/core/system.py:684
+#: ../src/katello/client/core/system.py:675
 #, python-format
 msgid "Could not update system [ %s ]"
 msgstr "No se pudo actualizar el sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:690
+#: ../src/katello/client/core/system.py:681
 msgid "systems report"
 msgstr "Reporte de sistemas"
 
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
 msgstr ""
-"Formato de reporte (valores posibles: 'html', 'text' (default), 'csv', "
-"'pdf')"
 
-#: ../src/katello/client/core/system.py:724
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
 msgid "system specific actions in the katello server"
 msgstr "Acciones específica de sistemas en el servidor de Katello"
 
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "Listar todos los filtros"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "Listar filtro"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "Crear un filtro"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "Descripción"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "Lista de nombres de paquetes/nvres separados por coma"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "Filtro creado correctamente [ %s ]"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "No se pudo crear filtro [ %s ]"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "Borrar un filtro"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "Filtro borrado correctamente  [ %s ]"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "Información sobre el filtro"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "Información de filtro"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "Añadir un paquete al filtro"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "Id de paquete (requerido)"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "Añadido correctamente paquete [ %s ] al filtro [ %s ]"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "Retirar un paquete del filtro"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "Retirado correctamente el paquete [ %s ] del filtro [ %s ]"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "Acciones específicas de filtraje en el servidor de Katello"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "Listar distribuciones en un repositorio"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "ID de repositorio"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "Nombre de repositorio"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "Nombre de organización. Por ejemplo, foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "Nombre de producto. Por ejemplo, Fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "Lista de distribución para repositorio %s"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "Listar información sobre una distribución"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "ID de repositorio (requerido)"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "ID de distribución. Por ejemplo, ks-rh-noarch (requerido)"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "Información de distribución"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "Acciones especificas de repositorios en el servidor de Katello"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "Obtener el estatus del servidor de Katello"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Estatus de Katello"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "Revisar el estatus del servidor"
-
-#: ../src/katello/client/core/package.py:40
+#: ../src/katello/client/core/package.py:38
 msgid "list information about a package"
 msgstr "Listar información sobre un paquete"
 
-#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:43
 msgid "package id, string value (required)"
 msgstr "ID de paquetes, valores de cadenas (requerido)"
 
-#: ../src/katello/client/core/package.py:91
+#: ../src/katello/client/core/package.py:87
 msgid "Package Information"
 msgstr "Información de paquetes"
 
-#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/package.py:94
 msgid "list packages in a repository"
 msgstr "Listar paquetes en un repositorio"
 
-#: ../src/katello/client/core/package.py:123
+#: ../src/katello/client/core/package.py:117
 #, python-format
 msgid "Package List For Repo %s"
 msgstr "Lista de paquetes para repositorio %s"
 
-#: ../src/katello/client/core/package.py:154
+#: ../src/katello/client/core/package.py:148
 msgid "search packages in a repository"
 msgstr "buscar paquetes en un repositorio"
 
-#: ../src/katello/client/core/package.py:159
+#: ../src/katello/client/core/package.py:153
 msgid ""
 "query string for searching packages, e.g. "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
@@ -1142,1312 +1918,247 @@ msgstr ""
 "solicitar cadena para buscar paquetes, por ejemplo,  "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
 
-#: ../src/katello/client/core/package.py:170
+#: ../src/katello/client/core/package.py:164
 #, python-format
 msgid "Package List For Repo %s and Query %s"
 msgstr "Lista de paquetes para repositorio %s y solicitud %s"
 
-#: ../src/katello/client/core/package.py:181
+#: ../src/katello/client/core/package.py:175
 msgid "package specific actions in the katello server"
 msgstr "Acciones específicas de paquetes en el servidor de Katello"
 
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "No hay descripción disponible"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "No se realiza ninguna acción: por favor ver --help"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "Acción inválida: por favor ver --help"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "Salida de grep fácil"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "Verbosa, salida más estructurada."
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
 msgstr ""
-"delimitador de columna en salida fácil de  grep, funciona solamente con la "
-"opción -g"
 
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "Se requiere opción %s; por favor --help"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "Opción %s está colisionando con %s; por favor vea --help"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "Una de  %s se requiere; por favor ver --help"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "Al menos uno de  %s es requerido; por favor vea  --help"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "Error: falló operación"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
 msgstr ""
-"ERROR: El nombre de host de servidor que ha configurado en "
-"/etc/katello/client.conf , no coincide"
 
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-"Nombre de host devuelto del servidor de Katello al que se está conectando."
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "Ejecutar la Interfaz de línea de comandos como una shell"
 
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "Usted tiene: [ %s ]  configurado pero obtuvo [ %s ] del servidor."
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "Nombre de proveedor (requerido)"
 
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "Por favor corrija el host en el archivo /etc/katello/client.conf"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "Credenciales no válidas o no se pueden autenticar"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "Opción %s: Valor booleano inválido: %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "Listar todos los usuarios conocidos"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "Lista de usuarios"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "Crear usuario"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "Nombre de usuario (requerido)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "Contraseña inicial (requerida)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "correo-e (requerido)"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "Cuenta inactiva (predeterminada es 'falsa')"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "nombre de organización predeterminada de usuario"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "nombre de entorno predeterminado de usuario"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "Usuario creado con éxito [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "No se pudo crear usuario [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "Listar información acerca del usuario"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "Información de usuarios"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "Borrar usuario"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "Usuario borrado con éxito [ %s ]"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "Actualizar un usuario"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "Contraseña inicial"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "correo-e "
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "Cuenta  desactivada"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "Entorno de usuario predeterminado es Ninguno"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "Usuario actualizado con éxito [ %s ]"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "Listar roles de usuario"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "Lista de roles de usuario"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "Sincronizar roles con grupos LDAP"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "Asignar rol a un usuario "
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "Retirar rol a un usuario"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "Rol de usuario (requerido)"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "Rol [ %s ] no se encontró"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "Reporte de usuario"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "Acciones específicas de usuarios en el servidor Katello"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "Ingresar contenido de la llave GPG (terminar entrada con CTRL+D):"
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "Listar todas las llaves GPG"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "Nombre de organización (requerido)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "No se encontraron las llaves GPG en organización [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "Lista de llaves GPG"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "Mostrar información sobre llave GPG"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "Nombre de llave de activación (requerida)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "No se pudo encontrar llave GPG [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "Repositorios"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "Información de llave GPG"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "Crear una llave GPG"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-"Archivo con llave GPG pública. Si no se especifica se utilizará la entrada "
-"estándar"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "Creada correctamente llave gpg [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "No se pudo crear llave GPG [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "Actualizar una llave de activación"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "Nuevo nombre de plantilla"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "Archivo con llave GPG pública"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "Solicita el nuevo contenido de la llave"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "Actualizada correctamente llave GPG  [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "No se pudo actualizar llave gpg [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "Borrar una llave GPG"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "Borrada correctamente llave GPG [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "Acciones específicas de llave GPG en el servidor de Katello"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "Listar todas las llaves de activación"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "Nombre de entorno por ejemplo: dev (predeterminado:library)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "No se encontraron las llaves en organización [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "No se encontraron las llaves en organización [ %s ] entorno [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "Lista de llaves de activación"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "Mostrar información sobre llave de activación"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "No se encontró llave de activación [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "Información de llave de activación"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "Crear una llave de activación"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "Nombre de entorno. Por ejemplo, dev (requerido)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "Descripción de llave de activación"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "Nombre de plantilla. Por ejemplo, servidores"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "No se pudo hallar plantilla [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "Llave de activación creada con éxito [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "No se pudo crear llave [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "Nuevo nombre de entorno. Por ejemplo, dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "Nueva descripción"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "Nuevo nombre de plantilla. Por ejemplo, servidores"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "Añadir un grupo a una llave de activación"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "Retirar un grupo de la llave de activación"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "Llave de activación actualizada con éxito [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "Borrar una llave de activación"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "Llave de activación borrada con éxito [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "Acciones específicas de llave de activación en el servidor de Katello"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "Lista disponible de grupos de paquetes"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "ID de repositorio, valor de cadena (requerido)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "No se hallaron grupos de paquetes en repositorio [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "Información de grupo de paquetes"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "Información de búsqueda para un grupo de paquetes"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "ID de grupo de paquetes, valor de cadena (requerido)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "No se encontró grupo de paquetes [ %s ]  en repositorio [ %s ] "
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "Lista de categorías de grupos de paquetes disponible"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-"No se hallaron categorías de grupos de paquetes en repositorio [ %s ] "
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "Información de categorías de grupos de paquetes"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "ID de categorías de grupos de paquetes, valor de cadena (requerido)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "No se halló categoría de grupos de paquetes [ %s ]  "
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "Información de categorías de grupos de paquetes"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "Acciones específicas de grupos de paquetes en el servidor de Katello"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "Listar nuevos Changesets de un entorno"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "Nombre de entorno (requerido)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "Lista de Changeset"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "Información detallada sobre un Changeset"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "Nombre de Changeset (requerido)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "Desplegará paquetes dependientes"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "Información de Changeset"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "Crear un nuevo Changeset de un entorno"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "Descripción de changeset"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "Changeset creado con éxito [ %s ] para entorno [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "No se pudo crear Changeset [ %s ] para entorno [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "Actualizaciones de contenido de un Changeset"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%a de estar precedido por %s"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "Nuevo nombre de changeset"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "Producto para añadir un Changeset"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "Producto para retirar un Changeset"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "Nombre de una plantilla a ser añadido al Changeset"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "Nombre de una plantilla a ser retirada del Changeset"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-"Determina el producto del cual se elige paquetes/erratas/repositorios."
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "Para añadir al changeset"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "Para retirar del Changeset\n"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "Actualizado Changeset con éxito [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "Borra un Changeset"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "Promueve un Changeset al nuevo entorno"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "Promoviendo el Changeset, por favor espere"
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "Changeset [ %s ] promovido"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "Falló la promoción de Changeset [ %s ]: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "Acciones específicas de Changeset en el servidor de Katello"
-
-#: ../src/katello/client/core/provider.py:59
+#: ../src/katello/client/core/provider.py:57
 msgid "list all known providers"
 msgstr "Listar todos los proveedores conocidos"
 
-#: ../src/katello/client/core/provider.py:81
+#: ../src/katello/client/core/provider.py:79
 msgid "Provider List"
 msgstr "Lista de proveedor"
 
-#: ../src/katello/client/core/provider.py:89
+#: ../src/katello/client/core/provider.py:87
 msgid "list information about a provider"
 msgstr "Información de lista sobre proveedor"
 
-#: ../src/katello/client/core/provider.py:104
+#: ../src/katello/client/core/provider.py:102
 msgid "Provider Information"
 msgstr "Información de proveedor"
 
-#: ../src/katello/client/core/provider.py:116
+#: ../src/katello/client/core/provider.py:114
 msgid "create a provider"
 msgstr "Crear un proveedor"
 
-#: ../src/katello/client/core/provider.py:118
+#: ../src/katello/client/core/provider.py:116
 msgid "update a provider"
 msgstr "Actualizar un proveedor"
 
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
 msgid "provider description"
 msgstr "Descripción de proveedor"
 
-#: ../src/katello/client/core/provider.py:139
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"URL de repositorio. Por ejemplo, "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
 msgid "provider name"
 msgstr "Nombre de proveedor (requerido)"
 
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "Opción --URL tiene que comenzar por http:// o https://"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "Opción --URL no está en un formato válido"
-
-#: ../src/katello/client/core/provider.py:159
+#: ../src/katello/client/core/provider.py:147
 #, python-format
 msgid "Successfully created provider [ %s ]"
 msgstr "Proveedor creado con éxito [ %s ]"
 
-#: ../src/katello/client/core/provider.py:160
+#: ../src/katello/client/core/provider.py:148
 #, python-format
 msgid "Could not create provider [ %s ]"
 msgstr "No se pudo crear proveedor [ %s ]"
 
-#: ../src/katello/client/core/provider.py:167
+#: ../src/katello/client/core/provider.py:155
 #, python-format
 msgid "Successfully updated provider [ %s ]"
 msgstr "Proveedor actualizado con éxito [ %s ]"
 
-#: ../src/katello/client/core/provider.py:185
+#: ../src/katello/client/core/provider.py:173
 msgid "delete a provider"
 msgstr "Borrar un proveedor"
 
-#: ../src/katello/client/core/provider.py:201
+#: ../src/katello/client/core/provider.py:189
 msgid "synchronize a provider"
 msgstr "Sincronizar un proveedor"
 
-#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/provider.py:204
 #, python-format
 msgid "Provider [ %s ] failed to sync: %s"
 msgstr "Falló sincronización de proveedor [ %s ]: %s"
 
-#: ../src/katello/client/core/provider.py:219
+#: ../src/katello/client/core/provider.py:207
 #, python-format
 msgid "Provider [ %s ] synchronization cancelled"
 msgstr "Sincronización de proveedor [ %s ] cancelada"
 
-#: ../src/katello/client/core/provider.py:222
+#: ../src/katello/client/core/provider.py:210
 #, python-format
 msgid "Provider [ %s ] synchronized"
 msgstr "Proveedor [ %s ] sincronizado"
 
-#: ../src/katello/client/core/provider.py:245
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "Cancelar sincronización actualmente en ejecución"
+
+#: ../src/katello/client/core/provider.py:233
 msgid "status of provider's synchronization"
 msgstr "Estatus de sincronización de proveedor"
 
-#: ../src/katello/client/core/provider.py:258
+#: ../src/katello/client/core/provider.py:246
 #, python-format
 msgid "%d%% done (%d of %d packages downloaded)"
 msgstr "%d%% listo (%d de %d paquetes descargados)"
 
-#: ../src/katello/client/core/provider.py:269
+#: ../src/katello/client/core/provider.py:257
 msgid "Provider Status"
 msgstr "Estatus de proveedor"
 
-#: ../src/katello/client/core/provider.py:277
+#: ../src/katello/client/core/provider.py:265
 msgid "import a manifest file"
 msgstr "Importar un archivo de manifiesto"
 
-#: ../src/katello/client/core/provider.py:283
+#: ../src/katello/client/core/provider.py:271
 msgid "path to the manifest file (required)"
 msgstr "Ruta al archivo de manifiesto (requerida)"
 
-#: ../src/katello/client/core/provider.py:285
+#: ../src/katello/client/core/provider.py:273
 msgid "force reimporting the manifest"
 msgstr "Forzar a reimportar el manifiesto"
 
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
 #, python-format
 msgid "File %s does not exist"
 msgstr "Archivo %s no existe"
 
-#: ../src/katello/client/core/provider.py:307
+#: ../src/katello/client/core/provider.py:295
 msgid "Importing manifest, please wait... "
 msgstr "Importando manifiesto, por favor espere.."
 
-#: ../src/katello/client/core/provider.py:320
+#: ../src/katello/client/core/provider.py:308
 msgid "refresh provider's products repositories"
 msgstr "Actualizar repositorios de productos de proveedor"
 
-#: ../src/katello/client/core/provider.py:329
+#: ../src/katello/client/core/provider.py:317
 #, python-format
 msgid "Provider successfully refreshed [ %s ]"
 msgstr "Proveedor ha sido actualizado  [ %s ]"
 
-#: ../src/katello/client/core/provider.py:336
+#: ../src/katello/client/core/provider.py:324
 msgid "provider specific actions in the katello server"
 msgstr "Acciones específicas de proveedor en el servidor de Katello"
 
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "Listar entornos desconocidos"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "Org"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "Entorno anterior"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "Lista de entorno"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "Listar un entorno específico"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "Nombre de entorno. Por ejemplo, foo.example.como (requerido)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "Información de entorno"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "Crear un entorno"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "Descripción de entorno. Por ejemplo, entorno de foo"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "Nombre de entorno anterior (requerido)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "Entorno creado con éxito [ %s ]"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "No se pudo crear entorno [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "Actualizar un entorno"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "Nombre de entorno anterior"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "Entorno actualizado con éxito [ %s ]"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "Borrar un entorno "
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "Entorno borrado con éxito [ %s ]"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "Acciones específicas de entorno en el servidor de Katello"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "Guardar una opción para la configuración de cliente"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-"Nombre de la opción a guardar (por ejemplo, entorno, proveedor, etc) "
-"(requerido)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "Valor a ser guardado bajo una opción específica (requerido)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "Exitosamente"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "No ha recordado la opción [ %s ]"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "Retirar una opción de la configuración de cliente"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "Nombre de la opción que va a ser borrada (requerido)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "Olvidó con éxito la opción  [ %s ]"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "No olvidó la opción  [ %s ]"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "Listar opciones guardadas en la configuración de cliente"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "Opciones guardadas"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "Acciones específicas de cliente en el servidor de Katello"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "Listar todos los formatos"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "Nombre de organización (requerido si se especifica e entorno)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "No se hallaron plantillas en el entorno [ %s ]"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "Lista de plantillas"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "Listar información sobre  una plantilla"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "Nombre de formato (requerido)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "Información de plantilla"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "Crear un archivo de plantillas e importar datos\n"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "Ruta al archivo de plantillas"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "Importando plantilla, por favor espere..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "Exportar la plantilla al archivo"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "Nombre de entorno, por ejemplo: dev"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "Formato de exportación, valores posibles: %s, predeterminado: json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "No se pudo crear archivo %s"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "Exportando plantilla, por favor espere..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "La plantilla fue exportada correctamente al archivo %s"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "Crear un archivo vacío de plantillas"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "Nombre de plantilla de principal"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "Descripción de plantilla"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "Plantilla creada con éxito [ %s ]"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "No se pudo crear una plantilla [ %s ]"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "Actualiza nombre y descripción de una plantilla"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "Cada % debe ir precedido por %s"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "Nombre o nvre del producto (epoch:name-rel.ease-ver.sio.n)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "Nombre del parámetro, %s debe seguir"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "Valor del parámetro"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "Nombre del parámetro"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "Nombre del grupo de paquetes"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "Nombre de categoría de grupos de paquetes"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "ID de distribución"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "Determina el producto desde el cual se escogen los repositorios "
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "Repositorio que va a ser añadido a la plantilla"
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "Repositorio que va a ser retirado de la plantilla"
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "Falta valor para parámetro '%s'"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "Actualizando la plantilla, por favor espere..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "Actualización exitosa de plantilla [ %s ]"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "Borra una plantilla"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-"Nombre de entorno, por ejemplo: foo.example.com (predeterminado: Library)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "Acciones específicas de plantilla en el servidor de katello"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "Ejecutar la Interfaz de línea de comandos como una shell"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "Listar sync_plans conocidos"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "lista de plan de sincronización"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "Imprimir información sobre un plan de sincronización"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "Nombre de plan de sincronización (requerido)"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "Información de plan de sincronización"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "Crear un plan de sincronización"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "Descripción del plan"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-"Intervalo de sincronizaciones recurrentes (opciones: [%s], default: none) "
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "Fecha de la primera sincronización (requerida, formato AAAA-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-"Hora de la primera sincronización (formato: HH:MM:SS, predeterminado: "
-"00:00:00)"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "Creado correctamente plan de sincronización [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "No se pudo crear plan de sincronización [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "Actualizar plan de sincronización"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "Nuevo nombre de plan de sincronización"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "Fecha de primera sincronización (formato: AAAA-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "Hora de la primera sincronización (formato: HH:MM:SS)"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "Debe especificar tanto --date y --time"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "Plan de sincronización actualizado correctamente [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "Borrar un plan de sincronización"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "Borrado correctamente plan de sincronización [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-"Acciones específicas de plan de sincronización en el servidor de katello"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "Obtener la versión del servidor de katello"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "Revisar la versión del servidor"
-
-#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "Obtener el estatus del servidor de Katello"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Estatus de Katello"
+
+#: ../src/katello/client/core/permission.py:53
 msgid "create a permission for a user role"
 msgstr "Crear un permiso para rol de usuario"
 
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "Nombre de rol (requerido)"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
 msgid "permission name (required)"
 msgstr "Nombre de permiso (requerido)"
 
-#: ../src/katello/client/core/permission.py:61
+#: ../src/katello/client/core/permission.py:58
 msgid "permission description"
 msgstr "Descripción de permiso"
 
-#: ../src/katello/client/core/permission.py:62
+#: ../src/katello/client/core/permission.py:59
 msgid "organization name"
 msgstr "Nombre de organización"
 
-#: ../src/katello/client/core/permission.py:63
+#: ../src/katello/client/core/permission.py:60
 msgid "scope of the permisson (required)"
 msgstr "Alcance del permiso (requerido)"
 
-#: ../src/katello/client/core/permission.py:64
+#: ../src/katello/client/core/permission.py:61
 msgid "verbs for the permission"
 msgstr "Verbos para el permiso"
 
-#: ../src/katello/client/core/permission.py:65
+#: ../src/katello/client/core/permission.py:62
 msgid "tags for the permission"
 msgstr "Etiquetas para el permiso"
 
-#: ../src/katello/client/core/permission.py:81
+#: ../src/katello/client/core/permission.py:76
 #, python-format
 msgid "Invalid scope [ %s ]"
 msgstr "Alcance inválido [ %s ]"
 
-#: ../src/katello/client/core/permission.py:88
+#: ../src/katello/client/core/permission.py:83
 #, python-format
 msgid "Could not find tag [ %s ] in scope of [ %s ]"
 msgstr "No se pudo encontrar pestaña [ %s ] en alcance de [ %s ]"
 
-#: ../src/katello/client/core/permission.py:112
+#: ../src/katello/client/core/permission.py:101
 #, python-format
 msgid "Successfully created permission [ %s ] for user role [ %s ]"
 msgstr "Creado correctamente permiso [ %s ] para rol de usuario [ %s ]"
 
-#: ../src/katello/client/core/permission.py:113
+#: ../src/katello/client/core/permission.py:102
 #, python-format
 msgid "Could not create permission [ %s ]"
 msgstr "No se pudo crear permiso [ %s ]"
 
-#: ../src/katello/client/core/permission.py:119
+#: ../src/katello/client/core/permission.py:108
 msgid "delete a permission"
 msgstr "Borrar un permiso"
 
-#: ../src/katello/client/core/permission.py:137
+#: ../src/katello/client/core/permission.py:125
 #, python-format
 msgid "Successfully deleted permission [ %s ] for role [ %s ]"
 msgstr "Borrado correctamente permiso [ %s ] para rol [ %s ]"
 
-#: ../src/katello/client/core/permission.py:143
+#: ../src/katello/client/core/permission.py:131
 msgid "list permissions for a user role"
 msgstr "Listar permisos para un rol de usuario"
 
-#: ../src/katello/client/core/permission.py:170
+#: ../src/katello/client/core/permission.py:158
 msgid "Permission List"
 msgstr "Lista de permisos"
 
-#: ../src/katello/client/core/permission.py:177
+#: ../src/katello/client/core/permission.py:165
 msgid "list available scopes, verbs and tags that can be set in a permission"
 msgstr ""
 "Lista alcances, verbos y etiquetas disponibles que pueden configurarse en un"
 " permiso"
 
-#: ../src/katello/client/core/permission.py:181
+#: ../src/katello/client/core/permission.py:169
 msgid ""
 "organization name eg: foo.example.com,\n"
 "lists organization specific verbs"
@@ -2455,26 +2166,102 @@ msgstr ""
 "Nombre de organización, por ejemplo: foo.example.com,\n"
 "lista verbos específicos de organización"
 
-#: ../src/katello/client/core/permission.py:182
+#: ../src/katello/client/core/permission.py:170
 msgid "filter listed results by scope"
 msgstr "Filtrar los resultados listados por alcance "
 
-#: ../src/katello/client/core/permission.py:200
+#: ../src/katello/client/core/permission.py:188
 #, python-format
 msgid "Available verbs and tags for permission scope %s"
 msgstr "Verbos disponibles y etiquetas para alcance de permiso %s"
 
-#: ../src/katello/client/core/permission.py:202
+#: ../src/katello/client/core/permission.py:190
 msgid "Available verbs"
 msgstr "Verbos disponibles"
 
-#: ../src/katello/client/core/permission.py:221
+#: ../src/katello/client/core/permission.py:209
 msgid "None"
 msgstr "Ninguno"
 
-#: ../src/katello/client/core/permission.py:259
+#: ../src/katello/client/core/permission.py:247
 msgid "permission pecific actions in the katello server"
 msgstr "Acciones específicas de permisos en el servidor de Katello"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "No hay descripción disponible"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "No se realiza ninguna acción: por favor ver --help"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "Acción inválida: por favor ver --help"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "Salida de grep fácil"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "Verbosa, salida más estructurada."
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+"delimitador de columna en salida fácil de  grep, funciona solamente con la "
+"opción -g"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+"ERROR: El nombre de host de servidor que ha configurado en "
+"/etc/katello/client.conf , no coincide"
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+"Nombre de host devuelto del servidor de Katello al que se está conectando."
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "Usted tiene: [ %s ]  configurado pero obtuvo [ %s ] del servidor."
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "Por favor corrija el host en el archivo /etc/katello/client.conf"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "Credenciales no válidas o no se pueden autenticar"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "Opción %s: Valor booleano inválido: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
 
 #: ../src/katello/client/core/errata.py:42
 msgid "list all errata for a repo"
@@ -2486,7 +2273,7 @@ msgstr "Erratas de filtro por tipo, por ejemplo: mejoras"
 
 #: ../src/katello/client/core/errata.py:60
 msgid "filter errata by severity"
-msgstr "Erratas de fitro por gravedad\n"
+msgstr "Erratas de fitro por gravedad"
 
 #: ../src/katello/client/core/errata.py:94
 msgid "Errata List"
@@ -2496,26 +2283,117 @@ msgstr "Lista de erratas"
 msgid "list errata for a system"
 msgstr "Listar erratas para un sistema"
 
-#: ../src/katello/client/core/errata.py:125
+#: ../src/katello/client/core/errata.py:124
 #, python-format
 msgid "Errata for system %s in organization %s"
 msgstr "Erratas para sistema %s en organización %s"
 
-#: ../src/katello/client/core/errata.py:132
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
 msgid "information about an errata"
 msgstr "Información acerca de una errata"
 
-#: ../src/katello/client/core/errata.py:136
+#: ../src/katello/client/core/errata.py:170
 msgid "errata id, string value (required)"
 msgstr "ID de erratas, valor de cadena (requerido)"
 
-#: ../src/katello/client/core/errata.py:185
+#: ../src/katello/client/core/errata.py:217
 msgid "Errata Information"
 msgstr "Información de erratas"
 
-#: ../src/katello/client/core/errata.py:194
+#: ../src/katello/client/core/errata.py:226
 msgid "errata specific actions in the katello server"
 msgstr "Acciones específicas de erratas en el servidor de Katello"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "Obtener la versión del servidor de katello"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "Revisar la versión del servidor"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "Lista disponible de grupos de paquetes"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "ID de repositorio, valor de cadena (requerido)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "No se hallaron grupos de paquetes en repositorio [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "Información de grupo de paquetes"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "Información de búsqueda para un grupo de paquetes"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "ID de grupo de paquetes, valor de cadena (requerido)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "No se encontró grupo de paquetes [ %s ]  en repositorio [ %s ] "
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "Lista de categorías de grupos de paquetes disponible"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+"No se hallaron categorías de grupos de paquetes en repositorio [ %s ] "
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "Información de categorías de grupos de paquetes"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "ID de categorías de grupos de paquetes, valor de cadena (requerido)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "No se halló categoría [ %s ] de grupos de paquetes [ %s ]  "
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "Información de categorías de grupos de paquetes"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "Acciones específicas de grupos de paquetes en el servidor de Katello"
 
 #: ../src/katello/client/core/repo.py:34
 msgid "Waiting"
@@ -2545,20 +2423,27 @@ msgstr "Expiración"
 msgid "Not synced"
 msgstr "No sincronizado"
 
-#: ../src/katello/client/core/repo.py:116
+#: ../src/katello/client/core/repo.py:114
 msgid "create a repository at a specified URL"
 msgstr "Crear un repositorio en una URL especificada"
 
-#: ../src/katello/client/core/repo.py:122
+#: ../src/katello/client/core/repo.py:120
 msgid "repository name to assign (required)"
 msgstr "Nombre de repositorio a asignar (requerido)"
 
-#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:122
 msgid "url path to the repository (required)"
 msgstr "Ruta de URL al repositorio (requerido)"
 
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "Nombre de producto (requerido)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
 msgid ""
 "GPG key to be assigned to the repository; by default, the product's GPG key "
 "will be used."
@@ -2566,29 +2451,29 @@ msgstr ""
 "Llave GPG a ser asignada al repositorio; de forma predeterminada, será "
 "utilizada la llave GPG del producto."
 
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
 msgid "Don't assign a GPG key to the repository."
 msgstr "No asigne una llave GPG al repositorio."
 
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
 #, python-format
 msgid "Successfully created repository [ %s ]"
 msgstr "Repositorio creado con éxito [ %s ]"
 
-#: ../src/katello/client/core/repo.py:154
+#: ../src/katello/client/core/repo.py:149
 msgid "discovery repositories contained within a URL"
 msgstr "Repositorios de descubrimiento contenidos dentro de una URL"
 
-#: ../src/katello/client/core/repo.py:160
+#: ../src/katello/client/core/repo.py:155
 msgid ""
 "repository name prefix to add to all the discovered repositories (required)"
 msgstr ""
 "Prefijo de nombre de repositorio a añadir a todos los repositorio "
 "descubiertos (requerido)"
 
-#: ../src/katello/client/core/repo.py:162
+#: ../src/katello/client/core/repo.py:157
 msgid ""
 "root url to perform discovery of repositories eg: "
 "http://porkchop.devel.redhat.com/ (required)"
@@ -2596,16 +2481,31 @@ msgstr ""
 "URL de root para realizar descubrimiento de repositorios. Por ejemplo, "
 "http://porkchop.devel.redhat.com/ (requerido)"
 
-#: ../src/katello/client/core/repo.py:192
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+"Suponga que Sí; automáticamente crea repositorios de candidatos para URL "
+"descubiertas (opcional)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "URL de repositorio descubiertas @ [ %s ]"
+
+#: ../src/katello/client/core/repo.py:183
 msgid "Discovering repository urls, this could take some time..."
 msgstr "Descubriendo las URL de repositorios, puede tomarse un tiempo..."
 
-#: ../src/katello/client/core/repo.py:196
+#: ../src/katello/client/core/repo.py:187
 #, python-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: ../src/katello/client/core/repo.py:216
+#: ../src/katello/client/core/repo.py:207
 msgid ""
 "\n"
 "Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
@@ -2613,336 +2513,806 @@ msgstr ""
 "\n"
 "Seleccionar URL para el cual se debe crear el repositorio candidato; use 'y' para confirmar (h para ayuda): "
 
-#: ../src/katello/client/core/repo.py:226
+#: ../src/katello/client/core/repo.py:217
 msgid "Operation aborted upon user request."
 msgstr "Operación anulada a petición del usuario"
 
-#: ../src/katello/client/core/repo.py:275
+#: ../src/katello/client/core/repo.py:266
 msgid "status information about a repository"
 msgstr "Información de estatus sobre un repositorio"
 
-#: ../src/katello/client/core/repo.py:298
+#: ../src/katello/client/core/repo.py:289
 msgid "Repository Status"
 msgstr "Estatus de repositorio"
 
-#: ../src/katello/client/core/repo.py:305
+#: ../src/katello/client/core/repo.py:296
 msgid "information about a repository"
 msgstr "Información sobre un repositorio"
 
-#: ../src/katello/client/core/repo.py:319
+#: ../src/katello/client/core/repo.py:310
 msgid "Progress"
 msgstr "En curso"
 
-#: ../src/katello/client/core/repo.py:322
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "Llave GPG"
+
+#: ../src/katello/client/core/repo.py:313
 #, python-format
 msgid "Information About Repo %s"
 msgstr "Información sobre repositorio %s"
 
-#: ../src/katello/client/core/repo.py:329
+#: ../src/katello/client/core/repo.py:320
 msgid "updates repository attributes"
 msgstr "Atributos de actualización de repositorios"
 
-#: ../src/katello/client/core/repo.py:345
+#: ../src/katello/client/core/repo.py:336
 #, python-format
 msgid "Successfully updated repository [ %s ]"
 msgstr "Repositorio actualizado correctamente [ %s ]"
 
-#: ../src/katello/client/core/repo.py:351
+#: ../src/katello/client/core/repo.py:342
 msgid "synchronize a repository"
 msgstr "Sincronizar un repositorio"
 
-#: ../src/katello/client/core/repo.py:361
+#: ../src/katello/client/core/repo.py:352
 #, python-format
 msgid "Repo [ %s ] synced"
 msgstr "Repositorio [ %s ] sincronizado"
 
-#: ../src/katello/client/core/repo.py:364
+#: ../src/katello/client/core/repo.py:355
 #, python-format
 msgid "Repo [ %s ] synchronization cancelled"
 msgstr "Sincronización de repositorio  [ %s ] cancelada"
 
-#: ../src/katello/client/core/repo.py:367
+#: ../src/katello/client/core/repo.py:358
 #, python-format
 msgid "Repo [ %s ] failed to sync: %s"
-msgstr "Falló sincronización de repositorio: %s"
+msgstr "Falló sincronización de repositorio [ %s ] : %s"
 
-#: ../src/katello/client/core/repo.py:373
+#: ../src/katello/client/core/repo.py:364
 msgid "cancel currently running synchronization of a repository"
 msgstr ""
 "Cancelar la sincronización de un repositorio que se está ejecutando "
 "actualmente "
 
-#: ../src/katello/client/core/repo.py:388
+#: ../src/katello/client/core/repo.py:379
 msgid "enable a repository"
 msgstr "Habilitar un repositorio"
 
-#: ../src/katello/client/core/repo.py:390
+#: ../src/katello/client/core/repo.py:381
 msgid "disable a repository"
 msgstr "Inhabilitar un repositorio"
 
-#: ../src/katello/client/core/repo.py:409
+#: ../src/katello/client/core/repo.py:400
 msgid "list repos within an organization"
 msgstr "Listar repositorios dentro de una organización"
 
-#: ../src/katello/client/core/repo.py:413
+#: ../src/katello/client/core/repo.py:404
 msgid "organization name eg: ACME_Corporation (required)"
 msgstr "Nombre de organización. Por ejemplo, ACME_Corporation (requerido)"
 
-#: ../src/katello/client/core/repo.py:419
+#: ../src/katello/client/core/repo.py:410
 msgid "list also disabled repositories"
 msgstr "Listar también los repositorios inhabilitados"
 
-#: ../src/katello/client/core/repo.py:439
+#: ../src/katello/client/core/repo.py:430
 #, python-format
 msgid "Repo List For Org %s Environment %s Product %s"
 msgstr "Lista de repositorios para Organización %s entorno %s Producto %s"
 
-#: ../src/katello/client/core/repo.py:446
+#: ../src/katello/client/core/repo.py:437
 #, python-format
 msgid "Repo List for Product %s in Org %s "
 msgstr "Lista de repositorios para Producto %s en Organización %s"
 
-#: ../src/katello/client/core/repo.py:453
+#: ../src/katello/client/core/repo.py:444
 #, python-format
 msgid "Repo List For Org %s Environment %s"
 msgstr "Lista de repositorios para Organización %s entorno %s"
 
-#: ../src/katello/client/core/repo.py:463
+#: ../src/katello/client/core/repo.py:454
 msgid "delete a repository"
 msgstr "Borrar un repositorio"
 
-#: ../src/katello/client/core/repo.py:476
+#: ../src/katello/client/core/repo.py:467
 msgid "list filters of a repository"
 msgstr "Listar filtros de un repositorios"
 
-#: ../src/katello/client/core/repo.py:482
+#: ../src/katello/client/core/repo.py:473
 msgid "prints also filters assigned to repository's product."
 msgstr ""
 "Imprime en pantalla los filtros asignados al producto del repositorio."
 
-#: ../src/katello/client/core/repo.py:492
+#: ../src/katello/client/core/repo.py:483
 msgid "Repository Filters"
 msgstr "Filtros de repositorio"
 
-#: ../src/katello/client/core/repo.py:506
+#: ../src/katello/client/core/repo.py:497
 msgid "add a filter to a repository"
 msgstr "Añadir un filtro a un repositorio"
 
-#: ../src/katello/client/core/repo.py:508
+#: ../src/katello/client/core/repo.py:499
 msgid "remove a filter from a repository"
 msgstr "Retirar un filtro a un repositorio"
 
-#: ../src/katello/client/core/repo.py:538
+#: ../src/katello/client/core/repo.py:529
 #, python-format
 msgid "Added filter [ %s ] to repository [ %s ]"
 msgstr "Se añadió filtro [ %s ] al repositorio [ %s ]"
 
-#: ../src/katello/client/core/repo.py:541
+#: ../src/katello/client/core/repo.py:532
 #, python-format
 msgid "Removed filter [ %s ] to repository [ %s ]"
 msgstr "Se retiró filtro [ %s ]  al  repositorio [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "Listar todos los roles conocidos"
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "Listar sync_plans conocidos"
 
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "Crear rol de usuario"
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "Descripción de rol"
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "Creado correctamente el rol de usuario [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "No se pudo crear rol de usuario [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "Lista de información sobre rol de usuario"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "Nombre de rol de usuario (requerido)"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
 msgstr ""
-"Imprimir en pantalla la información de cada uno de los permisos del rol"
 
-#: ../src/katello/client/core/user_role.py:109
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "lista de plan de sincronización"
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "Imprimir información sobre un plan de sincronización"
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "Nombre de plan de sincronización (requerido)"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "Información de plan de sincronización"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "Crear un plan de sincronización"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "Descripción del plan"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
 #, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+"Intervalo de sincronizaciones recurrentes (opciones: [%s], default: none) "
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "Fecha de la primera sincronización (requerida, formato AAAA-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+"Hora de la primera sincronización (formato: HH:MM:SS, predeterminado: "
+"00:00:00)"
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "Creado correctamente plan de sincronización [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "No se pudo crear plan de sincronización [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "Actualizar plan de sincronización"
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "Nuevo nombre de plan de sincronización"
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "Fecha de primera sincronización (formato: AAAA-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "Hora de la primera sincronización (formato: HH:MM:SS)"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "Plan de sincronización actualizado correctamente [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "Borrar un plan de sincronización"
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "Borrado correctamente plan de sincronización [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+"Acciones específicas de plan de sincronización en el servidor de katello"
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "Listar todas las organizaciones conocidas"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "Lista de organizaciones"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "Crear una organización"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "Descripción de usuario. Por ejemplo: organización de foo"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "Organización creada con [ %s ]"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "No se pudo crear organización [ %s ]"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "Listar información sobre una organización"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "Niveles de servicio disponibles"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "Información de organización"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "Borrar una organización"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "Borrar la organización, por favor espere..."
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "Organización borrada con éxito [ %s ]"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "Borrado de organización [ %s ] falló: %s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "Actualizar una organización"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "Organización actualizada con éxito[ %s ]"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "Generar y mostrar el certificado Ueber"
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "Regenerar el certificado"
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "Organización Uebercert"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "Mostrar suscripciones"
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "Suscripciones de organización"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "Acciones específicas de organización en el servidor de Katello"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "Establecer un plan de sincronización"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "Nombre de plan de sincronización (requerido)"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "Des-configurar un plan de sincronización"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "Lista de productos conocidos"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "Nombre de provedor, lista producto de proveedor en la biblioteca"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "Lista de productos para proveedor %s"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "Lista de productos para Organización %s, entorno '%s'"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "Sincronizar un producto"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "Falló la sincronización de producto [ %s ]: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "Sincronización de producto [ %s ] cancelada"
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "Producto [ %s ]  sincronizado"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "Estatus de sincronización de producto"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "Estatus de producto"
+
+#: ../src/katello/client/core/product.py:249
 msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
 msgstr ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+"Promover un producto a un entorno\n"
+"(crea un Changeset temporal con el producto y lo promueve) "
 
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "Información de rol de usuario"
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "Promoviendo el producto, por favor espere.."
 
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "Borrar rol de usuario"
-
-#: ../src/katello/client/core/user_role.py:152
+#: ../src/katello/client/core/product.py:275
 #, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "Rol de usuario borrado correctamente [ %s ]"
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "Producto [ %s ] promovido al entorno [ %s ] "
 
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "Actualizar un rol"
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "Nombre de rol del nuevo usuario"
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr "Proporcionar al menos un parámetro para actualizar el rol de usuario"
-
-#: ../src/katello/client/core/user_role.py:180
+#: ../src/katello/client/core/product.py:278
 #, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "Actualizado correctamente rol de usuario [ %s ]"
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "Promoción del producto [ %s ] falló: %s"
 
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "Asignar grupo LDAP a un rol"
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "Crear un nuevo producto para un proveedor personal"
 
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "Nuevo nombre de grupo LDAP (requerido)"
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "Descripción de producto"
 
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "Saltar descubrimiento de repositorio"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
 msgstr ""
-"Ha sido añadido con éxito el grupo LDAP [ %s ] al rol de usuario [ %s ]"
+"Asignar una llave GPG ; esta llave será utilizada para cada nuevo "
+"repositorio a menos que gpgkey o nogpgkey se especifique."
 
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "Retirar el grupo LDAP asignado al rol"
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "Nombre de grupo LDAP ha sido retirado (requerido)"
-
-#: ../src/katello/client/core/user_role.py:228
+#: ../src/katello/client/core/product.py:339
 #, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgid "Successfully created product [ %s ]"
+msgstr "Producto creado con éxito [ %s ] "
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "Actualizar atributos de un producto"
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "Cambiar descripción del producto"
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "Asignar una gpgkey al producto"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "Asignar también la gpgkey a los repositorios del producto"
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr "Producto [ %s ] actualizado correctamente"
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "Borrar un producto y su contenido"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "Listar filtros de un producto"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "Filtros del producto"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "Añadir un filtro a un producto"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "Retirar un filtro de un producto"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "Se añadió filtro [ %s ] al producto [ %s ]"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "Se retiró filtro [ %s ] al producto [ %s ] "
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "Acciones específicas de producto en el servidor de Katello"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "Listar todos los formatos"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "Nombre de organización (requerido si se especifica e entorno)"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "No se hallaron plantillas en el entorno [ %s ]"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "Lista de plantillas"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "Listar información sobre  una plantilla"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "Nombre de formato (requerido)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "Información de plantilla"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "Crear un archivo de plantillas e importar datos"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "Ruta al archivo de plantillas"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "Importando plantilla, por favor espere..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "Exportar la plantilla al archivo"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "Nombre de entorno, por ejemplo: dev"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "Formato de exportación, valores posibles: %s, predeterminado: json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "No se pudo crear archivo %s"
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "Exportando plantilla, por favor espere..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "La plantilla fue exportada correctamente al archivo %s"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "Crear un archivo vacío de plantillas"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "Nombre de plantilla de principal"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "Descripción de plantilla"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "Plantilla creada con éxito [ %s ]"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "No se pudo crear una plantilla [ %s ]"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "Actualiza nombre y descripción de una plantilla"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "Cada %s debe ir precedido por %s"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
 msgstr ""
-"Ha sido retirado con éxito el grupo LDAP [ %s ] del rol de usuario [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "Acciones específicas de rol de usuario en el servidor Katello"
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "Formato de tiempo es inválido. Debe ser: HH:MM:SS[+HH:MM]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "El formato de fecha es inválido. Debe ser: AAAA-MM-DD"
-
-#. These are a bunch of strings that are marked for translation in optparse,
-#. but not actually translated anywhere. Mark them for translation here,
-#. so we get it picked up. for local translation, and then optparse will
-#. use them.
-#: ../src/katello/client/i18n_optparse.py:48
+#: ../src/katello/client/core/template.py:320
 #, python-format
-msgid "Usage: %s\n"
-msgstr "Uso: %s"
+msgid "name of the parameter, %s must follow"
+msgstr "Nombre del parámetro, %s debe seguir"
 
-#: ../src/katello/client/i18n_optparse.py:49
-msgid "Usage"
-msgstr "Uso"
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "Valor del parámetro"
 
-#: ../src/katello/client/i18n_optparse.py:50
-msgid "%prog [options]"
-msgstr "%prog [opciones]"
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "Nombre del parámetro"
 
-#: ../src/katello/client/i18n_optparse.py:51
-msgid "Options"
-msgstr "Opciones"
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "Nombre del grupo de paquetes"
 
-#. stuff for option value sanity checking
-#: ../src/katello/client/i18n_optparse.py:54
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "Nombre de categoría de grupos de paquetes"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "ID de distribución"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "Determina el producto desde el cual se escogen los repositorios "
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "Repositorio que va a ser añadido a la plantilla"
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "Repositorio que va a ser retirado de la plantilla"
+
+#: ../src/katello/client/core/template.py:348
 #, python-format
-msgid "no such option: %s"
-msgstr "No hay tal opción: %s"
+msgid "missing value for parameter '%s'"
+msgstr "Falta valor para parámetro '%s'"
 
-#: ../src/katello/client/i18n_optparse.py:55
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "Actualizando la plantilla, por favor espere..."
+
+#: ../src/katello/client/core/template.py:410
 #, python-format
-msgid "ambiguous option: %s (%s?)"
-msgstr "Opción ambigua: %s (%s?)"
+msgid "Successfully updated template [ %s ]"
+msgstr "Actualización exitosa de plantilla [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:56
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "Borra una plantilla"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+"Nombre de entorno, por ejemplo: foo.example.com (predeterminado: Library)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "Acciones específicas de plantilla en el servidor de katello"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "Listar entornos desconocidos"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "Org"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "Entorno anterior"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "Lista de entorno"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "Listar un entorno específico"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "Nombre de entorno. Por ejemplo, foo.example.como (requerido)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "Información de entorno"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "Crear un entorno"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "Descripción de entorno. Por ejemplo, entorno de foo"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "Nombre de entorno anterior (requerido)"
+
+#: ../src/katello/client/core/environment.py:129
 #, python-format
-msgid "%s option requires an argument"
-msgstr "%s opción requiere un argumento"
+msgid "Successfully created environment [ %s ]"
+msgstr "Entorno creado con éxito [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:57
+#: ../src/katello/client/core/environment.py:130
 #, python-format
-msgid "%s option requires %d arguments"
-msgstr "%s opción requiere %s argumentos"
+msgid "Could not create environment [ %s ]"
+msgstr "No se pudo crear entorno [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:58
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "Actualizar un entorno"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "Nombre de entorno anterior"
+
+#: ../src/katello/client/core/environment.py:168
 #, python-format
-msgid "%s option does not take a value"
-msgstr "%s opción no lleva un valor"
+msgid "Successfully updated environment [ %s ]"
+msgstr "Entorno actualizado con éxito [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:59
-msgid "integer"
-msgstr "Entero"
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "Borrar un entorno "
 
-#: ../src/katello/client/i18n_optparse.py:60
-msgid "long integer"
-msgstr "Entero largo"
-
-#: ../src/katello/client/i18n_optparse.py:61
-msgid "floating-point"
-msgstr "Punto flotante"
-
-#: ../src/katello/client/i18n_optparse.py:62
-msgid "complex"
-msgstr "Complejo"
-
-#: ../src/katello/client/i18n_optparse.py:63
+#: ../src/katello/client/core/environment.py:194
 #, python-format
-msgid "option %s: invalid %s value: %r"
-msgstr "opción %s: inválido %s valor: %r"
+msgid "Successfully deleted environment [ %s ]"
+msgstr "Entorno borrado con éxito [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:64
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "Acciones específicas de entorno en el servidor de Katello"
+
+#: ../src/katello/client/server.py:96
 #, python-format
-msgid "option %s: invalid choice: %r (choose from %s)"
-msgstr "opción %s: selección inválida: %r (elegir de %s)"
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "Archivo de certificado [ %s ] no existe o no se puede leer"
 
-#. default options
-#: ../src/katello/client/i18n_optparse.py:67
-msgid "show this help message and exit"
-msgstr "Mostrar este mensaje de ejemplo y salir"
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "Archivo de clave %s no existe o no se puede leer"
 
-#: ../src/katello/client/i18n_optparse.py:68
-msgid "show program's version number and exit"
-msgstr "Mostrar número de versión de programa y salir"
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "No se pudo autenticar a través de kerberos"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "Se requiere opción %s; por favor --help"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "Opción %s está colisionando con %s; por favor vea --help"
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "Al menos uno de  %s es requerido; por favor vea  --help"

--- a/cli/po/fr.po
+++ b/cli/po/fr.po
@@ -3,85 +3,64 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # samfreemanz <sfriedma@redhat.com>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 # samfreemanz <sfriedma@redhat.com>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2012-05-28 08:04-0400\n"
-"Last-Translator: samfreemanz <sfriedma@redhat.com>\n"
+"PO-Revision-Date: 2012-08-24 02:27-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "le fichier certificat %s n'existe pas ou ne peut pas être lu"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "Le fichier-clé %s n'existe ou ne peut pas être lu"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "Authentification via kerberos impossible"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "imprime les informations de version"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Informations d'identification du compte utilisateur Katello"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "nom d'utilisateur du compte"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "mot de passe du compte"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Informations sur le serveur Katello"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "nom d'hôte du serveur Katello (par défaut : %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "Commande invalide, merci de voir --help"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "Aucune commande spécifiée, merci de voir --help"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "Organisation [ %s ] introuvable"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "Environnement [ %s ] introuvable dans l'organisation [ %s ]"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "Produit [ %s ] introuvable dans l'organisation [ %s ]"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
@@ -90,67 +69,72 @@ msgstr ""
 "Référentiel [ %s ] introuvable dans l'organisation [ %s ], le produit [ %s ]"
 " et l'environnement [ %s ]"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "Fournisseur [ %s ] introuvable dans l'organisation [ %s ]"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "Modèle [ %s ]  introuvable dans l'environnement [ %s ]"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "Changeset [ %s ] introuvable dans l'environnement [ %s ] "
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "Utilisateur [ %s ] introuvable"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "Rôle de l'utilisateur [ %s ] introuvable"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "Plan de synchronisation [ %s ] introuvable"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr "Permission [ %s ] pour le rôle de l'utilisateur [ %s ] introuvable"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "Filtre [ %s ] introuvable"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "Système [ %s ] introuvable dans l'organisation [ %s ]"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Systèmes [ %s ] ambigus trouvés dans l'environnement [ %s ] dans "
 "l'organisation [ %s ]"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Impossible de trouver le système [ %s ] dans l'environnement [ %s ] dans "
 "l'organisation [ %s ]"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
@@ -159,367 +143,1332 @@ msgstr ""
 "Systèmes [ %s ] ambigus trouvés dans l'organisation [ %s ], l'environnement "
 "doit être spécifié"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "nom"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "répertorier toutes les organisations connues"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "Liste des organisations"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "créer une organisation"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "nom de l'organisation ex. : foo.example.com (requis)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "description du consommateur ex. : organisation de foo"
-
-#: ../src/katello/client/core/organization.py:79
+#. These are a bunch of strings that are marked for translation in optparse,
+#. but not actually translated anywhere. Mark them for translation here,
+#. so we get it picked up. for local translation, and then optparse will
+#. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
+#: ../src/katello/client/i18n_optparse.py:48
 #, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "Création de l'organisation [ %s ] réussie"
+msgid "Usage: %s\n"
+msgstr "Utilisation : %s\n"
 
-#: ../src/katello/client/core/organization.py:80
+#: ../src/katello/client/i18n_optparse.py:49
+msgid "Usage"
+msgstr "Utilisation"
+
+#: ../src/katello/client/i18n_optparse.py:50
+msgid "%prog [options]"
+msgstr "%prog [options]"
+
+#: ../src/katello/client/i18n_optparse.py:51
+msgid "Options"
+msgstr "Options"
+
+#. stuff for option value sanity checking
+# stuff for option value sanity checking
+#: ../src/katello/client/i18n_optparse.py:54
 #, python-format
-msgid "Could not create org [ %s ]"
-msgstr "Impossible de créer l'organisation [ %s ]"
+msgid "no such option: %s"
+msgstr "pas d'option de ce type : %s"
 
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "répertorier les informations sur une organisation"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "Niveaux de service disponibles"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "Informations sur l'organisation"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "supprimer une organisation"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "Suppression de l'organisation, veuillez patienter..."
-
-#: ../src/katello/client/core/organization.py:135
+#: ../src/katello/client/i18n_optparse.py:55
 #, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "Suppression de l'organisation [ %s ] réussie"
+msgid "ambiguous option: %s (%s?)"
+msgstr "option ambiguë : %s (%s?)"
 
-#: ../src/katello/client/core/organization.py:138
+#: ../src/katello/client/i18n_optparse.py:56
 #, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "Échec de la suppression de l'organisation [ %s ] : %s"
+msgid "%s option requires an argument"
+msgstr "L'option %s requiert un argument"
 
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "mettre à jour une organisation"
-
-#: ../src/katello/client/core/organization.py:162
+#: ../src/katello/client/i18n_optparse.py:57
 #, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "Mise à jour de l'organisation [ %s ] réussie"
+msgid "%s option requires %d arguments"
+msgstr "L'option %s requiert %d arguments"
 
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "générer et afficher un certificat ueber"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "régénérer le certificat"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "Organisation Uebercert"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "afficher les abonnements"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "Abonnements de l'organisation"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "actions spécifiques à l'organisation dans le serveur katello"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "nom de produit (requis)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "nom de l'environnement ex. : production (par défaut : Library)"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "installer un plan de synchronisation"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "nom du plan de synchronisation (requis)"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "désinstaller un plan de synchronisation"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "répertorier les produits connus"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-"nom du fournisseur, répertorie le produit du fournisseur dans Library (la "
-"bibliothèque)"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "Clé GPG"
-
-#: ../src/katello/client/core/product.py:147
+#: ../src/katello/client/i18n_optparse.py:58
 #, python-format
-msgid "Product List For Provider %s"
-msgstr "Liste des produits du fournisseur %s"
+msgid "%s option does not take a value"
+msgstr "L'option %s ne prend pas de valeur"
 
-#: ../src/katello/client/core/product.py:153
+#: ../src/katello/client/i18n_optparse.py:59
+msgid "integer"
+msgstr "entier"
+
+#: ../src/katello/client/i18n_optparse.py:60
+msgid "long integer"
+msgstr "entier long"
+
+#: ../src/katello/client/i18n_optparse.py:61
+msgid "floating-point"
+msgstr "virgule flottante"
+
+#: ../src/katello/client/i18n_optparse.py:62
+msgid "complex"
+msgstr "complexe"
+
+#: ../src/katello/client/i18n_optparse.py:63
 #, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "Liste des produits de l'organisation %s, environnement %s"
+msgid "option %s: invalid %s value: %r"
+msgstr "option %s : valeur %s invalide : %r"
 
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "synchroniser un produit"
-
-#: ../src/katello/client/core/product.py:179
+#: ../src/katello/client/i18n_optparse.py:64
 #, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "Échec de la synchronisation du produit [ %s ] : %s"
+msgid "option %s: invalid choice: %r (choose from %s)"
+msgstr "option %s : choix invalide : %r (choisir à partir de %s)"
 
-#: ../src/katello/client/core/product.py:182
+#. default options
+# default options
+#: ../src/katello/client/i18n_optparse.py:67
+msgid "show this help message and exit"
+msgstr "afficher ce message d'aide puis quitter"
+
+#: ../src/katello/client/i18n_optparse.py:68
+msgid "show program's version number and exit"
+msgstr "afficher le numéro de version du programme puis quitter"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "répertorier tous les rôles d'utilisateur connus"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "Liste des rôles d'utilisateur"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "créer un rôle d'utilisateur"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "nom du rôle (requis)"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "description du rôle"
+
+#: ../src/katello/client/core/user_role.py:75
 #, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "Synchronisation du produit [ %s ] annulée"
+msgid "Successfully created user role [ %s ]"
+msgstr "Création du rôle d'utilisateur [ %s ] réussie"
 
-#: ../src/katello/client/core/product.py:185
+#: ../src/katello/client/core/user_role.py:76
 #, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "Produit [ %s ] synchronisé"
+msgid "Could not create user role [ %s ]"
+msgstr "Impossible de créer le rôle d'utilisateur [ %s ]"
 
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "annuler la synchronisation actuellement en cours d'exécution"
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "répertorier les informations sur le rôle de l'utilisateur"
 
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "état de la synchronisation du produit"
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "nom du rôle de l'utilisateur (requis)"
 
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "État du produit"
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "imprimer les détails de chaque permission du rôle"
 
-#: ../src/katello/client/core/product.py:242
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
 msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
 msgstr ""
-"attribuer un produit à un environnement\n"
-"(crée un changeset temporaire avec le produit et l'attribue)"
+"%s\n"
+"\tpour: %s\n"
+"\tverbes: %s\n"
+"\tsur: %s"
 
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "Attribution du produit, veuillez patienter..."
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "Informations sur le rôle de l'utilisateur"
 
-#: ../src/katello/client/core/product.py:268
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "supprimer un rôle d'utilisateur"
+
+#: ../src/katello/client/core/user_role.py:150
 #, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "Produit [ %s ] attribué à l'environnement [ %s ]"
+msgid "Successfully deleted user role [ %s ]"
+msgstr "Suppression du rôle de l'utilisateur [ %s ] réussie"
 
-#: ../src/katello/client/core/product.py:271
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "mettre un rôle à jour"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "nouveau nom du rôle de l'utilisateur"
+
+#: ../src/katello/client/core/user_role.py:177
 #, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "Échec de l'attribution du produit [ %s ] : %s"
+msgid "Successfully updated user role [ %s ]"
+msgstr "Mise à jour du rôle de l'utilisateur [ %s ] réussie"
 
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "créer un nouveau produit pour un fournisseur personnalisé"
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "assigner un groupe LDAP à un rôle"
 
-#: ../src/katello/client/core/product.py:297
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "nouveau nom du groupe LDAP (requis)"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+"Le groupe LDAP [ %s ] a été ajouté au rôle utilisateur [ %s ] avec succès"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "suppression du groupe LDAP assigné à un rôle"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "Nom du groupe LDAP à supprimer (requis)"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+"Le groupe LDAP [ %s ] a été supprimé du rôle utilisateur [ %s ] avec succès"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "actions spécifiques au rôle de l'utilisateur dans le serveur katello"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "enregistrer une option sur la configuration du client"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+"nom de l'option à enregistrer (ex. : organisation, environnement, "
+"fournisseur, etc.) (requis)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "valeur à stocker sous une option spécifiée (requis)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "Réussi(e)"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "Option [ %s ] mémorisée sans succès"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "supprimer une option de la configuration du client"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "nom de l'option à supprimer (requis)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "Option [ %s ] oubliée avec succès"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "Option [ %s ] oubliée sans succès"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "répertorier les options enregistrées dans la configuration client"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "Options enregistrées"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "actions spécifiques au client dans le serveur katello"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "répertorier toutes les clés d'activation"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
 #: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "nom du fournisseur (requis)"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "description du produit"
-
-#: ../src/katello/client/core/product.py:303
 #: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"URL du référentiel ex. : "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "Nom de l'organisation (requis)"
 
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "ignorer la découverte de référentiels"
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "nom de l'environnement ex. : dev (par défaut : Library)"
 
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-"supposer que oui ; automatiquement créer des référentiels candidats pour les"
-" URL découverts (optionnel)"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-"assigner une clé GPG ; cette clé sera utilisée pour nouveau référentiel à "
-"moins que gpgkey ou que nogpgkey ne soit spécifié pour le référentiel"
-
-#: ../src/katello/client/core/product.py:334
+#: ../src/katello/client/core/activation_key.py:69
 #, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "Création du produit [ %s ] réussie"
+msgid "No keys found in organization [ %s ]"
+msgstr "Aucune clé trouvée dans l'organisation [ %s ]"
 
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
+#: ../src/katello/client/core/activation_key.py:71
 #, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "URL de référentiels découverts @ [%s]"
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "Aucune clé trouvée dans l'organisation [ %s ] environnement [ %s ]"
 
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "mettre à jour les attributs d'un produit"
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "Liste des clés d'activation"
 
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "modifier la description du produit"
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "afficher les informations sur une clé d'activation"
 
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "assigner une clé GPG au produit"
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "nom de la clé d'activation (requis)"
 
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "aussi assigner la clé GPG aux référentiels du produit"
-
-#: ../src/katello/client/core/product.py:378
+#: ../src/katello/client/core/activation_key.py:121
 #, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "Mise à jour du produit [ %s ] réussie"
+msgid "Could not find activation key [ %s ]"
+msgstr "Clé d'activation [ %s ] introuvable"
 
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "supprimer un produit et son contenu"
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "Informations sur la clé d'activation"
 
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "répertorier les filtres d'un produit"
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "créer une clé d'activation"
 
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "Filtres de produits"
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "nom de l'environnement ex. : dev (requis)"
 
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "ajouter un filtre à un produit"
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "description de la clé d'activation"
 
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "supprimer un filtre d'un produit"
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "nom de modèle ex. : serveurs"
 
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "Impossible de trouver le modèle [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "Création de la clé d'activation [ %s ] réussie"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "Impossible de créer la clé d'activation [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "mettre à jour une clé d'activation"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "nom du nouvel environnement ex. : dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "nom du nouveau modèle"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "nouvelle description"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "nom du nouveau modèle ex. : serveurs"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "ajouter un pool à la clé d'activation"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "supprimer un pool de la clé d'activation"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "Mise à jour de la clé d'activation [ %s ] réussie"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "supprimer une clé d'activation"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "Suppression de la clé d'activation [ %s ] réussie"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "actions spécifiques aux clés d'activation dans le serveur katello"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "Le format de l'heure est invalide. Requis : HH:MM:SS[+HH:MM]"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "Le format de la date est invalide. Requis : AAAA-MM-JJ"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "répertorier tous les filtres"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "nom de l'organisation (requis)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "Liste des filtres"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "créer un filtre"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
 msgid "filter name (required)"
 msgstr "nom du filtre (requis)"
 
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "Ajout du filtre [ %s ] au produit [ %s ]"
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "description"
 
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "Suppression du filtre [ %s ] du produit [ %s ]"
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "liste séparée par des virgules des noms/nvres de paquetages"
 
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "actions spécifiques aux produits dans le serveur katello"
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "Création du filtre [ %s ] réussie"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "Impossible de créer le filtre [ %s ]"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "supprimer un filtre"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "Suppression du filtre [ %s ] réussie"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "informations sur le filtre"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "Informations sur le filtre"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "Ajouter un paquetage au filtre"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "id du paquetage (requis)"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "Ajout du paquetage [ %s ] au filtre [ %s ] réussi"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "Supprimer un paquetage du filtre"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "Suppression du paquetage [ %s ] du filtre [ %s ] réussie"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "actions spécifiques au filtre dans le serveur katello"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "répertorier les distributions dans un référentiel"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "id du référentiel"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "nom du référentiel"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "nom de l'organisation ex. : foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "nom de l'environnement ex. : production (par défaut : Library)"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "nom du produit ex. : fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "Liste des distributions pour le référentiel %s"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "répertorier les informations sur une distribution"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "ID de référentiel (requis)"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "ID de distribution ex. : ks-rh-noarch (requis)"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "Informations de distribution"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "actions spécifiques aux référentiels dans le serveur katello"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "Saisir le contenu de la clé GPG (terminez la saisie avec CTRL+D) :"
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "répertorier toutes les clés GPG"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "Référentiels"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+"fichier avec la clé GPG publique, si non spécifié, une entrée standard sera "
+"utilisée"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "fichier avec la clé GPG"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "demande du nouveau contenu de la clé"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "actions spécifiques à la clé GPG dans le serveur katello"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "nom de l'organisation ex. : foo.example.com (requis)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "Action distante [ %s ] en cours..."
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "Action distante terminée :"
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "Échec de l'action distante :"
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "répertorier tous les utilisateurs connus"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "Liste des utilisateurs"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "créer un utilisateur"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "nom d'utilisateur (requis)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "mot de passe initial (requis)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "email (requis)"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "compte désactivé (par défaut, « false »)"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "nom de l'organisation par défaut de l'utilisateur"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "nom de l'environnement par défaut de l'utilisateur"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "Création de l'utilisateur réussie [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "Impossible de créer l'utilisateur [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "répertorier les informations sur l'utilisateur"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "Informations sur l'utilisateur"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "supprimer l'utilisateur"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "Suppression de l'utilisateur réussie [ %s ]"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "mettre à jour un utilisateur"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "mot de passe initial"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "email"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "compte désactivé"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "l'environnement par défaut de l'utilisateur est « Aucun »"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "Mise à jour de l'utilisateur réussie [ %s ]"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "répertorier les rôles de l'utilisteur"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "synchronise les rôles avec les groupes LDAP"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "assigner le rôle à un utilisateur"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "désaffecter un rôle d'un utilisateur"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "rôle de l'utilisateur (requis)"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "Rôle [%s] introuvable"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "rapport de l'utilisateur"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+"format du rapport (valeurs possibles : 'html', 'text' (par défaut), 'csv', "
+"'pdf')"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "actions spécifiques à l'utilisateur dans le serveur katello"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "répertorier les nouveaux changesets d'un environnement"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "nom de l'environnement (requis)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "Liste des changesets"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "informations détaillées sur un changeset"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "nom du changeset (requis)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "affichera les paquetages dépendants"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "Informations sur le changeset"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "créer un nouveau changeset pour un environnement"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "description du changeset"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "Création du changeset [ %s ] pour l'environnement [ %s ] réussie"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "Création du changeset [ %s ] pour l'environnement [ %s ] impossible"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "met à jour le contenu d'un changeset"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s doit être précédé de %s"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "nouveau nom du changeset"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "produit doit ajouter au changeset"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "produit doit supprimer du changeset"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "nom du modèle à ajouter au changeset"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "nom du modèle à supprimer du changeset"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+"détermine le produit à partir duquel les paquetages/errata/référentiels sont"
+" choisis"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "à ajouter au changeset"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "à supprimer du changeset"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "Mise à jour du changeset réussie [ %s ] "
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "supprime un changeset"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "Échec de l'attribution du changeset [ %s ] : %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "actions spécifiques au changeset dans le serveur katello"
 
 #: ../src/katello/client/core/system.py:47
 msgid "list systems within an organization"
 msgstr "répertorie les systèmes dans une organisation"
 
 #: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
 msgid "environment name eg: development"
 msgstr "nom de l'environnement ex. : développement"
 
@@ -538,33 +1487,35 @@ msgid "Systems List For Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Liste des systèmes pour l'environnement [ %s ] dans l'organisation [ %s ]"
 
-#: ../src/katello/client/core/system.py:82
+#: ../src/katello/client/core/system.py:83
 #: ../src/katello/client/core/system.py:134
 msgid "Service Level"
 msgstr "Niveau de service"
 
-#: ../src/katello/client/core/system.py:89
+#: ../src/katello/client/core/system.py:90
 msgid "display a system within an organization"
 msgstr "affiche un système dans une organisation"
 
-#: ../src/katello/client/core/system.py:95
+#: ../src/katello/client/core/system.py:96
 #: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
 #: ../src/katello/client/core/errata.py:105
 msgid "system name (required)"
 msgstr "nom du système (requis)"
 
-#: ../src/katello/client/core/system.py:97
+#: ../src/katello/client/core/system.py:98
 #: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
 msgid "environment name"
 msgstr "nom de l'environnement"
 
@@ -631,13 +1582,13 @@ msgstr ""
 "Vous pouvez spécifier au plus une seule action d'installation, de "
 "suppression ou de mise à jour par appel"
 
-#: ../src/katello/client/core/system.py:189
+#: ../src/katello/client/core/system.py:188
 #, python-format
 msgid "Package Information for System [ %s ] in Org [ %s ]"
 msgstr ""
 "Informations de paquetage pour le système [ %s ] dans l'organisation [ %s ]"
 
-#: ../src/katello/client/core/system.py:191
+#: ../src/katello/client/core/system.py:190
 #, python-format
 msgid ""
 "Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
@@ -645,139 +1596,105 @@ msgstr ""
 "Informations de paquetage pour le système [ %s ] dans l'environnement [ %s ]"
 " dans l'organisation [ %s ]"
 
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "Action distante [ %s ] en cours..."
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "Action distante terminée :"
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "Échec de l'action distante :"
-
-#: ../src/katello/client/core/system.py:243
+#: ../src/katello/client/core/system.py:242
 msgid "display status of remote tasks"
 msgstr "afficher l'état des tâches distantes"
 
-#: ../src/katello/client/core/system.py:249
+#: ../src/katello/client/core/system.py:248
 msgid "system name"
 msgstr "nom du système"
 
-#: ../src/katello/client/core/system.py:261
+#: ../src/katello/client/core/system.py:260
 msgid "Remote tasks"
 msgstr "tâches distantes"
 
-#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:268
 msgid "Task id"
 msgstr "ID de la tâche"
 
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
 msgid "System"
 msgstr "Système"
 
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
 msgid "Action"
 msgstr "Action"
 
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
 msgid "Started"
 msgstr "Démarré(e)"
 
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
 #: ../src/katello/client/core/repo.py:37
 msgid "Finished"
 msgstr "Terminé(e)"
 
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
 msgid "Status"
 msgstr "État"
 
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
 msgid "Result"
 msgstr "Résultat"
 
-#: ../src/katello/client/core/system.py:283
+#: ../src/katello/client/core/system.py:282
 msgid "display status of remote task"
 msgstr "afficher l'état de la tâche distante"
 
-#: ../src/katello/client/core/system.py:287
+#: ../src/katello/client/core/system.py:286
 msgid "UUID of the task"
 msgstr "UUID de la tâche"
 
-#: ../src/katello/client/core/system.py:295
+#: ../src/katello/client/core/system.py:294
 msgid "Remote task"
 msgstr "Tâche distante"
 
-#: ../src/katello/client/core/system.py:313
+#: ../src/katello/client/core/system.py:312
 msgid "list releases available for the system"
 msgstr "répertorier les versions disponibles pour le système"
 
-#: ../src/katello/client/core/system.py:319
+#: ../src/katello/client/core/system.py:318
 msgid "system name (if not specified, list all releases in the environment)"
 msgstr ""
 "nom du système (si non-spécifié, répertorier toutes les versions dans "
 "l'environnement)"
 
-#: ../src/katello/client/core/system.py:341
+#: ../src/katello/client/core/system.py:340
 msgid "Available releases"
 msgstr "Versions disponibles"
 
-#: ../src/katello/client/core/system.py:349
+#: ../src/katello/client/core/system.py:348
 msgid "display a the hardware facts of a system"
 msgstr "afficher les faits matériels d'un système"
 
-#: ../src/katello/client/core/system.py:369
+#: ../src/katello/client/core/system.py:367
 #, python-format
 msgid "System Facts For System [ %s ] in Org [ %s ]"
 msgstr "Faits système du système [ %s ] dans l'organisation [ %s ]"
 
-#: ../src/katello/client/core/system.py:371
+#: ../src/katello/client/core/system.py:369
 #, python-format
 msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
 msgstr ""
 "Faits système du système [ %s ] dans l'environnement [ %s ] dans "
 "l'organisation [ %s ]"
 
-#: ../src/katello/client/core/system.py:388
+#: ../src/katello/client/core/system.py:386
 msgid "register a system"
 msgstr "enregistrer un système"
 
 #: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "nom de l'organisation (requis)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
+#: ../src/katello/client/core/system.py:641
 msgid "service level agreement"
 msgstr "contrat de niveau de service"
 
-#: ../src/katello/client/core/system.py:396
+#: ../src/katello/client/core/system.py:394
 msgid ""
 "activation key, more keys are separated with comma e.g. "
 "--activationkey=key1,key2"
@@ -785,113 +1702,108 @@ msgstr ""
 "clé d'activation, davantage de clés sont séparées par des virgules ex. : "
 "--activationkey=key1,key2"
 
-#: ../src/katello/client/core/system.py:397
+#: ../src/katello/client/core/system.py:395
 msgid "values of $releasever for the system"
 msgstr "valeurs de $releasever pour le système"
 
-#: ../src/katello/client/core/system.py:399
+#: ../src/katello/client/core/system.py:397
 msgid "system facts"
 msgstr "faits du système"
 
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "L'option %s ne peut pas être spécifiée avec %s"
-
-#: ../src/katello/client/core/system.py:429
+#: ../src/katello/client/core/system.py:419
 #, python-format
 msgid "Successfully registered system [ %s ]"
 msgstr "Enregistrement du système [ %s ] réussi"
 
-#: ../src/katello/client/core/system.py:430
+#: ../src/katello/client/core/system.py:420
 #, python-format
 msgid "Could not register system [ %s ]"
 msgstr "Impossible d'enregistrer le système [ %s ]"
 
-#: ../src/katello/client/core/system.py:435
+#: ../src/katello/client/core/system.py:425
 msgid "remove a deletion record for hypervisor"
 msgstr "supprimer une archive de suppression pour l'hyperviseur"
 
-#: ../src/katello/client/core/system.py:439
+#: ../src/katello/client/core/system.py:429
 msgid "hypervisor uuid (required"
 msgstr "UUID de l'hyperviseur (requis"
 
-#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:437
 #, python-format
 msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
 msgstr ""
 "Suppression de l'archive de suppression réussie pour l'hyperviseur avec "
 "l'UUID [ %s ]"
 
-#: ../src/katello/client/core/system.py:453
+#: ../src/katello/client/core/system.py:443
 msgid "unregister a system"
 msgstr "désenregistrer un système"
 
-#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:470
 #, python-format
 msgid "Successfully unregistered System [ %s ]"
 msgstr "Système [ %s ] désenregistré avec succès"
 
-#: ../src/katello/client/core/system.py:486
+#: ../src/katello/client/core/system.py:475
 msgid "subscribe a system to certificate"
 msgstr "abonner un système à un certificat"
 
-#: ../src/katello/client/core/system.py:494
+#: ../src/katello/client/core/system.py:483
 msgid "certificate serial to unsubscribe (required)"
 msgstr "Certificat sériel à désenregistrer (requis)"
 
-#: ../src/katello/client/core/system.py:496
+#: ../src/katello/client/core/system.py:485
 msgid "quantity (default: 1)"
 msgstr "quantité (par défaut : 1)"
 
-#: ../src/katello/client/core/system.py:512
+#: ../src/katello/client/core/system.py:499
 #, python-format
 msgid "Successfully subscribed System [ %s ]"
 msgstr "Abonnement du système [ %s ] réussi"
 
-#: ../src/katello/client/core/system.py:517
+#: ../src/katello/client/core/system.py:504
 msgid "list subscriptions for a system"
 msgstr "répertorier les abonnements d'un système"
 
-#: ../src/katello/client/core/system.py:524
+#: ../src/katello/client/core/system.py:511
 msgid "show available subscriptions"
 msgstr "afficher les abonnements disponibles"
 
-#: ../src/katello/client/core/system.py:542
+#: ../src/katello/client/core/system.py:528
 #, python-format
 msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
 msgstr ""
 "Aucun abonnement trouvé pour le système [ %s ] dans l'organisation [ %s ]"
 
-#: ../src/katello/client/core/system.py:554
+#: ../src/katello/client/core/system.py:540
 #, python-format
 msgid "Current Subscriptions for System [ %s ]"
 msgstr "Abonnements actuels du système [ %s ]"
 
-#: ../src/katello/client/core/system.py:556
+#: ../src/katello/client/core/system.py:542
 msgid "Serial Id"
 msgstr "ID de série"
 
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
 msgid "Provided products"
 msgstr "Produits fournis"
 
-#: ../src/katello/client/core/system.py:570
+#: ../src/katello/client/core/system.py:556
 #, python-format
 msgid "No Pools found for System [ %s ] in Org [ %s ]"
 msgstr "Aucun pool trouvé pour le système [ %s ] dans l'organisation [ %s ]"
 
-#: ../src/katello/client/core/system.py:580
+#: ../src/katello/client/core/system.py:566
 #, python-format
 msgid "Available Subscriptions for System [ %s ]"
 msgstr "Abonnements disponibles pour le système [ %s ]"
 
-#: ../src/katello/client/core/system.py:595
+#: ../src/katello/client/core/system.py:581
 msgid "unsubscribe a system from certificate"
 msgstr "désabonner un système d'un certificat"
 
-#: ../src/katello/client/core/system.py:603
+#: ../src/katello/client/core/system.py:589
 msgid ""
 "entitlement id to unsubscribe from (either entitlement or serial or all is "
 "required)"
@@ -899,7 +1811,7 @@ msgstr ""
 "ID du droit d'accès dont il faut se désabonner (soit le droit d'accès, soit "
 "le numéro de série, ou le tout est requis)"
 
-#: ../src/katello/client/core/system.py:605
+#: ../src/katello/client/core/system.py:591
 msgid ""
 "serial id of a certificate to unsubscribe from (either entitlement or serial"
 " or all is required)"
@@ -907,7 +1819,7 @@ msgstr ""
 "ID de série du certificat dont il faut se désabonner (soit le droit d'accès,"
 " soit le numéro de série, ou le tout est requis)"
 
-#: ../src/katello/client/core/system.py:607
+#: ../src/katello/client/core/system.py:593
 msgid ""
 "unsubscribe from all currently subscribed certificates (either entitlement "
 "or serial or all is required)"
@@ -915,236 +1827,98 @@ msgstr ""
 "se désabonner de tous les certificats actuellement souscrits (soit le droit "
 "d'accès, soit le numéro de série, ou le tout est requis)"
 
-#: ../src/katello/client/core/system.py:629
+#: ../src/katello/client/core/system.py:614
 #, python-format
 msgid "Successfully unsubscribed System [ %s ]"
 msgstr "Annulation de l'abonnement du système [ %s ] réussie"
 
-#: ../src/katello/client/core/system.py:635
+#: ../src/katello/client/core/system.py:620
 msgid "update a system"
 msgstr "mettre à jour un système"
 
-#: ../src/katello/client/core/system.py:646
+#: ../src/katello/client/core/system.py:631
 msgid "a new name for the system"
 msgstr "un nouveau nom pour le système"
 
-#: ../src/katello/client/core/system.py:648
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
 msgid "a description of the system"
 msgstr "une description du système"
 
-#: ../src/katello/client/core/system.py:650
+#: ../src/katello/client/core/system.py:637
 msgid "location of the system"
 msgstr "emplacement du système"
 
-#: ../src/katello/client/core/system.py:652
+#: ../src/katello/client/core/system.py:639
 msgid "value of $releasever for the system"
 msgstr "valeur de $releasever pour le système"
 
-#: ../src/katello/client/core/system.py:683
+#: ../src/katello/client/core/system.py:674
 #, python-format
 msgid "Successfully updated system [ %s ]"
 msgstr "Mise à jour du système [ %s ] réussie"
 
-#: ../src/katello/client/core/system.py:684
+#: ../src/katello/client/core/system.py:675
 #, python-format
 msgid "Could not update system [ %s ]"
 msgstr "Impossible de mettre à jour le système [ %s ]"
 
-#: ../src/katello/client/core/system.py:690
+#: ../src/katello/client/core/system.py:681
 msgid "systems report"
 msgstr "rapport systèmes"
 
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
 msgstr ""
-"format du rapport (valeurs possibles : 'html', 'text' (par défaut), 'csv', "
-"'pdf')"
 
-#: ../src/katello/client/core/system.py:724
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
 msgid "system specific actions in the katello server"
 msgstr "actions spécifique au système dans le serveur Katello"
 
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "répertorier tous les filtres"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "Liste des filtres"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "créer un filtre"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "description"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "liste séparée par des virgules des noms/nvres de paquetages"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "Création du filtre [ %s ] réussie"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "Impossible de créer le filtre [ %s ]"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "supprimer un filtre"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "Suppression du filtre [ %s ] réussie"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "informations sur le filtre"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "Informations sur le filtre"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "Ajouter un paquetage au filtre"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "id du paquetage (requis)"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "Ajout du paquetage [ %s ] au filtre [ %s ] réussi"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "Supprimer un paquetage du filtre"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "Suppression du paquetage [ %s ] du filtre [ %s ] réussie"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "actions spécifiques au filtre dans le serveur katello"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "répertorier les distributions dans un référentiel"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "id du référentiel"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "nom du référentiel"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "nom de l'organisation ex. : foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "nom du produit ex. : fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "Liste des distributions pour le référentiel %s"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "répertorier les informations sur une distribution"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "ID de référentiel (requis)"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "ID de distribution ex. : ks-rh-noarch (requis)"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "Informations de distribution"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "actions spécifiques aux référentiels dans le serveur katello"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "obtenir l'état du serveur katello"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "État Katello"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "Vérifier l'état du serveur"
-
-#: ../src/katello/client/core/package.py:40
+#: ../src/katello/client/core/package.py:38
 msgid "list information about a package"
 msgstr "répertorier les informations sur un paquetage"
 
-#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:43
 msgid "package id, string value (required)"
 msgstr "id de paquetage, valeur de chaîne (requis)"
 
-#: ../src/katello/client/core/package.py:91
+#: ../src/katello/client/core/package.py:87
 msgid "Package Information"
 msgstr "Informations sur le paquetage"
 
-#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/package.py:94
 msgid "list packages in a repository"
 msgstr "répertorier les paquetages dans un référentiel"
 
-#: ../src/katello/client/core/package.py:123
+#: ../src/katello/client/core/package.py:117
 #, python-format
 msgid "Package List For Repo %s"
 msgstr "Liste des paquetages du référentiel %s"
 
-#: ../src/katello/client/core/package.py:154
+#: ../src/katello/client/core/package.py:148
 msgid "search packages in a repository"
 msgstr "rechercher des paquetages dans un référentiel"
 
-#: ../src/katello/client/core/package.py:159
+#: ../src/katello/client/core/package.py:153
 msgid ""
 "query string for searching packages, e.g. "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
@@ -1152,1316 +1926,248 @@ msgstr ""
 "chaîne de recherche pour la recherche de paquetages. Par exemple, "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
 
-#: ../src/katello/client/core/package.py:170
+#: ../src/katello/client/core/package.py:164
 #, python-format
 msgid "Package List For Repo %s and Query %s"
 msgstr "Liste des paquetages pour le référentiel %s et la recherche %s"
 
-#: ../src/katello/client/core/package.py:181
+#: ../src/katello/client/core/package.py:175
 msgid "package specific actions in the katello server"
 msgstr "actions spécifiques aux paquetages dans le serveur katello"
 
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "aucune description disponible"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "aucune action spécifiée : merci de voir --help"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "action invalide : merci de voir --help"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "sortie conviviale grep"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "sortie verbeuse, plus structurée"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
 msgstr ""
-"délimiteur de colonne de la sortie de grep, fonctionne uniquement avec "
-"l'option -g"
 
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "L'option %s est requise : merci de voir --help"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "L'option %s est en conflit avec %s ; veuillez voir -- help"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "L'un de %s est requis ; merci de voir --help"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "Au moins l'un de %s est requis ; veuillez voir --help"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "erreur : échec de l'opération"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
 msgstr ""
-"ERREUR : le nom d'hôte du serveur configuré dans /etc/katello/client.conf ne"
-" correspond pas au "
 
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-"nom d'hôte retourné depuis le serveur katello auquel vous vous connectez."
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "exécuter le cli en tant que shell"
 
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "Vous avez  : [%s] configuré mais vous avez : [%s] depuis le serveur."
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "nom du fournisseur (requis)"
 
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "Veuillez corriger l'hôte dans le fichier /etc/katello/client.conf"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-"Informations d'identification invalides ou authentification impossible"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "option %s : valeur booléenne invalide : %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "répertorier tous les utilisateurs connus"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "Liste des utilisateurs"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "créer un utilisateur"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "nom d'utilisateur (requis)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "mot de passe initial (requis)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "email (requis)"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "compte désactivé (par défaut, « false »)"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "nom de l'organisation par défaut de l'utilisateur"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "nom de l'environnement par défaut de l'utilisateur"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "Création de l'utilisateur réussie [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "Impossible de créer l'utilisateur [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "répertorier les informations sur l'utilisateur"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "Informations sur l'utilisateur"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "supprimer l'utilisateur"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "Suppression de l'utilisateur réussie [ %s ]"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "mettre à jour un utilisateur"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "mot de passe initial"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "email"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "compte désactivé"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "l'environnement par défaut de l'utilisateur est « Aucun »"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "Mise à jour de l'utilisateur réussie [ %s ]"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "répertorier les rôles de l'utilisteur"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "Liste des rôles d'utilisateur"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "synchronise les rôles avec les groupes LDAP"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "assigner le rôle à un utilisateur"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "désaffecter un rôle d'un utilisateur"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "rôle de l'utilisateur (requis)"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "Rôle [%s] introuvable"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "rapport de l'utilisateur"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "actions spécifiques à l'utilisateur dans le serveur katello"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "Saisir le contenu de la clé GPG (terminez la saisie avec CTRL+D) :"
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "répertorier toutes les clés GPG"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "Nom de l'organisation (requis)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "aucune clé GPG trouvée dans l'organisation [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "Liste des clés GPG"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "afficher les informations sur une clé GPG"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "nom de la clé d'activation (requis)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "Impossible de trouver le clé GPG [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "Référentiels"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "Informations sur la clé GPG"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "créer une clé GPG"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-"fichier avec la clé GPG publique, si non spécifié, une entrée standard sera "
-"utilisée"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "Création de la clé GPG [ %s ] réussie"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "Impossible de créer la clé GPG [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "mettre à jour une clé d'activation"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "nom du nouveau modèle"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "fichier avec la clé GPG"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "demande du nouveau contenu de la clé"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "Mise à jour de la clé GPG [ %s ] réussie"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "Mise à jour de la clé GPG [ %s ] impossible"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "supprimer une clé GPG"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "Suppression de la clé GPG [ %s ] réussie"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "actions spécifiques à la clé GPG dans le serveur katello"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "répertorier toutes les clés d'activation"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "nom de l'environnement ex. : dev (par défaut : Library)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "Aucune clé trouvée dans l'organisation [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "Aucune clé trouvée dans l'organisation [ %s ] environnement [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "Liste des clés d'activation"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "afficher les informations sur une clé d'activation"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "Clé d'activation [ %s ] introuvable"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "Informations sur la clé d'activation"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "créer une clé d'activation"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "nom de l'environnement ex. : dev (requis)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "description de la clé d'activation"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "nom de modèle ex. : serveurs"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "Impossible de trouver le modèle [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "Création de la clé d'activation [ %s ] réussie"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "Impossible de créer la clé d'activation [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "nom du nouvel environnement ex. : dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "nouvelle description"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "nom du nouveau modèle ex. : serveurs"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "ajouter un pool à la clé d'activation"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "supprimer un pool de la clé d'activation"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "Mise à jour de la clé d'activation [ %s ] réussie"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "supprimer une clé d'activation"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "Suppression de la clé d'activation [ %s ] réussie"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "actions spécifiques aux clés d'activation dans le serveur katello"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "répertorier les groupes de paquetages disponibles"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "id de référentiel, valeur de chaîne (requis)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "Aucun groupe de paquetages trouvé dans le référentiel [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "Informations de groupe de paquetages"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "rechercher des informations sur un groupe de paquetages"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "id de groupe de paquetages, valeur de chaîne (requis)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "Groupe de paquetages [%s] introuvable dans le référentiel [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "répertorier les catégories des groupes de paquetages disponibles"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-"Aucune catégorie de groupes de paquetages trouvée dans le référentiel [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "Informations sur les catégories de groupes de paquetages"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "ID de catégorie de groupe de paquetages, valeur de chaîne (requis)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-"Catégorie de groupe de paquetages [%s] introuvable dans le référentiel [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "Informations sur la catégorie de groupes de paquetages"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "actions spécifiques aux groupe de paquetages dans le serveur katello"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "répertorier les nouveaux changesets d'un environnement"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "nom de l'environnement (requis)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "Liste des changesets"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "informations détaillées sur un changeset"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "nom du changeset (requis)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "affichera les paquetages dépendants"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "Informations sur le changeset"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "créer un nouveau changeset pour un environnement"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "description du changeset"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "Création du changeset [ %s ] pour l'environnement [ %s ] réussie"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "Création du changeset [ %s ] pour l'environnement [ %s ] impossible"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "met à jour le contenu d'un changeset"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s doit être précédé de %s"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "nouveau nom du changeset"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "produit doit ajouter au changeset"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "produit doit supprimer du changeset"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "nom du modèle à ajouter au changeset"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "nom du modèle à supprimer du changeset"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-"détermine le produit à partir duquel les paquetages/errata/référentiels sont"
-" choisis"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "à ajouter au changeset"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "à supprimer du changeset"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "Mise à jour du changeset réussie [ %s ] "
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "supprime un changeset"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "attribue un changeset à l'environnement suivant"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "Attribution du changeset, veuillez patienter..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "Changeset [ %s ] attribué"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "Échec de l'attribution du changeset [ %s ] : %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "actions spécifiques au changeset dans le serveur katello"
-
-#: ../src/katello/client/core/provider.py:59
+#: ../src/katello/client/core/provider.py:57
 msgid "list all known providers"
 msgstr "répertorier tous les fournisseurs connus"
 
-#: ../src/katello/client/core/provider.py:81
+#: ../src/katello/client/core/provider.py:79
 msgid "Provider List"
 msgstr "Liste des fournisseurs"
 
-#: ../src/katello/client/core/provider.py:89
+#: ../src/katello/client/core/provider.py:87
 msgid "list information about a provider"
 msgstr "répertorier des informations sur un fournisseur"
 
-#: ../src/katello/client/core/provider.py:104
+#: ../src/katello/client/core/provider.py:102
 msgid "Provider Information"
 msgstr "Informations de fournisseur"
 
-#: ../src/katello/client/core/provider.py:116
+#: ../src/katello/client/core/provider.py:114
 msgid "create a provider"
 msgstr "créer un fournisseur"
 
-#: ../src/katello/client/core/provider.py:118
+#: ../src/katello/client/core/provider.py:116
 msgid "update a provider"
 msgstr "mettre à jour un fournisseur"
 
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
 msgid "provider description"
 msgstr "description du fournisseur"
 
-#: ../src/katello/client/core/provider.py:139
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"URL du référentiel ex. : "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
 msgid "provider name"
 msgstr "nom du fournisseur"
 
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "L'option --url doit commencer par http:// ou https://"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "L'option --url n'est pas sous un format valide"
-
-#: ../src/katello/client/core/provider.py:159
+#: ../src/katello/client/core/provider.py:147
 #, python-format
 msgid "Successfully created provider [ %s ]"
 msgstr "Création du fournisseur [ %s ] réussie"
 
-#: ../src/katello/client/core/provider.py:160
+#: ../src/katello/client/core/provider.py:148
 #, python-format
 msgid "Could not create provider [ %s ]"
 msgstr "Impossible de créer le fournisseur [ %s ]"
 
-#: ../src/katello/client/core/provider.py:167
+#: ../src/katello/client/core/provider.py:155
 #, python-format
 msgid "Successfully updated provider [ %s ]"
 msgstr "Mise à jour du fournisseur [ %s ] réussie"
 
-#: ../src/katello/client/core/provider.py:185
+#: ../src/katello/client/core/provider.py:173
 msgid "delete a provider"
 msgstr "supprimer un fournisseur"
 
-#: ../src/katello/client/core/provider.py:201
+#: ../src/katello/client/core/provider.py:189
 msgid "synchronize a provider"
 msgstr "synchroniser un fournisseur"
 
-#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/provider.py:204
 #, python-format
 msgid "Provider [ %s ] failed to sync: %s"
 msgstr "Échec de la synchronisation du fournisseur [ %s ] : %s"
 
-#: ../src/katello/client/core/provider.py:219
+#: ../src/katello/client/core/provider.py:207
 #, python-format
 msgid "Provider [ %s ] synchronization cancelled"
 msgstr "Synchronisation du fournisseur [ %s ] annulée"
 
-#: ../src/katello/client/core/provider.py:222
+#: ../src/katello/client/core/provider.py:210
 #, python-format
 msgid "Provider [ %s ] synchronized"
 msgstr "Fournisseur [ %s ] synchronisé"
 
-#: ../src/katello/client/core/provider.py:245
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "annuler la synchronisation actuellement en cours d'exécution"
+
+#: ../src/katello/client/core/provider.py:233
 msgid "status of provider's synchronization"
 msgstr "état de la synchronisation du fournisseur"
 
-#: ../src/katello/client/core/provider.py:258
+#: ../src/katello/client/core/provider.py:246
 #, python-format
 msgid "%d%% done (%d of %d packages downloaded)"
 msgstr "%d%% effectué (%d sur %d paquetages téléchargés)"
 
-#: ../src/katello/client/core/provider.py:269
+#: ../src/katello/client/core/provider.py:257
 msgid "Provider Status"
 msgstr "État du fournisseur"
 
-#: ../src/katello/client/core/provider.py:277
+#: ../src/katello/client/core/provider.py:265
 msgid "import a manifest file"
 msgstr "importer un fichier manifeste"
 
-#: ../src/katello/client/core/provider.py:283
+#: ../src/katello/client/core/provider.py:271
 msgid "path to the manifest file (required)"
 msgstr "chemin vers le fichier manifeste (requis)"
 
-#: ../src/katello/client/core/provider.py:285
+#: ../src/katello/client/core/provider.py:273
 msgid "force reimporting the manifest"
 msgstr "forcer la ré-importation du manifeste"
 
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
 #, python-format
 msgid "File %s does not exist"
 msgstr "Le fichier %s n'existe pas"
 
-#: ../src/katello/client/core/provider.py:307
+#: ../src/katello/client/core/provider.py:295
 msgid "Importing manifest, please wait... "
 msgstr "Importation du manifeste, veuillez patienter..."
 
-#: ../src/katello/client/core/provider.py:320
+#: ../src/katello/client/core/provider.py:308
 msgid "refresh provider's products repositories"
 msgstr "rafraîchir les référentiels des produits du fournisseur"
 
-#: ../src/katello/client/core/provider.py:329
+#: ../src/katello/client/core/provider.py:317
 #, python-format
 msgid "Provider successfully refreshed [ %s ]"
 msgstr "Fournisseur rafraîchi avec succès [ %s ]"
 
-#: ../src/katello/client/core/provider.py:336
+#: ../src/katello/client/core/provider.py:324
 msgid "provider specific actions in the katello server"
 msgstr "actions spécifiques aux fournisseurs dans le serveur katello"
 
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "répertorier les environnements connus"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "Org"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "Environnement précédent"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "Liste des environnements"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "répertorier un environnement spécifique"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "nom de l'environnement ex. : foo.example.com (requis)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "Informations sur l'environnement"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "créer un environnement"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "description de l'environnement ex. : environnement de foo"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "nom de l'environnement précédent"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "Création de l'environnement [ %s ] réussie"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "Impossible de créer l'environnement [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "mettre à jour un environnement"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "nom de l'environnement précédent"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "Mise à jour de l'environnement [ %s ] réussie"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "supprimer un environnement"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "Suppression de l'environnement [ %s ] réussie"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "actions spécifiques à l'environnement dans le serveur katello"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "enregistrer une option sur la configuration du client"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-"nom de l'option à enregistrer (ex. : organisation, environnement, "
-"fournisseur, etc.) (requis)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "valeur à stocker sous une option spécifiée (requis)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "Réussi(e)"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "Option [ %s ] mémorisée sans succès"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "supprimer une option de la configuration du client"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "nom de l'option à supprimer (requis)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "Option [ %s ] oubliée avec succès"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "Option [ %s ] oubliée sans succès"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "répertorier les options enregistrées dans la configuration client"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "Options enregistrées"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "actions spécifiques au client dans le serveur katello"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "répertorier tous les modèles"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "nom de l'organisation (requis si l'environnement est spécifié)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "Aucun modèle trouvé dans l'environnement [ %s ]"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "Liste des modèles"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "répertorier les informations sur un modèle"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "nom du modèle (requis)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "Informations sur le modèle"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "créer un fichier modèle et importer des données"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "chemin vers le fichier modèle (requis)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "Importation du modèle, veuillez patienter..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "exporter le modèle dans le fichier"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "nom de l'environnement ex. : dev"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "format de l'export, valeurs possibles : %s, par défaut : json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "Impossible de créer le fichier %s"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "Exportation du modèle, veuillez patienter..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "Le modèle a été exporté avec succès sur le fichier %s"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "créer un fichier modèle vide"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "nom du modèle parent"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "description du modèle"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "Création du modèle [ %s ] réussie"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "Impossible de créer le modèle [ %s ]"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "met à jour le nom et la description d'un modèle"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "chaque %s doit être précédé par %s"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "nom ou nvre du produit (epoch:name-rel.ease-ver.sio.n)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "nom du paramètre, %s doit suivre"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "valeur du paramètre"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "nom du paramètre"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "nom du groupe de paquetages"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "nom de la catégorie du groupe de paquetages"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "ID de la distribution"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "détermine le produit à partir duquel les référentiels sont choisis"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "référentiel à ajouter au modèle"
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "référentiel à supprimer du modèle"
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "valeur manquante pour le paramètre '%s'"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "Mise à jour du modèle, veuillez patienter..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "Mise à jour du modèle [ %s ] réussie"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "supprime un modèle"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "nom de l'environnement ex. : foo.example.com (par défaut : Library)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "actions spécifique aux modèles dans le serveur Katello"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "exécuter le cli en tant que shell"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "répertorier les sync_plans connus"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "Liste des plans de synchronisation"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "imprimer les informations sur un plan de synchronisation"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "nom du plan de synchronisation (requis)"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "Informations sur le plan de synchronisation"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "créer un plan de synchronisation"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "description du plan"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-"intervalle des synchronisations récurrente (choix : [%s], par défaut : "
-"aucun)"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "date de la première synchronisation (requise, format : AAAA-MM-JJ)"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-"heure de la première synchronisation (format : HH:MM:SS, par défaut : "
-"00:00:00)"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "Création du plan de synchronisation [ %s ] réussie"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "Création du plan de synchronisation [ %s ] impossible"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "mettre à jour un plan de synchronisation"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "nouveau nom de plan de synchronisation"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "date de la première synchronisation (format : AAAA-MM-JJ)"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "heure de la première synchronisation (format : HH:MM:SS)"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "Vous devez spécifier la date --date et l'heure --time"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "Mise à jour du plan de synchronisation [%s] réussie"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "supprimer un plan de synchronisation"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "Suppression du plan de synchronisation [ %s ] réussie"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-"actions spécifiques au plan de synchronisation dans le serveur katello"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "obtenir la version du serveur katello"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "Vérifier la version du serveur"
-
-#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "obtenir l'état du serveur katello"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "État Katello"
+
+#: ../src/katello/client/core/permission.py:53
 msgid "create a permission for a user role"
 msgstr "créer une permission pour un rôle d'utilisateur"
 
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "nom du rôle (requis)"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
 msgid "permission name (required)"
 msgstr "nom de la permission (requis)"
 
-#: ../src/katello/client/core/permission.py:61
+#: ../src/katello/client/core/permission.py:58
 msgid "permission description"
 msgstr "description de la permission"
 
-#: ../src/katello/client/core/permission.py:62
+#: ../src/katello/client/core/permission.py:59
 msgid "organization name"
 msgstr "nom de l'organisation"
 
-#: ../src/katello/client/core/permission.py:63
+#: ../src/katello/client/core/permission.py:60
 msgid "scope of the permisson (required)"
 msgstr "étendue de la permission (requis)"
 
-#: ../src/katello/client/core/permission.py:64
+#: ../src/katello/client/core/permission.py:61
 msgid "verbs for the permission"
 msgstr "verbes pour la permission"
 
-#: ../src/katello/client/core/permission.py:65
+#: ../src/katello/client/core/permission.py:62
 msgid "tags for the permission"
 msgstr "balises pour la permission"
 
-#: ../src/katello/client/core/permission.py:81
+#: ../src/katello/client/core/permission.py:76
 #, python-format
 msgid "Invalid scope [ %s ]"
 msgstr "Étendue [ %s ] invalide"
 
-#: ../src/katello/client/core/permission.py:88
+#: ../src/katello/client/core/permission.py:83
 #, python-format
 msgid "Could not find tag [ %s ] in scope of [ %s ]"
 msgstr "Balise [ %s ] introuvable dans l'étendue de [ %s ]"
 
-#: ../src/katello/client/core/permission.py:112
+#: ../src/katello/client/core/permission.py:101
 #, python-format
 msgid "Successfully created permission [ %s ] for user role [ %s ]"
 msgstr ""
 "Création de la permission [ %s ] pour le rôle d'utilisateur [ %s ] réussie"
 
-#: ../src/katello/client/core/permission.py:113
+#: ../src/katello/client/core/permission.py:102
 #, python-format
 msgid "Could not create permission [ %s ]"
 msgstr "Création de la permission [ %s ] impossible"
 
-#: ../src/katello/client/core/permission.py:119
+#: ../src/katello/client/core/permission.py:108
 msgid "delete a permission"
 msgstr "supprimer une permission"
 
-#: ../src/katello/client/core/permission.py:137
+#: ../src/katello/client/core/permission.py:125
 #, python-format
 msgid "Successfully deleted permission [ %s ] for role [ %s ]"
 msgstr "Suppression de la permission [ %s ] pour le rôle [ %s ] réussie"
 
-#: ../src/katello/client/core/permission.py:143
+#: ../src/katello/client/core/permission.py:131
 msgid "list permissions for a user role"
 msgstr "répertorier les permission d'un rôle d'utilisateur"
 
-#: ../src/katello/client/core/permission.py:170
+#: ../src/katello/client/core/permission.py:158
 msgid "Permission List"
 msgstr "Liste des permissions"
 
-#: ../src/katello/client/core/permission.py:177
+#: ../src/katello/client/core/permission.py:165
 msgid "list available scopes, verbs and tags that can be set in a permission"
 msgstr ""
 "répertorier les étendues, verbes et balises disponibles pouvant être définis"
 " dans une permission"
 
-#: ../src/katello/client/core/permission.py:181
+#: ../src/katello/client/core/permission.py:169
 msgid ""
 "organization name eg: foo.example.com,\n"
 "lists organization specific verbs"
@@ -2469,26 +2175,103 @@ msgstr ""
 "nom d'organisation ex. : foo.example.com,\n"
 "répertorie les verbes spécifiques à l'organisation"
 
-#: ../src/katello/client/core/permission.py:182
+#: ../src/katello/client/core/permission.py:170
 msgid "filter listed results by scope"
 msgstr "filtrer les résultats répertoriés par étendue"
 
-#: ../src/katello/client/core/permission.py:200
+#: ../src/katello/client/core/permission.py:188
 #, python-format
 msgid "Available verbs and tags for permission scope %s"
 msgstr "Verbes et balises disponibles pour l'étendue de la permission %s "
 
-#: ../src/katello/client/core/permission.py:202
+#: ../src/katello/client/core/permission.py:190
 msgid "Available verbs"
 msgstr "verbes disponibles"
 
-#: ../src/katello/client/core/permission.py:221
+#: ../src/katello/client/core/permission.py:209
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/katello/client/core/permission.py:259
+#: ../src/katello/client/core/permission.py:247
 msgid "permission pecific actions in the katello server"
 msgstr "actions spécifiques aux permissions dans le serveur katello"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "aucune description disponible"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "aucune action spécifiée : merci de voir --help"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "action invalide : merci de voir --help"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "sortie conviviale grep"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "sortie verbeuse, plus structurée"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+"délimiteur de colonne de la sortie de grep, fonctionne uniquement avec "
+"l'option -g"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+"ERREUR : le nom d'hôte du serveur configuré dans /etc/katello/client.conf ne"
+" correspond pas au "
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+"nom d'hôte retourné depuis le serveur katello auquel vous vous connectez."
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "Vous avez  : [%s] configuré mais vous avez : [%s] depuis le serveur."
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "Veuillez corriger l'hôte dans le fichier /etc/katello/client.conf"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+"Informations d'identification invalides ou authentification impossible"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "option %s : valeur booléenne invalide : %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
 
 #: ../src/katello/client/core/errata.py:42
 msgid "list all errata for a repo"
@@ -2510,26 +2293,118 @@ msgstr "Liste des errata"
 msgid "list errata for a system"
 msgstr "répertorier les errata d'un système"
 
-#: ../src/katello/client/core/errata.py:125
+#: ../src/katello/client/core/errata.py:124
 #, python-format
 msgid "Errata for system %s in organization %s"
 msgstr "Errata du système %s dans l'organisation %s"
 
-#: ../src/katello/client/core/errata.py:132
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
 msgid "information about an errata"
 msgstr "informations sur un errata"
 
-#: ../src/katello/client/core/errata.py:136
+#: ../src/katello/client/core/errata.py:170
 msgid "errata id, string value (required)"
 msgstr "ID d'errata, valeur de chaîne (requis)"
 
-#: ../src/katello/client/core/errata.py:185
+#: ../src/katello/client/core/errata.py:217
 msgid "Errata Information"
 msgstr "Informations d'errata"
 
-#: ../src/katello/client/core/errata.py:194
+#: ../src/katello/client/core/errata.py:226
 msgid "errata specific actions in the katello server"
 msgstr "actions spécifiques aux errata dans le serveur katello"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "obtenir la version du serveur katello"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "Vérifier la version du serveur"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "répertorier les groupes de paquetages disponibles"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "id de référentiel, valeur de chaîne (requis)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "Aucun groupe de paquetages trouvé dans le référentiel [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "Informations de groupe de paquetages"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "rechercher des informations sur un groupe de paquetages"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "id de groupe de paquetages, valeur de chaîne (requis)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "Groupe de paquetages [%s] introuvable dans le référentiel [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "répertorier les catégories des groupes de paquetages disponibles"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+"Aucune catégorie de groupes de paquetages trouvée dans le référentiel [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "Informations sur les catégories de groupes de paquetages"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "ID de catégorie de groupe de paquetages, valeur de chaîne (requis)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+"Catégorie de groupe de paquetages [%s] introuvable dans le référentiel [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "Informations sur la catégorie de groupes de paquetages"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "actions spécifiques aux groupe de paquetages dans le serveur katello"
 
 #: ../src/katello/client/core/repo.py:34
 msgid "Waiting"
@@ -2559,20 +2434,27 @@ msgstr "Délai dépassé"
 msgid "Not synced"
 msgstr "Non synchronisé"
 
-#: ../src/katello/client/core/repo.py:116
+#: ../src/katello/client/core/repo.py:114
 msgid "create a repository at a specified URL"
 msgstr "créer un référentiel sur un URL spécifié"
 
-#: ../src/katello/client/core/repo.py:122
+#: ../src/katello/client/core/repo.py:120
 msgid "repository name to assign (required)"
 msgstr "nom du référentiel à assigner (requis)"
 
-#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:122
 msgid "url path to the repository (required)"
 msgstr "chemin URL vers le référentiel (requis)"
 
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "nom de produit (requis)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
 msgid ""
 "GPG key to be assigned to the repository; by default, the product's GPG key "
 "will be used."
@@ -2580,29 +2462,29 @@ msgstr ""
 "Clé GPG à assigner au référentiel ; par défaut, la clé GPG du produit sera "
 "utilisée."
 
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
 msgid "Don't assign a GPG key to the repository."
 msgstr "Ne pas assigner de clé GPG au référentiel."
 
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
 #, python-format
 msgid "Successfully created repository [ %s ]"
 msgstr "Référentiel [ %s ] créé avec succès"
 
-#: ../src/katello/client/core/repo.py:154
+#: ../src/katello/client/core/repo.py:149
 msgid "discovery repositories contained within a URL"
 msgstr "référentiels de découverte contenus dans un URL"
 
-#: ../src/katello/client/core/repo.py:160
+#: ../src/katello/client/core/repo.py:155
 msgid ""
 "repository name prefix to add to all the discovered repositories (required)"
 msgstr ""
 "préfixe de nom de référentiel à ajouter à tous les référentiels découverts "
 "(requis)"
 
-#: ../src/katello/client/core/repo.py:162
+#: ../src/katello/client/core/repo.py:157
 msgid ""
 "root url to perform discovery of repositories eg: "
 "http://porkchop.devel.redhat.com/ (required)"
@@ -2610,16 +2492,31 @@ msgstr ""
 "URL racine pour procéder à la découverte de référentiels ex. : "
 "http://porkchop.devel.redhat.com/ (requis)"
 
-#: ../src/katello/client/core/repo.py:192
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+"supposer que oui ; automatiquement créer des référentiels candidats pour les"
+" URL découverts (optionnel)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "URL de référentiels découverts @ [%s]"
+
+#: ../src/katello/client/core/repo.py:183
 msgid "Discovering repository urls, this could take some time..."
 msgstr "Découverte d'URL de référentiels, ceci peut prendre du temps..."
 
-#: ../src/katello/client/core/repo.py:196
+#: ../src/katello/client/core/repo.py:187
 #, python-format
 msgid "Error: %s"
 msgstr "Erreur : %s"
 
-#: ../src/katello/client/core/repo.py:216
+#: ../src/katello/client/core/repo.py:207
 msgid ""
 "\n"
 "Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
@@ -2627,334 +2524,806 @@ msgstr ""
 "\n"
 "Sélectionner les URL pour lesquels des référentiels candidats devraient être créés ; utilisez `y` pour confirmer (h pour obtenir de l'aide) :"
 
-#: ../src/katello/client/core/repo.py:226
+#: ../src/katello/client/core/repo.py:217
 msgid "Operation aborted upon user request."
 msgstr "Opération annulée sur la requête de l'utilisateur."
 
-#: ../src/katello/client/core/repo.py:275
+#: ../src/katello/client/core/repo.py:266
 msgid "status information about a repository"
 msgstr "informations d'état sur un référentiel"
 
-#: ../src/katello/client/core/repo.py:298
+#: ../src/katello/client/core/repo.py:289
 msgid "Repository Status"
 msgstr "État du référentiel"
 
-#: ../src/katello/client/core/repo.py:305
+#: ../src/katello/client/core/repo.py:296
 msgid "information about a repository"
 msgstr "informations sur un référentiel"
 
-#: ../src/katello/client/core/repo.py:319
+#: ../src/katello/client/core/repo.py:310
 msgid "Progress"
 msgstr "Progrès"
 
-#: ../src/katello/client/core/repo.py:322
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "Clé GPG"
+
+#: ../src/katello/client/core/repo.py:313
 #, python-format
 msgid "Information About Repo %s"
 msgstr "Informations sur le référentiel %s"
 
-#: ../src/katello/client/core/repo.py:329
+#: ../src/katello/client/core/repo.py:320
 msgid "updates repository attributes"
 msgstr "mettre à jour les attributs du référentiel"
 
-#: ../src/katello/client/core/repo.py:345
+#: ../src/katello/client/core/repo.py:336
 #, python-format
 msgid "Successfully updated repository [ %s ]"
 msgstr "Mise à jour du référentiel [ %s ] réussie"
 
-#: ../src/katello/client/core/repo.py:351
+#: ../src/katello/client/core/repo.py:342
 msgid "synchronize a repository"
 msgstr "synchroniser un référentiel"
 
-#: ../src/katello/client/core/repo.py:361
+#: ../src/katello/client/core/repo.py:352
 #, python-format
 msgid "Repo [ %s ] synced"
 msgstr "Référentiel [ %s ] synchronisé"
 
-#: ../src/katello/client/core/repo.py:364
+#: ../src/katello/client/core/repo.py:355
 #, python-format
 msgid "Repo [ %s ] synchronization cancelled"
 msgstr "Synchronisation du référentiel [ %s ] annulée"
 
-#: ../src/katello/client/core/repo.py:367
+#: ../src/katello/client/core/repo.py:358
 #, python-format
 msgid "Repo [ %s ] failed to sync: %s"
 msgstr "Échec de la synchronisation du référentiel [ %s ] : %s"
 
-#: ../src/katello/client/core/repo.py:373
+#: ../src/katello/client/core/repo.py:364
 msgid "cancel currently running synchronization of a repository"
 msgstr "annuler une synchronisation de référentiel en cours d'exécution"
 
-#: ../src/katello/client/core/repo.py:388
+#: ../src/katello/client/core/repo.py:379
 msgid "enable a repository"
 msgstr "activer un référentiel"
 
-#: ../src/katello/client/core/repo.py:390
+#: ../src/katello/client/core/repo.py:381
 msgid "disable a repository"
 msgstr "désactiver un référentiel"
 
-#: ../src/katello/client/core/repo.py:409
+#: ../src/katello/client/core/repo.py:400
 msgid "list repos within an organization"
 msgstr "répertorier les référentiels dans une organisation"
 
-#: ../src/katello/client/core/repo.py:413
+#: ../src/katello/client/core/repo.py:404
 msgid "organization name eg: ACME_Corporation (required)"
 msgstr "nom de l'organisation ex. : ACME_Corporation (requis)"
 
-#: ../src/katello/client/core/repo.py:419
+#: ../src/katello/client/core/repo.py:410
 msgid "list also disabled repositories"
 msgstr "aussi répertorier les référentiels désactivés"
 
-#: ../src/katello/client/core/repo.py:439
+#: ../src/katello/client/core/repo.py:430
 #, python-format
 msgid "Repo List For Org %s Environment %s Product %s"
 msgstr ""
 "Liste des référentiels pour l'organisation %s, environnement %s, produit %s"
 
-#: ../src/katello/client/core/repo.py:446
+#: ../src/katello/client/core/repo.py:437
 #, python-format
 msgid "Repo List for Product %s in Org %s "
 msgstr "Liste des référentiels pour le produit %s dans l'organisation %s"
 
-#: ../src/katello/client/core/repo.py:453
+#: ../src/katello/client/core/repo.py:444
 #, python-format
 msgid "Repo List For Org %s Environment %s"
 msgstr "Liste des référentiels pour l'organisation %s, environnement %s"
 
-#: ../src/katello/client/core/repo.py:463
+#: ../src/katello/client/core/repo.py:454
 msgid "delete a repository"
 msgstr "supprimer un référentiel"
 
-#: ../src/katello/client/core/repo.py:476
+#: ../src/katello/client/core/repo.py:467
 msgid "list filters of a repository"
 msgstr "répertorier les filtres d'un référentiel"
 
-#: ../src/katello/client/core/repo.py:482
+#: ../src/katello/client/core/repo.py:473
 msgid "prints also filters assigned to repository's product."
 msgstr "aussi imprimer les filtres assignés au produit du référentiel."
 
-#: ../src/katello/client/core/repo.py:492
+#: ../src/katello/client/core/repo.py:483
 msgid "Repository Filters"
 msgstr "Filtres de référentiel"
 
-#: ../src/katello/client/core/repo.py:506
+#: ../src/katello/client/core/repo.py:497
 msgid "add a filter to a repository"
 msgstr "ajouter un filtre à un référentiel"
 
-#: ../src/katello/client/core/repo.py:508
+#: ../src/katello/client/core/repo.py:499
 msgid "remove a filter from a repository"
 msgstr "supprimer un filtre d'un référentiel"
 
-#: ../src/katello/client/core/repo.py:538
+#: ../src/katello/client/core/repo.py:529
 #, python-format
 msgid "Added filter [ %s ] to repository [ %s ]"
 msgstr "Filtre [ %s ] ajouté au référentiel [ %s ]"
 
-#: ../src/katello/client/core/repo.py:541
+#: ../src/katello/client/core/repo.py:532
 #, python-format
 msgid "Removed filter [ %s ] to repository [ %s ]"
 msgstr "Filtre [ %s ] supprimé du référentiel [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "répertorier tous les rôles d'utilisateur connus"
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "répertorier les sync_plans connus"
 
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "créer un rôle d'utilisateur"
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
 
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "description du rôle"
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "Liste des plans de synchronisation"
 
-#: ../src/katello/client/core/user_role.py:77
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "imprimer les informations sur un plan de synchronisation"
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "nom du plan de synchronisation (requis)"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "Informations sur le plan de synchronisation"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "créer un plan de synchronisation"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "description du plan"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
 #, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "Création du rôle d'utilisateur [ %s ] réussie"
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+"intervalle des synchronisations récurrente (choix : [%s], par défaut : "
+"aucun)"
 
-#: ../src/katello/client/core/user_role.py:78
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "date de la première synchronisation (requise, format : AAAA-MM-JJ)"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+"heure de la première synchronisation (format : HH:MM:SS, par défaut : "
+"00:00:00)"
+
+#: ../src/katello/client/core/sync_plan.py:135
 #, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "Impossible de créer le rôle d'utilisateur [ %s ]"
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "Création du plan de synchronisation [ %s ] réussie"
 
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "répertorier les informations sur le rôle de l'utilisateur"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "nom du rôle de l'utilisateur (requis)"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "imprimer les détails de chaque permission du rôle"
-
-#: ../src/katello/client/core/user_role.py:109
+#: ../src/katello/client/core/sync_plan.py:136
 #, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "Création du plan de synchronisation [ %s ] impossible"
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "mettre à jour un plan de synchronisation"
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "nouveau nom de plan de synchronisation"
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "date de la première synchronisation (format : AAAA-MM-JJ)"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "heure de la première synchronisation (format : HH:MM:SS)"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "Mise à jour du plan de synchronisation [%s] réussie"
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "supprimer un plan de synchronisation"
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "Suppression du plan de synchronisation [ %s ] réussie"
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+"actions spécifiques au plan de synchronisation dans le serveur katello"
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "répertorier toutes les organisations connues"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "Liste des organisations"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "créer une organisation"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "description du consommateur ex. : organisation de foo"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "Création de l'organisation [ %s ] réussie"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "Impossible de créer l'organisation [ %s ]"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "répertorier les informations sur une organisation"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "Niveaux de service disponibles"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "Informations sur l'organisation"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "supprimer une organisation"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "Suppression de l'organisation, veuillez patienter..."
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "Suppression de l'organisation [ %s ] réussie"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "Échec de la suppression de l'organisation [ %s ] : %s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "mettre à jour une organisation"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "Mise à jour de l'organisation [ %s ] réussie"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "générer et afficher un certificat ueber"
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "régénérer le certificat"
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "Organisation Uebercert"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "afficher les abonnements"
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "Abonnements de l'organisation"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "actions spécifiques à l'organisation dans le serveur katello"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "installer un plan de synchronisation"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "nom du plan de synchronisation (requis)"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "désinstaller un plan de synchronisation"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "répertorier les produits connus"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+"nom du fournisseur, répertorie le produit du fournisseur dans Library (la "
+"bibliothèque)"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "Liste des produits du fournisseur %s"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "Liste des produits de l'organisation %s, environnement %s"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "synchroniser un produit"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "Échec de la synchronisation du produit [ %s ] : %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "Synchronisation du produit [ %s ] annulée"
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "Produit [ %s ] synchronisé"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "état de la synchronisation du produit"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "État du produit"
+
+#: ../src/katello/client/core/product.py:249
 msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
 msgstr ""
-"%s\n"
-"\tpour: %s\n"
-"\tverbes: %s\n"
-"\tsur: %s"
+"attribuer un produit à un environnement\n"
+"(crée un changeset temporaire avec le produit et l'attribue)"
 
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "Informations sur le rôle de l'utilisateur"
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "Attribution du produit, veuillez patienter..."
 
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "supprimer un rôle d'utilisateur"
-
-#: ../src/katello/client/core/user_role.py:152
+#: ../src/katello/client/core/product.py:275
 #, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "Suppression du rôle de l'utilisateur [ %s ] réussie"
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "Produit [ %s ] attribué à l'environnement [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "mettre un rôle à jour"
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "Échec de l'attribution du produit [ %s ] : %s"
 
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "nouveau nom du rôle de l'utilisateur"
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "créer un nouveau produit pour un fournisseur personnalisé"
 
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "description du produit"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "ignorer la découverte de référentiels"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
 msgstr ""
-"Fournissez au moins un paramètre pour mettre à jour le rôle de l'utilisateur"
+"assigner une clé GPG ; cette clé sera utilisée pour nouveau référentiel à "
+"moins que gpgkey ou que nogpgkey ne soit spécifié pour le référentiel"
 
-#: ../src/katello/client/core/user_role.py:180
+#: ../src/katello/client/core/product.py:339
 #, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "Mise à jour du rôle de l'utilisateur [ %s ] réussie"
+msgid "Successfully created product [ %s ]"
+msgstr "Création du produit [ %s ] réussie"
 
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "assigner un groupe LDAP à un rôle"
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "mettre à jour les attributs d'un produit"
 
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "nouveau nom du groupe LDAP (requis)"
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "modifier la description du produit"
 
-#: ../src/katello/client/core/user_role.py:204
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "assigner une clé GPG au produit"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "aussi assigner la clé GPG aux référentiels du produit"
+
+#: ../src/katello/client/core/product.py:383
 #, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgid "Successfully updated product [ %s ]"
+msgstr "Mise à jour du produit [ %s ] réussie"
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "supprimer un produit et son contenu"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "répertorier les filtres d'un produit"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "Filtres de produits"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "ajouter un filtre à un produit"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "supprimer un filtre d'un produit"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "Ajout du filtre [ %s ] au produit [ %s ]"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "Suppression du filtre [ %s ] du produit [ %s ]"
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "actions spécifiques aux produits dans le serveur katello"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "répertorier tous les modèles"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "nom de l'organisation (requis si l'environnement est spécifié)"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "Aucun modèle trouvé dans l'environnement [ %s ]"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "Liste des modèles"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "répertorier les informations sur un modèle"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "nom du modèle (requis)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "Informations sur le modèle"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "créer un fichier modèle et importer des données"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "chemin vers le fichier modèle (requis)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "Importation du modèle, veuillez patienter..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "exporter le modèle dans le fichier"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "nom de l'environnement ex. : dev"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "format de l'export, valeurs possibles : %s, par défaut : json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "Impossible de créer le fichier %s"
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "Exportation du modèle, veuillez patienter..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "Le modèle a été exporté avec succès sur le fichier %s"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "créer un fichier modèle vide"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "nom du modèle parent"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "description du modèle"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "Création du modèle [ %s ] réussie"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "Impossible de créer le modèle [ %s ]"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "met à jour le nom et la description d'un modèle"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "chaque %s doit être précédé par %s"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
 msgstr ""
-"Le groupe LDAP [ %s ] a été ajouté au rôle utilisateur [ %s ] avec succès"
 
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "suppression du groupe LDAP assigné à un rôle"
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "Nom du groupe LDAP à supprimer (requis)"
-
-#: ../src/katello/client/core/user_role.py:228
+#: ../src/katello/client/core/template.py:320
 #, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgid "name of the parameter, %s must follow"
+msgstr "nom du paramètre, %s doit suivre"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "valeur du paramètre"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "nom du paramètre"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "nom du groupe de paquetages"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "nom de la catégorie du groupe de paquetages"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "ID de la distribution"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "détermine le produit à partir duquel les référentiels sont choisis"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "référentiel à ajouter au modèle"
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "référentiel à supprimer du modèle"
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "valeur manquante pour le paramètre '%s'"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "Mise à jour du modèle, veuillez patienter..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "Mise à jour du modèle [ %s ] réussie"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "supprime un modèle"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "nom de l'environnement ex. : foo.example.com (par défaut : Library)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "actions spécifique aux modèles dans le serveur Katello"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "répertorier les environnements connus"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "Org"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "Environnement précédent"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "Liste des environnements"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "répertorier un environnement spécifique"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "nom de l'environnement ex. : foo.example.com (requis)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "Informations sur l'environnement"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "créer un environnement"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "description de l'environnement ex. : environnement de foo"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "nom de l'environnement précédent"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "Création de l'environnement [ %s ] réussie"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "Impossible de créer l'environnement [ %s ]"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "mettre à jour un environnement"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "nom de l'environnement précédent"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "Mise à jour de l'environnement [ %s ] réussie"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "supprimer un environnement"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "Suppression de l'environnement [ %s ] réussie"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "actions spécifiques à l'environnement dans le serveur katello"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "le fichier certificat %s n'existe pas ou ne peut pas être lu"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "Le fichier-clé %s n'existe ou ne peut pas être lu"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
 msgstr ""
-"Le groupe LDAP [ %s ] a été supprimé du rôle utilisateur [ %s ] avec succès"
 
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "actions spécifiques au rôle de l'utilisateur dans le serveur katello"
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "Authentification via kerberos impossible"
 
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "Le format de l'heure est invalide. Requis : HH:MM:SS[+HH:MM]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "Le format de la date est invalide. Requis : AAAA-MM-JJ"
-
-#. These are a bunch of strings that are marked for translation in optparse,
-#. but not actually translated anywhere. Mark them for translation here,
-#. so we get it picked up. for local translation, and then optparse will
-#. use them.
-#: ../src/katello/client/i18n_optparse.py:48
+#: ../src/katello/client/utils/option_validator.py:86
 #, python-format
-msgid "Usage: %s\n"
-msgstr "Utilisation : %s"
+msgid "Option %s is required; please see --help"
+msgstr "L'option %s est requise : merci de voir --help"
 
-#: ../src/katello/client/i18n_optparse.py:49
-msgid "Usage"
-msgstr "Utilisation"
-
-#: ../src/katello/client/i18n_optparse.py:50
-msgid "%prog [options]"
-msgstr "%prog [options]"
-
-#: ../src/katello/client/i18n_optparse.py:51
-msgid "Options"
-msgstr "Options"
-
-#. stuff for option value sanity checking
-#: ../src/katello/client/i18n_optparse.py:54
+#: ../src/katello/client/utils/option_validator.py:128
 #, python-format
-msgid "no such option: %s"
-msgstr "pas d'option de ce type : %s"
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:55
+#: ../src/katello/client/utils/option_validator.py:130
 #, python-format
-msgid "ambiguous option: %s (%s?)"
-msgstr "option ambiguë : %s (%s?)"
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "L'option %s est en conflit avec %s ; veuillez voir -- help"
 
-#: ../src/katello/client/i18n_optparse.py:56
+#: ../src/katello/client/utils/option_validator.py:133
 #, python-format
-msgid "%s option requires an argument"
-msgstr "L'option %s requiert un argument"
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:57
+#: ../src/katello/client/utils/option_validator.py:135
 #, python-format
-msgid "%s option requires %d arguments"
-msgstr "L'option %s requiert %d arguments"
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:58
+#: ../src/katello/client/utils/option_validator.py:167
 #, python-format
-msgid "%s option does not take a value"
-msgstr "L'option %s ne prend pas de valeur"
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:59
-msgid "integer"
-msgstr "entier"
-
-#: ../src/katello/client/i18n_optparse.py:60
-msgid "long integer"
-msgstr "entier long"
-
-#: ../src/katello/client/i18n_optparse.py:61
-msgid "floating-point"
-msgstr "virgule flottante"
-
-#: ../src/katello/client/i18n_optparse.py:62
-msgid "complex"
-msgstr "complexe"
-
-#: ../src/katello/client/i18n_optparse.py:63
+#: ../src/katello/client/utils/option_validator.py:200
 #, python-format
-msgid "option %s: invalid %s value: %r"
-msgstr "option %s : valeur %s invalide : %r"
-
-#: ../src/katello/client/i18n_optparse.py:64
-#, python-format
-msgid "option %s: invalid choice: %r (choose from %s)"
-msgstr "option %s : choix invalide : %r (choisir à partir de %s)"
-
-#. default options
-#: ../src/katello/client/i18n_optparse.py:67
-msgid "show this help message and exit"
-msgstr "afficher ce message d'aide puis quitter"
-
-#: ../src/katello/client/i18n_optparse.py:68
-msgid "show program's version number and exit"
-msgstr "afficher le numéro de version du programme puis quitter"
+msgid "At least one of %s is required; please see --help"
+msgstr "Au moins l'un de %s est requis ; veuillez voir --help"

--- a/cli/po/gu.po
+++ b/cli/po/gu.po
@@ -16,2774 +16,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: gu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "ખાતા વપરાશકર્તાનામ"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "ખાતા પાસવર્ડ"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello સર્વર જાણકારી"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "katello સર્વર યજમાન નામ (મૂળભૂત: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "અયોગ્ય આદેશ; મહેરબાની કરીને --help જુઓ"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "આદેશ આપેલ નથી; મહેરબાની કરીને --help જુઓ"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "સંસ્થા યાદી"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "સંસ્થાને બનાવો"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "સંસ્થા જાણકારી"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "સંસ્થાને કાઢી નાંખો"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "સંસ્થાને સુધારો"
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "સફળતાપૂર્વક સુધારેલ સંસ્થા [ %s ]"
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "પ્રોડક્ટ નામ (જરૂરી)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "પ્રોડક્ટ વર્ણન"
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "પર્યાવરણ નામ"
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr "Org [ %s ] માટે સિસ્ટમ જાણકારી"
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "સમાપ્ત"
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr "સિસ્ટમનાં હાર્ડવેર તથ્યોને દર્શાવો"
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "સિસ્ટમ રજીસ્ટર કરો"
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "સંસ્થા નામ (જરૂરી)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr "સિસ્ટમ સુધારો"
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr "સિસ્ટમ માટે નવું નામ"
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr "સિસ્ટમનું વર્ણન"
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr "સિસ્ટમનું સ્થાન"
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "રિપોઝીટરી id"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "રિપોઝીટરી નામ"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "વિતરણ જાણકારી"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "સર્વરની પરિસ્થિતિને ચકાસો"
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr "પેકેજ વિશે યાદી જાણકારી"
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr "પેકેજ જાણકારી"
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr "રિપોઝીટરીમાં પેકેજોની યાદી કરો"
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "વપરાશકર્તા યાદી"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "વપરાશકર્તાને બનાવો"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "વપરાશકર્તા નામ (જરૂરી)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "વપરાશકર્તા જાણકારી"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "વપરાશકર્તાને કાઢી નાંખો"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "સક્રિયકરણ કી નામ (જરૂરી)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "સક્રિયકરણ કીને સુધારો"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "નવું ટૅમ્પલેટ નામ"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "બધી સક્રિયકરણ કીઓની યાદી"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "સક્રિયકરણ કી યાદી"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "સક્રિયકરણ કી વિશે જાણકારીને બતાવો"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "સક્રિયકરણ કી જાણકારી"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "સક્રિયકરણ કીને બનાવો"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "સક્રિયકરણ કી વર્ણન"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "ટૅમ્પલેટ નામ દાત: સર્વરો"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "ટૅમ્પલેટને શોધી શક્યા નહિં [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "નવું વર્ણન"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "નવું ટૅમ્પલેટ નામ દાત: સર્વરો"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "સક્રિયકરણ કી કાઢી નાંખો"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "ઉપલબ્ધ પેકેજ જૂથોની યાદી"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "પેકેજ જૂથ જાણકારી"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "પેકેજ જૂથ માટે જાણકારીને જુઓ"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "પર્યાવરણ નામ (જરૂરી)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr "ફાઇલ %s અસ્તિત્વ ધરાવતુ નથી"
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "પર્યાવરણ યાદી"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "પર્યાવરણ જાણકારી"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "પર્યાવરણને બનાવો"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "પર્યાવરણને સુધારો"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "પર્યાવરણને કાઢી નાંખો"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "ક્લાઇન્ટ રૂપરેખામાંથી વિકલ્પને દૂર કરો"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "ક્લાઇન્ટ રૂપરેખામાં સંગ્રહાયેલ વિકલ્પોની યાદી"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "સંગ્રહાયેલ વિકલ્પો"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "બધા ટૅમ્પલેટની યાદી"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "ટૅમ્પલેટ યાદી"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "ટૅમ્પલેટ વિશે જાણકારીની યાદી"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "ટૅમ્પલેટ નામ (જરૂરી)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "ટૅમ્પલેટ જાણકારી"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "ટૅમ્પલેટ ફાઇલ અને આયાત માહિતીને બનાવો"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "ટૅમ્પલેટ ફાઇલનો પાથ (જરૂરી)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "ટૅમ્પલેટને આયાત કરી રહ્યા છે, મહેરબાની કરીને થોભો.."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "ખાલી ટૅમ્પલેટ ફાઇલને બનાવો"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "મુખ્ય ટૅમ્પલેટનું નામ"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "ટૅમ્પલેટ વર્ણન"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "સફળતાપૂર્વક બનાવેલ ટૅમ્પલેટ [ %s ]"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "પરિમાણની કિંમત"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "પરિમાણનું નામ"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "પેકેજ જૂથનું નામ"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "પેકેજ જૂથ વર્ગનું નામ"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "પરિમાણ '%s' માટે ગુમ થયેલ કિંમત"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "ટૅમ્પલેટને સુધારી રહ્યા છે, મહેરબાની કરીને થોભો..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "સફળતાપૂર્વક સુધારેલ ટૅમ્પલેટ [ %s ]"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "ટૅમ્પલેટને કાઢી નાંખે છે"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr "એરાટા યાદી"
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr "સિસ્ટમ માટે એરાટા યાદી"
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr "સંસ્થા %s માં સિસ્ટમ %s માટે એરાટા"
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr "એરાટા વિશે જાણકારી"
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr "એરાટા જાણકારી"
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "રાહ જોઇ રહ્યા છે"
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "ચાલી રહ્યુ છે"
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "ભૂલ"
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "રદ થયેલ છે"
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "સમય સમાપ્ત"
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr "સુમેળ નથી"
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr "સ્પષ્ટ થયેલ URL પર રિપોઝીટરીને બનાવો"
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "ભૂલ: %s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "રિપોઝીટરી પરિસ્થિતિ"
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "રિપોઝીટરી વિશે જાણકારી"
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "પ્રગતિ"
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr "રિપો %s વિશે જાણકારી"
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr "રિપોઝીટરીને કાઢી નાંખો"
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2802,6 +159,7 @@ msgid "Options"
 msgstr "વિકલ્પો"
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2854,10 +212,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "ક્લાઇન્ટ રૂપરેખામાંથી વિકલ્પને દૂર કરો"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "ક્લાઇન્ટ રૂપરેખામાં સંગ્રહાયેલ વિકલ્પોની યાદી"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "સંગ્રહાયેલ વિકલ્પો"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "બધી સક્રિયકરણ કીઓની યાદી"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "સક્રિયકરણ કી યાદી"
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "સક્રિયકરણ કી વિશે જાણકારીને બતાવો"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "સક્રિયકરણ કી નામ (જરૂરી)"
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "સક્રિયકરણ કી જાણકારી"
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "સક્રિયકરણ કીને બનાવો"
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "સક્રિયકરણ કી વર્ણન"
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "ટૅમ્પલેટ નામ દાત: સર્વરો"
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "ટૅમ્પલેટને શોધી શક્યા નહિં [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "સક્રિયકરણ કીને સુધારો"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "નવું ટૅમ્પલેટ નામ"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "નવું વર્ણન"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "નવું ટૅમ્પલેટ નામ દાત: સર્વરો"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "સક્રિયકરણ કી કાઢી નાંખો"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "સંસ્થા નામ (જરૂરી)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "રિપોઝીટરી id"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "રિપોઝીટરી નામ"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "વિતરણ જાણકારી"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "વપરાશકર્તા યાદી"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "વપરાશકર્તાને બનાવો"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "વપરાશકર્તા નામ (જરૂરી)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "વપરાશકર્તા જાણકારી"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "વપરાશકર્તાને કાઢી નાંખો"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "પર્યાવરણ નામ (જરૂરી)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "પર્યાવરણ નામ"
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr "Org [ %s ] માટે સિસ્ટમ જાણકારી"
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "સમાપ્ત"
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr "સિસ્ટમનાં હાર્ડવેર તથ્યોને દર્શાવો"
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "સિસ્ટમ રજીસ્ટર કરો"
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr "સિસ્ટમ સુધારો"
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr "સિસ્ટમ માટે નવું નામ"
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr "સિસ્ટમનું વર્ણન"
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr "સિસ્ટમનું સ્થાન"
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr "પેકેજ વિશે યાદી જાણકારી"
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr "પેકેજ જાણકારી"
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr "રિપોઝીટરીમાં પેકેજોની યાદી કરો"
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr "ફાઇલ %s અસ્તિત્વ ધરાવતુ નથી"
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr "એરાટા યાદી"
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr "સિસ્ટમ માટે એરાટા યાદી"
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr "સંસ્થા %s માં સિસ્ટમ %s માટે એરાટા"
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr "એરાટા વિશે જાણકારી"
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr "એરાટા જાણકારી"
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "ઉપલબ્ધ પેકેજ જૂથોની યાદી"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "પેકેજ જૂથ જાણકારી"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "પેકેજ જૂથ માટે જાણકારીને જુઓ"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "રાહ જોઇ રહ્યા છે"
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "ચાલી રહ્યુ છે"
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "ભૂલ"
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "રદ થયેલ છે"
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "સમય સમાપ્ત"
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr "સુમેળ નથી"
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr "સ્પષ્ટ થયેલ URL પર રિપોઝીટરીને બનાવો"
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "પ્રોડક્ટ નામ (જરૂરી)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "ભૂલ: %s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "રિપોઝીટરી પરિસ્થિતિ"
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "રિપોઝીટરી વિશે જાણકારી"
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "પ્રગતિ"
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr "રિપો %s વિશે જાણકારી"
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr "રિપોઝીટરીને કાઢી નાંખો"
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "સંસ્થા યાદી"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "સંસ્થાને બનાવો"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "સંસ્થા જાણકારી"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "સંસ્થાને કાઢી નાંખો"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "સંસ્થાને સુધારો"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "સફળતાપૂર્વક સુધારેલ સંસ્થા [ %s ]"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "પ્રોડક્ટ વર્ણન"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "બધા ટૅમ્પલેટની યાદી"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "ટૅમ્પલેટ યાદી"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "ટૅમ્પલેટ વિશે જાણકારીની યાદી"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "ટૅમ્પલેટ નામ (જરૂરી)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "ટૅમ્પલેટ જાણકારી"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "ટૅમ્પલેટ ફાઇલ અને આયાત માહિતીને બનાવો"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "ટૅમ્પલેટ ફાઇલનો પાથ (જરૂરી)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "ટૅમ્પલેટને આયાત કરી રહ્યા છે, મહેરબાની કરીને થોભો.."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "ખાલી ટૅમ્પલેટ ફાઇલને બનાવો"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "મુખ્ય ટૅમ્પલેટનું નામ"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "ટૅમ્પલેટ વર્ણન"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "સફળતાપૂર્વક બનાવેલ ટૅમ્પલેટ [ %s ]"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "પરિમાણની કિંમત"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "પરિમાણનું નામ"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "પેકેજ જૂથનું નામ"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "પેકેજ જૂથ વર્ગનું નામ"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "પરિમાણ '%s' માટે ગુમ થયેલ કિંમત"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "ટૅમ્પલેટને સુધારી રહ્યા છે, મહેરબાની કરીને થોભો..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "સફળતાપૂર્વક સુધારેલ ટૅમ્પલેટ [ %s ]"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "ટૅમ્પલેટને કાઢી નાંખે છે"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "પર્યાવરણ યાદી"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "પર્યાવરણ જાણકારી"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "પર્યાવરણને બનાવો"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "પર્યાવરણને સુધારો"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "પર્યાવરણને કાઢી નાંખો"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/hi.po
+++ b/cli/po/hi.po
@@ -15,2774 +15,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: hi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2801,6 +158,7 @@ msgid "Options"
 msgstr ""
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2853,10 +211,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/it.po
+++ b/cli/po/it.po
@@ -17,74 +17,52 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "file del certificato %s non esiste o non può essere letto"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "il file della chiave %s non esiste o non può essere letto"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "Impossibile autenticare tramite kerberos"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "stampa le informazioni sulla versione"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Credenziali account utente di katello"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "nome utente account"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "password account"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Informazioni server di katello"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "Hostname del server di katello (default: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "Comando non valido; consultare --help"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "Nessun comando dato; consultare --help"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "Impossibile trovare l'organizzazione [ %s ]"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 "Impossibile trovare l'ambiente [ %s ] all'interno dell'organizzazione [ %s ]"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 "Impossibile trovare il prodotto [ %s ] all'interno dell'organizzazione [ %s "
 "]"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
@@ -93,69 +71,74 @@ msgstr ""
 "Impossibile trovare il repositorio [ %s ] all'interno dell'organizzazione [ "
 "%s ], prodotto [ %s ] ed ambiente [ %s ]"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 "Impossibile trovare il provider [ %s ] all'interno dell'organizzazione [ %s "
 "]"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 "Impossibile trovare il modello [ %s ] all'interno dell'ambiente [ %s ]"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "Impossibile trovare changeset [ %s ] all'interno dell'ambiente [ %s ]"
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "Impossibile trovare l'utente [ %s ]"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "Impossibile trovare il ruolo dell'utente [ %s ]"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 "Impossibile trovare il trovare il programma di sincronizzazione [ %s ]"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 "Impossibile trovare il permesso [ %s ] per il ruolo dell'utente [ %s ]"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "Impossibile trovare il filtro [ %s ]"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "Impossibile trovare il sistema [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "Trovati sistemi ambigui [ %s ] in Ambiente [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Impossibile trovare il sistema [ %s ] in Ambiente [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
@@ -164,365 +147,1329 @@ msgstr ""
 "Trovati sistemi ambigui [ %s ] in Org [ %s ], è necessario specificare "
 "l'ambiente"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "nome"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "elenca tutte le organizzazioni conosciute"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "Elenco organizzazioni"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "crea una organizzazione"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "nome organizzazione es: foo.example.com (necessario)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "descrizione utenza es: organizzazione foo"
-
-#: ../src/katello/client/core/organization.py:79
+#. These are a bunch of strings that are marked for translation in optparse,
+#. but not actually translated anywhere. Mark them for translation here,
+#. so we get it picked up. for local translation, and then optparse will
+#. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
+#: ../src/katello/client/i18n_optparse.py:48
 #, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "Org [ %s ] creata con successo"
+msgid "Usage: %s\n"
+msgstr "Utilizzo: %s\n"
 
-#: ../src/katello/client/core/organization.py:80
+#: ../src/katello/client/i18n_optparse.py:49
+msgid "Usage"
+msgstr "Utilizzo"
+
+#: ../src/katello/client/i18n_optparse.py:50
+msgid "%prog [options]"
+msgstr "%prog [options]"
+
+#: ../src/katello/client/i18n_optparse.py:51
+msgid "Options"
+msgstr "Opzioni"
+
+#. stuff for option value sanity checking
+# stuff for option value sanity checking
+#: ../src/katello/client/i18n_optparse.py:54
 #, python-format
-msgid "Could not create org [ %s ]"
-msgstr "Impossibile creare l'org [ %s ]"
+msgid "no such option: %s"
+msgstr "opzione non trovata: %s"
 
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "elenca le informazioni di una organizzazione"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "Livelli di servizio disponibili"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "Informazioni organizzazione"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "cancella una organizzazione"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "Rimozione organizzazione in corso, attendere prego..."
-
-#: ../src/katello/client/core/organization.py:135
+#: ../src/katello/client/i18n_optparse.py:55
 #, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "Org [ %s ] cancellata con successo"
+msgid "ambiguous option: %s (%s?)"
+msgstr "opzione ambigua: %s (%s?)"
 
-#: ../src/katello/client/core/organization.py:138
+#: ../src/katello/client/i18n_optparse.py:56
 #, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "Rimozione organizzazione [ %s ] fallita: %s"
+msgid "%s option requires an argument"
+msgstr "l'opzione %s richiede un argomento"
 
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "aggiorna una organizzazione"
-
-#: ../src/katello/client/core/organization.py:162
+#: ../src/katello/client/i18n_optparse.py:57
 #, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "Org [ %s ] aggiornata con successo"
+msgid "%s option requires %d arguments"
+msgstr "l'opzione %s richiede gli argomenti %d"
 
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "genera e mostra il certificato ueber"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "genera nuovamente il certificato"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "Organizzazione Uebercert"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "mostra le sottoscrizioni"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "Sottoscrizioni dell'organizzazione"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "azioni specifiche dell'organizzazione nel server di katello"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "nome prodotto (necessario)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "nome ambiente eg: produzione (default: Library)"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "imposta un programma di sincronizzazione"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "Nome programma di sincronizzazione (necessario)"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "rimuovi impostazione del programma di sincronizzazione"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "elenca prodotti conosciuti"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "nome del provider, elenca il prodotto del provider in Library"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "Chiave GPG"
-
-#: ../src/katello/client/core/product.py:147
+#: ../src/katello/client/i18n_optparse.py:58
 #, python-format
-msgid "Product List For Provider %s"
-msgstr "Elenco prodotti per provider %s"
+msgid "%s option does not take a value"
+msgstr "l'opzione %s non accetta alcun valore"
 
-#: ../src/katello/client/core/product.py:153
+#: ../src/katello/client/i18n_optparse.py:59
+msgid "integer"
+msgstr "Intero"
+
+#: ../src/katello/client/i18n_optparse.py:60
+msgid "long integer"
+msgstr "Intero lungo"
+
+#: ../src/katello/client/i18n_optparse.py:61
+msgid "floating-point"
+msgstr "virgola mobile"
+
+#: ../src/katello/client/i18n_optparse.py:62
+msgid "complex"
+msgstr "complesso"
+
+#: ../src/katello/client/i18n_optparse.py:63
 #, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "Elenco prodotti per organizzazione %s, Ambiente '%s'"
+msgid "option %s: invalid %s value: %r"
+msgstr "opzione %s: valore %s invalido: %r"
 
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "sincronizza un prodotto"
-
-#: ../src/katello/client/core/product.py:179
+#: ../src/katello/client/i18n_optparse.py:64
 #, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "Sincronizzazione prodotto [ %s ] fallita: %s"
+msgid "option %s: invalid choice: %r (choose from %s)"
+msgstr "opzione %s: selezione invalida: %r (scegliere da %s)"
 
-#: ../src/katello/client/core/product.py:182
+#. default options
+# default options
+#: ../src/katello/client/i18n_optparse.py:67
+msgid "show this help message and exit"
+msgstr "mostra questo messaggio d'aiuto ed esci"
+
+#: ../src/katello/client/i18n_optparse.py:68
+msgid "show program's version number and exit"
+msgstr "mostra il numero della versione del programma ed esci"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "elenca tutti i ruoli utente conosciuti"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "Elenco ruoli utente"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "crea ruolo utente"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "nome ruolo (necessario)"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "descrizione ruolo"
+
+#: ../src/katello/client/core/user_role.py:75
 #, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "Sincronizzazione del prodotto [ %s ] cancellata"
+msgid "Successfully created user role [ %s ]"
+msgstr "Ruolo utente [ %s ] creato con successo"
 
-#: ../src/katello/client/core/product.py:185
+#: ../src/katello/client/core/user_role.py:76
 #, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "Prodotto [ %s ] sincronizzato"
+msgid "Could not create user role [ %s ]"
+msgstr "Impossibile creare ruolo utente [ %s ]"
 
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "cancella la sincronizzazione attualemente in esecuzione"
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "elenca informazioni sul ruolo utente"
 
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "stato sincronizzazione del prodotto"
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "nome ruolo utente (necessario)"
 
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "Stato del prodotto"
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "stampa i dettagli su ogni permesso del ruolo"
 
-#: ../src/katello/client/core/product.py:242
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
 msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
 msgstr ""
-"trasferisce un prodotto su un ambiente¶\n"
-"(crea un changeset temporaneo con il prodotto e lo trasferisce)"
+"%s\n"
+"\tper: %s\n"
+"\tverb: %s\n"
+"\tsu: %s"
 
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "Trasferimento prodotto in corso, attendere prego..."
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "Informazioni ruolo utente"
 
-#: ../src/katello/client/core/product.py:268
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "cancella un ruolo utente"
+
+#: ../src/katello/client/core/user_role.py:150
 #, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "Prodotto [ %s ] trasferito sull'ambiente [ %s ]"
+msgid "Successfully deleted user role [ %s ]"
+msgstr "Ruolo utente [ %s ] cancellato con successo"
 
-#: ../src/katello/client/core/product.py:271
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "aggiorna un ruolo"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "nuovo nome ruolo utente"
+
+#: ../src/katello/client/core/user_role.py:177
 #, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "Avanzamento prodotto [ %s ] fallito: %s"
+msgid "Successfully updated user role [ %s ]"
+msgstr "Ruolo utente [ %s ] aggiornato con successo"
 
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "crea un nuovo prodotto per un provider personalizzato"
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "assegna il gruppo LDAP ad un ruolo"
 
-#: ../src/katello/client/core/product.py:297
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "nuovo nome del gruppo LDAP (necessario)"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr "Aggiunto con successo il gruppo LDAP [ %s ] l ruolo utente [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "rimuovi il gruppo LDAP assegnato ad un ruolo"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "Nome gruppo LDAP da rimuovere (necessario)"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr "Gruppo LDAP [ %s ] rimosso con successo dal ruolo utente [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "azioni specifiche del ruolo utente nel server di katello"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "salva una opzione sulla configurazione del client"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+"nome dell'opzione da salvare (es org, environment, provider, ecc) "
+"(necessario)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "valore da archiviare sotto una opzione specificata (necessario)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "Con successo"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "Memorizzazione opzione [ %s ] senza successo"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "rimuovi una opzione dalla configurazione del client"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "nome dell'opzione da cancellare (necessario)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "Opzione [ %s ] dimenticata con successo"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "Opzione [ %s ] non dimenticata"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "elenca le opzioni salvate nella configurazione del client"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "Opzioni salvate"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "azioni specifiche del client nel server di katello"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "elenca tutte le chiavi di attivazione"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
 #: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "nome provider (necessario)"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "descrizione prodotto"
-
-#: ../src/katello/client/core/product.py:303
 #: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"url repositorio es: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "nome di una organizzazione (necessario)"
 
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "salta la scoperta del repositorio"
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "nome ambiente es: dev (default: Library)"
 
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-"assume si; crea automaticamente i repositori candidati per gli url scoperti "
-"(facoltativo)"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-"assegna una chiave gpg; questa chiave verrà usata per ogni nuovo repositorio"
-" a meno che non sia specificato gpgkey o nogpgkey per il repositorio"
-
-#: ../src/katello/client/core/product.py:334
+#: ../src/katello/client/core/activation_key.py:69
 #, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "Prodotto [ %s ] creato con successo"
+msgid "No keys found in organization [ %s ]"
+msgstr "Nessuna chiave trovata nell'organizzazione [ %s ]"
 
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
+#: ../src/katello/client/core/activation_key.py:71
 #, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "Url dei repositori scoperti @ [%s]"
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "Nessuna chiave trovata nell'organizzazione [ %s ] ambiente [ %s ]"
 
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "aggiorna gli attributi di un prodotto"
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "Elenco chiavi di attivazione"
 
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "cambia la descrizione del prodotto"
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "mostra le informazioni su di una chiave di attivazione"
 
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "assegna un gpgkey al prodotto"
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "nome chiave di attivazione(necessario)"
 
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "assegna gpgkey anche ai repositori del prodotto"
-
-#: ../src/katello/client/core/product.py:378
+#: ../src/katello/client/core/activation_key.py:121
 #, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "Prodotto [ %s ] aggiornato con successo"
+msgid "Could not find activation key [ %s ]"
+msgstr "Impossibile trovare la chiave di attivazione [ %s ]"
 
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "cancella un prodotto ed il suo contenuto"
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "Informazioni chiave di attivazione"
 
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "elenca filtri di un prodotto"
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "crea una chiave di attivazione"
 
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "Filtri del prodotto"
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "nome ambiente es: dev (necessario)"
 
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "aggiunge un filtro ad un prodotto"
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "descrizione chiave di attivazione"
 
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "rimuove un filtro da un prodotto"
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "nome template es: server"
 
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "Impossibile trovare il template [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "Chiave di attivazione [ %s ] attivata con successo"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "Impossibile creare chiave di attivazione [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "aggiorna una chiave di attivazione"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "nuovo nome ambiente es: dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "nuovo nome del template"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "nuova descrizione"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "nuovo nome del template es: server"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "aggiungi un gruppo alla chiave di attivazione"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "rimuovi un gruppo dalla chiave di attivazione"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "Chiave di attivazione [ %s ] aggiornata con successo"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "cancella una chiave di attivazione"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "Chiave di attivazione [ %s ] cancellata con successo"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "azioni specifiche alla chiave di attivazione nel server di katello"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "Il formato dell'ora non è valido. Necessario: HH:MM:SS[+HH:MM]"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "Il formato della data non è valido. Necessario: YYYY-MM-DD"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "elenca tutti i filtri"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "nome organizzazione (necessario)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "Elenco filtri"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "crea un filtro"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
 msgid "filter name (required)"
 msgstr "nome filtro (necessario)"
 
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "Filtro [ %s ] aggiunto al prodotto [ %s ]"
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "descrizione"
 
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "Filtro [ %s ] rimosso dal prodotto [ %s ]"
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "elenco di nomi/nvres dei pacchetti separati da virgole"
 
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "azioni specifiche del prodotto nel server di katello"
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "Filtro [ %s ] creato con successo"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "Impossibile creare il filtro [ %s ]"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "cancella un filtro"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "Filtro [ %s ] rimosso con successo"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "Informazioni filtro"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "Informazioni filtro"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "Aggiungi un pacchetto al filtro"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "id del pacchetto (necessario)"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "Pacchetto [ %s ]  aggiunto con successo al filtro [ %s ]"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "rimuovi il pacchetto dal filtro"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "Pacchetto [ %s ]  rimosso con successo dal filtro [ %s ]"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "azioni specifiche del filtro nel server di katello"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "elenca distribuzioni in un repositorio"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "id del repositorio"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "nome repositorio"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "nome organizzazione es: foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "nome ambiente eg: produzione (default: Library)"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "nome prodotto es: fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "Elenco distribuzioni per repo %s"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "elenca informazioni relative ad una distribuzione"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "id repositorio (necessario)"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "id distribuzione es: ks-rh-noarch (necessario)"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "Informazioni sulla distribuzione"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "azioni specifiche per il repo nel server di katello"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+"Inserire il contenuto della chiave GPG (terminare l'input con CTRL+D):"
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "elenca tutte le chiavi GPG"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "Repositori"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+"file con chiave GPG pubblica, se non specificato, verrà usato l'input "
+"standard"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "file con chiave GPG pubblica"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "propmt per il nuovo contenuto della chiave"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "azioni specifiche della chiave GPG nel server di katello"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "nome organizzazione es: foo.example.com (necessario)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "Esecuzione azione remota [ %s ] in corso..."
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "Azione remot terminata:"
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "Azione remota fallita:"
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "elenca tutti gli utenti conosciuti"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "Elenco utenti"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "crea utente"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "nome utente (necessario)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "password iniziale (necessaria)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "email (necessaria)"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "account disabilitato (l'impostazione predefinita è 'falso')"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "nome organizzazione predefinita dell'utente"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "nome ambiente predefinito dell'utente"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "Utente creato con successo [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "Impossibile creare l'utente [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "elenca le informazioni sull'utente"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "Informazioni utente"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "cancella utente"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "Utente [ %s ] cancellato con successo"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "aggiorna un utente"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "password iniziale"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "email"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "account disabilitato"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "l'ambiente predefinito dell'utente è None"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "Utente [ %s ] aggiornato con successo"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "elenca ruoli utente"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "sincronizza i ruoli con i gruppi LDAP"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "assegna ruolo ad un utente"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "rimuovi ruolo ad un utente"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "ruolo utente (necessario)"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "Ruolo [%s] non trovato"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "notifica utente"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+"formato notifica (valori possibili: 'html', 'text' (default), 'csv', 'pdf')"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "azioni specifiche dell'utente nel server di katello"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "elenca nuovi changesets di un ambiente"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "nome ambiente (necessario)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "Elenco changeset"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "informazioni dettagliate su di un changeset"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "nome changeset (necessario)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "mostrerà i pacchetti dipendenti"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "Informazioni changeset"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "crea un nuovo changeset per un ambiente"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "descrizione di changeset"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "Changeset [ %s ] creato con successo per ambiente [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "Impossibile creare changeset [ %s ] per ambiente [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "aggiornamenti contenuto di un changeset"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s deve essere preceduto da %s"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "nuovo nome di changeset"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "prodotto da aggiungere al changeset"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "prodotto da rimuovere dal changeset"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "nome di un template da aggiungere al changeset"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "nome di un template da rimuovere dal changeset"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+"determina il prodotto dal quale selezionare i pacchetti/errata/repositori"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "da aggiungere al changeset"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "da rimuovere dal changeset"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "Changeset [ %s ] aggiornato con successo"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "cancella un changeset"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "Avanzamento Changeset [ %s ] fallito: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "Azioni specifiche al changeset nel server di katello"
 
 #: ../src/katello/client/core/system.py:47
 msgid "list systems within an organization"
 msgstr "elenca i sistemi all'interno dell'organizzazione"
 
 #: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
 msgid "environment name eg: development"
 msgstr "nome ambiente es: development"
 
@@ -540,33 +1487,35 @@ msgstr "Elenco sistemi per Org [ %s ]"
 msgid "Systems List For Environment [ %s ] in Org [ %s ]"
 msgstr "Elenco sistemi per Ambiente [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:82
+#: ../src/katello/client/core/system.py:83
 #: ../src/katello/client/core/system.py:134
 msgid "Service Level"
 msgstr "Livello del servizio"
 
-#: ../src/katello/client/core/system.py:89
+#: ../src/katello/client/core/system.py:90
 msgid "display a system within an organization"
 msgstr "mostra un sistema all'interno di una organizzazione"
 
-#: ../src/katello/client/core/system.py:95
+#: ../src/katello/client/core/system.py:96
 #: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
 #: ../src/katello/client/core/errata.py:105
 msgid "system name (required)"
 msgstr "nome sistema (necessario)"
 
-#: ../src/katello/client/core/system.py:97
+#: ../src/katello/client/core/system.py:98
 #: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
 msgid "environment name"
 msgstr "nome ambiente"
 
@@ -630,149 +1579,115 @@ msgstr ""
 "È possibile specificare al massimo un'azione di "
 "installazione/rimozione/aggiornamento per chiamata"
 
-#: ../src/katello/client/core/system.py:189
+#: ../src/katello/client/core/system.py:188
 #, python-format
 msgid "Package Information for System [ %s ] in Org [ %s ]"
 msgstr "Informazioni pacchetto per sistema [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:191
+#: ../src/katello/client/core/system.py:190
 #, python-format
 msgid ""
 "Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Informazioni pacchetto per sistema [ %s ] in Ambiente [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "Esecuzione azione remota [ %s ] in corso..."
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "Azione remot terminata:"
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "Azione remota fallita:"
-
-#: ../src/katello/client/core/system.py:243
+#: ../src/katello/client/core/system.py:242
 msgid "display status of remote tasks"
 msgstr "mostra stato attività remota"
 
-#: ../src/katello/client/core/system.py:249
+#: ../src/katello/client/core/system.py:248
 msgid "system name"
 msgstr "nome del sistema"
 
-#: ../src/katello/client/core/system.py:261
+#: ../src/katello/client/core/system.py:260
 msgid "Remote tasks"
 msgstr "Attività remote"
 
-#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:268
 msgid "Task id"
 msgstr "id attività"
 
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
 msgid "System"
 msgstr "Sistema"
 
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
 msgid "Action"
 msgstr "Azione"
 
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
 msgid "Started"
 msgstr "Avviata"
 
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
 #: ../src/katello/client/core/repo.py:37
 msgid "Finished"
 msgstr "Terminata"
 
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
 msgid "Status"
 msgstr "Stato"
 
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
 msgid "Result"
 msgstr "Risultato"
 
-#: ../src/katello/client/core/system.py:283
+#: ../src/katello/client/core/system.py:282
 msgid "display status of remote task"
 msgstr "mostra stato attività remota"
 
-#: ../src/katello/client/core/system.py:287
+#: ../src/katello/client/core/system.py:286
 msgid "UUID of the task"
 msgstr "UUID attività"
 
-#: ../src/katello/client/core/system.py:295
+#: ../src/katello/client/core/system.py:294
 msgid "Remote task"
 msgstr "Attività remota"
 
-#: ../src/katello/client/core/system.py:313
+#: ../src/katello/client/core/system.py:312
 msgid "list releases available for the system"
 msgstr "elenca le realese disponibili per il sistema"
 
-#: ../src/katello/client/core/system.py:319
+#: ../src/katello/client/core/system.py:318
 msgid "system name (if not specified, list all releases in the environment)"
 msgstr ""
 "nome del sistema (se non specificato elenca tutte le release nell'ambiente)"
 
-#: ../src/katello/client/core/system.py:341
+#: ../src/katello/client/core/system.py:340
 msgid "Available releases"
 msgstr "Release disponibili"
 
-#: ../src/katello/client/core/system.py:349
+#: ../src/katello/client/core/system.py:348
 msgid "display a the hardware facts of a system"
 msgstr "mostra gli eventi hardware di un sistema"
 
-#: ../src/katello/client/core/system.py:369
+#: ../src/katello/client/core/system.py:367
 #, python-format
 msgid "System Facts For System [ %s ] in Org [ %s ]"
 msgstr "Eventi di sistema per il sistema [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:371
+#: ../src/katello/client/core/system.py:369
 #, python-format
 msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
 msgstr ""
 "Eventi di sistema per il sistema [ %s ] in Ambiente [ %s]  in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:388
+#: ../src/katello/client/core/system.py:386
 msgid "register a system"
 msgstr "registra un sistema"
 
 #: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "nome organizzazione (necessario)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
+#: ../src/katello/client/core/system.py:641
 msgid "service level agreement"
 msgstr "agreement livello del servizio"
 
-#: ../src/katello/client/core/system.py:396
+#: ../src/katello/client/core/system.py:394
 msgid ""
 "activation key, more keys are separated with comma e.g. "
 "--activationkey=key1,key2"
@@ -780,112 +1695,107 @@ msgstr ""
 "activation key, more keys are separated with comma e.g. "
 "--activationkey=key1,key2"
 
-#: ../src/katello/client/core/system.py:397
+#: ../src/katello/client/core/system.py:395
 msgid "values of $releasever for the system"
 msgstr "valori di $releasever per il sistema"
 
-#: ../src/katello/client/core/system.py:399
+#: ../src/katello/client/core/system.py:397
 msgid "system facts"
 msgstr "eventi del sistema"
 
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "L'opzione %s non può essere specificata con %s"
-
-#: ../src/katello/client/core/system.py:429
+#: ../src/katello/client/core/system.py:419
 #, python-format
 msgid "Successfully registered system [ %s ]"
 msgstr "Sistema [ %s ] registrato con successo"
 
-#: ../src/katello/client/core/system.py:430
+#: ../src/katello/client/core/system.py:420
 #, python-format
 msgid "Could not register system [ %s ]"
 msgstr "Impossibile registrare il sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:435
+#: ../src/katello/client/core/system.py:425
 msgid "remove a deletion record for hypervisor"
 msgstr "rimuovere un record di rimozione per l'hypervisor"
 
-#: ../src/katello/client/core/system.py:439
+#: ../src/katello/client/core/system.py:429
 msgid "hypervisor uuid (required"
 msgstr "uuid hypervisor (necessario)"
 
-#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:437
 #, python-format
 msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
 msgstr ""
 "Rimosso con successo il record di rimozione per l'hypervisor con uuid [ %s ]"
 
-#: ../src/katello/client/core/system.py:453
+#: ../src/katello/client/core/system.py:443
 msgid "unregister a system"
 msgstr "rimuovi registrazione di un sistema"
 
-#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:470
 #, python-format
 msgid "Successfully unregistered System [ %s ]"
 msgstr "Rimozione registrazione del sistema [ %s ] eseguita con successo"
 
-#: ../src/katello/client/core/system.py:486
+#: ../src/katello/client/core/system.py:475
 msgid "subscribe a system to certificate"
 msgstr "sottoscrivere un sistema al certificato"
 
-#: ../src/katello/client/core/system.py:494
+#: ../src/katello/client/core/system.py:483
 msgid "certificate serial to unsubscribe (required)"
 msgstr ""
 "certificato seriale per la rimozione della sottoscrizione (necessario)"
 
-#: ../src/katello/client/core/system.py:496
+#: ../src/katello/client/core/system.py:485
 msgid "quantity (default: 1)"
 msgstr "quantità (default: 1)"
 
-#: ../src/katello/client/core/system.py:512
+#: ../src/katello/client/core/system.py:499
 #, python-format
 msgid "Successfully subscribed System [ %s ]"
 msgstr "Sistema [ %s ] sottoscritto con successo"
 
-#: ../src/katello/client/core/system.py:517
+#: ../src/katello/client/core/system.py:504
 msgid "list subscriptions for a system"
 msgstr "elenca sottoscrizioni per un sistema"
 
-#: ../src/katello/client/core/system.py:524
+#: ../src/katello/client/core/system.py:511
 msgid "show available subscriptions"
 msgstr "mostra sottoscrizioni disponibili"
 
-#: ../src/katello/client/core/system.py:542
+#: ../src/katello/client/core/system.py:528
 #, python-format
 msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
 msgstr "Nessuna sottoscrizione trovata per il sistema [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:554
+#: ../src/katello/client/core/system.py:540
 #, python-format
 msgid "Current Subscriptions for System [ %s ]"
 msgstr "Sottoscrizioni correnti per il sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:556
+#: ../src/katello/client/core/system.py:542
 msgid "Serial Id"
 msgstr "ID seriale"
 
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
 msgid "Provided products"
 msgstr "Prodotti disponibili"
 
-#: ../src/katello/client/core/system.py:570
+#: ../src/katello/client/core/system.py:556
 #, python-format
 msgid "No Pools found for System [ %s ] in Org [ %s ]"
 msgstr "Nessun gruppo trovato per il sistema [ %s ] in Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:580
+#: ../src/katello/client/core/system.py:566
 #, python-format
 msgid "Available Subscriptions for System [ %s ]"
 msgstr "Sottoscrizioni disponibili per il sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:595
+#: ../src/katello/client/core/system.py:581
 msgid "unsubscribe a system from certificate"
 msgstr "rimuovi sottoscrizione di un sistema dal certificato"
 
-#: ../src/katello/client/core/system.py:603
+#: ../src/katello/client/core/system.py:589
 msgid ""
 "entitlement id to unsubscribe from (either entitlement or serial or all is "
 "required)"
@@ -893,7 +1803,7 @@ msgstr ""
 "id entitlement dal quale rimuovere la sottoscrizione (sia entitlement o "
 "seriale o entrambi sono  necessari)"
 
-#: ../src/katello/client/core/system.py:605
+#: ../src/katello/client/core/system.py:591
 msgid ""
 "serial id of a certificate to unsubscribe from (either entitlement or serial"
 " or all is required)"
@@ -901,7 +1811,7 @@ msgstr ""
 "id seriale di un certificato dal quale rimuovere la sottoscrizione (sia "
 "entitlement o seriale o entrambi sono necessari)"
 
-#: ../src/katello/client/core/system.py:607
+#: ../src/katello/client/core/system.py:593
 msgid ""
 "unsubscribe from all currently subscribed certificates (either entitlement "
 "or serial or all is required)"
@@ -909,235 +1819,98 @@ msgstr ""
 "rimuovi sottoscrizione da tutti i certificati attualmente sottoscritti (sia "
 "entitlement o seriale o entrambi sono necessari)"
 
-#: ../src/katello/client/core/system.py:629
+#: ../src/katello/client/core/system.py:614
 #, python-format
 msgid "Successfully unsubscribed System [ %s ]"
 msgstr "Rimozione sottoscrizione del sistema [ %s ] con successo"
 
-#: ../src/katello/client/core/system.py:635
+#: ../src/katello/client/core/system.py:620
 msgid "update a system"
 msgstr "aggiorna un sistema"
 
-#: ../src/katello/client/core/system.py:646
+#: ../src/katello/client/core/system.py:631
 msgid "a new name for the system"
 msgstr "un nuovo nome per il sistema"
 
-#: ../src/katello/client/core/system.py:648
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
 msgid "a description of the system"
 msgstr "una descrizione del sistema"
 
-#: ../src/katello/client/core/system.py:650
+#: ../src/katello/client/core/system.py:637
 msgid "location of the system"
 msgstr "posizione del sistema"
 
-#: ../src/katello/client/core/system.py:652
+#: ../src/katello/client/core/system.py:639
 msgid "value of $releasever for the system"
 msgstr "valore di $releasever per il sistema"
 
-#: ../src/katello/client/core/system.py:683
+#: ../src/katello/client/core/system.py:674
 #, python-format
 msgid "Successfully updated system [ %s ]"
 msgstr "Sistema [ %s ] aggiornato con successo"
 
-#: ../src/katello/client/core/system.py:684
+#: ../src/katello/client/core/system.py:675
 #, python-format
 msgid "Could not update system [ %s ]"
 msgstr "Impossibile aggiornare il sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:690
+#: ../src/katello/client/core/system.py:681
 msgid "systems report"
 msgstr "notifica dei sistemi"
 
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
 msgstr ""
-"formato notifica (valori possibili: 'html', 'text' (default), 'csv', 'pdf')"
 
-#: ../src/katello/client/core/system.py:724
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
 msgid "system specific actions in the katello server"
 msgstr "azioni specifiche del sistema nel server di katello"
 
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "elenca tutti i filtri"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "Elenco filtri"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "crea un filtro"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "descrizione"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "elenco di nomi/nvres dei pacchetti separati da virgole"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "Filtro [ %s ] creato con successo"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "Impossibile creare il filtro [ %s ]"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "cancella un filtro"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "Filtro [ %s ] rimosso con successo"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "Informazioni filtro"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "Informazioni filtro"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "Aggiungi un pacchetto al filtro"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "id del pacchetto (necessario)"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "Pacchetto [ %s ]  aggiunto con successo al filtro [ %s ]"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "rimuovi il pacchetto dal filtro"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "Pacchetto [ %s ]  rimosso con successo dal filtro [ %s ]"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "azioni specifiche del filtro nel server di katello"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "elenca distribuzioni in un repositorio"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "id del repositorio"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "nome repositorio"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "nome organizzazione es: foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "nome prodotto es: fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "Elenco distribuzioni per repo %s"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "elenca informazioni relative ad una distribuzione"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "id repositorio (necessario)"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "id distribuzione es: ks-rh-noarch (necessario)"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "Informazioni sulla distribuzione"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "azioni specifiche per il repo nel server di katello"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "acquisisci lo stato del server di katello"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Stato di katello"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "Controlla lo stato del server"
-
-#: ../src/katello/client/core/package.py:40
+#: ../src/katello/client/core/package.py:38
 msgid "list information about a package"
 msgstr "elenca le informazioni relative ad un pacchetto"
 
-#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:43
 msgid "package id, string value (required)"
 msgstr "id del pacchetto, valore stringa (necessario)"
 
-#: ../src/katello/client/core/package.py:91
+#: ../src/katello/client/core/package.py:87
 msgid "Package Information"
 msgstr "Informazioni del pacchetto"
 
-#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/package.py:94
 msgid "list packages in a repository"
 msgstr "elenca i pacchetti in un repositorio"
 
-#: ../src/katello/client/core/package.py:123
+#: ../src/katello/client/core/package.py:117
 #, python-format
 msgid "Package List For Repo %s"
 msgstr "Elenco pacchetti per Repo %s"
 
-#: ../src/katello/client/core/package.py:154
+#: ../src/katello/client/core/package.py:148
 msgid "search packages in a repository"
 msgstr "ricerca pacchetti in un repositorio"
 
-#: ../src/katello/client/core/package.py:159
+#: ../src/katello/client/core/package.py:153
 msgid ""
 "query string for searching packages, e.g. "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
@@ -1145,1312 +1918,247 @@ msgstr ""
 "interrogazione stringa per la ricerca dei pacchetti, es "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
 
-#: ../src/katello/client/core/package.py:170
+#: ../src/katello/client/core/package.py:164
 #, python-format
 msgid "Package List For Repo %s and Query %s"
 msgstr "Elenco pacchetti per il repo %s ed Interrogazione %s"
 
-#: ../src/katello/client/core/package.py:181
+#: ../src/katello/client/core/package.py:175
 msgid "package specific actions in the katello server"
 msgstr "azioni specifiche al pacchetto nel server di katello"
 
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "nessuna descrizione disponibile"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "nessuna azione data: consultare --help"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "azione non valida: consultare --help"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "output grep-friendly"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "verboso, output più strutturato"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
 msgstr ""
-"delimitatore colonna nell'output semplice di grep, funziona solo con "
-"l'opzione -g"
 
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "L'opzione %s è necessaria; consultare --help"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "L'opzione %s è in contrasto con %s; consultare --help"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "È necessario un %s; consultare --help"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "Almeno uno di %s è necessrio; consultare --help"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "Errore: operazione fallita"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
 msgstr ""
-"ERRORE: L'hostname del server configurato in /etc/katello/client.conf non "
-"corrisponde al"
 
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "hostname ritornato dal server di katello usato per il collegamento."
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "esegui cli come una shell"
 
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-"Sei in possesso: [%s] configurati ma è stato ricevuto: [%s] dal server."
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "nome provider (necessario)"
 
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "Correggere l'host nel file /etc/katello/client.conf"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "Credenziali invalide o impossibile eseguire l'autenticazione"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "opzione %s: valore booleano invalido: %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "elenca tutti gli utenti conosciuti"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "Elenco utenti"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "crea utente"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "nome utente (necessario)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "password iniziale (necessaria)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "email (necessaria)"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "account disabilitato (l'impostazione predefinita è 'falso')"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "nome organizzazione predefinita dell'utente"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "nome ambiente predefinito dell'utente"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "Utente creato con successo [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "Impossibile creare l'utente [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "elenca le informazioni sull'utente"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "Informazioni utente"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "cancella utente"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "Utente [ %s ] cancellato con successo"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "aggiorna un utente"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "password iniziale"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "email"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "account disabilitato"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "l'ambiente predefinito dell'utente è None"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "Utente [ %s ] aggiornato con successo"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "elenca ruoli utente"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "Elenco ruoli utente"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "sincronizza i ruoli con i gruppi LDAP"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "assegna ruolo ad un utente"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "rimuovi ruolo ad un utente"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "ruolo utente (necessario)"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "Ruolo [%s] non trovato"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "notifica utente"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "azioni specifiche dell'utente nel server di katello"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-"Inserire il contenuto della chiave GPG (terminare l'input con CTRL+D):"
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "elenca tutte le chiavi GPG"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "nome di una organizzazione (necessario)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "Nessuna chiave gpg trovata nell'organizzazione [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "Elenco chiave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "mostra le informazioni su una chiave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "nome chiave di attivazione(necessario)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "Impossibile trovare la chiave gpg [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "Repositori"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "Informazioni chiave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "crea una chiave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-"file con chiave GPG pubblica, se non specificato, verrà usato l'input "
-"standard"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "Chiave gpg [ %s ] creata con successo"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "Impossibile creare la chiave gpg [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "aggiorna una chiave di attivazione"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "nuovo nome del template"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "file con chiave GPG pubblica"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "propmt per il nuovo contenuto della chiave"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "Chiave gpg [ %s ] aggiornata con successo"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "Impossibile aggiornare la chiave gpg [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "cancella una chiave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "Chiave gpg [ %s ] cancellata con successo"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "azioni specifiche della chiave GPG nel server di katello"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "elenca tutte le chiavi di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "nome ambiente es: dev (default: Library)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "Nessuna chiave trovata nell'organizzazione [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "Nessuna chiave trovata nell'organizzazione [ %s ] ambiente [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "Elenco chiavi di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "mostra le informazioni su di una chiave di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "Impossibile trovare la chiave di attivazione [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "Informazioni chiave di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "crea una chiave di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "nome ambiente es: dev (necessario)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "descrizione chiave di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "nome template es: server"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "Impossibile trovare il template [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "Chiave di attivazione [ %s ] attivata con successo"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "Impossibile creare chiave di attivazione [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "nuovo nome ambiente es: dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "nuova descrizione"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "nuovo nome del template es: server"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "aggiungi un gruppo alla chiave di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "rimuovi un gruppo dalla chiave di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "Chiave di attivazione [ %s ] aggiornata con successo"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "cancella una chiave di attivazione"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "Chiave di attivazione [ %s ] cancellata con successo"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "azioni specifiche alla chiave di attivazione nel server di katello"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "elenca gruppi di pacchetti disponibili"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "id repositorio, valore stringa (necessario)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "Nessun gruppo di pacchetti trovato nel repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "Informazioni gruppo di pacchetti"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "cerca informazioni per un gruppo di pacchetti"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "id gruppo di pacchetti, valore stringa (necessario)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "Gruppo di pacchetti [%s] non trovato in repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "elenca categorie di gruppi di pacchetti disponibili"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "Nessuna categoria del gruppo di pacchetti trovata in repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "Informazioni categoria gruppo di pacchetti"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "id categoria gruppo di pacchetti, valore stringa (necessario)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "Categoria gruppo di pacchetti [%s] non trovato in repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "Informazioni categoria gruppo di pacchetti"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "azioni specifiche al gruppo di pacchetti nel server di katello"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "elenca nuovi changesets di un ambiente"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "nome ambiente (necessario)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "Elenco changeset"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "informazioni dettagliate su di un changeset"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "nome changeset (necessario)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "mostrerà i pacchetti dipendenti"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "Informazioni changeset"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "crea un nuovo changeset per un ambiente"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "descrizione di changeset"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "Changeset [ %s ] creato con successo per ambiente [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "Impossibile creare changeset [ %s ] per ambiente [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "aggiornamenti contenuto di un changeset"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s deve essere preceduto da %s"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "nuovo nome di changeset"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "prodotto da aggiungere al changeset"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "prodotto da rimuovere dal changeset"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "nome di un template da aggiungere al changeset"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "nome di un template da rimuovere dal changeset"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-"determina il prodotto dal quale selezionare i pacchetti/errata/repositori"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "da aggiungere al changeset"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "da rimuovere dal changeset"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "Changeset [ %s ] aggiornato con successo"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "cancella un changeset"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "trasferisce un changeset all'ambiente successivo"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "Avanzamento changeset, attendere prego..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "Changeset [ %s ] trasferito"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "Avanzamento Changeset [ %s ] fallito: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "Azioni specifiche al changeset nel server di katello"
-
-#: ../src/katello/client/core/provider.py:59
+#: ../src/katello/client/core/provider.py:57
 msgid "list all known providers"
 msgstr "elenca tutti i provider conosciuti"
 
-#: ../src/katello/client/core/provider.py:81
+#: ../src/katello/client/core/provider.py:79
 msgid "Provider List"
 msgstr "Elenco provider"
 
-#: ../src/katello/client/core/provider.py:89
+#: ../src/katello/client/core/provider.py:87
 msgid "list information about a provider"
 msgstr "elenca le informazioni relative ad un provider"
 
-#: ../src/katello/client/core/provider.py:104
+#: ../src/katello/client/core/provider.py:102
 msgid "Provider Information"
 msgstr "Informazioni del provider"
 
-#: ../src/katello/client/core/provider.py:116
+#: ../src/katello/client/core/provider.py:114
 msgid "create a provider"
 msgstr "crea un provider"
 
-#: ../src/katello/client/core/provider.py:118
+#: ../src/katello/client/core/provider.py:116
 msgid "update a provider"
 msgstr "aggiorna un provider"
 
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
 msgid "provider description"
 msgstr "descrizione del provider"
 
-#: ../src/katello/client/core/provider.py:139
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"url repositorio es: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
 msgid "provider name"
 msgstr "nome provider"
 
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "L'opzione --url deve iniziare con http:// o https://"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "L'opzione --url non presenta un formato valido"
-
-#: ../src/katello/client/core/provider.py:159
+#: ../src/katello/client/core/provider.py:147
 #, python-format
 msgid "Successfully created provider [ %s ]"
 msgstr "Provider [ %s ] creato con successo"
 
-#: ../src/katello/client/core/provider.py:160
+#: ../src/katello/client/core/provider.py:148
 #, python-format
 msgid "Could not create provider [ %s ]"
 msgstr "Impossibile creare il provider [ %s ]"
 
-#: ../src/katello/client/core/provider.py:167
+#: ../src/katello/client/core/provider.py:155
 #, python-format
 msgid "Successfully updated provider [ %s ]"
 msgstr "Provider [ %s ] aggiornato con successo"
 
-#: ../src/katello/client/core/provider.py:185
+#: ../src/katello/client/core/provider.py:173
 msgid "delete a provider"
 msgstr "cancella un provider"
 
-#: ../src/katello/client/core/provider.py:201
+#: ../src/katello/client/core/provider.py:189
 msgid "synchronize a provider"
 msgstr "sincronizza un provider"
 
-#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/provider.py:204
 #, python-format
 msgid "Provider [ %s ] failed to sync: %s"
 msgstr "Sincronizzazione provider [ %s ] fallita: %s"
 
-#: ../src/katello/client/core/provider.py:219
+#: ../src/katello/client/core/provider.py:207
 #, python-format
 msgid "Provider [ %s ] synchronization cancelled"
 msgstr "Sincronizzazione del provider [ %s ] cancellata"
 
-#: ../src/katello/client/core/provider.py:222
+#: ../src/katello/client/core/provider.py:210
 #, python-format
 msgid "Provider [ %s ] synchronized"
 msgstr "Provider [ %s ] sincronizzato"
 
-#: ../src/katello/client/core/provider.py:245
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "cancella la sincronizzazione attualemente in esecuzione"
+
+#: ../src/katello/client/core/provider.py:233
 msgid "status of provider's synchronization"
 msgstr "stato sincronizzazione del provider"
 
-#: ../src/katello/client/core/provider.py:258
+#: ../src/katello/client/core/provider.py:246
 #, python-format
 msgid "%d%% done (%d of %d packages downloaded)"
 msgstr "%d%% fatto (%d di %d pacchetti scaricati)"
 
-#: ../src/katello/client/core/provider.py:269
+#: ../src/katello/client/core/provider.py:257
 msgid "Provider Status"
 msgstr "Stato del provider"
 
-#: ../src/katello/client/core/provider.py:277
+#: ../src/katello/client/core/provider.py:265
 msgid "import a manifest file"
 msgstr "Importa un file del manifesto"
 
-#: ../src/katello/client/core/provider.py:283
+#: ../src/katello/client/core/provider.py:271
 msgid "path to the manifest file (required)"
 msgstr "percorso per il file del manifesto (necessario)"
 
-#: ../src/katello/client/core/provider.py:285
+#: ../src/katello/client/core/provider.py:273
 msgid "force reimporting the manifest"
 msgstr "forza la nuova importazione del manifesto"
 
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
 #, python-format
 msgid "File %s does not exist"
 msgstr "Il file %s non esiste"
 
-#: ../src/katello/client/core/provider.py:307
+#: ../src/katello/client/core/provider.py:295
 msgid "Importing manifest, please wait... "
 msgstr "Processo di importazione manifesto in corso, attendere prego..."
 
-#: ../src/katello/client/core/provider.py:320
+#: ../src/katello/client/core/provider.py:308
 msgid "refresh provider's products repositories"
 msgstr "aggiorna i repositori dei prodotti del provider"
 
-#: ../src/katello/client/core/provider.py:329
+#: ../src/katello/client/core/provider.py:317
 #, python-format
 msgid "Provider successfully refreshed [ %s ]"
 msgstr "Provider aggiornato con successo [ %s ]"
 
-#: ../src/katello/client/core/provider.py:336
+#: ../src/katello/client/core/provider.py:324
 msgid "provider specific actions in the katello server"
 msgstr "azioni specifiche del provider nel server di katello"
 
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "elenca ambienti conosciuti"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "Org"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "Ambiente precedente"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "Elenco ambiente"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "elenca un ambiente specifico"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "nome ambiente es: foo.example.com (necessario)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "Informazioni ambiente"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "crea un ambiente"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "descrizione ambiente es: ambiente di foo"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "nome dell'ambiente precedente (necessario)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "Ambiente creato con successo [ %s ]"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "Impossibile creare l'ambiente [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "aggiorna un ambiente"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "nome dell'ambiente precedente"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "Ambiente aggiornato con successo [ %s ]"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "cancella un ambiente"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "Ambiente cancellato con successo [ %s ]"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "azioni specifiche all'ambiente nel server di katello"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "salva una opzione sulla configurazione del client"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-"nome dell'opzione da salvare (es org, environment, provider, ecc) "
-"(necessario)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "valore da archiviare sotto una opzione specificata (necessario)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "Con successo"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "Memorizzazione opzione [ %s ] senza successo"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "rimuovi una opzione dalla configurazione del client"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "nome dell'opzione da cancellare (necessario)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "Opzione [ %s ] dimenticata con successo"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "Opzione [ %s ] non dimenticata"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "elenca le opzioni salvate nella configurazione del client"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "Opzioni salvate"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "azioni specifiche del client nel server di katello"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "elenca tutti i template"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "nome dell'organizzazione (necessario se si specifica un ambiente)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "Nessun template trovato nell'ambiente [ %s ]"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "Elenco template"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "elenca le informazioni relative ad un template"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "nome template (necessario)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "Informazioni del template"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "crea un file del template ed importare i dati"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "percorso per il file del template (necessario)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "Processo di importazione template in corso, attendere prego..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "esporta il template nel file"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "nome ambiente es: dev"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "formato dell'esportazione, valori possibili: %s, default: json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "Impossibile creare il file %s"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "Esportazione template, attendere prego..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "Il template è stato esportato con successo sul file %s"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "crea un file del template vuoto"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "nome del template genitore"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "descrizione template"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "Template [ %s ] creato con successo"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "Impossibile creare il template [ %s ]"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "aggiornamenti nome e descrizione di un template"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "ogni %s deve essere preceduto da %s"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "nome o nvre del prodotto (epoch:name-rel.ease-ver.sio.n)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "nome del parametro, deve seguire %s"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "valore del parametro"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "nome del parametro"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "nome del gruppo di pacchetti"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "nome della categoria del gruppo di pacchetti"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "id distribuzione"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "determina il prodotto dal quale i repositori sono selezionati"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "repositorio da aggiungere al template"
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "repositorio da rimuovere dal template"
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "valore mancante per il parametro '%s'"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "Aggiornamento template in corso, attendere prego..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "Template [ %s ] aggiornato con successo"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "cancella un template"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "nome ambiente es: foo.example.com (default: Library)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "azioni specifiche del template nel server di katello"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "esegui cli come una shell"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "elenca sync_plans conosicuti"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "Programmi di sinc"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "stampa le informazioni sul programma di sinc"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "nome del programma di sincronizzazione (necessario)"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "Informazioni del programma di sincronizzazione"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "crea un programma di sincronizzazione"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "descrizione programma"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-"intervallo delle sincronizzazioni ricorrenti (possibilità: [%s], default: "
-"none)"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-"data della prima sincronizzazione (necessaria, formato: anno-mese-giorno)"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-"ora della prima sincronizzazione (formato: HH:MM:SS, default: 00:00:00)"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "Programma di sincronizzazione creato con successo [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "Impossibile creare il programma di sincronizzazione [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "aggiorna un programma di sincronizzazione"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "nuovo nome del programma di sincronizzazione"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "data della prima sincronizzazione (formato: anno-mese-giorno)"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "ora della prima sincronizzazione (formato: HH:MM:SS)"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "È necessario specificare sia --date che --time"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "Programma di sincronizzazione [ %s ] aggiornato con successo"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "cancella un programma di sincronizzazione"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "Programma di sincronizzazione [ %s ] cancellato con successo"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-"azioni specifiche del programma di sincronizzazione nel server di katello"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "ottieni la versione del server di katello"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "Controlla la versione del server"
-
-#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "acquisisci lo stato del server di katello"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Stato di katello"
+
+#: ../src/katello/client/core/permission.py:53
 msgid "create a permission for a user role"
 msgstr "crea un permesso per un ruolo utente"
 
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "nome ruolo (necessario)"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
 msgid "permission name (required)"
 msgstr "nome permesso (necessario)"
 
-#: ../src/katello/client/core/permission.py:61
+#: ../src/katello/client/core/permission.py:58
 msgid "permission description"
 msgstr "descrizione permesso"
 
-#: ../src/katello/client/core/permission.py:62
+#: ../src/katello/client/core/permission.py:59
 msgid "organization name"
 msgstr "nome organizzazione"
 
-#: ../src/katello/client/core/permission.py:63
+#: ../src/katello/client/core/permission.py:60
 msgid "scope of the permisson (required)"
 msgstr "Ambito del permesso (necessario)"
 
-#: ../src/katello/client/core/permission.py:64
+#: ../src/katello/client/core/permission.py:61
 msgid "verbs for the permission"
 msgstr "verb per il permesso"
 
-#: ../src/katello/client/core/permission.py:65
+#: ../src/katello/client/core/permission.py:62
 msgid "tags for the permission"
 msgstr "tag per il permesso"
 
-#: ../src/katello/client/core/permission.py:81
+#: ../src/katello/client/core/permission.py:76
 #, python-format
 msgid "Invalid scope [ %s ]"
 msgstr "Ambito [ %s ] non valido"
 
-#: ../src/katello/client/core/permission.py:88
+#: ../src/katello/client/core/permission.py:83
 #, python-format
 msgid "Could not find tag [ %s ] in scope of [ %s ]"
 msgstr "Impossibile trovare il tag [ %s ] nell'ambito [ %s ]"
 
-#: ../src/katello/client/core/permission.py:112
+#: ../src/katello/client/core/permission.py:101
 #, python-format
 msgid "Successfully created permission [ %s ] for user role [ %s ]"
 msgstr "Permesso [ %s ] creato con successo per il ruolo utente [ %s ]"
 
-#: ../src/katello/client/core/permission.py:113
+#: ../src/katello/client/core/permission.py:102
 #, python-format
 msgid "Could not create permission [ %s ]"
 msgstr "Impossibile creare il permesso [ %s ]"
 
-#: ../src/katello/client/core/permission.py:119
+#: ../src/katello/client/core/permission.py:108
 msgid "delete a permission"
 msgstr "cancella un permesso"
 
-#: ../src/katello/client/core/permission.py:137
+#: ../src/katello/client/core/permission.py:125
 #, python-format
 msgid "Successfully deleted permission [ %s ] for role [ %s ]"
 msgstr "Permesso [ %s ] cancellato con successo per il ruolo [ %s ]"
 
-#: ../src/katello/client/core/permission.py:143
+#: ../src/katello/client/core/permission.py:131
 msgid "list permissions for a user role"
 msgstr "elenca i permessi per un ruolo utente"
 
-#: ../src/katello/client/core/permission.py:170
+#: ../src/katello/client/core/permission.py:158
 msgid "Permission List"
 msgstr "Elenco permessi"
 
-#: ../src/katello/client/core/permission.py:177
+#: ../src/katello/client/core/permission.py:165
 msgid "list available scopes, verbs and tags that can be set in a permission"
 msgstr ""
 "elenca ambiti disponibili, verb e tag che possono essere impostati in un "
 "permesso"
 
-#: ../src/katello/client/core/permission.py:181
+#: ../src/katello/client/core/permission.py:169
 msgid ""
 "organization name eg: foo.example.com,\n"
 "lists organization specific verbs"
@@ -2458,26 +2166,102 @@ msgstr ""
 "nome organizzazione es: foo.example.com,¶\n"
 "elenca i verb specifici dell'organizzazione"
 
-#: ../src/katello/client/core/permission.py:182
+#: ../src/katello/client/core/permission.py:170
 msgid "filter listed results by scope"
 msgstr "filtra i risultati elencati in base all'ambito"
 
-#: ../src/katello/client/core/permission.py:200
+#: ../src/katello/client/core/permission.py:188
 #, python-format
 msgid "Available verbs and tags for permission scope %s"
 msgstr "Verb e tag disponibili per l'ambito del permesso %s"
 
-#: ../src/katello/client/core/permission.py:202
+#: ../src/katello/client/core/permission.py:190
 msgid "Available verbs"
 msgstr "Verb disponibili"
 
-#: ../src/katello/client/core/permission.py:221
+#: ../src/katello/client/core/permission.py:209
 msgid "None"
 msgstr "Nessuno"
 
-#: ../src/katello/client/core/permission.py:259
+#: ../src/katello/client/core/permission.py:247
 msgid "permission pecific actions in the katello server"
 msgstr "azioni specifiche al permesso nel server di katello"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "nessuna descrizione disponibile"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "nessuna azione data: consultare --help"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "azione non valida: consultare --help"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "output grep-friendly"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "verboso, output più strutturato"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+"delimitatore colonna nell'output semplice di grep, funziona solo con "
+"l'opzione -g"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+"ERRORE: L'hostname del server configurato in /etc/katello/client.conf non "
+"corrisponde al"
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "hostname ritornato dal server di katello usato per il collegamento."
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+"Sei in possesso: [%s] configurati ma è stato ricevuto: [%s] dal server."
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "Correggere l'host nel file /etc/katello/client.conf"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "Credenziali invalide o impossibile eseguire l'autenticazione"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "opzione %s: valore booleano invalido: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
 
 #: ../src/katello/client/core/errata.py:42
 msgid "list all errata for a repo"
@@ -2499,26 +2283,116 @@ msgstr "Elenco errata"
 msgid "list errata for a system"
 msgstr "elenca errata per un sistema"
 
-#: ../src/katello/client/core/errata.py:125
+#: ../src/katello/client/core/errata.py:124
 #, python-format
 msgid "Errata for system %s in organization %s"
 msgstr "Errata per il sistema %s nell'organizzazione %s"
 
-#: ../src/katello/client/core/errata.py:132
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
 msgid "information about an errata"
 msgstr "Informazioni relative ad un errata"
 
-#: ../src/katello/client/core/errata.py:136
+#: ../src/katello/client/core/errata.py:170
 msgid "errata id, string value (required)"
 msgstr "id errata, valore stringa (necessario)"
 
-#: ../src/katello/client/core/errata.py:185
+#: ../src/katello/client/core/errata.py:217
 msgid "Errata Information"
 msgstr "Informazioni errata"
 
-#: ../src/katello/client/core/errata.py:194
+#: ../src/katello/client/core/errata.py:226
 msgid "errata specific actions in the katello server"
 msgstr "azioni specifiche dell'errata nel server di katello"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "ottieni la versione del server di katello"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "Controlla la versione del server"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "elenca gruppi di pacchetti disponibili"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "id repositorio, valore stringa (necessario)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "Nessun gruppo di pacchetti trovato nel repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "Informazioni gruppo di pacchetti"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "cerca informazioni per un gruppo di pacchetti"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "id gruppo di pacchetti, valore stringa (necessario)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "Gruppo di pacchetti [%s] non trovato in repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "elenca categorie di gruppi di pacchetti disponibili"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "Nessuna categoria del gruppo di pacchetti trovata in repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "Informazioni categoria gruppo di pacchetti"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "id categoria gruppo di pacchetti, valore stringa (necessario)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "Categoria gruppo di pacchetti [%s] non trovato in repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "Informazioni categoria gruppo di pacchetti"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "azioni specifiche al gruppo di pacchetti nel server di katello"
 
 #: ../src/katello/client/core/repo.py:34
 msgid "Waiting"
@@ -2548,20 +2422,27 @@ msgstr "Scaduto"
 msgid "Not synced"
 msgstr "Non sincronizzato"
 
-#: ../src/katello/client/core/repo.py:116
+#: ../src/katello/client/core/repo.py:114
 msgid "create a repository at a specified URL"
 msgstr "crea un repositorio su un URL specificato"
 
-#: ../src/katello/client/core/repo.py:122
+#: ../src/katello/client/core/repo.py:120
 msgid "repository name to assign (required)"
 msgstr "nome repositorio da assegnare (necessario)"
 
-#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:122
 msgid "url path to the repository (required)"
 msgstr "percorso url per il repositorio (necessario)"
 
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "nome prodotto (necessario)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
 msgid ""
 "GPG key to be assigned to the repository; by default, the product's GPG key "
 "will be used."
@@ -2569,29 +2450,29 @@ msgstr ""
 "Chiave GPG da assegnare al repositorio; per default, verrà utilizzata la "
 "chiave GPG del prodotto."
 
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
 msgid "Don't assign a GPG key to the repository."
 msgstr "Non assegnare una chiave GPG al repositorio."
 
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
 #, python-format
 msgid "Successfully created repository [ %s ]"
 msgstr "Repositorio [ %s ] creato con successo"
 
-#: ../src/katello/client/core/repo.py:154
+#: ../src/katello/client/core/repo.py:149
 msgid "discovery repositories contained within a URL"
 msgstr "scoperta repositori contenuti all'interno di un URL"
 
-#: ../src/katello/client/core/repo.py:160
+#: ../src/katello/client/core/repo.py:155
 msgid ""
 "repository name prefix to add to all the discovered repositories (required)"
 msgstr ""
 "prefisso nome repositorio da aggiungere su tutti i repositori scoperti "
 "(necessario)"
 
-#: ../src/katello/client/core/repo.py:162
+#: ../src/katello/client/core/repo.py:157
 msgid ""
 "root url to perform discovery of repositories eg: "
 "http://porkchop.devel.redhat.com/ (required)"
@@ -2599,18 +2480,33 @@ msgstr ""
 "url root per eseguire la scoperta dei repositori es: "
 "http://porkchop.devel.redhat.com/ (necessario)"
 
-#: ../src/katello/client/core/repo.py:192
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+"assume si; crea automaticamente i repositori candidati per gli url scoperti "
+"(facoltativo)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "Url dei repositori scoperti @ [%s]"
+
+#: ../src/katello/client/core/repo.py:183
 msgid "Discovering repository urls, this could take some time..."
 msgstr ""
 "Scoperta url dei repositori, questo processo potrebbe richiedere qualche "
 "minuto..."
 
-#: ../src/katello/client/core/repo.py:196
+#: ../src/katello/client/core/repo.py:187
 #, python-format
 msgid "Error: %s"
 msgstr "Errore: %s"
 
-#: ../src/katello/client/core/repo.py:216
+#: ../src/katello/client/core/repo.py:207
 msgid ""
 "\n"
 "Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
@@ -2618,331 +2514,804 @@ msgstr ""
 "\n"
 "Selezionare gli url per i quali creare i repositori candidati; usare `y` per confermare (h per help):"
 
-#: ../src/katello/client/core/repo.py:226
+#: ../src/katello/client/core/repo.py:217
 msgid "Operation aborted upon user request."
 msgstr "Operazione interrotta su richiesta dell'utente"
 
-#: ../src/katello/client/core/repo.py:275
+#: ../src/katello/client/core/repo.py:266
 msgid "status information about a repository"
 msgstr "informazioni sullo stato relative ad un repositorio"
 
-#: ../src/katello/client/core/repo.py:298
+#: ../src/katello/client/core/repo.py:289
 msgid "Repository Status"
 msgstr "Stato repositorio"
 
-#: ../src/katello/client/core/repo.py:305
+#: ../src/katello/client/core/repo.py:296
 msgid "information about a repository"
 msgstr "Informazioni relative ad un repositorio"
 
-#: ../src/katello/client/core/repo.py:319
+#: ../src/katello/client/core/repo.py:310
 msgid "Progress"
 msgstr "Progresso"
 
-#: ../src/katello/client/core/repo.py:322
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "Chiave GPG"
+
+#: ../src/katello/client/core/repo.py:313
 #, python-format
 msgid "Information About Repo %s"
 msgstr "Informazioni relative al repositorio %s"
 
-#: ../src/katello/client/core/repo.py:329
+#: ../src/katello/client/core/repo.py:320
 msgid "updates repository attributes"
 msgstr "aggiorna gli attributi del repositorio"
 
-#: ../src/katello/client/core/repo.py:345
+#: ../src/katello/client/core/repo.py:336
 #, python-format
 msgid "Successfully updated repository [ %s ]"
 msgstr "Repositorio [ %s ] aggiornato con successo"
 
-#: ../src/katello/client/core/repo.py:351
+#: ../src/katello/client/core/repo.py:342
 msgid "synchronize a repository"
 msgstr "sincronizza un repositorio"
 
-#: ../src/katello/client/core/repo.py:361
+#: ../src/katello/client/core/repo.py:352
 #, python-format
 msgid "Repo [ %s ] synced"
 msgstr "Repo [ %s ] sincronizzato"
 
-#: ../src/katello/client/core/repo.py:364
+#: ../src/katello/client/core/repo.py:355
 #, python-format
 msgid "Repo [ %s ] synchronization cancelled"
 msgstr "Sincronizzazione repo [ %s ] cancellata"
 
-#: ../src/katello/client/core/repo.py:367
+#: ../src/katello/client/core/repo.py:358
 #, python-format
 msgid "Repo [ %s ] failed to sync: %s"
 msgstr "Sincronizzazione repo [ %s ] fallita: %s"
 
-#: ../src/katello/client/core/repo.py:373
+#: ../src/katello/client/core/repo.py:364
 msgid "cancel currently running synchronization of a repository"
 msgstr ""
 "cancella la sincronizzazione attualemente in esecuzione di un repositorio"
 
-#: ../src/katello/client/core/repo.py:388
+#: ../src/katello/client/core/repo.py:379
 msgid "enable a repository"
 msgstr "abilita un repositorio"
 
-#: ../src/katello/client/core/repo.py:390
+#: ../src/katello/client/core/repo.py:381
 msgid "disable a repository"
 msgstr "disabilita un repositorio"
 
-#: ../src/katello/client/core/repo.py:409
+#: ../src/katello/client/core/repo.py:400
 msgid "list repos within an organization"
 msgstr "elenca i repo all'interno di una organizzazione"
 
-#: ../src/katello/client/core/repo.py:413
+#: ../src/katello/client/core/repo.py:404
 msgid "organization name eg: ACME_Corporation (required)"
 msgstr "nome organizzazione es: ACME_Corporation (necessario)"
 
-#: ../src/katello/client/core/repo.py:419
+#: ../src/katello/client/core/repo.py:410
 msgid "list also disabled repositories"
 msgstr "elenca anche i repositori disabilitati"
 
-#: ../src/katello/client/core/repo.py:439
+#: ../src/katello/client/core/repo.py:430
 #, python-format
 msgid "Repo List For Org %s Environment %s Product %s"
 msgstr "Elenco repo per Org %s Ambiente %s Prodotto %s"
 
-#: ../src/katello/client/core/repo.py:446
+#: ../src/katello/client/core/repo.py:437
 #, python-format
 msgid "Repo List for Product %s in Org %s "
 msgstr "Elenco repo per il prodotto %s in Org %s "
 
-#: ../src/katello/client/core/repo.py:453
+#: ../src/katello/client/core/repo.py:444
 #, python-format
 msgid "Repo List For Org %s Environment %s"
 msgstr "Elenco repo per Org %s Ambiente %s"
 
-#: ../src/katello/client/core/repo.py:463
+#: ../src/katello/client/core/repo.py:454
 msgid "delete a repository"
 msgstr "cancella un repositorio"
 
-#: ../src/katello/client/core/repo.py:476
+#: ../src/katello/client/core/repo.py:467
 msgid "list filters of a repository"
 msgstr "elenca i filtri di un repositorio"
 
-#: ../src/katello/client/core/repo.py:482
+#: ../src/katello/client/core/repo.py:473
 msgid "prints also filters assigned to repository's product."
 msgstr "stampa anche i filtri assegnati al prodotto del repositorio."
 
-#: ../src/katello/client/core/repo.py:492
+#: ../src/katello/client/core/repo.py:483
 msgid "Repository Filters"
 msgstr "Filtri del repositorio"
 
-#: ../src/katello/client/core/repo.py:506
+#: ../src/katello/client/core/repo.py:497
 msgid "add a filter to a repository"
 msgstr "aggiungi un filtro ad un repositorio"
 
-#: ../src/katello/client/core/repo.py:508
+#: ../src/katello/client/core/repo.py:499
 msgid "remove a filter from a repository"
 msgstr "rimuovi un filtro da un repositorio"
 
-#: ../src/katello/client/core/repo.py:538
+#: ../src/katello/client/core/repo.py:529
 #, python-format
 msgid "Added filter [ %s ] to repository [ %s ]"
 msgstr "Filtro [ %s ] aggiunto ad un repositorio [ %s ]"
 
-#: ../src/katello/client/core/repo.py:541
+#: ../src/katello/client/core/repo.py:532
 #, python-format
 msgid "Removed filter [ %s ] to repository [ %s ]"
 msgstr "Filtro [ %s ] rimosso da un repositorio [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "elenca tutti i ruoli utente conosciuti"
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "elenca sync_plans conosicuti"
 
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "crea ruolo utente"
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "descrizione ruolo"
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "Ruolo utente [ %s ] creato con successo"
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "Impossibile creare ruolo utente [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "elenca informazioni sul ruolo utente"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "nome ruolo utente (necessario)"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "stampa i dettagli su ogni permesso del ruolo"
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
 msgstr ""
-"%s\n"
-"\tper: %s\n"
-"\tverb: %s\n"
-"\tsu: %s"
 
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "Informazioni ruolo utente"
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "Programmi di sinc"
 
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "cancella un ruolo utente"
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "stampa le informazioni sul programma di sinc"
 
-#: ../src/katello/client/core/user_role.py:152
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "nome del programma di sincronizzazione (necessario)"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "Informazioni del programma di sincronizzazione"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "crea un programma di sincronizzazione"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "descrizione programma"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
 #, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "Ruolo utente [ %s ] cancellato con successo"
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+"intervallo delle sincronizzazioni ricorrenti (possibilità: [%s], default: "
+"none)"
 
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "aggiorna un ruolo"
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+"data della prima sincronizzazione (necessaria, formato: anno-mese-giorno)"
 
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "nuovo nome ruolo utente"
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+"ora della prima sincronizzazione (formato: HH:MM:SS, default: 00:00:00)"
 
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr "Fornisci almeno un parametro per aggiornare il ruolo utente"
-
-#: ../src/katello/client/core/user_role.py:180
+#: ../src/katello/client/core/sync_plan.py:135
 #, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "Ruolo utente [ %s ] aggiornato con successo"
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "Programma di sincronizzazione creato con successo [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "assegna il gruppo LDAP ad un ruolo"
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "nuovo nome del gruppo LDAP (necessario)"
-
-#: ../src/katello/client/core/user_role.py:204
+#: ../src/katello/client/core/sync_plan.py:136
 #, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr "Aggiunto con successo il gruppo LDAP [ %s ] l ruolo utente [ %s ]"
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "Impossibile creare il programma di sincronizzazione [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "rimuovi il gruppo LDAP assegnato ad un ruolo"
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "aggiorna un programma di sincronizzazione"
 
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "Nome gruppo LDAP da rimuovere (necessario)"
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "nuovo nome del programma di sincronizzazione"
 
-#: ../src/katello/client/core/user_role.py:228
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "data della prima sincronizzazione (formato: anno-mese-giorno)"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "ora della prima sincronizzazione (formato: HH:MM:SS)"
+
+#: ../src/katello/client/core/sync_plan.py:176
 #, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr "Gruppo LDAP [ %s ] rimosso con successo dal ruolo utente [ %s ]"
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "Programma di sincronizzazione [ %s ] aggiornato con successo"
 
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "azioni specifiche del ruolo utente nel server di katello"
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "cancella un programma di sincronizzazione"
 
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "Il formato dell'ora non è valido. Necessario: HH:MM:SS[+HH:MM]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "Il formato della data non è valido. Necessario: YYYY-MM-DD"
-
-#. These are a bunch of strings that are marked for translation in optparse,
-#. but not actually translated anywhere. Mark them for translation here,
-#. so we get it picked up. for local translation, and then optparse will
-#. use them.
-#: ../src/katello/client/i18n_optparse.py:48
+#: ../src/katello/client/core/sync_plan.py:198
 #, python-format
-msgid "Usage: %s\n"
-msgstr "Utilizzo: %s\n"
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "Programma di sincronizzazione [ %s ] cancellato con successo"
 
-#: ../src/katello/client/i18n_optparse.py:49
-msgid "Usage"
-msgstr "Utilizzo"
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+"azioni specifiche del programma di sincronizzazione nel server di katello"
 
-#: ../src/katello/client/i18n_optparse.py:50
-msgid "%prog [options]"
-msgstr "%prog [options]"
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "elenca tutte le organizzazioni conosciute"
 
-#: ../src/katello/client/i18n_optparse.py:51
-msgid "Options"
-msgstr "Opzioni"
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "Elenco organizzazioni"
 
-#. stuff for option value sanity checking
-#: ../src/katello/client/i18n_optparse.py:54
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "crea una organizzazione"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "descrizione utenza es: organizzazione foo"
+
+#: ../src/katello/client/core/organization.py:77
 #, python-format
-msgid "no such option: %s"
-msgstr "opzione non trovata: %s"
+msgid "Successfully created org [ %s ]"
+msgstr "Org [ %s ] creata con successo"
 
-#: ../src/katello/client/i18n_optparse.py:55
+#: ../src/katello/client/core/organization.py:78
 #, python-format
-msgid "ambiguous option: %s (%s?)"
-msgstr "opzione ambigua: %s (%s?)"
+msgid "Could not create org [ %s ]"
+msgstr "Impossibile creare l'org [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:56
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "elenca le informazioni di una organizzazione"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "Livelli di servizio disponibili"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "Informazioni organizzazione"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "cancella una organizzazione"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "Rimozione organizzazione in corso, attendere prego..."
+
+#: ../src/katello/client/core/organization.py:133
 #, python-format
-msgid "%s option requires an argument"
-msgstr "l'opzione %s richiede un argomento"
+msgid "Successfully deleted org [ %s ]"
+msgstr "Org [ %s ] cancellata con successo"
 
-#: ../src/katello/client/i18n_optparse.py:57
+#: ../src/katello/client/core/organization.py:136
 #, python-format
-msgid "%s option requires %d arguments"
-msgstr "l'opzione %s richiede gli argomenti %d"
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "Rimozione organizzazione [ %s ] fallita: %s"
 
-#: ../src/katello/client/i18n_optparse.py:58
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "aggiorna una organizzazione"
+
+#: ../src/katello/client/core/organization.py:160
 #, python-format
-msgid "%s option does not take a value"
-msgstr "l'opzione %s non accetta alcun valore"
+msgid "Successfully updated org [ %s ]"
+msgstr "Org [ %s ] aggiornata con successo"
 
-#: ../src/katello/client/i18n_optparse.py:59
-msgid "integer"
-msgstr "Intero"
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "genera e mostra il certificato ueber"
 
-#: ../src/katello/client/i18n_optparse.py:60
-msgid "long integer"
-msgstr "Intero lungo"
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "genera nuovamente il certificato"
 
-#: ../src/katello/client/i18n_optparse.py:61
-msgid "floating-point"
-msgstr "virgola mobile"
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "Organizzazione Uebercert"
 
-#: ../src/katello/client/i18n_optparse.py:62
-msgid "complex"
-msgstr "complesso"
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "mostra le sottoscrizioni"
 
-#: ../src/katello/client/i18n_optparse.py:63
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "Sottoscrizioni dell'organizzazione"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "azioni specifiche dell'organizzazione nel server di katello"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "imposta un programma di sincronizzazione"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "Nome programma di sincronizzazione (necessario)"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "rimuovi impostazione del programma di sincronizzazione"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "elenca prodotti conosciuti"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "nome del provider, elenca il prodotto del provider in Library"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
 #, python-format
-msgid "option %s: invalid %s value: %r"
-msgstr "opzione %s: valore %s invalido: %r"
+msgid "Product List For Provider %s"
+msgstr "Elenco prodotti per provider %s"
 
-#: ../src/katello/client/i18n_optparse.py:64
+#: ../src/katello/client/core/product.py:151
 #, python-format
-msgid "option %s: invalid choice: %r (choose from %s)"
-msgstr "opzione %s: selezione invalida: %r (scegliere da %s)"
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "Elenco prodotti per organizzazione %s, Ambiente '%s'"
 
-#. default options
-#: ../src/katello/client/i18n_optparse.py:67
-msgid "show this help message and exit"
-msgstr "mostra questo messaggio d'aiuto ed esci"
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "sincronizza un prodotto"
 
-#: ../src/katello/client/i18n_optparse.py:68
-msgid "show program's version number and exit"
-msgstr "mostra il numero della versione del programma ed esci"
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "Sincronizzazione prodotto [ %s ] fallita: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "Sincronizzazione del prodotto [ %s ] cancellata"
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "Prodotto [ %s ] sincronizzato"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "stato sincronizzazione del prodotto"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "Stato del prodotto"
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+"trasferisce un prodotto su un ambiente¶\n"
+"(crea un changeset temporaneo con il prodotto e lo trasferisce)"
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "Trasferimento prodotto in corso, attendere prego..."
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "Prodotto [ %s ] trasferito sull'ambiente [ %s ]"
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "Avanzamento prodotto [ %s ] fallito: %s"
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "crea un nuovo prodotto per un provider personalizzato"
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "descrizione prodotto"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "salta la scoperta del repositorio"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+"assegna una chiave gpg; questa chiave verrà usata per ogni nuovo repositorio"
+" a meno che non sia specificato gpgkey o nogpgkey per il repositorio"
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr "Prodotto [ %s ] creato con successo"
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "aggiorna gli attributi di un prodotto"
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "cambia la descrizione del prodotto"
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "assegna un gpgkey al prodotto"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "assegna gpgkey anche ai repositori del prodotto"
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr "Prodotto [ %s ] aggiornato con successo"
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "cancella un prodotto ed il suo contenuto"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "elenca filtri di un prodotto"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "Filtri del prodotto"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "aggiunge un filtro ad un prodotto"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "rimuove un filtro da un prodotto"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "Filtro [ %s ] aggiunto al prodotto [ %s ]"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "Filtro [ %s ] rimosso dal prodotto [ %s ]"
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "azioni specifiche del prodotto nel server di katello"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "elenca tutti i template"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "nome dell'organizzazione (necessario se si specifica un ambiente)"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "Nessun template trovato nell'ambiente [ %s ]"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "Elenco template"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "elenca le informazioni relative ad un template"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "nome template (necessario)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "Informazioni del template"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "crea un file del template ed importare i dati"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "percorso per il file del template (necessario)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "Processo di importazione template in corso, attendere prego..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "esporta il template nel file"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "nome ambiente es: dev"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "formato dell'esportazione, valori possibili: %s, default: json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "Impossibile creare il file %s"
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "Esportazione template, attendere prego..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "Il template è stato esportato con successo sul file %s"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "crea un file del template vuoto"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "nome del template genitore"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "descrizione template"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "Template [ %s ] creato con successo"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "Impossibile creare il template [ %s ]"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "aggiornamenti nome e descrizione di un template"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "ogni %s deve essere preceduto da %s"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "nome del parametro, deve seguire %s"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "valore del parametro"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "nome del parametro"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "nome del gruppo di pacchetti"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "nome della categoria del gruppo di pacchetti"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "id distribuzione"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "determina il prodotto dal quale i repositori sono selezionati"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "repositorio da aggiungere al template"
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "repositorio da rimuovere dal template"
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "valore mancante per il parametro '%s'"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "Aggiornamento template in corso, attendere prego..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "Template [ %s ] aggiornato con successo"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "cancella un template"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "nome ambiente es: foo.example.com (default: Library)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "azioni specifiche del template nel server di katello"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "elenca ambienti conosciuti"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "Org"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "Ambiente precedente"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "Elenco ambiente"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "elenca un ambiente specifico"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "nome ambiente es: foo.example.com (necessario)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "Informazioni ambiente"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "crea un ambiente"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "descrizione ambiente es: ambiente di foo"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "nome dell'ambiente precedente (necessario)"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "Ambiente creato con successo [ %s ]"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "Impossibile creare l'ambiente [ %s ]"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "aggiorna un ambiente"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "nome dell'ambiente precedente"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "Ambiente aggiornato con successo [ %s ]"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "cancella un ambiente"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "Ambiente cancellato con successo [ %s ]"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "azioni specifiche all'ambiente nel server di katello"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "file del certificato %s non esiste o non può essere letto"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "il file della chiave %s non esiste o non può essere letto"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "Impossibile autenticare tramite kerberos"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "L'opzione %s è necessaria; consultare --help"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "L'opzione %s è in contrasto con %s; consultare --help"
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "Almeno uno di %s è necessrio; consultare --help"

--- a/cli/po/ja.po
+++ b/cli/po/ja.po
@@ -3,2800 +3,146 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # nnakakit <nnakakit@fedoraproject.org>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 # noriko <noriko@fedoraproject.org>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2012-05-23 09:04-0400\n"
-"Last-Translator: noriko <noriko@fedoraproject.org>\n"
+"PO-Revision-Date: 2012-08-24 03:00-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "証明書ファイル %s が存在していないか、読み取り不能です"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "キーファイル %s が存在していないか、読み取り不能です"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "kerberos で認証できませんでした"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "バージョン情報を表示します"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Katello ユーザーアカウントの資格情報"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "アカウントのユーザー名"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "アカウントのパスワード"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello サーバー情報"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "Katello サーバーのホスト名 (デフォルト: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "無効なコマンドです; --help を参照してください"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "コマンドが指定されていません; --help を参照してください"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "組織 [ %s ] が見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "環境 [ %s ] が組織 [ %s ] で見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "製品 [ %s ] が組織 [ %s ] で見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr "リポジトリ [ %s ] が組織 [ %s ] 、 製品 [ %s ] 、 環境 [ %s ] で見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "プロバイダー [ %s ] が組織 [ %s ] で見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "テンプレート [ %s ] が環境 [ %s ] で見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "変更セット [ %s ] が環境 [ %s ] で見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "ユーザー [ %s ] が見つかりませんでした"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "ロール [ %s ] が見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "同期プラン [ %s ] が見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr "パーミッション [ %s ]  が見つかりません (ユーザーロール [ %s ] )"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "フィルター [ %s ] が見つかりません"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "システム [ %s ] が組織 [ %s ] で見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "定義が不明確なシステム [ %s ] を環境 [ %s ] 、 組織 [ %s ] に見つけました"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "システム [ %s ] が 環境 [ %s ]、 組織 [ %s ] に見つかりませんでした"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr "定義が不明確なシステム [ %s ] を組織 [ %s ] に見つけました、 環境を指定してください"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "名前"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "既知の組織の全一覧を表示"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "組織の一覧"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "組織を作成"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "組織名、例: foo.example.com (必須)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "コンシューマーの詳細、 例: foo の組織"
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "組織 [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr "組織 [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "組織に関する情報を一覧表示"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "利用可能なサービスレベル"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "組織情報"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "組織を削除"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "組織の削除中、 お待ちください..."
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "組織 [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "組織 [ %s ] の削除に失敗しました: %s"
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "組織を更新"
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "組織 [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "ueber 証明書を生成して表示"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "証明書の再生成"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "組織の Ueber 証明書"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "サブスクリプションの表示"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "組織のサブスクリプション"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "Katello サーバーの組織に固有の動作"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "製品名 (必須)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "環境名、 例: 実稼働 (デフォルト: ライブラリ)"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "同期プランをセットする"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "同期プラン名 (必須)"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "同期プランのセットを外す"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "既知の製品を一覧表示"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "プロバイダー名、 ライブラリ内のプロバイダーの製品を一覧表示"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "GPG キー"
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr "プロバイダー %s の製品一覧"
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "組織 %s、環境 '%s' の製品一覧、"
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "製品を同期"
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "製品 [ %s ] の同期に失敗しました: %s"
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "製品 [ %s ] の同期が取り消されました"
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "製品 [ %s ] が同期されました"
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "現在実行中の同期を取り消す"
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "製品の同期のステータス"
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "製品のステータス"
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-"製品を環境にプロモートする\n"
-"(製品で一時的な変更セットを作成しそれをプロモートします)"
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "製品のプロモート中、 お待ちください..."
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "製品 [ %s ] が環境 [ %s ] にプロモートされました"
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "製品 [ %s ] のプロモートが失敗しました: %s"
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "カスタムプロバイダーに新しい製品を作成"
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "プロバイダー名 (必須)"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "製品の詳細"
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"リポジトリ URL、 例: http://download.fedoraproject.org/pub/fedora/linux/releases/"
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "リポジトリの検出を省略"
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr "yes と仮定、 検出された URL に対する候補リポジトリを自動的に作成します (オプション)"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-"GPG キーの割り当て; このキーはリポジトリに gpgkey や nogpgkey が指定されない限り新規の各リポジトリすべてに使用されます"
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "製品 [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "検出されたリポジトリ URL @ [%s]"
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "製品の属性を更新"
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "製品の詳細を変更"
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "gpgkey を製品に割り当てる"
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "gpgkey を製品のリポジトリにも割り当てる"
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "プロダクト [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "製品とそのコンテンツを削除"
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "製品のフィルターを一覧表示"
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "製品のフィルター"
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "フィルターを製品に追加"
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "フィルターを製品から削除"
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr "フィルター名 (必須)"
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "フィルター [ %s ] が製品 [ %s ] に追加されました"
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "フィルター [ %s ] が製品 [ %s ] から削除されました"
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "Katello サーバーで製品に固有の動作"
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr "組織内のシステム群を一覧表示"
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr "環境名、 例: 開発"
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr "サブスクリプションごとにシステムを"
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr "組織 [ %s ] のシステム一覧"
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr "環境 [ %s ] に関する組織 [ %s ] のシステム一覧"
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr "サービスレベル"
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr "組織内のシステムを表示"
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr "システム名 (必須)"
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "環境名"
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr "組織 [ %s ] のシステム情報"
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr "環境 [ %s ] に関する組織 [ %s ] のシステム情報"
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr "表示してインストールしたシステムのパッケージで操作"
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr "システムに遠隔操作でインストールするパッケージです、 複数のパッケージ名はコンマで区切ります"
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr "システムから遠隔操作で削除を行うパッケージです、 複数のパッケージ名はコンマで区切ります"
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr "システムで更新を行うパッケージです、 --all を使用すると全パッケージが更新されます、 複数のパッケージ名はコンマで区切ります"
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr "システムに遠隔操作でインストールするパッケージグループです、 複数のグループ名はコンマで区切ります"
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr "システムから遠隔操作で削除を行うパッケージグループです、 複数のグループ名はコンマで区切ります"
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr "指定できるインストール／削除／更新の動作は 1 コールにつき 1 動作のみです"
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr "システム [ %s ] に関する組織 [ %s ] のパッケージ情報"
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr "システム [ %s ] に関する環境 [ %s ] 組織 [ %s ] のパッケージ情報"
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "リモート動作 の [ %s ] を実行中..."
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "リモート動作が終了しました:"
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "リモート動作が失敗しました:"
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr "リモートタスクの状態を表示"
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr "システム名"
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr "リモートタスク"
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr "タスク ID"
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr "システム"
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr "動作"
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr "起動しました"
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "終了しました"
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr "状態"
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr "結果"
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr "リモートタスクの状態を表示"
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr "タスクの UUID"
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr "リモートタスク"
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr "システムで使用できるリリースを一覧表示"
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr "システム名 (指定がないと環境内の全リリースが一覧表示されます)"
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr "使用できるリリース"
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr "システムのハードウェア情報を表示"
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr "システム [ %s ] に関する組織 [ %s ] のシステム情報"
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr "システム [ %s ] に関する環境 [ %s] 組織 [ %s ] のシステム情報"
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "システムを登録"
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "組織名 (必須)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr "Service Level Agreement"
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr "アクティベーションキー、 キーが複数ある場合はコンマで区切ります (例: --activationkey=key1,key2)"
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr "システムの $releasever の値です"
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr "システム情報"
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "オプション %s は %s で指定できません"
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr "システム [ %s ] が正常に登録されました"
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr "システム [ %s ] を登録できませんでした"
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr "ハイパーバイザーの削除記録を消去"
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr "ハイパーバイザーの UUID (必須"
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr "UUID [ %s ] のハイパーバイザーの削除記録が正常に消去されました"
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr "システムを登録解除"
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr "システム [ %s ] が正常に登録解除されました"
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr "システムを証明書にサブスクライブする"
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr "サブスクリプションを解除する証明書のシリアル番号 (必須)"
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr "数量 (デフォルト: 1)"
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr "システム [ %s ] を正常にサブスクライブできました"
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr "システムのサブスクリプションを一覧表示"
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr "利用可能なサブスクリプションの表示"
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr "システム [ %s ] に関する組織 [ %s ] のサブスクリプションが見つかりません"
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr "システム [ %s ] の現在のサブスクリプション"
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr "シリアル ID"
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr "提供製品"
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr "システム [ %s ] に関する組織 [ %s ] のプールが見つかりません"
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr "システム [ %s ] に使用できるサブスクリプション"
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr "証明書からシステムのサブスクリプションを解除"
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr "サブスクリプションを解除するエンタイトルメントの ID (エンタイトルメントとシリアルのいずれかまたは両方が必要)"
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr "サブスクリプションを解除するシリアル ID (エンタイトルメントとシリアルのいずれかまたは両方が必要)"
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr "現在サブスクライブしている証明書のサブスクリプションをすべて解除"
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr "システム [ %s ] のサブスクリプションが正常に解除されました"
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr "システムを更新"
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr "システムの新しい名前"
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr "システムの詳細"
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr "システムの場所"
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr "システムの $releasever の値"
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr "システム [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr "システム [ %s ] を更新できませんでした"
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr "システムレポート"
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr "レポート形式 (使用可能な形式:「html」、「text (デフォルト)」、「csv」、「pdf」)"
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr "Katello サーバーのシステムに固有の動作"
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "全フィルターの表示"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "フィルターの一覧"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "フィルターの作成"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "詳細"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "コンマで区切られたパッケージ名／nvre の一覧"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "フィルター [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "フィルター [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "フィルターの削除"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "フィルター [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "フィルター情報"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "フィルター情報"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "パッケージをフィルターに追加"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "パッケージ ID (必須)"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "パッケージ [ %s ] がフィルター [ %s ] に正常に追加されました"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "フィルターからパッケージを削除"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "パッケージ [ %s ] がフィルター [ %s ] から正常に削除されました"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "katello サーバーでフィルタ固有の動作"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "リポジトリ内のディストリビューションを一覧表示"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "リポジトリ id"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "リポジトリ名"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "組織名、例: foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "製品名、例: fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "リポジトリ %s のディストリビューション一覧"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "ディストリビューションの情報を一覧表示"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "リポジトリ ID (必須)"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "ディストリビューション id、例: ks-rh-noarch (必須)"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "ディストリビューションの情報"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "Katello サーバーでリポジトリに固有の動作"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "Katello サーバーのステータスを取得"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Katello ステータス"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "サーバーステータスを確認"
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr "パッケージ情報を一覧表示"
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr "パッケージ id、文字列値 (必須)"
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr "パッケージ情報"
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr "リポジトリのパッケージを一覧表示"
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr "リポジトリ %s のパッケージ一覧"
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr "リポジトリ内のパッケージ検索"
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr "検索するパッケージのクエリー文字列、 例、「kernel*」、 「kernel-3.3.0-4.el6.x86_64」"
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr "リポジトリ %s でクエリー %s のパッケージ一覧"
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr "Katello サーバーのパッケージに固有の動作"
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "詳細はありません"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "動作が指定されていません: --help を参照してください"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "無効な動作です: --help を参照してください"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "grep が使いやすい出力"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "詳細な構造化された出力"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr "grep で認識できる出力内のコラム区切り記号、 -g オプションを付けた場合にのみ動作します"
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "オプション %s は必須です: --help を参照してください"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "オプション %s は %s と衝突しています、 --help を参照してください"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "%s のひとつが必須です: --help を参照してください"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "少なくとも %s がひとつ必要です、 --help を参照してください"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "エラー: 操作が失敗しました"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr "エラー: /etc/katello/client.conf で設定したサーバーのホスト名が一致しません"
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "接続している Katello サーバーから返されたホスト名"
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "[%s] は設定されましたが、サーバーより [%s] を取得しました。"
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "/etc/katello/client.conf ファイルのホストを修正してください"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "認証情報が無効であるか、 または認証不能です"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "オプション %s: 無効なブール値: %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "すべての既知のユーザーを一覧表示"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "ユーザーの一覧"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "ユーザーを作成"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "ユーザー名 (必須)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "初期パスワード (必須)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "Email (必須)"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "無効なアカウント (デフォルトは「false」)"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "ユーザーのデフォルトの組織名"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "ユーザーのデフォルトの環境名"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "ユーザー [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "ユーザー [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "ユーザー情報を一覧表示"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "ユーザー情報"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "ユーザーを削除"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "ユーザー [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "ユーザーを更新"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "初期パスワード"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "Email"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "無効なアカウント"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "ユーザーにデフォルトの環境がありません"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "ユーザー [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "ユーザーロールの一覧表示"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "ユーザーロール一覧"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "ロールを LDAP グループと同期"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "ユーザーへのロールの割り当て"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "ユーザーへのロール割り当てを削除"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "ユーザーロール (必須)"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "ロール [ %s ] が見つかりません"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "ユーザーレポート"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "Katello サーバーでユーザーに固有の動作"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "GPG キーの内容を入力 (CTRL+D で入力の終了)"
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "全 GPG キーを一覧表示"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "組織の名前 (必須)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "組織 [ %s ] に GPG キーが見つかりません"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "GPG キーの一覧"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "GPG キーに関する情報を表示"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "アクティベーションキーの名前 (必須)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "GPG キー [ %s ] が見つかりませんでした"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "リポジトリ"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "GPG キー 情報"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "GPG キーの作成"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr "パブリック GPG キーを持つファイル、 指定しない場合は標準入力が使用されます"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "GPG キー [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "GPG キー [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "アクティベーションキーを更新"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "新しいテンプレート名"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "パブリック GPG キーを持つファイル"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "キーの新しい内容の入力を求めるプロンプト"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "GPGキー [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "GPG キー [ %s ] を更新できませんでした"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "GPG キーの削除"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "GPG キー [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "katello サーバーで GPG キーに固有の動作"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "すべてのアクティベーションキーを一覧表示"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "環境名、 例: 開発 (デフォルト: ライブラリ)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "組織 [ %s ] にキーが見つかりません"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "組織 [ %s ] 環境 [ %s ] にキーが見つかりません"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "アクティベーションキーの一覧"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "アクティベーションキーの情報を表示"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "アクティベーションキー [ %s ] が見つかりませんでした"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "アクティベーションキーの情報"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "アクティベーションキーを作成"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "環境名、例: dev (必須)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "アクティベーションキーの詳細"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "テンプレート名、例: サーバー"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "テンプレート [ %s ] が見つかりませんでした"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "アクティベーションキー [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "アクティベーションキー [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "新しい環境名、例: dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "新しい詳細"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "新しいテンプレート名、例: サーバー"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "アクティベーションキーにプールを追加"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "アクティベーションキーからプールを削除"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "アクティベーションキー [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "アクティベーションキーを削除"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "アクティベーションキー [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "Katello サーバーのアクティベーションキーに固有の動作"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "利用可能なパッケージグループを一覧表示"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "リポジトリ id、文字列値 (必須)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "リポジトリ [%s] でパッケージグループが見つかりません"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "パッケージグループの情報"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "パッケージグループの情報を検索"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "パッケージグループ id、文字列値 (必須)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "パッケージグループ [%s] がリポジトリ [%s] で見つかりません"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "利用可能なパッケージグループカテゴリを一覧表示"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "リポジトリ [%s] でパッケージグループカテゴリが見つかりません"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "パッケージグループカテゴリの情報"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "パッケージグループカテゴリ id、文字列値 (必須)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "パッケージグループカテゴリ [%s] がリポジトリ [%s] で見つかりません"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "パッケージグループカテゴリの情報"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "Katello サーバーのパッケージグループに固有の動作"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "環境の新しい変更セットを一覧表示"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "環境名 (必須)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "変更セットの一覧"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "変更セットに関する詳細情報"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "変更セットの名前 (必須)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "依存パッケージを表示します"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "変更セットの情報"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "環境の新しい変更セットを作成"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "変更セットの詳細"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "変更セット [ %s ] が環境 [ %s ] に対して正常に作成されました"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "変更セット [ %s ] を環境 [ %s ] に対して作成できませんでした"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "変更セットのコンテンツを更新"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s の前に %s を指定する必要があります"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "新しい変更セット名"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "変更セットに追加する製品"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "変更セットから削除する製品"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "変更セットに追加されるテンプレートの名前"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "変更セットから削除されるテンプレートの名前"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr "パッケージ/エラータ/リポジトリが選択される製品を決定"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "変更セットに追加"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "変更セットから削除"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "変更セット [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "変更セットを削除"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "変更セットを次の環境へプロモート"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "変更セットをプロモートしています、 お待ちください..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "変更セット [ %s ] がプロモートされました"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "変更セット [ %s ] のプロモーションが失敗しました: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "Katello サーバーで変更セットに固有の動作"
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr "すべての既知のプロバイダーを一覧表示"
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr "プロバイダーの一覧"
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr "プロバイダー情報を一覧表示"
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr "プロバイダー情報"
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr "プロバイダーを作成"
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr "プロバイダーを更新"
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr "プロバイダーの詳細"
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr "プロバイダー名"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "オプション --url は http:// か https:// で開始する必要があります"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "オプション --url は有効な形式ではありません"
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr "プロバイダー [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr "プロバイダー [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr "プロバイダー [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr "プロバイダーを削除"
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr "プロバイダーを同期"
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr "プロバイダー [ %s ] の同期に失敗しました: %s"
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr "プロバイダー [ %s ] の同期が取り消されました"
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr "プロバイダー [ %s ] が同期されました"
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr "プロバイダーの同期ステータス"
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr "%d%% 完了 (%d ダウンロード済み、 %d パッケージ合計数)"
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr "プロバイダーのステータス"
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr "マニフェストファイルをインポート"
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr "マニフェストファイルへのパス (必須)"
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr "マニフェストの再インポートを強制する"
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr "ファイル %s がありません"
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr "マニフェストをインポートしています、 お待ちください..."
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr "プロバイダーの製品リポジトリをリフレッシュ"
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr "プロバイダーを正しくリフレッシュしました [%s]"
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr "Katello サーバーのプロバイダーに固有の動作"
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "既知の環境を一覧表示"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "組織"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "以前の環境"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "環境の一覧"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "特定の環境を表示"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "環境名、例: foo.example.com (必須)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "環境情報"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "環境を作成"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "環境の詳細、例: foo の環境"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "以前の環境名 (必須)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "環境 [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "環境 [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "環境を更新"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "以前の環境名"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "環境 [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "環境を削除"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "環境 [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "Katello サーバーの環境に固有の動作"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "クライアント設定にオプションを保存"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr "保存するオプション名 (例: 組織、 環境、 プロバイダーなど) (必須)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "特定のオプションで保存される値 (必須)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "成功"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "オプション [%s] を「記憶する」機能の実行に失敗しました。"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "クライアント設定からオプションを削除"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "削除されるオプションの名前 (必須)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "オプション [%s] の「忘れる」機能の実行に成功しました"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "オプション [%s] の 「忘れる」機能の実行に失敗しました"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "クライアント設定に保存されたオプションを一覧表示"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "オプションが保存されました"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "Katello サーバーのクライアントに固有の動作"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "すべてのテンプレートを一覧表示"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "組織名 (環境を指定する場合は必須)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "環境 [ %s ] にテンプレートが見つかりません"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "テンプレート一覧"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "テンプレート情報を一覧表示"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "テンプレート名 (必須)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "テンプレート情報"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "テンプレートファイルを作成し、データをインポート"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "テンプレートファイルへのパス (必須)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "テンプレートをインポートしています、 お待ちください..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "テンプレートをファイルにエクスポート"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "環境名、 例: 開発"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "エクスポートの形式、 可能な値: %s、 デフォルト: json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "%s ファイルを作成できませんでした"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "テンプレートのエクスポート中、 お待ちください..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "テンプレートは %s ファイルに正常にエクスポートされました"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "空のテンプレートファイルを作成"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "親テンプレートの名前"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "テンプレートの詳細"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "テンプレート [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "テンプレート [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "テンプレートの名前と詳細を更新"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "各 %s の前に %s を指定する必要があります"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "製品名または nvre (エポック: name-rel.eas-ver.sio.n)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "パラメーターの名前 %s が後に続く必要があります"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "パラメーターの値"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "パラメーターの名前"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "パッケージグループの名前"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "パッケージグループカテゴリの名前"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "ディストリビューション ID"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "リポジトリの選択先となる製品を確定"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "テンプレートに追加するリポジトリ"
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "テンプレートから削除するリポジトリ"
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "パラメーター '%s' の値がありません"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "テンプレートを更新中、 お待ちください..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "テンプレート [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "テンプレートを削除"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "環境名、 例: foo.example.com (デフォルト: ライブラリ)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "Katello サーバーのテンプレートに固有の動作"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "シェルとして cli を実行"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "既知の sync_plans を一覧表示"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "同期プランの一覧"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "同期プランに関する情報を表示"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "同期プラン名 (必須)"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "同期プラン情報"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "同期プランの作成"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "プラン詳細"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr "同期が反復する間隔 (選択: [%s]、 デフォルト: なし)"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "初回同期の日付 (必須、 形式: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr "初回同期の時間 (形式:HH:MM:SS、 デフォルト: 00:00:00)"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "同期プラン [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "同期プラン [ %s ] が作成できませんでした"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "同期プランの更新"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "新規の同期プラン名"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "初回同期の日付 (形式: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "初回同期の時間 (形式: HH:MM:SS)"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "-date と --time の両方を指定する必要があります"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "同期プラン [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "同期プランの削除"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "同期プラン [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr "katello サーバーで同期プランに固有の動作"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "katello サーバーのバージョンを取得"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "サーバーのバージョンを確認"
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr "ユーザーロールのパーミッションを作成"
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "ロール名 (必須)"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr "パーミッション名 (必須)"
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr "パーミッションの詳細"
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr "組織名"
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr "パーミッションの範囲 (必須)"
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr "パーミッションの動詞"
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr "パーミッションのタグ"
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr "無効な範囲 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr "タグ [ %s ] が [ %s ] の範囲内に見つかりませんでした"
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr "パーミッション [ %s ] がユーザーロール [ %s ] に対して正常に作成されました"
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr "パーミッション [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr "パーミッションの削除"
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr "パーミッション [ %s ] がユーザーロール [ %s ] に対して正常に削除されました"
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr "ユーザーロールのパーミッションを一覧表示"
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr "パーミッション一覧"
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr "パーミッションに設定できる使用可能な範囲、 動詞、 タグを一覧表示"
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-"組織名、 例: foo.example.com\n"
-"組織固有の動詞を一覧表示"
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr "範囲別の表示結果にフィルターをかける"
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr "パーミッション範囲 %s に使用できる動詞とタグ"
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr "利用可能な動詞"
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr "なし"
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr "katello サーバーでパーミッションに固有の動作"
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr "リポジトリのすべてのエラータを一覧表示"
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr "タイプ別にエラータにフィルターをかける、 例: 機能強化"
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr "重要別にエラータにフィルターをかける"
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr "エラータの一覧"
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr "システムのエラータを一覧表示"
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr "組織 %s 内のシステム %s のエラータ"
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr "エラータに関する情報"
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr "エラータ id、文字列値 (必須)"
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr "エラータ情報"
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr "Katello サーバーのエラータに固有の動作"
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "待機中"
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "実行中"
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "エラー"
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "取り消しました"
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr "取り消しました"
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "タイムアウトしました"
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr "同期されていません"
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr "指定 URL でリポジトリを作成"
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr "割り当てるリポジトリ名 (必須)"
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr "リポジトリへの URL パス (必須)"
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr "リポジトリに割り当てる GPG キー; デフォルトでは製品の GPG キーが使用されます。"
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr "GPG キーをリポジトリに割り当てないでください。"
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr "リポジトリ [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr "URL 内に含まれる検出リポジトリ"
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr "検出されたすべてのリポジトリに追加するリポジトリ名のプレフィックス (必須)"
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr "リポジトリの検出を実行する root URL、 例: http://porkchop.devel.redhat.com/ (必須)"
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr "リポジトリ URL を検出中、 時間がかかる場合があります..."
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "エラー: %s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-"\n"
-"候補リポジトリを作成する URL を選択、 確定する場合は「y」を入力します (ヘルプは h):"
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr "ユーザー要求により動作が中断しました。"
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr "リポジトリのステータス情報"
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "リポジトリステータス"
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "リポジトリに関する情報"
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "進行状況"
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr "リポジトリ %s に関する情報"
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr "リポジトリの属性を更新"
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr "リポジトリ 正常に更新されました"
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr "リポジトリを同期"
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr "リポジトリ [ %s ] が同期しました"
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr "リポジトリ [ %s ] の同期が取り消されました"
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr "リポジトリ [ %s ] の同期に失敗しました: %s"
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr "現在実行中のリポジトリの同期を取り消す"
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr "リポジトリの有効化"
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr "リポジトリの無効化"
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr "組織のリポジトリを一覧表示"
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr "組織名、例: ACME_Corporation (必須)"
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr "無効にしたリポジトリも一覧表示する"
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr "組織 %s 環境 %s 製品 %s のリポジトリ一覧"
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr "製品 %s に関する組織 %s のリポジトリ一覧 "
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr "組織 %s に関する環境 %s のリポジトリ一覧"
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr "リポジトリを削除"
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr "リポジトリのフィルターを一覧表示"
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr "リポジトリの製品に割り当てられたフィルターも表示します。"
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr "リポジトリのフィルター"
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr "フィルターをリポジトリに追加"
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr "フィルターをリポジトリから削除"
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr "フィルター [ %s ] をリポジトリ [ %s ] に追加しました"
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr "フィルター [ %s ] をリポジトリ [ %s ] から削除しました"
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "既知のユーザーロールをすべて表示"
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "ユーザーロールの作成"
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "ロール詳細"
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "ユーザーロール [ %s ] が正常に作成されました"
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "ユーザーロール [ %s ] を作成できませんでした"
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "ユーザーロール情報を表示"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "ユーザーロール名 (必須)"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "各ロールのパーミッション情報を出力"
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "ユーザーロール情報"
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "ユーザーロールの削除"
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "ユーザーロール [ %s ] が正常に削除されました"
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "ロールの更新"
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "新規のユーザーロール名"
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr "ユーザーロールを更新する場合はパラメータが少なくとも一つ必要です"
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "ユーザーロール [ %s ] が正常に更新されました"
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "LDAP グループをロールに割り当てる"
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "新規の LDAP グループ名 (必須)"
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr "LDAP グループ [%s] がユーザーロール [%s] に正常に追加されました"
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "ロールに割り当てられている LDAP グループの削除"
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "削除する LDAP グループ名 (必須)"
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr "LDAP グループ [%s] をユーザーロール [%s] から正常に削除しました"
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "katello サーバー内でのユーザーロール固有の動作"
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "時刻形式が無効です、 HH:MM:SS[+HH:MM] の形式にしてください"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "日付形式が無効です、 YYYY-MM-DD の形式にしてください"
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2815,6 +161,7 @@ msgid "Options"
 msgstr "オプション"
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2867,6 +214,7 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr "オプション %s: 無効な選択: %r (%s から選択)"
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr "このヘルプメッセージを表示して終了"
@@ -2874,3 +222,3025 @@ msgstr "このヘルプメッセージを表示して終了"
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
 msgstr "プログラムのバージョン番号を表示して終了"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "既知のユーザーロールをすべて表示"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "ユーザーロール一覧"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "ユーザーロールの作成"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "ロール名 (必須)"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "ロール詳細"
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr "ユーザーロール [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr "ユーザーロール [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "ユーザーロール情報を表示"
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "ユーザーロール名 (必須)"
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "各ロールのパーミッション情報を出力"
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "ユーザーロール情報"
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "ユーザーロールの削除"
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr "ユーザーロール [ %s ] が正常に削除されました"
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "ロールの更新"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "新規のユーザーロール名"
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr "ユーザーロール [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "LDAP グループをロールに割り当てる"
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "新規の LDAP グループ名 (必須)"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr "LDAP グループ [%s] がユーザーロール [%s] に正常に追加されました"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "ロールに割り当てられている LDAP グループの削除"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "削除する LDAP グループ名 (必須)"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr "LDAP グループ [%s] をユーザーロール [%s] から正常に削除しました"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "katello サーバー内でのユーザーロール固有の動作"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "クライアント設定にオプションを保存"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr "保存するオプション名 (例: 組織、 環境、 プロバイダーなど) (必須)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "特定のオプションで保存される値 (必須)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "成功"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "オプション [%s] を「記憶する」機能の実行に失敗しました。"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "クライアント設定からオプションを削除"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "削除されるオプションの名前 (必須)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "オプション [%s] の「忘れる」機能の実行に成功しました"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "オプション [%s] の 「忘れる」機能の実行に失敗しました"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "クライアント設定に保存されたオプションを一覧表示"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "オプションが保存されました"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "Katello サーバーのクライアントに固有の動作"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "すべてのアクティベーションキーを一覧表示"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "組織の名前 (必須)"
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "環境名、 例: 開発 (デフォルト: ライブラリ)"
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr "組織 [ %s ] にキーが見つかりません"
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "組織 [ %s ] 環境 [ %s ] にキーが見つかりません"
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "アクティベーションキーの一覧"
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "アクティベーションキーの情報を表示"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "アクティベーションキーの名前 (必須)"
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr "アクティベーションキー [ %s ] が見つかりませんでした"
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "アクティベーションキーの情報"
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "アクティベーションキーを作成"
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "環境名、例: dev (必須)"
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "アクティベーションキーの詳細"
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "テンプレート名、例: サーバー"
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "テンプレート [ %s ] が見つかりませんでした"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "アクティベーションキー [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "アクティベーションキー [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "アクティベーションキーを更新"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "新しい環境名、例: dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "新しいテンプレート名"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "新しい詳細"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "新しいテンプレート名、例: サーバー"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "アクティベーションキーにプールを追加"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "アクティベーションキーからプールを削除"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "アクティベーションキー [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "アクティベーションキーを削除"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "アクティベーションキー [ %s ] が正常に削除されました"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "Katello サーバーのアクティベーションキーに固有の動作"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "時刻形式が無効です、 HH:MM:SS[+HH:MM] の形式にしてください"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "日付形式が無効です、 YYYY-MM-DD の形式にしてください"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "全フィルターの表示"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "組織名 (必須)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "フィルターの一覧"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "フィルターの作成"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr "フィルター名 (必須)"
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "詳細"
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "コンマで区切られたパッケージ名／nvre の一覧"
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "フィルター [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "フィルター [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "フィルターの削除"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "フィルター [ %s ] が正常に削除されました"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "フィルター情報"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "フィルター情報"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "パッケージをフィルターに追加"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "パッケージ ID (必須)"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "パッケージ [ %s ] がフィルター [ %s ] に正常に追加されました"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "フィルターからパッケージを削除"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "パッケージ [ %s ] がフィルター [ %s ] から正常に削除されました"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "katello サーバーでフィルタ固有の動作"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "リポジトリ内のディストリビューションを一覧表示"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "リポジトリ id"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "リポジトリ名"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "組織名、例: foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "環境名、 例: 実稼働 (デフォルト: ライブラリ)"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "製品名、例: fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "リポジトリ %s のディストリビューション一覧"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "ディストリビューションの情報を一覧表示"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "リポジトリ ID (必須)"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "ディストリビューション id、例: ks-rh-noarch (必須)"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "ディストリビューションの情報"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "Katello サーバーでリポジトリに固有の動作"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "GPG キーの内容を入力 (CTRL+D で入力の終了)"
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "全 GPG キーを一覧表示"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "リポジトリ"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr "パブリック GPG キーを持つファイル、 指定しない場合は標準入力が使用されます"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "パブリック GPG キーを持つファイル"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "キーの新しい内容の入力を求めるプロンプト"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "katello サーバーで GPG キーに固有の動作"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "組織名、例: foo.example.com (必須)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "リモート動作 の [ %s ] を実行中..."
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "リモート動作が終了しました:"
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "リモート動作が失敗しました:"
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "すべての既知のユーザーを一覧表示"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "ユーザーの一覧"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "ユーザーを作成"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "ユーザー名 (必須)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "初期パスワード (必須)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "Email (必須)"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "無効なアカウント (デフォルトは「false」)"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "ユーザーのデフォルトの組織名"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "ユーザーのデフォルトの環境名"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "ユーザー [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "ユーザー [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "ユーザー情報を一覧表示"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "ユーザー情報"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "ユーザーを削除"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "ユーザー [ %s ] が正常に削除されました"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "ユーザーを更新"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "初期パスワード"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "Email"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "無効なアカウント"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "ユーザーにデフォルトの環境がありません"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "ユーザー [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "ユーザーロールの一覧表示"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "ロールを LDAP グループと同期"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "ユーザーへのロールの割り当て"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "ユーザーへのロール割り当てを削除"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "ユーザーロール (必須)"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "ロール [ %s ] が見つかりません"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "ユーザーレポート"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr "レポート形式 (使用可能な形式:「html」、「text (デフォルト)」、「csv」、「pdf」)"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "Katello サーバーでユーザーに固有の動作"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "環境の新しい変更セットを一覧表示"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "環境名 (必須)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "変更セットの一覧"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "変更セットに関する詳細情報"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "変更セットの名前 (必須)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "依存パッケージを表示します"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "変更セットの情報"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "環境の新しい変更セットを作成"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "変更セットの詳細"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "変更セット [ %s ] が環境 [ %s ] に対して正常に作成されました"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "変更セット [ %s ] を環境 [ %s ] に対して作成できませんでした"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "変更セットのコンテンツを更新"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s の前に %s を指定する必要があります"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "新しい変更セット名"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "変更セットに追加する製品"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "変更セットから削除する製品"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "変更セットに追加されるテンプレートの名前"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "変更セットから削除されるテンプレートの名前"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr "パッケージ/エラータ/リポジトリが選択される製品を決定"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "変更セットに追加"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "変更セットから削除"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "変更セット [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "変更セットを削除"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "変更セット [ %s ] のプロモーションが失敗しました: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "Katello サーバーで変更セットに固有の動作"
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr "組織内のシステム群を一覧表示"
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr "環境名、 例: 開発"
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr "サブスクリプションごとにシステムを"
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr "組織 [ %s ] のシステム一覧"
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr "環境 [ %s ] に関する組織 [ %s ] のシステム一覧"
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr "サービスレベル"
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr "組織内のシステムを表示"
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr "システム名 (必須)"
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "環境名"
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr "組織 [ %s ] のシステム情報"
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr "環境 [ %s ] に関する組織 [ %s ] のシステム情報"
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr "表示してインストールしたシステムのパッケージで操作"
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr "システムに遠隔操作でインストールするパッケージです、 複数のパッケージ名はコンマで区切ります"
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr "システムから遠隔操作で削除を行うパッケージです、 複数のパッケージ名はコンマで区切ります"
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr "システムで更新を行うパッケージです、 --all を使用すると全パッケージが更新されます、 複数のパッケージ名はコンマで区切ります"
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr "システムに遠隔操作でインストールするパッケージグループです、 複数のグループ名はコンマで区切ります"
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr "システムから遠隔操作で削除を行うパッケージグループです、 複数のグループ名はコンマで区切ります"
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr "指定できるインストール／削除／更新の動作は 1 コールにつき 1 動作のみです"
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr "システム [ %s ] に関する組織 [ %s ] のパッケージ情報"
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr "システム [ %s ] に関する環境 [ %s ] 組織 [ %s ] のパッケージ情報"
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr "リモートタスクの状態を表示"
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr "システム名"
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr "リモートタスク"
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr "タスク ID"
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr "システム"
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr "動作"
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr "起動しました"
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "終了しました"
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr "状態"
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr "結果"
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr "リモートタスクの状態を表示"
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr "タスクの UUID"
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr "リモートタスク"
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr "システムで使用できるリリースを一覧表示"
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr "システム名 (指定がないと環境内の全リリースが一覧表示されます)"
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr "使用できるリリース"
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr "システムのハードウェア情報を表示"
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr "システム [ %s ] に関する組織 [ %s ] のシステム情報"
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr "システム [ %s ] に関する環境 [ %s] 組織 [ %s ] のシステム情報"
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "システムを登録"
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr "Service Level Agreement"
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr "アクティベーションキー、 キーが複数ある場合はコンマで区切ります (例: --activationkey=key1,key2)"
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr "システムの $releasever の値です"
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr "システム情報"
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr "システム [ %s ] が正常に登録されました"
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr "システム [ %s ] を登録できませんでした"
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr "ハイパーバイザーの削除記録を消去"
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr "ハイパーバイザーの UUID (必須"
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr "UUID [ %s ] のハイパーバイザーの削除記録が正常に消去されました"
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr "システムを登録解除"
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr "システム [ %s ] が正常に登録解除されました"
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr "システムを証明書にサブスクライブする"
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr "サブスクリプションを解除する証明書のシリアル番号 (必須)"
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr "数量 (デフォルト: 1)"
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr "システム [ %s ] を正常にサブスクライブできました"
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr "システムのサブスクリプションを一覧表示"
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr "利用可能なサブスクリプションの表示"
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr "システム [ %s ] に関する組織 [ %s ] のサブスクリプションが見つかりません"
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr "システム [ %s ] の現在のサブスクリプション"
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr "シリアル ID"
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr "提供製品"
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr "システム [ %s ] に関する組織 [ %s ] のプールが見つかりません"
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr "システム [ %s ] に使用できるサブスクリプション"
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr "証明書からシステムのサブスクリプションを解除"
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr "サブスクリプションを解除するエンタイトルメントの ID (エンタイトルメントとシリアルのいずれかまたは両方が必要)"
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr "サブスクリプションを解除するシリアル ID (エンタイトルメントとシリアルのいずれかまたは両方が必要)"
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr "現在サブスクライブしている証明書のサブスクリプションをすべて解除"
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr "システム [ %s ] のサブスクリプションが正常に解除されました"
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr "システムを更新"
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr "システムの新しい名前"
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr "システムの詳細"
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr "システムの場所"
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr "システムの $releasever の値"
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr "システム [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr "システム [ %s ] を更新できませんでした"
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr "システムレポート"
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr "Katello サーバーのシステムに固有の動作"
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr "パッケージ情報を一覧表示"
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr "パッケージ id、文字列値 (必須)"
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr "パッケージ情報"
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr "リポジトリのパッケージを一覧表示"
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr "リポジトリ %s のパッケージ一覧"
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr "リポジトリ内のパッケージ検索"
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr "検索するパッケージのクエリー文字列、 例、「kernel*」、 「kernel-3.3.0-4.el6.x86_64」"
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr "リポジトリ %s でクエリー %s のパッケージ一覧"
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr "Katello サーバーのパッケージに固有の動作"
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "シェルとして cli を実行"
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "プロバイダー名 (必須)"
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr "すべての既知のプロバイダーを一覧表示"
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr "プロバイダーの一覧"
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr "プロバイダー情報を一覧表示"
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr "プロバイダー情報"
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr "プロバイダーを作成"
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr "プロバイダーを更新"
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr "プロバイダーの詳細"
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"リポジトリ URL、 例: http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr "プロバイダー名"
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr "プロバイダー [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr "プロバイダー [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr "プロバイダー [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr "プロバイダーを削除"
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr "プロバイダーを同期"
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr "プロバイダー [ %s ] の同期に失敗しました: %s"
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr "プロバイダー [ %s ] の同期が取り消されました"
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr "プロバイダー [ %s ] が同期されました"
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "現在実行中の同期を取り消す"
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr "プロバイダーの同期ステータス"
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr "%d%% 完了 (%d ダウンロード済み、 %d パッケージ合計数)"
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr "プロバイダーのステータス"
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr "マニフェストファイルをインポート"
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr "マニフェストファイルへのパス (必須)"
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr "マニフェストの再インポートを強制する"
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr "ファイル %s がありません"
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr "マニフェストをインポートしています、 お待ちください..."
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr "プロバイダーの製品リポジトリをリフレッシュ"
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr "プロバイダーを正しくリフレッシュしました [%s]"
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr "Katello サーバーのプロバイダーに固有の動作"
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "Katello サーバーのステータスを取得"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Katello ステータス"
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr "ユーザーロールのパーミッションを作成"
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr "パーミッション名 (必須)"
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr "パーミッションの詳細"
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr "組織名"
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr "パーミッションの範囲 (必須)"
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr "パーミッションの動詞"
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr "パーミッションのタグ"
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr "無効な範囲 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr "タグ [ %s ] が [ %s ] の範囲内に見つかりませんでした"
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr "パーミッション [ %s ] がユーザーロール [ %s ] に対して正常に作成されました"
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr "パーミッション [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr "パーミッションの削除"
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr "パーミッション [ %s ] がユーザーロール [ %s ] に対して正常に削除されました"
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr "ユーザーロールのパーミッションを一覧表示"
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr "パーミッション一覧"
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr "パーミッションに設定できる使用可能な範囲、 動詞、 タグを一覧表示"
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+"組織名、 例: foo.example.com\n"
+"組織固有の動詞を一覧表示"
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr "範囲別の表示結果にフィルターをかける"
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr "パーミッション範囲 %s に使用できる動詞とタグ"
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr "利用可能な動詞"
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr "なし"
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr "katello サーバーでパーミッションに固有の動作"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "詳細はありません"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "動作が指定されていません: --help を参照してください"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "無効な動作です: --help を参照してください"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "grep が使いやすい出力"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "詳細な構造化された出力"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr "grep で認識できる出力内のコラム区切り記号、 -g オプションを付けた場合にのみ動作します"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr "エラー: /etc/katello/client.conf で設定したサーバーのホスト名が一致しません"
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "接続している Katello サーバーから返されたホスト名"
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "[%s] は設定されましたが、サーバーより [%s] を取得しました。"
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "/etc/katello/client.conf ファイルのホストを修正してください"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "認証情報が無効であるか、 または認証不能です"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "オプション %s: 無効なブール値: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr "リポジトリのすべてのエラータを一覧表示"
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr "タイプ別にエラータにフィルターをかける、 例: 機能強化"
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr "重要別にエラータにフィルターをかける"
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr "エラータの一覧"
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr "システムのエラータを一覧表示"
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr "組織 %s 内のシステム %s のエラータ"
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr "エラータに関する情報"
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr "エラータ id、文字列値 (必須)"
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr "エラータ情報"
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr "Katello サーバーのエラータに固有の動作"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "katello サーバーのバージョンを取得"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "サーバーのバージョンを確認"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "利用可能なパッケージグループを一覧表示"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "リポジトリ id、文字列値 (必須)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "リポジトリ [%s] でパッケージグループが見つかりません"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "パッケージグループの情報"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "パッケージグループの情報を検索"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "パッケージグループ id、文字列値 (必須)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "パッケージグループ [%s] がリポジトリ [%s] で見つかりません"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "利用可能なパッケージグループカテゴリを一覧表示"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "リポジトリ [%s] でパッケージグループカテゴリが見つかりません"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "パッケージグループカテゴリの情報"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "パッケージグループカテゴリ id、文字列値 (必須)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "パッケージグループカテゴリ [%s] がリポジトリ [%s] で見つかりません"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "パッケージグループカテゴリの情報"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "Katello サーバーのパッケージグループに固有の動作"
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "待機中"
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "実行中"
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "エラー"
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "取り消しました"
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr "取り消しました"
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "タイムアウトしました"
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr "同期されていません"
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr "指定 URL でリポジトリを作成"
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr "割り当てるリポジトリ名 (必須)"
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr "リポジトリへの URL パス (必須)"
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "製品名 (必須)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr "リポジトリに割り当てる GPG キー; デフォルトでは製品の GPG キーが使用されます。"
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr "GPG キーをリポジトリに割り当てないでください。"
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr "リポジトリ [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr "URL 内に含まれる検出リポジトリ"
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr "検出されたすべてのリポジトリに追加するリポジトリ名のプレフィックス (必須)"
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr "リポジトリの検出を実行する root URL、 例: http://porkchop.devel.redhat.com/ (必須)"
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr "yes と仮定、 検出された URL に対する候補リポジトリを自動的に作成します (オプション)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "検出されたリポジトリ URL @ [%s]"
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr "リポジトリ URL を検出中、 時間がかかる場合があります..."
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "エラー: %s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+"\n"
+"候補リポジトリを作成する URL を選択、 確定する場合は「y」を入力します (ヘルプは h):"
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr "ユーザー要求により動作が中断しました。"
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr "リポジトリのステータス情報"
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "リポジトリステータス"
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "リポジトリに関する情報"
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "進行状況"
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "GPG キー"
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr "リポジトリ %s に関する情報"
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr "リポジトリの属性を更新"
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr "リポジトリを同期"
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr "リポジトリ [ %s ] が同期しました"
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr "リポジトリ [ %s ] の同期が取り消されました"
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr "リポジトリ [ %s ] の同期に失敗しました: %s"
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr "現在実行中のリポジトリの同期を取り消す"
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr "リポジトリの有効化"
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr "リポジトリの無効化"
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr "組織のリポジトリを一覧表示"
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr "組織名、例: ACME_Corporation (必須)"
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr "無効にしたリポジトリも一覧表示する"
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr "組織 %s 環境 %s 製品 %s のリポジトリ一覧"
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr "製品 %s に関する組織 %s のリポジトリ一覧 "
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr "組織 %s に関する環境 %s のリポジトリ一覧"
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr "リポジトリを削除"
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr "リポジトリのフィルターを一覧表示"
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr "リポジトリの製品に割り当てられたフィルターも表示します。"
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr "リポジトリのフィルター"
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr "フィルターをリポジトリに追加"
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr "フィルターをリポジトリから削除"
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr "フィルター [ %s ] をリポジトリ [ %s ] に追加しました"
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr "フィルター [ %s ] をリポジトリ [ %s ] から削除しました"
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "既知の sync_plans を一覧表示"
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "同期プランの一覧"
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "同期プランに関する情報を表示"
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "同期プラン名 (必須)"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "同期プラン情報"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "同期プランの作成"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "プラン詳細"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr "同期が反復する間隔 (選択: [%s]、 デフォルト: なし)"
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "初回同期の日付 (必須、 形式: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr "初回同期の時間 (形式:HH:MM:SS、 デフォルト: 00:00:00)"
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "同期プラン [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "同期プラン [ %s ] が作成できませんでした"
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "同期プランの更新"
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "新規の同期プラン名"
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "初回同期の日付 (形式: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "初回同期の時間 (形式: HH:MM:SS)"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "同期プラン [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "同期プランの削除"
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "同期プラン [ %s ] が正常に削除されました"
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr "katello サーバーで同期プランに固有の動作"
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "既知の組織の全一覧を表示"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "組織の一覧"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "組織を作成"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "コンシューマーの詳細、 例: foo の組織"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "組織 [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "組織 [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "組織に関する情報を一覧表示"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "利用可能なサービスレベル"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "組織情報"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "組織を削除"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "組織の削除中、 お待ちください..."
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "組織 [ %s ] が正常に削除されました"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "組織 [ %s ] の削除に失敗しました: %s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "組織を更新"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "組織 [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "ueber 証明書を生成して表示"
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "証明書の再生成"
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "組織の Ueber 証明書"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "サブスクリプションの表示"
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "組織のサブスクリプション"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "Katello サーバーの組織に固有の動作"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "同期プランをセットする"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "同期プラン名 (必須)"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "同期プランのセットを外す"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "既知の製品を一覧表示"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "プロバイダー名、 ライブラリ内のプロバイダーの製品を一覧表示"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "プロバイダー %s の製品一覧"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "組織 %s、環境 '%s' の製品一覧、"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "製品を同期"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "製品 [ %s ] の同期に失敗しました: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "製品 [ %s ] の同期が取り消されました"
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "製品 [ %s ] が同期されました"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "製品の同期のステータス"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "製品のステータス"
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+"製品を環境にプロモートする\n"
+"(製品で一時的な変更セットを作成しそれをプロモートします)"
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "製品のプロモート中、 お待ちください..."
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "製品 [ %s ] が環境 [ %s ] にプロモートされました"
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "製品 [ %s ] のプロモートが失敗しました: %s"
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "カスタムプロバイダーに新しい製品を作成"
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "製品の詳細"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "リポジトリの検出を省略"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+"GPG キーの割り当て; このキーはリポジトリに gpgkey や nogpgkey が指定されない限り新規の各リポジトリすべてに使用されます"
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr "製品 [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "製品の属性を更新"
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "製品の詳細を変更"
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "gpgkey を製品に割り当てる"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "gpgkey を製品のリポジトリにも割り当てる"
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr "プロダクト [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "製品とそのコンテンツを削除"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "製品のフィルターを一覧表示"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "製品のフィルター"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "フィルターを製品に追加"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "フィルターを製品から削除"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "フィルター [ %s ] が製品 [ %s ] に追加されました"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "フィルター [ %s ] が製品 [ %s ] から削除されました"
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "Katello サーバーで製品に固有の動作"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "すべてのテンプレートを一覧表示"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "組織名 (環境を指定する場合は必須)"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "環境 [ %s ] にテンプレートが見つかりません"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "テンプレート一覧"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "テンプレート情報を一覧表示"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "テンプレート名 (必須)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "テンプレート情報"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "テンプレートファイルを作成し、データをインポート"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "テンプレートファイルへのパス (必須)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "テンプレートをインポートしています、 お待ちください..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "テンプレートをファイルにエクスポート"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "環境名、 例: 開発"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "エクスポートの形式、 可能な値: %s、 デフォルト: json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "%s ファイルを作成できませんでした"
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "テンプレートのエクスポート中、 お待ちください..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "テンプレートは %s ファイルに正常にエクスポートされました"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "空のテンプレートファイルを作成"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "親テンプレートの名前"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "テンプレートの詳細"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "テンプレート [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "テンプレート [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "テンプレートの名前と詳細を更新"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "各 %s の前に %s を指定する必要があります"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "パラメーターの名前 %s が後に続く必要があります"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "パラメーターの値"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "パラメーターの名前"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "パッケージグループの名前"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "パッケージグループカテゴリの名前"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "ディストリビューション ID"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "リポジトリの選択先となる製品を確定"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "テンプレートに追加するリポジトリ"
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "テンプレートから削除するリポジトリ"
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "パラメーター '%s' の値がありません"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "テンプレートを更新中、 お待ちください..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "テンプレート [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "テンプレートを削除"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "環境名、 例: foo.example.com (デフォルト: ライブラリ)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "Katello サーバーのテンプレートに固有の動作"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "既知の環境を一覧表示"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "組織"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "以前の環境"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "環境の一覧"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "特定の環境を表示"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "環境名、例: foo.example.com (必須)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "環境情報"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "環境を作成"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "環境の詳細、例: foo の環境"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "以前の環境名 (必須)"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "環境 [ %s ] が正常に作成されました"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "環境 [ %s ] を作成できませんでした"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "環境を更新"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "以前の環境名"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "環境 [ %s ] が正常に更新されました"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "環境を削除"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "環境 [ %s ] が正常に削除されました"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "Katello サーバーの環境に固有の動作"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "証明書ファイル %s が存在していないか、読み取り不能です"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "キーファイル %s が存在していないか、読み取り不能です"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "kerberos で認証できませんでした"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "オプション %s は必須です: --help を参照してください"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "オプション %s は %s と衝突しています、 --help を参照してください"
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "少なくとも %s がひとつ必要です、 --help を参照してください"

--- a/cli/po/keys.pot
+++ b/cli/po/keys.pot
@@ -8,2772 +8,128 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-05-14 12:17-0400\n"
+"POT-Creation-Date: 2012-08-24 13:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
-msgstr ""
-
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: http://download.fedoraproject.org/pub/fedora/linux/"
-"releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated "
-"with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated "
-"with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. --activationkey=key1,"
-"key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial "
-"or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid "report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. 'kernel*','kernel-3.3.0-4.el6."
-"x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products', action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products', action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: http://porkchop.devel."
-"redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm "
-"(h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
 msgstr ""
 
 #. These are a bunch of strings that are marked for translation in optparse,
@@ -2856,4 +212,3012 @@ msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid "report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated "
+"with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated "
+"with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. --activationkey=key1,"
+"key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial "
+"or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. 'kernel*','kernel-3.3.0-4.el6."
+"x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: http://download.fedoraproject.org/pub/fedora/linux/"
+"releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: http://porkchop.devel."
+"redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm "
+"(h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append", help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products', action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/kn.po
+++ b/cli/po/kn.po
@@ -15,2774 +15,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: kn\n"
 "Plural-Forms: nplurals=2; plural=(n!=1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2801,6 +158,7 @@ msgid "Options"
 msgstr ""
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2853,10 +211,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/ko.po
+++ b/cli/po/ko.po
@@ -3,2803 +3,150 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # eukim <eukim@fedoraproject.org>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 # eukim <eukim@fedoraproject.org>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2012-05-24 11:07-0400\n"
-"Last-Translator: eukim <eukim@fedoraproject.org>\n"
+"PO-Revision-Date: 2012-08-24 02:58-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "인증서 파일 %s이 존재하지 않거나 읽을 수 없음 "
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "키 파일 %s이 존재하지 않거나 읽을 수 없음 "
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "커베로스를 통해 인증할 수 없음 "
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "버전 정보 표시 "
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Katello 사용자 계정 인증서 "
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "계정 사용자 이름 "
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "계정 암호 "
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello 서버 정보 "
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "katello 서버 호스트 이름 (디폴트: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "잘못된 명령; --help를 참조하십시오 "
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "주어진 명령이 없음; --help를 참조하십시오 "
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "조직 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "조직 [ %s ] 내에서 환경 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "조직 [ %s ]에서 제품 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr "조직 [ %s ], 제품 [ %s ], 환경 [ %s ]에서 리포지터리 [ %s ]를 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "조직 [ %s ]에서 공급자 [ %s ]를 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "환경 [ %s ]에서 템플릿 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "환경 [ %s ]에서 변경 집합 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "사용자 [ %s ]를 찾을 수 없음 "
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "사용자 역할 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "동기화 계획 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
-msgstr "사용자 역할 [ %s ]의 권한을 찾을 수 없음 "
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "필터 [ %s ]를 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "조직 [ %s ]에서 시스템 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "조직 [ %s ]의 환경 [ %s ]에서 불명확한 시스템 [ %s ]을 찾음 "
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "조직 [ %s ]의 환경 [ %s ]에서 시스템 [ %s ]을 찾을 수 없음 "
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr "조직 [ %s ]에서 불명확한 시스템 [ %s ]을 찾았습니다, 환경을 지정하십시오."
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "이름 "
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "모든 알려진 조직 목록 보기 "
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "조직 목록 "
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "조직 생성 "
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "조직 이름 예: foo.example.com (필수 사항) "
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "컨슈머 설명 예: foo의 조직 "
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "조직 [ %s ]이 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr "조직 [ %s ]을 생성할 수 없음 "
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "조직 정보 목록 보기 "
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "사용 가능한 서비스 수준 "
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "조직 정보 "
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "조직 삭제 "
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "조직 삭제 중, 잠시만 기다리십시오..."
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "조직 [ %s ]이 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "조직 [ %s ] 삭제 실패함: %s"
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "조직 업데이트 "
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "조직 [ %s ]이 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "ueber 인증서 생성 및 보기 "
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "인증서 다시 생성 "
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "조직의 ueber 인증서 "
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "서브스크립션 보기 "
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "조직의 서브스크립션 "
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "katello 서버에서 조직의 특정 동작 "
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "제품 이름 (필수 사항) "
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "환경 이름 예: production (디폴트: Library) "
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "동기화 계획 설정 "
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "동기화 계획 이름 (필수 사항) "
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "동기화 계획 설정 해제 "
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "알려진 제품 목록 보기 "
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "공급자 이름, Library에 있는 공급자의 제품 목록 보기 "
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "GPG 키  "
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr "공급자 %s에 대한 제품 목록 "
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "조직 %s, 환경 %s에 대한 제품 목록 "
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "제품 동기화 "
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "제품 [ %s ] 동기화 실패: %s"
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "제품 [ %s ] 동기화가 취소됨 "
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "제품 [ %s ]이 동기화됨 "
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "현재 실행되고 있는 동기화가 취소됨 "
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "제품의 동기화 상태 "
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "제품 상태 "
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-"제품 환경 승격 \n"
-"(제품에 임시적인 변경 집합을 생성하고 이를 승격함) "
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "제품 승격 중, 잠시만 기다리십시오..."
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "제품 [ %s ]이 환경 [ %s ]으로 승격됨 "
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "제품 [ %s ] 승격 실패: %s"
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "사용자 지정 공급자에 새 제품 생성 "
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "공급자 이름 (필수 사항) "
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "제품 설명 "
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"리포지터리 url 예: http://download.fedoraproject.org/pub/fedora/linux/releases/"
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "리포지터리 검색 생략 "
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr "yes라고 가정; 검색된 url에 대해 후보 리포지터리를 자동으로 생성 (옵션) "
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-"gpg 키 할당; 리포지터리에 gpgkey 또는 nogpgkey가 지정되어 있지 않을 경우 이 키는 모든 새로운 리포지터리에 사용됩니다 "
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "제품 [ %s ]이 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "검색된 리포지터리 Url @ [% s] "
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "제품의 속성 업데이트 "
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "제품 설명 변경 "
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "제품에 gpgkey 할당 "
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "제품의 리포지터리에 gpgkey 할당 "
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "제품 [ %s ]이 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "제품 및 컨텐츠 삭제 "
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "제품의 필터 목록 보기 "
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "제품 필터 "
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "제품에 필터 추가 "
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "제품에서 필터 제거 "
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr "필터 이름 (필수 사항) "
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "제품 [ %s ]에 필터 [ %s ]이(가) 추가됨 "
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "제품 [ %s ]에 필터 [ %s ]이(가) 제거됨 "
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "katello 서버에서 제품의 특정 동작 "
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr "조직에 있는 시스템 목록 보기 "
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr "환경 이름 예: development "
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr "서브스크립션에 따라 시스템을 필터링하기 위한 풀 ID "
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr "조직 [ %s ]의 시스템 목록 "
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr "조직 [ %s ]에 있는 환경 [ %s ]의 시스템 목록 "
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr "서비스 수준 "
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr "조직에 있는 시스템 표시 "
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr "시스템 이름 (필수 사항) "
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "환경 이름 "
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr "조직 [ %s ]의 시스템 정보 "
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr "조직 [ %s ]에 있는 환경의 시스템 정보 "
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr "시스템에 설치된 패키지 표시 및 처리 "
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr "시스템에 원격으로 설치된 패키지입니다, 패키지 이름은 콤마로 구분됩니다 "
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr "시스템에서 원격으로 제거된 패키지입니다, 패키지 이름은 콤마로 구분됩니다 "
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr "시스템에서 업데이트할 패키지입니다, 을 사용하여 모든 패키지를 업데이트합니다, 패키지 이름은 콤마로 구분됩니다 "
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr "시스템에 원격으로 설치된 패키지 그룹입니다, 그룹 이름은 콤마로 구분됩니다 "
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr "시스템에서 원격으로 제거된 패키지 그룹입니다, 그룹 이름은 콤마로 구분됩니다 "
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr "호출 당 최대 하나의 설치/제거/업데이트 작업을 지정할 수 있습니다 "
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr "조직 [ %s ]에 있는 시스템 [ %s ]의 패키지 정보 "
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr "조직 [ %s ]에 있는 환경 [ %s ]의 시스템에 대한 패키지 정보 "
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "원격 동작 [ %s ] 실행 중..."
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "원격 동작이 완료됨: "
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "원격 동작이 실패함: "
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr "원격 작업의 상태 표시 "
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr "시스템 이름 "
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr "원격 작업 "
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr "작업 ID "
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr "시스템 "
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr "동작 "
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr "시작됨 "
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "완료됨 "
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr "상태"
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr "결과 "
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr "원격 작업 상태 표시 "
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr "작업의 UUID "
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr "원격 작업 "
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr "시스템에서 사용 가능한 릴리즈 목록 "
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr "시스템 이름 (지정하지 않은 경우 환경에 있는 모든 릴리즈가 나열됨)"
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr "사용 가능한 릴리즈 "
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr "시스템의 하드웨어 정보 표시 "
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr "조직 [ %s ]에 있는 시스템 [ %s ]의 시스템 정보 "
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr "조직 [ %s ]에 있는 환경 [ %s ]의 시스템 [ %s ]에 대한 시스템 정보 "
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "시스템 등록 "
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "조직 이름 (필수 사항) "
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr "서비스 수준 계약서 "
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr "활성화 키, 여러 키는 콤마로 구분함. 예: --activationkey=key1,key2"
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr "시스템의 $releasever 값 "
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr "시스템 정보 "
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "옵션 %s은 %s로 지정할 수 없음 "
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr "시스템 [ %s ]을 성공적으로 등록함 "
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr "시스템 [ %s ]을 등록할 수 없음 "
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr "하이퍼바이저의 삭제 기록 제거 "
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr "하이퍼바이저 uuid (필수 사항) "
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr "uuid [ %s ]의 하이퍼바이저 삭제 기록이 성공적으로 제거되었습니다 "
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr "시스템 등록 해제 "
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr "시스템 [ %s ]을 성공적으로 등록 해제함 "
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr "시스템을 인증서에 등록 "
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr "등록 해제를 위한 인증서 일련 변호 (필수 사항) "
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr "수량 (디폴트: 1) "
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr "시스템 [ %s ]을 성공적으로 등록함 "
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr "시스템의 서브스크립션 목록 보기 "
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr "사용 가능한 서브스크립션 보기 "
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr "조직 [ %s ]에서 시스템 [ %s ]에 대한 서브스크립션을 찾을 수 없음 "
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr "시스템 [ %s ]의 현재 서브스크립션 "
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr "시리얼 ID "
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr "제공되는 제품 "
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr "조직 [ %s ]에서 시스템 [ %s ]에 대한 풀을 찾을 수 없음 "
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr "시스템 [ %s ]의 사용 가능한 서브스크립션 "
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr "인증서에서 시스템을 등록 해제 "
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr "등록 해제할 인타이틀먼트 ID (인타이틀먼트 또는 시리얼 중 하나 또는 두 가지 모두 필요할 수 있음)"
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr "등록 해제할 인증서의 시리얼 ID (인타이틀먼트 또는 시리얼 중 하나 또는 두 가지 모두 필요할 수 있음) "
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr "현재 등록된 모든 인증서에서 등록 해제 (인타이틀먼트 또는 시리얼 중 하나 또는 두 가지 모두 필요할 수 있음)"
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr "시스템 [ %s ]이 성공적으로 등록 해제됨 "
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr "시스템 업데이트 "
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr "시스템의 새 이름 "
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr "시스템 설명 "
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr "시스템 위치 "
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr "시스템의 $releasever 값 "
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr "시스템 [ %s ]이 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr "시스템 [ %s ]을 업데이트할 수 없음 "
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr "시스템 보고 "
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr "보고 형식 (사용 가능한 값: 'html', 'text' (디폴트), 'csv', 'pdf')"
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr "katello 서버에서 시스템의 특정 동작 "
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "모든 필터 목록 보기 "
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "필터 목록 "
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "필터 생성 "
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "설명 "
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "콤마로 구분된 패키지 이름/nvre 목록 "
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "필터 [ %s ]이(가) 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "필터 [ %s ]을(를) 생성할 수 없음 "
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "필터 삭제 "
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "필터 [ %s ]이(가) 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "필터 정보 "
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "필터 정보 "
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "필터에 패키지 추가 "
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "패키지 ID (필수 사항) "
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "필터 [ %s ]에 패키지 [ %s ]를 성공적으로 추가함 "
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "필터에서 패키지 제거 "
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "필터 [ %s ]에서 패키지 [ %s ]를 성공적으로 제거함"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "katello 서버에서 필터의 특정 동작 "
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "리포지터리에 있는 배포 버전 목록 보기 "
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "리포지터리 id"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "리포지터리 이름 "
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "조직 이름 예: foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "제품 이름 예: fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "리포지터리 %s에 대한 배포 목록 "
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "배포 버전에 관한 정보 목록 보기 "
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "리포지터리 id (필수 사항) "
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "배포 ID 예: ks-rh-noarch (필수 사항) "
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "배포 정보 "
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "katello 서버에서 리포지터리의 특정 동작 "
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr " katello 서버의 상태 획득 "
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Katello 상태 "
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "서버 상태 확인 "
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr "패키지에 관한 정보 목록 보기 "
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr "패키지 ID, 문자열 값 (필수 사항) "
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr "패키지 정보 "
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr "리포지터리에 있는 패키지 목록 보기 "
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr "리포지터리 %s에 대한 패키지 목록 "
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr "리포지터리에 있는 패키지 검색 "
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr "패키지 검색을 위한 쿼리 문자열, 예: 'kernel*','kernel-3.3.0-4.el6.x86_64'"
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr "리포지터리 %s 및 쿼리 %s 의 패키지 목록 "
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr "katello 서버에서 패키지의 특정 동작 "
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "사용 가능한 설명이 없음 "
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "동작이 주어지지 않음: --help 참조 "
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "잘못된 동작: --help 참조 "
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "grep 출력 결과 "
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "상세하고 보다 구조화된 출력 결과 "
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr "grep 출력 결과에서 컬럼 구분 기호, -g 옵션을 선택한 경우에만 작동함 "
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "옵션 %s이 필요함; --help 참조 "
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "옵션 %s이 %s와 충돌함: --help 참조 "
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "%s 중 하나가 필요함; --help 참조 "
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "최소 %s 중 하나가 필요함; --help 참조 "
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "오류: 작업 실패함 "
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr "오류: /etc/katello/client.conf에서 설정한 서버 호스트 이름이 다음과 일치하지 않음 "
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "연결하려는 katello 서버에서 반환된 호스트 이름 "
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "[%s]이 설정되어 있으나 서버에서 [%s]을 갖고 있음. "
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "/etc/katello/client.conf 파일에 있는 호스트를 올바르게 수정하십시오. "
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "잘못된 인증서 또는 인증할 수 없음 "
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "옵션 %s: 잘못된 부울 값: %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "모든 알려진 사용자 목록 보기 "
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "사용자 목록 "
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "사용자 생성 "
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "사용자 이름 (필수 사항) "
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "초기 암호 (필수 사항) "
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "이메일 (필수 사항) "
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "비활성화된 계정 (디폴트는 'false'임) "
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "사용자의 디폴트 조직 이름 "
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "사용자의 디폴트 환경 이름 "
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "사용자 [ %s ]가 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "사용자 [ %s ]를 생성할 수 없음 "
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "사용자 정보 목로 보기 "
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "사용자 정보 "
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "사용자 삭제 "
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "사용자 [ %s ]가 성공적으로 삭제되었습니다 "
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "사용자 업데이트 "
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "초기 암호 "
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "이메일 "
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "비활성화된 계정 "
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "사용자의 디폴트 환경이 없습니다 "
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "사용자 [ %s ]가 성공적으로 업데이트되었습니다 "
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "사용자 역할 목록 보기 "
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "사용자 역할 목록 "
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "역할을 LDAP 그룹과 동기화함 "
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "사용자에게 역할 할당 "
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "사용자에게 역할 할당 해제 "
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "사용자 역할 (필수 사항) "
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "사용자 [ %s ]을(를) 찾을 수 없음 "
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "사용자 보고 "
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "katello 서버에서 실행되는 사용자의 특정 동작 "
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "GPG 키 내용을 입력 (CTRL+D로 입력 종료): "
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "모든 GPG 키 목록 보기 "
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "조직 이름 (필수 사항) "
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "조직 [ %s ]에서 gpg 키를 찾을 수 없음 "
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "Gpg 키 목록 "
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "gpg 키에 대한 정보 표시 "
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "활성키 이름 (필수 사항) "
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "gpg 키 [ %s ]를 찾을 수 없음 "
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "리포지터리 "
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "Gpg 키 정보 "
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "gpg 키 생성 "
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr "공개 GPG 키를 갖는 파일을 지정하지 않으면 표준 입력이 사용됩니다 "
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "gpg 키 [ %s ]가 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "gpg 키 [ %s ]를 생성할 수 없음 "
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "활성키 업데이트 "
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "새 템플릿 이름 "
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "공개 GPG 키를 갖는 파일 "
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "키의 새로운 내용을 입력하라는 프롬프트 "
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "gpg 키 [ %s ]가 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "gpg 키 [ %s ]를 업데이트할 수 없음 "
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "gpg 키 삭제 "
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "gpg 키 [ %s ]가 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "katello 서버에서 GPG 키의 특정 동작 "
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "모든 활성키 목록 보기 "
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "환경 이름 예: dev (디폴트: Library)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "조직 [ %s ]에서 키를 찾을 수 없음 "
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "조직 [ %s ] 환경 [ %s ]에서 키를 찾을 수 없음 "
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "활성키 목록"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "활성키에 대한 정보 표시"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "활성키 [ %s ]를 찾을 수 없음 "
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "활성키 정보 "
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "활성키 생성 "
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "환경 이름 예: dev (필수 사항) "
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "활성키 설명"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "템플릿 이름 예: servers "
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "템플릿 [ %s ]을 찾을 수 없음 "
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "활성키 [ %s ]가 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "활성키 [ %s ]를 생성할 수 없음 "
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "새 환경 이름 예: dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "새 설명 "
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "새 템플릿 이름 예: servers"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "활성키에 풀 추가 "
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "활성키에서 풀 제거 "
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "활성키 [ %s ]가 성공적으로 업데이트됨"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "활성키 삭제 "
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "활성키 [ %s ]가 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "katello 서버에서 활성키의 특정 동작 "
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "사용 가능한 패키지 그룹 목록 보기 "
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "리포지터리 id, 문자열 값 (필수 사항) "
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "리포지터리 [%s]에서 검색된 패키지 그룹이 없음 "
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "패키지 그룹 정보 "
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "패키지 그룹에 대한 정보 검색 "
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "패키지 그룹 ID, 문자열 값 (필수 사항) "
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "패키지 그룹 [%s]을 리포지터리 [%s]에서 찾을 수 없음  "
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "사용 가능한 패키지 그룹 카테고리 목록 보기 "
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "리포지터리 [%s]에 패키지 그룹 카테고리를 찾을 수 없음 "
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "패키지 그룹 카테고리 정보 "
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "패키지 그룹 카테고리 ID, 문자열 값 (필수 사항) "
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "패키지 그룹 카테고리 [%s]를 리포지터리 [%s]에서 찾을 수 없음 "
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "패키지 그룹 카테고리 정보 "
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "katello 서버에서 패키지 그룹의 특정 동작 "
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "환경의 새 변경 집합 목록 보기 "
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "환경 이름 (필수 사항) "
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "변경 집합 목록 "
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "변경 집합에 관한 상세 정보 "
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "변경 집합 이름 (필수 사항) "
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "의존 패키지를 표시함 "
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "변경 집합 정보 "
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "환경의 새 변경 집합 생성 "
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "변경 집합 설명 "
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "환경 [ %s ]에 대해 변경 집합 [ %s ]이 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "환경 [ %s ]에 대해 변경 집합 [ %s ]을 생성할 수 없음 "
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "변경 집합 컨텐츠 업데이트 "
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s 앞에 %s를 지정해야 함 "
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "새 변경 집합 이름 "
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "변경 집합에 추가할 제품 "
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "변경 집합에서 삭제할 제품 "
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "변경 집합에 추가된 템플릿 이름 "
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "변경 집합에서 삭제된 템플릿 이름 "
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr "패키지/에라타/리포지터리를 선택하는 제품을 결정 "
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "변경 집합에 추가 "
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "변경 집합에서 삭제 "
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "변경 집합 [ %s ]이 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "변경 집합 삭제 "
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "변경 집합을 다음 환경에 승격함 "
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "변경 집합을 승격하는 중, 잠시만 기다리십시오..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "변경 집합 [ %s ]이 승격됨 "
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "변경 집합 [ %s ] 승격 실패: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "katello 서버에서 변경 집합의 특정 동작  "
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr "모든 알려진 공급자 목록 보기 "
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr "공급자 목록 "
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr "공급자에 대한 정보 목록 보기 "
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr "공급자 정보 "
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr "공급자 생성 "
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr "공급자 업데이트 "
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr "공급자 설명 "
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr "공급자 이름 "
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "옵션 --url은 http:// 또는 https://로 시작해야 합니다. "
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "옵션 -url이 유효한 형식으로 되어 있지 않습니다 "
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr "공급자 [ %s ]가 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr "공급자 [ %s ]를 생성할 수 없음 "
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr "공급자 [ %s ]가 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr "공급자 삭제 "
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr "공급자 동기화 "
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr "공급자 [ %s ] 동기화 실패: %s"
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr "공급자 [ %s ] 동기화가 취소됨 "
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr "공급자 [ %s ]가 동기화됨 "
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr "공급자의 동기화 상태 "
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr "%d%% 완료 (%d 개의 패키지 중 %d 개가 다운로드됨)"
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr "공급자 상태 "
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr "매니페스트 파일 가져오기 "
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr "매니페스트 파일로의 경로 (필수 사항) "
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr "매니페스트를 강제로 다시 가져오기 "
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr "파일 %s이 존재하지 않음 "
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr "매니페스트 파일을 가져오는 중, 잠시만 기다리십시오..."
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr "공급자의 제품 리포지터리를 새로 고침 "
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr "공급자가 성공적으로 새로 고침됨 [ %s ]"
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr "katello 서버에서 공급자의 특정 동작 "
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "알려진 환경 목록 보기 "
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "조직 "
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "이전 환경 "
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "환경 목록 "
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "특정 환경 목록 보기 "
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "환경 이름 예: foo.example.com (필수 사항) "
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "환경 정보 "
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "환경 생성 "
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "환경 설명 예: foo 환경 "
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "이전 환경 이름 (필수 사항) "
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "환경 [ %s ]이 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "환경 [ %s ]을 생성할 수 없음 "
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "환경 업데이트 "
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "이전 환경 이름 "
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "환경 [ %s ]이 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "환경 삭제 "
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "환경 [ %s ]이 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "katello 서버 환경의 특정 동작  "
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "클라이언트 config에 옵션을 저장 "
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr "저장될 옵션 이름 (예: 조직, 환경, 공급자 등) (필수 사항) "
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "특정 옵션에 저장될 값 (필수 사항) "
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "성공 "
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "옵션 [ %s ]에 대해 기억 기능을 성공적으로 실행하지 못함 "
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "클라이언트 config에서 옵션을 삭제 "
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "삭제될 옵션 이름 (필수 사항) "
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "옵션 [ %s ]에 대해 잊기 기능을 성공적으로 실행함 "
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "옵션 [ %s ]에 대해 잊기 기능을 성공적으로 실행하지 못함 "
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "클라이언트 config에 저장된 옵션 목록 보기 "
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "저장된 옵션 "
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "katello 서버에서 클라이언트의 특정 동작 "
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "모든 템플릿 목록 보기 "
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "조직 이름 (환경을 지정할 경우 필요) "
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "환경 [ %s ]에서 템플릿을 찾을 수 없음 "
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "템플릿 목록 "
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "템플릿에 관한 정보 목록 보기 "
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "템플릿 이름 (필수 사항) "
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "템플릿 정보 "
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "템플릿 파일을 생성하고 데이터를 가져옴 "
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "템플릿 파일로의 경로 (필수 사항) "
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "템플릿을 가져오는 중, 잠시만 기다리십시오..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "템플릿을 파일로 내보내기 "
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "환경 이름 예: dev"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "내보내기 형식, 가능한 값: %s, 디폴트: json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "파일 %s을(를) 생성할 수 없음 "
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "템플릿을 내보내는 중, 잠시만 기다리십시오..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "템플릿을 성공적으로 파일 %s로 내보내기함  "
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "빈 템플릿 파일 생성 "
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "부모 템플릿 이름 "
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "템플릿 설명 "
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "템플릿 [ %s ]을 성공적으로 생성함 "
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "템플릿 [ %s ]을 생성할 수 없음 "
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "템플릿 이름 및 설명 업데이트 "
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "각각의 %s 앞에 %s을 지정해야 함 "
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "제품 이름 또는 nvre (epoch:name-rel.ease-ver.sio.n)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "매개 변수 이름, %s이 뒤따라야 함 "
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "매개 변수 값 "
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "매개 변수 이름 "
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "패키지 그룹 이름 "
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "패키지 그룹 카테고리 이름 "
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "배포 ID"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "리포지터리 선택 대상 제품을 지정 "
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "템플릿에 추가될 리포지터리 "
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "템플릿에서 제거될 리포지터리 "
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "매개 변수 '%s'에 대해 누락된 값 "
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "템플릿 업데이트 중, 잠시만 기다리십시오..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "템플릿 [ %s ]을 성공적으로 업데이트함 "
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "템플릿 삭제 "
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "환경 이름 예: foo.example.com (디폴트: Library)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "katello 서버에서 템플릿의 특정 동작 "
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "쉘로 cli를 실행 "
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "알려진 sync_plans 목록 보기 "
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "동기화 계획 목록 "
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "동기화 계획에 관한 정보 출력 "
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "동기화 계획 이름 (필수 사항) "
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "동기화 계획 정보 "
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "동기화 계획 생성 "
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "계획 설명 "
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr "동기화 반복 간격 (선택: [%s], 디폴트: 없음)"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "처음 동기화 날짜 (필수 사항, 형식: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr "처음 동기화 시간 (형식: HH:MM:SS, 디폴트: 00:00:00) "
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "동기화 계획 [ %s ]이 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "동기화 계획 [ %s ]을 생성할 수 없음 "
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "동기화 계획 업데이트 "
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "새 동기화 계획 이름 "
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "처음 동기화 날짜 (형식: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "처음 동기화 시간 (형식: HH:MM:SS)"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "--date와 --time 모두를 지정해야 함 "
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "동기화 계획 [ %s ]이 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "동기화 계획 삭제 "
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "동기화 계획 [ %s ]이 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr "katello 서버에 있는 동기화 계획의 특정 동작 "
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "katello 서버의 버전을 가져옴 "
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "서버 버전 확인 "
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr "사용자 역할에 대한 권한 생성 "
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "역할 이름 (필수 사항) "
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr "권한 이름 (필수 사항) "
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr "권한 설명 "
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr "조직 이름 "
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr "권한 범위 (필수 사항) "
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr "권한 동사 "
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr "권한 태그 "
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr "잘못된 범위 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr "[ %s ] 범위에서 태그 [ %s ]을 찾을 수 없음 "
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr "사용자 역할 [ %s ]의 권한 [ %s ]이 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr "권한 [ %s ]을 생성할 수 없음 "
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr "권한 삭제 "
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr "역할 [ %s ]의 권한 [ %s ]이 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr "사용자 역할의 권한 목록 보기 "
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr "권한 목록 "
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr "권한에 설정할 수 있는 사용 가능한 범위, 동사, 태그 목록 보기 "
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-"조직 이름 예: foo.example.com, \n"
-"조직의 특정 동사 목록 보기 "
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr "범위에 따라 나열된 결과를 필터링하기 "
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr "권한 범위 %s의 사용 가능한 동사 및 태그 "
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr "사용 가능한 동사 "
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr "없음 "
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr "katello 서버에서 권한의 특정 동작 "
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr "리포지터리의 모든 에라타 목록 보기 "
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr "유형에 따라 에라타 필터링하기 예: 기능 강화 "
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr "중요도에 따라 에라타 필터링하기 "
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr "에라타 목록 "
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr "시스템의 에라타 목록 보기 "
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr "조직 %s에서 시스템 %s에 대한 에라타 "
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr "에라타에 관한 정보 "
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr "에라타 ID, 문자열 값 (필수 사항) "
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr "에라타 정보 "
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr "katello 서버에서 에라타의 특정 동작 "
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "대기 중 "
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "실행 중 "
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "오류 "
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "취소됨 "
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr "취소됨 "
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "시간 초과됨 "
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr "동기화되지 않음 "
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr "지정된 URL에 리포지터리 생성 "
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr "할당할 리포지터리 이름 (필수 사항) "
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr "리포지터리로의 url 경로 (필수 사항) "
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr "리포지터리에 할당된 GPG 키; 디폴트로 제품의 GPG 키가 사용됩니다. "
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr "리포지터리에 GPG 키를 할당하지 않습니다. "
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr "리포지터리 [ %s ]가 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr "URL에 들어 있는 검색 리포지터리 "
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr "검색된 모든 리포지터리에 추가할 리포지터리 이름 접두사 (필수 사항) "
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-"리포지터리 검색을 실행하기 위한 root url 예: http://porkchop.devel.redhat.com/ (필수 사항) "
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr "리포지터리 url을 검색 중입니다. 이는 시간이 다소 소요될 수 있습니다. "
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "오류: %s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr "후보 리포지터리가 생성되어야 하는 url을 선택합니다; `y`를 사용하여 확인합니다 (도움말의 경우 h 사용): "
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr "사용자 요청에 따라 작업을 중지했습니다. "
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr "리포지터리에 대한 상태 정보 "
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "리포지터리 상태 "
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "리포지터리에 대한 정보 "
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "진행 상태 "
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr "리포지터리 %s에 대한 정보 "
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr "리포지터리 속성 업데이트 "
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr "리포지터리 [ %s ]가 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr "리포지터리 동기화 "
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr "리포지터리 [ %s ]가 동기화됨 "
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr "리포지터리 [ %s ] 동기화가 취소됨 "
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr "리포지터리 [ %s ] 동기화 실패: %s"
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr "현재 실행되고 있는 리포지터리 동기화가 취소됨 "
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr "리포지터리 활성화 "
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr "리포지터리 비활성화 "
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr "조직의 리포지터리 목록 보기 "
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr "조직 이름 예: ACME_Corporation (필수 사항) "
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr "비활성화된 리포지터리 목록 보기 "
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr "조직 %s 환경 %s 제품 %s에 대한 리포지터리 목록 "
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr "조직 %s에 있는 제품 %s에 대한 리포지터리 목록 "
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr "조직 %s 환경 %s에 대한 리포지터리 목록 "
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr "리포지터리 삭제 "
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr "리포지터리 필터 목록 보기 "
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr "리포지터리의 제품에 할당된 필터 인쇄 "
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr "리포지터리 필터 "
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr "리포지터리에 필터 추가 "
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr "리포지터리에서 필터 제거 "
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr "리포지터리 [ %s ]에 필터 [ %s ]이(가) 추가됨 "
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr "리포지터리 [ %s ]에 필터 [ %s ]이(가) 제거됨 "
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "모든 알려진 사용자 역할 목록 보기 "
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "사용자 역할 생성 "
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "역할 설명 "
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "사용자 역할 [ %s ]이 성공적으로 생성됨 "
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "사용자 역할 [ %s ]을 생성할 수 없음 "
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "사용자 역할에 관한 정보 목록 보기 "
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "사용자 역할 이름 (필수 사항) "
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "각 역할의 권한 정보를 출력 "
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-"%s¶\n"
-"for: %s¶\n"
-"verbs: %s¶\n"
-"on: %s"
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "사용자 역할 정보 "
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "사용자 역할 삭제 "
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "사용자 역할 [ %s ]이(가) 성공적으로 삭제됨 "
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "역할 업데이트 "
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "새 사용자 역할 이름 "
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr "사용자 역할을 업데이트하기 위해 최소 하나의 매개 변수가 필요함 "
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "사용자 역할 [ %s ]이(가) 성공적으로 업데이트됨 "
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "역할에 LDAP 그룹 할당 "
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "새 LDAP 그룹 이름 (필수 사항) "
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr "사용자 역할 [ %s ]에 성공적으로 LDAP 그룹 [ %s ]을 추가함 "
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "역할에 할당된 LDAP 그룹 제거 "
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "제거된 LDAP 그룹 이름 (필수 사항) "
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr "사용자 역할 [ %s ]에서 성공적으로 삭제된 LDAP 그룹 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "katello 서버에서 사용자 역할의 특정 동작 "
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "시간 형식이 잘못되어 있습니다. HH:MM:SS[+HH:MM] 형식으로 하십시오. "
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "날짜 형식이 잘못되어 있습니다. YYYY-MM-DD 형식으로 하십시오. "
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
-msgstr "사용법: %s¶"
+msgstr "사용법: %s\n"
 
 #: ../src/katello/client/i18n_optparse.py:49
 msgid "Usage"
@@ -2814,6 +161,7 @@ msgid "Options"
 msgstr "옵션 "
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2866,6 +214,7 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr "옵션 %s: 잘못된 선택: %r (%s에서 선택) "
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr "도움말 메세지를 보여준 후 종료 "
@@ -2873,3 +222,3024 @@ msgstr "도움말 메세지를 보여준 후 종료 "
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
 msgstr "프로그램의 버전 번호를 보여준 후 종료 "
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "모든 알려진 사용자 역할 목록 보기 "
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "사용자 역할 목록 "
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "사용자 역할 생성 "
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "역할 이름 (필수 사항) "
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "역할 설명 "
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr "사용자 역할 [ %s ]이 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr "사용자 역할 [ %s ]을 생성할 수 없음 "
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "사용자 역할에 관한 정보 목록 보기 "
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "사용자 역할 이름 (필수 사항) "
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "각 역할의 권한 정보를 출력 "
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+"%s¶\n"
+"for: %s¶\n"
+"verbs: %s¶\n"
+"on: %s"
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "사용자 역할 정보 "
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "사용자 역할 삭제 "
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr "사용자 역할 [ %s ]이(가) 성공적으로 삭제됨 "
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "역할 업데이트 "
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "새 사용자 역할 이름 "
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr "사용자 역할 [ %s ]이(가) 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "역할에 LDAP 그룹 할당 "
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "새 LDAP 그룹 이름 (필수 사항) "
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr "사용자 역할 [ %s ]에 성공적으로 LDAP 그룹 [ %s ]을 추가함 "
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "역할에 할당된 LDAP 그룹 제거 "
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "제거된 LDAP 그룹 이름 (필수 사항) "
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr "사용자 역할 [ %s ]에서 성공적으로 삭제된 LDAP 그룹 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "katello 서버에서 사용자 역할의 특정 동작 "
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "클라이언트 config에 옵션을 저장 "
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr "저장될 옵션 이름 (예: 조직, 환경, 공급자 등) (필수 사항) "
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "특정 옵션에 저장될 값 (필수 사항) "
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "성공 "
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "옵션 [ %s ]에 대해 기억 기능을 성공적으로 실행하지 못함 "
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "클라이언트 config에서 옵션을 삭제 "
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "삭제될 옵션 이름 (필수 사항) "
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "옵션 [ %s ]에 대해 잊기 기능을 성공적으로 실행함 "
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "옵션 [ %s ]에 대해 잊기 기능을 성공적으로 실행하지 못함 "
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "클라이언트 config에 저장된 옵션 목록 보기 "
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "저장된 옵션 "
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "katello 서버에서 클라이언트의 특정 동작 "
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "모든 활성키 목록 보기 "
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "조직 이름 (필수 사항) "
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "환경 이름 예: dev (디폴트: Library)"
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr "조직 [ %s ]에서 키를 찾을 수 없음 "
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "조직 [ %s ] 환경 [ %s ]에서 키를 찾을 수 없음 "
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "활성키 목록"
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "활성키에 대한 정보 표시"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "활성키 이름 (필수 사항) "
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr "활성키 [ %s ]를 찾을 수 없음 "
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "활성키 정보 "
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "활성키 생성 "
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "환경 이름 예: dev (필수 사항) "
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "활성키 설명"
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "템플릿 이름 예: servers "
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "템플릿 [ %s ]을 찾을 수 없음 "
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "활성키 [ %s ]가 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "활성키 [ %s ]를 생성할 수 없음 "
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "활성키 업데이트 "
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "새 환경 이름 예: dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "새 템플릿 이름 "
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "새 설명 "
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "새 템플릿 이름 예: servers"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "활성키에 풀 추가 "
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "활성키에서 풀 제거 "
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "활성키 [ %s ]가 성공적으로 업데이트됨"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "활성키 삭제 "
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "활성키 [ %s ]가 성공적으로 삭제됨 "
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "katello 서버에서 활성키의 특정 동작 "
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "시간 형식이 잘못되어 있습니다. HH:MM:SS[+HH:MM] 형식으로 하십시오. "
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "날짜 형식이 잘못되어 있습니다. YYYY-MM-DD 형식으로 하십시오. "
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "모든 필터 목록 보기 "
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "조직 이름 (필수 사항) "
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "필터 목록 "
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "필터 생성 "
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr "필터 이름 (필수 사항) "
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "설명 "
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "콤마로 구분된 패키지 이름/nvre 목록 "
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "필터 [ %s ]이(가) 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "필터 [ %s ]을(를) 생성할 수 없음 "
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "필터 삭제 "
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "필터 [ %s ]이(가) 성공적으로 삭제됨 "
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "필터 정보 "
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "필터 정보 "
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "필터에 패키지 추가 "
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "패키지 ID (필수 사항) "
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "필터 [ %s ]에 패키지 [ %s ]를 성공적으로 추가함 "
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "필터에서 패키지 제거 "
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "필터 [ %s ]에서 패키지 [ %s ]를 성공적으로 제거함"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "katello 서버에서 필터의 특정 동작 "
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "리포지터리에 있는 배포 버전 목록 보기 "
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "리포지터리 id"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "리포지터리 이름 "
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "조직 이름 예: foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "환경 이름 예: production (디폴트: Library) "
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "제품 이름 예: fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "리포지터리 %s에 대한 배포 목록 "
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "배포 버전에 관한 정보 목록 보기 "
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "리포지터리 id (필수 사항) "
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "배포 ID 예: ks-rh-noarch (필수 사항) "
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "배포 정보 "
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "katello 서버에서 리포지터리의 특정 동작 "
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "GPG 키 내용을 입력 (CTRL+D로 입력 종료): "
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "모든 GPG 키 목록 보기 "
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "리포지터리 "
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr "공개 GPG 키를 갖는 파일을 지정하지 않으면 표준 입력이 사용됩니다 "
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "공개 GPG 키를 갖는 파일 "
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "키의 새로운 내용을 입력하라는 프롬프트 "
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "katello 서버에서 GPG 키의 특정 동작 "
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "조직 이름 예: foo.example.com (필수 사항) "
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "원격 동작 [ %s ] 실행 중..."
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "원격 동작이 완료됨: "
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "원격 동작이 실패함: "
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "모든 알려진 사용자 목록 보기 "
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "사용자 목록 "
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "사용자 생성 "
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "사용자 이름 (필수 사항) "
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "초기 암호 (필수 사항) "
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "이메일 (필수 사항) "
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "비활성화된 계정 (디폴트는 'false'임) "
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "사용자의 디폴트 조직 이름 "
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "사용자의 디폴트 환경 이름 "
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "사용자 [ %s ]가 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "사용자 [ %s ]를 생성할 수 없음 "
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "사용자 정보 목로 보기 "
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "사용자 정보 "
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "사용자 삭제 "
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "사용자 [ %s ]가 성공적으로 삭제되었습니다 "
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "사용자 업데이트 "
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "초기 암호 "
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "이메일 "
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "비활성화된 계정 "
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "사용자의 디폴트 환경이 없습니다 "
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "사용자 [ %s ]가 성공적으로 업데이트되었습니다 "
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "사용자 역할 목록 보기 "
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "역할을 LDAP 그룹과 동기화함 "
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "사용자에게 역할 할당 "
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "사용자에게 역할 할당 해제 "
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "사용자 역할 (필수 사항) "
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "사용자 [ %s ]을(를) 찾을 수 없음 "
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "사용자 보고 "
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr "보고 형식 (사용 가능한 값: 'html', 'text' (디폴트), 'csv', 'pdf')"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "katello 서버에서 실행되는 사용자의 특정 동작 "
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "환경의 새 변경 집합 목록 보기 "
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "환경 이름 (필수 사항) "
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "변경 집합 목록 "
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "변경 집합에 관한 상세 정보 "
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "변경 집합 이름 (필수 사항) "
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "의존 패키지를 표시함 "
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "변경 집합 정보 "
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "환경의 새 변경 집합 생성 "
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "변경 집합 설명 "
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "환경 [ %s ]에 대해 변경 집합 [ %s ]이 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "환경 [ %s ]에 대해 변경 집합 [ %s ]을 생성할 수 없음 "
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "변경 집합 컨텐츠 업데이트 "
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s 앞에 %s를 지정해야 함 "
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "새 변경 집합 이름 "
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "변경 집합에 추가할 제품 "
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "변경 집합에서 삭제할 제품 "
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "변경 집합에 추가된 템플릿 이름 "
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "변경 집합에서 삭제된 템플릿 이름 "
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr "패키지/에라타/리포지터리를 선택하는 제품을 결정 "
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "변경 집합에 추가 "
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "변경 집합에서 삭제 "
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "변경 집합 [ %s ]이 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "변경 집합 삭제 "
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "변경 집합 [ %s ] 승격 실패: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "katello 서버에서 변경 집합의 특정 동작  "
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr "조직에 있는 시스템 목록 보기 "
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr "환경 이름 예: development "
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr "서브스크립션에 따라 시스템을 필터링하기 위한 풀 ID "
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr "조직 [ %s ]의 시스템 목록 "
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr "조직 [ %s ]에 있는 환경 [ %s ]의 시스템 목록 "
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr "서비스 수준 "
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr "조직에 있는 시스템 표시 "
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr "시스템 이름 (필수 사항) "
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "환경 이름 "
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr "조직 [ %s ]의 시스템 정보 "
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr "시스템에 설치된 패키지 표시 및 처리 "
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr "시스템에 원격으로 설치된 패키지입니다, 패키지 이름은 콤마로 구분됩니다 "
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr "시스템에서 원격으로 제거된 패키지입니다, 패키지 이름은 콤마로 구분됩니다 "
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr "시스템에서 업데이트할 패키지입니다, 을 사용하여 모든 패키지를 업데이트합니다, 패키지 이름은 콤마로 구분됩니다 "
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr "시스템에 원격으로 설치된 패키지 그룹입니다, 그룹 이름은 콤마로 구분됩니다 "
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr "시스템에서 원격으로 제거된 패키지 그룹입니다, 그룹 이름은 콤마로 구분됩니다 "
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr "호출 당 최대 하나의 설치/제거/업데이트 작업을 지정할 수 있습니다 "
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr "조직 [ %s ]에 있는 시스템 [ %s ]의 패키지 정보 "
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr "원격 작업의 상태 표시 "
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr "시스템 이름 "
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr "원격 작업 "
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr "작업 ID "
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr "시스템 "
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr "동작 "
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr "시작됨 "
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "완료됨 "
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr "상태"
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr "결과 "
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr "원격 작업 상태 표시 "
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr "작업의 UUID "
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr "원격 작업 "
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr "시스템에서 사용 가능한 릴리즈 목록 "
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr "시스템 이름 (지정하지 않은 경우 환경에 있는 모든 릴리즈가 나열됨)"
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr "사용 가능한 릴리즈 "
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr "시스템의 하드웨어 정보 표시 "
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr "조직 [ %s ]에 있는 시스템 [ %s ]의 시스템 정보 "
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr "조직 [ %s ]에 있는 환경 [ %s ]의 시스템 [ %s ]에 대한 시스템 정보 "
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "시스템 등록 "
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr "서비스 수준 계약서 "
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr "활성화 키, 여러 키는 콤마로 구분함. 예: --activationkey=key1,key2"
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr "시스템의 $releasever 값 "
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr "시스템 정보 "
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr "시스템 [ %s ]을 성공적으로 등록함 "
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr "시스템 [ %s ]을 등록할 수 없음 "
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr "하이퍼바이저의 삭제 기록 제거 "
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr "하이퍼바이저 uuid (필수 사항) "
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr "uuid [ %s ]의 하이퍼바이저 삭제 기록이 성공적으로 제거되었습니다 "
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr "시스템 등록 해제 "
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr "시스템 [ %s ]을 성공적으로 등록 해제함 "
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr "시스템을 인증서에 등록 "
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr "등록 해제를 위한 인증서 일련 변호 (필수 사항) "
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr "수량 (디폴트: 1) "
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr "시스템 [ %s ]을 성공적으로 등록함 "
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr "시스템의 서브스크립션 목록 보기 "
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr "사용 가능한 서브스크립션 보기 "
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr "조직 [ %s ]에서 시스템 [ %s ]에 대한 서브스크립션을 찾을 수 없음 "
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr "시스템 [ %s ]의 현재 서브스크립션 "
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr "시리얼 ID "
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr "제공되는 제품 "
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr "조직 [ %s ]에서 시스템 [ %s ]에 대한 풀을 찾을 수 없음 "
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr "시스템 [ %s ]의 사용 가능한 서브스크립션 "
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr "인증서에서 시스템을 등록 해제 "
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr "등록 해제할 인타이틀먼트 ID (인타이틀먼트 또는 시리얼 중 하나 또는 두 가지 모두 필요할 수 있음)"
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr "등록 해제할 인증서의 시리얼 ID (인타이틀먼트 또는 시리얼 중 하나 또는 두 가지 모두 필요할 수 있음) "
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr "현재 등록된 모든 인증서에서 등록 해제 (인타이틀먼트 또는 시리얼 중 하나 또는 두 가지 모두 필요할 수 있음)"
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr "시스템 [ %s ]이 성공적으로 등록 해제됨 "
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr "시스템 업데이트 "
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr "시스템의 새 이름 "
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr "시스템 설명 "
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr "시스템 위치 "
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr "시스템의 $releasever 값 "
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr "시스템 [ %s ]이 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr "시스템 [ %s ]을 업데이트할 수 없음 "
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr "시스템 보고 "
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr "katello 서버에서 시스템의 특정 동작 "
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr "패키지에 관한 정보 목록 보기 "
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr "패키지 ID, 문자열 값 (필수 사항) "
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr "패키지 정보 "
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr "리포지터리에 있는 패키지 목록 보기 "
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr "리포지터리 %s에 대한 패키지 목록 "
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr "리포지터리에 있는 패키지 검색 "
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr "패키지 검색을 위한 쿼리 문자열, 예: 'kernel*','kernel-3.3.0-4.el6.x86_64'"
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr "리포지터리 %s 및 쿼리 %s 의 패키지 목록 "
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr "katello 서버에서 패키지의 특정 동작 "
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "쉘로 cli를 실행 "
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "공급자 이름 (필수 사항) "
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr "모든 알려진 공급자 목록 보기 "
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr "공급자 목록 "
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr "공급자에 대한 정보 목록 보기 "
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr "공급자 정보 "
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr "공급자 생성 "
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr "공급자 업데이트 "
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr "공급자 설명 "
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"리포지터리 url 예: http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr "공급자 이름 "
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr "공급자 [ %s ]가 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr "공급자 [ %s ]를 생성할 수 없음 "
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr "공급자 [ %s ]가 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr "공급자 삭제 "
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr "공급자 동기화 "
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr "공급자 [ %s ] 동기화 실패: %s"
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr "공급자 [ %s ] 동기화가 취소됨 "
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr "공급자 [ %s ]가 동기화됨 "
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "현재 실행되고 있는 동기화가 취소됨 "
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr "공급자의 동기화 상태 "
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr "%d%% 완료 (%d 개의 패키지 중 %d 개가 다운로드됨)"
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr "공급자 상태 "
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr "매니페스트 파일 가져오기 "
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr "매니페스트 파일로의 경로 (필수 사항) "
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr "매니페스트를 강제로 다시 가져오기 "
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr "파일 %s이 존재하지 않음 "
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr "매니페스트 파일을 가져오는 중, 잠시만 기다리십시오..."
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr "공급자의 제품 리포지터리를 새로 고침 "
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr "공급자가 성공적으로 새로 고침됨 [ %s ]"
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr "katello 서버에서 공급자의 특정 동작 "
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr " katello 서버의 상태 획득 "
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Katello 상태 "
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr "사용자 역할에 대한 권한 생성 "
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr "권한 이름 (필수 사항) "
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr "권한 설명 "
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr "조직 이름 "
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr "권한 범위 (필수 사항) "
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr "권한 동사 "
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr "권한 태그 "
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr "잘못된 범위 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr "[ %s ] 범위에서 태그 [ %s ]을 찾을 수 없음 "
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr "사용자 역할 [ %s ]의 권한 [ %s ]이 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr "권한 [ %s ]을 생성할 수 없음 "
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr "권한 삭제 "
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr "역할 [ %s ]의 권한 [ %s ]이 성공적으로 삭제됨 "
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr "사용자 역할의 권한 목록 보기 "
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr "권한 목록 "
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr "권한에 설정할 수 있는 사용 가능한 범위, 동사, 태그 목록 보기 "
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+"조직 이름 예: foo.example.com, \n"
+"조직의 특정 동사 목록 보기 "
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr "범위에 따라 나열된 결과를 필터링하기 "
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr "권한 범위 %s의 사용 가능한 동사 및 태그 "
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr "사용 가능한 동사 "
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr "없음 "
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr "katello 서버에서 권한의 특정 동작 "
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "사용 가능한 설명이 없음 "
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "동작이 주어지지 않음: --help 참조 "
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "잘못된 동작: --help 참조 "
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "grep 출력 결과 "
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "상세하고 보다 구조화된 출력 결과 "
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr "grep 출력 결과에서 컬럼 구분 기호, -g 옵션을 선택한 경우에만 작동함 "
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr "오류: /etc/katello/client.conf에서 설정한 서버 호스트 이름이 다음과 일치하지 않음 "
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "연결하려는 katello 서버에서 반환된 호스트 이름 "
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "[%s]이 설정되어 있으나 서버에서 [%s]을 갖고 있음. "
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "/etc/katello/client.conf 파일에 있는 호스트를 올바르게 수정하십시오. "
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "잘못된 인증서 또는 인증할 수 없음 "
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "옵션 %s: 잘못된 부울 값: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr "리포지터리의 모든 에라타 목록 보기 "
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr "유형에 따라 에라타 필터링하기 예: 기능 강화 "
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr "중요도에 따라 에라타 필터링하기 "
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr "에라타 목록 "
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr "시스템의 에라타 목록 보기 "
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr "조직 %s에서 시스템 %s에 대한 에라타 "
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr "에라타에 관한 정보 "
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr "에라타 ID, 문자열 값 (필수 사항) "
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr "에라타 정보 "
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr "katello 서버에서 에라타의 특정 동작 "
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "katello 서버의 버전을 가져옴 "
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "서버 버전 확인 "
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "사용 가능한 패키지 그룹 목록 보기 "
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "리포지터리 id, 문자열 값 (필수 사항) "
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "리포지터리 [%s]에서 검색된 패키지 그룹이 없음 "
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "패키지 그룹 정보 "
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "패키지 그룹에 대한 정보 검색 "
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "패키지 그룹 ID, 문자열 값 (필수 사항) "
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "패키지 그룹 [%s]을 리포지터리 [%s]에서 찾을 수 없음  "
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "사용 가능한 패키지 그룹 카테고리 목록 보기 "
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "리포지터리 [%s]에 패키지 그룹 카테고리를 찾을 수 없음 "
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "패키지 그룹 카테고리 정보 "
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "패키지 그룹 카테고리 ID, 문자열 값 (필수 사항) "
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "패키지 그룹 카테고리 [%s]를 리포지터리 [%s]에서 찾을 수 없음 "
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "패키지 그룹 카테고리 정보 "
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "katello 서버에서 패키지 그룹의 특정 동작 "
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "대기 중 "
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "실행 중 "
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "오류 "
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "취소됨 "
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr "취소됨 "
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "시간 초과됨 "
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr "동기화되지 않음 "
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr "지정된 URL에 리포지터리 생성 "
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr "할당할 리포지터리 이름 (필수 사항) "
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr "리포지터리로의 url 경로 (필수 사항) "
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "제품 이름 (필수 사항) "
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr "리포지터리에 할당된 GPG 키; 디폴트로 제품의 GPG 키가 사용됩니다. "
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr "리포지터리에 GPG 키를 할당하지 않습니다. "
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr "리포지터리 [ %s ]가 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr "URL에 들어 있는 검색 리포지터리 "
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr "검색된 모든 리포지터리에 추가할 리포지터리 이름 접두사 (필수 사항) "
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+"리포지터리 검색을 실행하기 위한 root url 예: http://porkchop.devel.redhat.com/ (필수 사항) "
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr "yes라고 가정; 검색된 url에 대해 후보 리포지터리를 자동으로 생성 (옵션) "
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "검색된 리포지터리 Url @ [% s] "
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr "리포지터리 url을 검색 중입니다. 이는 시간이 다소 소요될 수 있습니다. "
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "오류: %s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr "후보 리포지터리가 생성되어야 하는 url을 선택합니다; `y`를 사용하여 확인합니다 (도움말의 경우 h 사용): "
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr "사용자 요청에 따라 작업을 중지했습니다. "
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr "리포지터리에 대한 상태 정보 "
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "리포지터리 상태 "
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "리포지터리에 대한 정보 "
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "진행 상태 "
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "GPG 키  "
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr "리포지터리 %s에 대한 정보 "
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr "리포지터리 속성 업데이트 "
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr "리포지터리 [ %s ]가 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr "리포지터리 동기화 "
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr "리포지터리 [ %s ]가 동기화됨 "
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr "리포지터리 [ %s ] 동기화가 취소됨 "
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr "리포지터리 [ %s ] 동기화 실패: %s"
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr "현재 실행되고 있는 리포지터리 동기화가 취소됨 "
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr "리포지터리 활성화 "
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr "리포지터리 비활성화 "
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr "조직의 리포지터리 목록 보기 "
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr "조직 이름 예: ACME_Corporation (필수 사항) "
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr "비활성화된 리포지터리 목록 보기 "
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr "조직 %s 환경 %s 제품 %s에 대한 리포지터리 목록 "
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr "조직 %s에 있는 제품 %s에 대한 리포지터리 목록 "
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr "조직 %s 환경 %s에 대한 리포지터리 목록 "
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr "리포지터리 삭제 "
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr "리포지터리 필터 목록 보기 "
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr "리포지터리의 제품에 할당된 필터 인쇄 "
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr "리포지터리 필터 "
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr "리포지터리에 필터 추가 "
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr "리포지터리에서 필터 제거 "
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr "리포지터리 [ %s ]에 필터 [ %s ]이(가) 추가됨 "
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr "리포지터리 [ %s ]에 필터 [ %s ]이(가) 제거됨 "
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "알려진 sync_plans 목록 보기 "
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "동기화 계획 목록 "
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "동기화 계획에 관한 정보 출력 "
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "동기화 계획 이름 (필수 사항) "
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "동기화 계획 정보 "
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "동기화 계획 생성 "
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "계획 설명 "
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr "동기화 반복 간격 (선택: [%s], 디폴트: 없음)"
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "처음 동기화 날짜 (필수 사항, 형식: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr "처음 동기화 시간 (형식: HH:MM:SS, 디폴트: 00:00:00) "
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "동기화 계획 [ %s ]이 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "동기화 계획 [ %s ]을 생성할 수 없음 "
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "동기화 계획 업데이트 "
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "새 동기화 계획 이름 "
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "처음 동기화 날짜 (형식: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "처음 동기화 시간 (형식: HH:MM:SS)"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "동기화 계획 [ %s ]이 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "동기화 계획 삭제 "
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "동기화 계획 [ %s ]이 성공적으로 삭제됨 "
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr "katello 서버에 있는 동기화 계획의 특정 동작 "
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "모든 알려진 조직 목록 보기 "
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "조직 목록 "
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "조직 생성 "
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "컨슈머 설명 예: foo의 조직 "
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "조직 [ %s ]이 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "조직 [ %s ]을 생성할 수 없음 "
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "조직 정보 목록 보기 "
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "사용 가능한 서비스 수준 "
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "조직 정보 "
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "조직 삭제 "
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "조직 삭제 중, 잠시만 기다리십시오..."
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "조직 [ %s ]이 성공적으로 삭제됨 "
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "조직 [ %s ] 삭제 실패함: %s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "조직 업데이트 "
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "조직 [ %s ]이 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "ueber 인증서 생성 및 보기 "
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "인증서 다시 생성 "
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "조직의 ueber 인증서 "
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "서브스크립션 보기 "
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "조직의 서브스크립션 "
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "katello 서버에서 조직의 특정 동작 "
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "동기화 계획 설정 "
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "동기화 계획 이름 (필수 사항) "
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "동기화 계획 설정 해제 "
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "알려진 제품 목록 보기 "
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "공급자 이름, Library에 있는 공급자의 제품 목록 보기 "
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "공급자 %s에 대한 제품 목록 "
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "조직 %s, 환경 %s에 대한 제품 목록 "
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "제품 동기화 "
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "제품 [ %s ] 동기화 실패: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "제품 [ %s ] 동기화가 취소됨 "
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "제품 [ %s ]이 동기화됨 "
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "제품의 동기화 상태 "
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "제품 상태 "
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+"제품 환경 승격 \n"
+"(제품에 임시적인 변경 집합을 생성하고 이를 승격함) "
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "제품 승격 중, 잠시만 기다리십시오..."
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "제품 [ %s ]이 환경 [ %s ]으로 승격됨 "
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "제품 [ %s ] 승격 실패: %s"
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "사용자 지정 공급자에 새 제품 생성 "
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "제품 설명 "
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "리포지터리 검색 생략 "
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+"gpg 키 할당; 리포지터리에 gpgkey 또는 nogpgkey가 지정되어 있지 않을 경우 이 키는 모든 새로운 리포지터리에 사용됩니다 "
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr "제품 [ %s ]이 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "제품의 속성 업데이트 "
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "제품 설명 변경 "
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "제품에 gpgkey 할당 "
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "제품의 리포지터리에 gpgkey 할당 "
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr "제품 [ %s ]이 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "제품 및 컨텐츠 삭제 "
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "제품의 필터 목록 보기 "
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "제품 필터 "
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "제품에 필터 추가 "
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "제품에서 필터 제거 "
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "제품 [ %s ]에 필터 [ %s ]이(가) 추가됨 "
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "제품 [ %s ]에 필터 [ %s ]이(가) 제거됨 "
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "katello 서버에서 제품의 특정 동작 "
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "모든 템플릿 목록 보기 "
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "조직 이름 (환경을 지정할 경우 필요) "
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "환경 [ %s ]에서 템플릿을 찾을 수 없음 "
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "템플릿 목록 "
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "템플릿에 관한 정보 목록 보기 "
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "템플릿 이름 (필수 사항) "
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "템플릿 정보 "
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "템플릿 파일을 생성하고 데이터를 가져옴 "
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "템플릿 파일로의 경로 (필수 사항) "
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "템플릿을 가져오는 중, 잠시만 기다리십시오..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "템플릿을 파일로 내보내기 "
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "환경 이름 예: dev"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "내보내기 형식, 가능한 값: %s, 디폴트: json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "파일 %s을(를) 생성할 수 없음 "
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "템플릿을 내보내는 중, 잠시만 기다리십시오..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "템플릿을 성공적으로 파일 %s로 내보내기함  "
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "빈 템플릿 파일 생성 "
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "부모 템플릿 이름 "
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "템플릿 설명 "
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "템플릿 [ %s ]을 성공적으로 생성함 "
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "템플릿 [ %s ]을 생성할 수 없음 "
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "템플릿 이름 및 설명 업데이트 "
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "각각의 %s 앞에 %s을 지정해야 함 "
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "매개 변수 이름, %s이 뒤따라야 함 "
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "매개 변수 값 "
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "매개 변수 이름 "
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "패키지 그룹 이름 "
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "패키지 그룹 카테고리 이름 "
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "배포 ID"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "리포지터리 선택 대상 제품을 지정 "
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "템플릿에 추가될 리포지터리 "
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "템플릿에서 제거될 리포지터리 "
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "매개 변수 '%s'에 대해 누락된 값 "
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "템플릿 업데이트 중, 잠시만 기다리십시오..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "템플릿 [ %s ]을 성공적으로 업데이트함 "
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "템플릿 삭제 "
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "환경 이름 예: foo.example.com (디폴트: Library)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "katello 서버에서 템플릿의 특정 동작 "
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "알려진 환경 목록 보기 "
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "조직 "
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "이전 환경 "
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "환경 목록 "
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "특정 환경 목록 보기 "
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "환경 이름 예: foo.example.com (필수 사항) "
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "환경 정보 "
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "환경 생성 "
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "환경 설명 예: foo 환경 "
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "이전 환경 이름 (필수 사항) "
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "환경 [ %s ]이 성공적으로 생성됨 "
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "환경 [ %s ]을 생성할 수 없음 "
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "환경 업데이트 "
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "이전 환경 이름 "
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "환경 [ %s ]이 성공적으로 업데이트됨 "
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "환경 삭제 "
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "환경 [ %s ]이 성공적으로 삭제됨 "
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "katello 서버 환경의 특정 동작  "
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "인증서 파일 %s이 존재하지 않거나 읽을 수 없음 "
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "키 파일 %s이 존재하지 않거나 읽을 수 없음 "
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "커베로스를 통해 인증할 수 없음 "
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "옵션 %s이 필요함; --help 참조 "
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "옵션 %s이 %s와 충돌함: --help 참조 "
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "최소 %s 중 하나가 필요함; --help 참조 "

--- a/cli/po/ml.po
+++ b/cli/po/ml.po
@@ -15,2774 +15,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ml\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2801,6 +158,7 @@ msgid "Options"
 msgstr ""
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2853,10 +211,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/mr.po
+++ b/cli/po/mr.po
@@ -15,2774 +15,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: mr\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2801,6 +158,7 @@ msgid "Options"
 msgstr ""
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2853,10 +211,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/or.po
+++ b/cli/po/or.po
@@ -15,2774 +15,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: or\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2801,6 +158,7 @@ msgid "Options"
 msgstr ""
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2853,10 +211,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/pa.po
+++ b/cli/po/pa.po
@@ -16,2774 +16,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pa\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "ਅਕਾਊਂਟ ਯੂਜ਼ਰ-ਨਾਂ"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "ਅਕਾਊਂਟ ਪਾਸਵਰਡ"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "\\"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "ਸੰਗਠਨ ਅੱਪਡੇਟ ਕਰੋ"
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "ਸੰਗਠਨ [ %s ] ਸਫਲਤਾਪੂਰਕ ਅੱਪਡੇਟ ਹੋ ਗਿਆ ਹੈ"
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "ਇਨਵਾਇਰਮੈਂਟ ਨਾਂ"
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "ਮੁਕੰਮਲ"
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "ਇੱਕ ਸਿਸਟਮ ਰਜਿਸਟਰ ਕਰੋ"
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "ਸੰਗਠਨ ਨਾਂ (ਲੋੜੀਂਦਾ ਹੈ)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr "ਸਿਸਟਮ [ %s ] ਸਫਲਤਾਪੂਰਕ ਰਜਿਸਟਰ ਹੋ ਗਿਆ ਹੈ"
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr "ਸਿਸਟਮ [ %s ] ਨੂੰ ਰਜਿਸਟਰ ਨਹੀਂ ਕਰ ਸਕਿਆ"
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr "ਇੱਕ ਸਿਸਟਮ ਅਨ-ਰਜਿਸਟਰ ਕਰੋ"
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "ਚੋਣ %s: ਗਲਤ ਬੂਲੀਅਨ ਮੁੱਲ: %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "ਸਭ ਜਾਣੇ-ਪਛਾਣੇ ਯੂਜ਼ਰ ਵੇਖਾਓ"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "ਯੂਜ਼ਰ ਲਿਸਟ"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "ਯੂਜ਼ਰ ਬਣਾਓ"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "ਯੂਜ਼ਰ ਨਾਂ (ਲੋੜ ਹੈ)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "ਸ਼ੁਰੂਆਤੀ ਪਾਸਵਰਡ (ਲੋੜੀਂਦਾ ਹੈ)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "ਅਯੋਗ ਖਾਤੇ (ਮੂਲ 'false' ਹੈ)"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "ਯੂਜ਼ਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਬਣ ਗਿਆ ਹੈ"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "ਯੂਜ਼ਰ [ %s ] ਬਣਾ ਨਹੀਂ ਸਕਿਆ"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "ਯੂਜ਼ਰ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "ਯੂਜ਼ਰ ਜਾਣਕਾਰੀ"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "ਯੂਜ਼ਰ ਹਟਾਓ"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "ਯੂਜ਼ਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਹਟਾਇਆ ਗਿਆ ਹੈ"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "ਇੱਕ ਯੂਜ਼ਰ ਅੱਪਡੇਟ ਕਰੋ"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "ਗਲਤ ਪਾਸਵਰਡ"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "ਯੂਜ਼ਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਅੱਪਡੇਟ ਹੋ ਗਿਆ ਹੈ"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr "ਸਭ ਜਾਣੇ-ਪਛਾਣੇ ਪਰੋਵਾਈਡਰ ਵੇਖਾਓ"
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr "ਪਰੋਵਾਈਡਰ ਲਿਸਟ"
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr "ਪਰੋਵਾਈਡਰ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr "ਪਰੋਵਾਈਡਰ ਜਾਣਕਾਰੀ"
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr "ਪਰੋਵਾਈਡਰ ਬਣਾਓ"
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr "ਪਰੋਵਾਈਡਰ ਅੱਪਡੇਟ ਕਰੋ"
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr "ਪਰੋਵਾਈਡਰ ਵੇਰਵਾ"
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr "ਪਰੋਵਾਈਡਰ ਨਾਂ"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "ਚੋਣ --url ਦਾ http:// ਜਾਂ https:// ਨਾਲ ਸ਼ੁਰੂ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "ਚੋਣ --url ਸਹੀ ਫਾਰਮੈਟ ਵਿੱਚ ਨਹੀਂ ਹੈ"
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr "ਪਰੋਵਾਈਡਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਬਣ ਗਿਆ ਹੈ"
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr "ਪਰੋਵਾਈਡਰ [ %s ] ਨੂੰ ਬਣਾ ਨਹੀਂ ਸਕਿਆ"
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr "ਪਰੋਵਾਈਡਰ ਹਟਾਓ"
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr "ਪਰੋਵਾਈਡਰ ਸਮਕਾਲੀ ਬਣਾਓ"
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr "ਪਰੋਵਾਈਡਰ ਹਾਲਤ"
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr "ਫਾਇਲ %s ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "ਜਾਣੇ-ਪਛਾਣੇ ਇਨਵਾਇਰਮੈਂਟ ਵੇਖਾਓ"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "ਸੰਗਠਨ"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "ਪਹਿਲਾ ਇਨਵਾਇਰਮੈਂਟ"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "ਇਨਵਾਇਰਮੈਂਟ ਸੂਚੀ"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "ਇਨਵਾਇਰਮੈਂਟ ਜਾਣਕਾਰੀ"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "ਇੱਕ ਇਨਵਾਇਰਮੈਂਟ ਬਣਾਓ"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "ਇਨਵਾਇਰਮੈਂਟ ਹਟਾਓ"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "ਸਭ ਟੈਪਲਿਟ ਵੇਖਾਓ"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "ਟੈਂਪਲਿਟ ਲਿਸਟ"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "ਟੈਂਪਲਿਟ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "ਟੈਂਪਲਿਟ ਨਾਂ (ਲੋੜੀਂਦਾ ਹੈ)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "ਟੈਂਪਲਿਟ ਜਾਣਕਾਰੀ"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr "ਇਰੱਟਾ ਲਿਸਟ"
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "ਉਡੀਕ ਵਿੱਚ"
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "ਚੱਲ ਰਿਹਾ"
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "ਗਲਤੀ"
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "ਰੱਦ ਕੀਤਾ"
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "ਸਮਾਂ ਖਤਮ"
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "ਗਲਤੀ: %s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "ਰਿਪੋਜ਼ਟਰੀ ਹਾਲਤ"
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "ਰਿਪੋਜ਼ਟਰੀ ਬਾਰੇ ਜਾਣਕਾਰੀ"
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "ਤਰੱਕੀ"
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2802,6 +159,7 @@ msgid "Options"
 msgstr "ਚੋਣਾਂ"
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2854,6 +212,7 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr "ਚੋਣ %s: ਗਲਤ ਚੋਣ: %r (%s ਤੋਂ ਚੁਣੋ)"
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr "ਇਹ ਮੱਦਦ ਸੁਨੇਹਾ ਵੇਖਾਓ ਅਤੇ ਬੰਦ ਕਰੋ"
@@ -2861,3 +220,3013 @@ msgstr "ਇਹ ਮੱਦਦ ਸੁਨੇਹਾ ਵੇਖਾਓ ਅਤੇ ਬੰ�
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
 msgstr "ਪਰੋਗਰਾਮ ਦਾ ਵਰਜਨ ਨੰਬਰ ਵੇਖਾਓ ਅਤੇ ਬੰਦ ਕਰੋ"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "ਸੰਗਠਨ ਨਾਂ (ਲੋੜੀਂਦਾ ਹੈ)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "\\"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "ਸਭ ਜਾਣੇ-ਪਛਾਣੇ ਯੂਜ਼ਰ ਵੇਖਾਓ"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "ਯੂਜ਼ਰ ਲਿਸਟ"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "ਯੂਜ਼ਰ ਬਣਾਓ"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "ਯੂਜ਼ਰ ਨਾਂ (ਲੋੜ ਹੈ)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "ਸ਼ੁਰੂਆਤੀ ਪਾਸਵਰਡ (ਲੋੜੀਂਦਾ ਹੈ)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "ਅਯੋਗ ਖਾਤੇ (ਮੂਲ 'false' ਹੈ)"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "ਯੂਜ਼ਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਬਣ ਗਿਆ ਹੈ"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "ਯੂਜ਼ਰ [ %s ] ਬਣਾ ਨਹੀਂ ਸਕਿਆ"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "ਯੂਜ਼ਰ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "ਯੂਜ਼ਰ ਜਾਣਕਾਰੀ"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "ਯੂਜ਼ਰ ਹਟਾਓ"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "ਯੂਜ਼ਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਹਟਾਇਆ ਗਿਆ ਹੈ"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "ਇੱਕ ਯੂਜ਼ਰ ਅੱਪਡੇਟ ਕਰੋ"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "ਗਲਤ ਪਾਸਵਰਡ"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "ਯੂਜ਼ਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਅੱਪਡੇਟ ਹੋ ਗਿਆ ਹੈ"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "ਇਨਵਾਇਰਮੈਂਟ ਨਾਂ"
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "ਮੁਕੰਮਲ"
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "ਇੱਕ ਸਿਸਟਮ ਰਜਿਸਟਰ ਕਰੋ"
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr "ਸਿਸਟਮ [ %s ] ਸਫਲਤਾਪੂਰਕ ਰਜਿਸਟਰ ਹੋ ਗਿਆ ਹੈ"
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr "ਸਿਸਟਮ [ %s ] ਨੂੰ ਰਜਿਸਟਰ ਨਹੀਂ ਕਰ ਸਕਿਆ"
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr "ਇੱਕ ਸਿਸਟਮ ਅਨ-ਰਜਿਸਟਰ ਕਰੋ"
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr "ਸਭ ਜਾਣੇ-ਪਛਾਣੇ ਪਰੋਵਾਈਡਰ ਵੇਖਾਓ"
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr "ਪਰੋਵਾਈਡਰ ਲਿਸਟ"
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr "ਪਰੋਵਾਈਡਰ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr "ਪਰੋਵਾਈਡਰ ਜਾਣਕਾਰੀ"
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr "ਪਰੋਵਾਈਡਰ ਬਣਾਓ"
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr "ਪਰੋਵਾਈਡਰ ਅੱਪਡੇਟ ਕਰੋ"
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr "ਪਰੋਵਾਈਡਰ ਵੇਰਵਾ"
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr "ਪਰੋਵਾਈਡਰ ਨਾਂ"
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr "ਪਰੋਵਾਈਡਰ [ %s ] ਸਫਲਤਾਪੂਰਕ ਬਣ ਗਿਆ ਹੈ"
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr "ਪਰੋਵਾਈਡਰ [ %s ] ਨੂੰ ਬਣਾ ਨਹੀਂ ਸਕਿਆ"
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr "ਪਰੋਵਾਈਡਰ ਹਟਾਓ"
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr "ਪਰੋਵਾਈਡਰ ਸਮਕਾਲੀ ਬਣਾਓ"
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr "ਪਰੋਵਾਈਡਰ ਹਾਲਤ"
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr "ਫਾਇਲ %s ਮੌਜੂਦ ਨਹੀਂ ਹੈ"
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "ਚੋਣ %s: ਗਲਤ ਬੂਲੀਅਨ ਮੁੱਲ: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr "ਇਰੱਟਾ ਲਿਸਟ"
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "ਉਡੀਕ ਵਿੱਚ"
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "ਚੱਲ ਰਿਹਾ"
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "ਗਲਤੀ"
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "ਰੱਦ ਕੀਤਾ"
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "ਸਮਾਂ ਖਤਮ"
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "ਗਲਤੀ: %s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "ਰਿਪੋਜ਼ਟਰੀ ਹਾਲਤ"
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "ਰਿਪੋਜ਼ਟਰੀ ਬਾਰੇ ਜਾਣਕਾਰੀ"
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "ਤਰੱਕੀ"
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "ਸੰਗਠਨ ਅੱਪਡੇਟ ਕਰੋ"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "ਸੰਗਠਨ [ %s ] ਸਫਲਤਾਪੂਰਕ ਅੱਪਡੇਟ ਹੋ ਗਿਆ ਹੈ"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "ਸਭ ਟੈਪਲਿਟ ਵੇਖਾਓ"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "ਟੈਂਪਲਿਟ ਲਿਸਟ"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "ਟੈਂਪਲਿਟ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖਾਓ"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "ਟੈਂਪਲਿਟ ਨਾਂ (ਲੋੜੀਂਦਾ ਹੈ)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "ਟੈਂਪਲਿਟ ਜਾਣਕਾਰੀ"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "ਜਾਣੇ-ਪਛਾਣੇ ਇਨਵਾਇਰਮੈਂਟ ਵੇਖਾਓ"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "ਸੰਗਠਨ"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "ਪਹਿਲਾ ਇਨਵਾਇਰਮੈਂਟ"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "ਇਨਵਾਇਰਮੈਂਟ ਸੂਚੀ"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "ਇਨਵਾਇਰਮੈਂਟ ਜਾਣਕਾਰੀ"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "ਇੱਕ ਇਨਵਾਇਰਮੈਂਟ ਬਣਾਓ"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "ਇਨਵਾਇਰਮੈਂਟ ਹਟਾਓ"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr ""

--- a/cli/po/pt.po
+++ b/cli/po/pt.po
@@ -3,85 +3,63 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # gcintra <gcintra@fedoraproject.org>, 2011. #zanata
-# gcintra <gcintra@fedoraproject.org>, 2012. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2012-05-30 10:11-0400\n"
-"Last-Translator: gcintra <gcintra@fedoraproject.org>\n"
+"PO-Revision-Date: 2012-08-24 02:54-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: pt-BR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "arquivo de certificado %s não existe ou não pode ser lido"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "arquivo de chave %s não existe ou não pode ser lido"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "Não foi possível autenticar via kerberos"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "Imprime informações sobre versão"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Credenciais da Conta de Usuário do Katello"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "username da conta"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "senha da conta"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Informações do Servidor do Katello"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "Nome da máquina do servidor do katello (padrão: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "Comando inválido; por favor veja --help"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "Não foi dado nenhum comando; por favor veja --help"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "Não foi possível encontrar empresa [ %s ]"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "Não foi possível encontrar ambiente [ %s ] dentro da empresa  [ %s ] "
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "Não foi possível encontrar produto [ %s ] dentro da empresa  [ %s ] "
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
@@ -90,66 +68,71 @@ msgstr ""
 "Não foi possível encontrar repositório [ %s ] dentro da empresa  [%s] , "
 "produto [%s] e ambiente [ %s ]"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "Não foi possível encontrar provedor [ %s ] dentro da empresa  [ %s ] "
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "Não foi possível encontrar modelo [ %s ] dentro da empresa  [ %s ] "
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 "Não foi possível encontrar o changeset [ %s ] dentro da empresa  [ %s ] "
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "Não foi possível encontrar usuário [ %s ]"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "Não foi possível encontrar função [ %s ]"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "Não foi possível encontrar plano de sincronização [ %s ]"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 "Não foi possível encontrar permissão [ %s ] para a função do usuário [ %s ]"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "Não foi possível encontrar filtro [ %s ]"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "Não foi possível encontrar Sistema [ %s ] na empresa  [%s]"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "Sistemas ambiguos encontrados [ %s ] no Ambiente [ %s ] na Org [ %s ]"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Não foi possível encontrar o Sistema [ %s ] no Ambiente [ %s ] na Org [ %s ]"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
@@ -158,365 +141,1331 @@ msgstr ""
 "Sistemas ambiguos encontrados [ %s ] na Org [ %s ], você precisa especificar"
 " o ambiente"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "nome"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "listar todas as empresas conhecidas"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "Listar as Empresas"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "criar uma empresa"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "nome de empresa ex: foo.example.com (requerido)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "descrição do consumidor ex: empresa do foo"
-
-#: ../src/katello/client/core/organization.py:79
+#. These are a bunch of strings that are marked for translation in optparse,
+#. but not actually translated anywhere. Mark them for translation here,
+#. so we get it picked up. for local translation, and then optparse will
+#. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
+#: ../src/katello/client/i18n_optparse.py:48
 #, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "Empresa criada com sucesso [ %s ]"
+msgid "Usage: %s\n"
+msgstr "Uso: %s\n"
 
-#: ../src/katello/client/core/organization.py:80
+#: ../src/katello/client/i18n_optparse.py:49
+msgid "Usage"
+msgstr "Uso: %s"
+
+#: ../src/katello/client/i18n_optparse.py:50
+msgid "%prog [options]"
+msgstr "%prog [options]"
+
+#: ../src/katello/client/i18n_optparse.py:51
+msgid "Options"
+msgstr "Opções"
+
+#. stuff for option value sanity checking
+# stuff for option value sanity checking
+#: ../src/katello/client/i18n_optparse.py:54
 #, python-format
-msgid "Could not create org [ %s ]"
-msgstr "Não foi possível criar empresa [ %s ]"
+msgid "no such option: %s"
+msgstr "não existe tal opção: %s"
 
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "Informações da lista sobre uma empresa"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "Níveis de Serviços Disponíveis"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "Informações da Empresa"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "remover uma empresa"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "Removendo a empresa, por favor aguarde..."
-
-#: ../src/katello/client/core/organization.py:135
+#: ../src/katello/client/i18n_optparse.py:55
 #, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "Empresa removida com sucesso [ %s ]"
+msgid "ambiguous option: %s (%s?)"
+msgstr "opção ambígua:  %s (%s?)"
 
-#: ../src/katello/client/core/organization.py:138
+#: ../src/katello/client/i18n_optparse.py:56
 #, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "Remoção da empresa [ %s ] falhou: %s"
+msgid "%s option requires an argument"
+msgstr "%s opção requer um argumento"
 
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "atualizar uma empresa"
-
-#: ../src/katello/client/core/organization.py:162
+#: ../src/katello/client/i18n_optparse.py:57
 #, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "Empresa atualizada com sucesso [ %s ]"
+msgid "%s option requires %d arguments"
+msgstr "%s opção requer um %d argumento"
 
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "gerar e exibir certificado de ueber"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "regenerar o certificado"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "Uebercert da Empresa"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "mostrar subscrições"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "Subscrições de Empresa"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "ações específicas da emrpesa no servidor do katello"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "nome do produto (requerido)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "nome do ambiente ex: produção (padrão: Biblioteca)"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "definir um plano de sincronização"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "nome do plano de sincronização (necessário)"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "cancelar definição de um plano de sincronização"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "lista produtos conhecidos"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "nome do provedor, lista o produto do provedor na Biblioteca"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "Chave GPG"
-
-#: ../src/katello/client/core/product.py:147
+#: ../src/katello/client/i18n_optparse.py:58
 #, python-format
-msgid "Product List For Provider %s"
-msgstr "Lista de Produto para o Provedor %s"
+msgid "%s option does not take a value"
+msgstr "%s opção não leva um valor"
 
-#: ../src/katello/client/core/product.py:153
+#: ../src/katello/client/i18n_optparse.py:59
+msgid "integer"
+msgstr "inteiro"
+
+#: ../src/katello/client/i18n_optparse.py:60
+msgid "long integer"
+msgstr "longo inteiro"
+
+#: ../src/katello/client/i18n_optparse.py:61
+msgid "floating-point"
+msgstr "ponto flutuante"
+
+#: ../src/katello/client/i18n_optparse.py:62
+msgid "complex"
+msgstr "complexo"
+
+#: ../src/katello/client/i18n_optparse.py:63
 #, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "Lista de Produto para a Empresa %s, Ambiente '%s'"
+msgid "option %s: invalid %s value: %r"
+msgstr "opção %s: inválido %s valor: %r"
 
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "sincronizar um produto"
-
-#: ../src/katello/client/core/product.py:179
+#: ../src/katello/client/i18n_optparse.py:64
 #, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "Produto [ %s ] falhou na sincronização: %s"
+msgid "option %s: invalid choice: %r (choose from %s)"
+msgstr "opção %s: escolha inválida: %r (escolha a partir do %s)"
 
-#: ../src/katello/client/core/product.py:182
+#. default options
+# default options
+#: ../src/katello/client/i18n_optparse.py:67
+msgid "show this help message and exit"
+msgstr "Mostra esta mensagem de ajuda e sai"
+
+#: ../src/katello/client/i18n_optparse.py:68
+msgid "show program's version number and exit"
+msgstr "mostra o número de versão do programa e sai"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "lista todos as funções dos usuários conhecidos"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "Lista de funções de Usuários"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "criar função de usuário"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "nome da função (necessário)"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "descrição da função"
+
+#: ../src/katello/client/core/user_role.py:75
 #, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "Produto [ %s ]  sincronização cancelado."
+msgid "Successfully created user role [ %s ]"
+msgstr "Função de usuário criada com sucesso[ %s ]"
 
-#: ../src/katello/client/core/product.py:185
+#: ../src/katello/client/core/user_role.py:76
 #, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "Produto [ %s ] sincronizado"
+msgid "Could not create user role [ %s ]"
+msgstr "Não foi possível criar função do usuário [ %s ]"
 
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "cancelar a sincronização em execução no momento"
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "listar informações sobre função do usuário"
 
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "status da sincronização do produto"
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "nome da função do usuário(necessário)"
 
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "Status do Produto"
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "imprimir detalhes sobre cada permissão de função"
 
-#: ../src/katello/client/core/product.py:242
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
 msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
 msgstr ""
-"promover um produto em um ambiente\n"
-"(cria um changeset temporário com o produto e o promove)"
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
 
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "Promovendo o produto, por favor aguarde..."
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "Informações de função de usuário"
 
-#: ../src/katello/client/core/product.py:268
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "remover uma função de usuário"
+
+#: ../src/katello/client/core/user_role.py:150
 #, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "Produto [ %s ] promovido em ambiente [ %s ]"
+msgid "Successfully deleted user role [ %s ]"
+msgstr "Função de usuário removida com sucesso [ %s ]"
 
-#: ../src/katello/client/core/product.py:271
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "atualizar uma função"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "nome da função nova do usuário"
+
+#: ../src/katello/client/core/user_role.py:177
 #, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "Produto  [ %s ] falha na promoção: %s"
+msgid "Successfully updated user role [ %s ]"
+msgstr "Função de usuário atualizada com sucesso[ %s ]"
 
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "criar um novo produto em um provedor padronizado"
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "atribuir o grupo LDAP à uma função"
 
-#: ../src/katello/client/core/product.py:297
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "novo nome de grupo  LDAP (necessário)"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+"Grupo LDAP adicionado com sucesso  [ %s ] para a função do usuário [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "remover o grupo LDAP atribuído à uma função"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "Nome do grupo LDAP para ser removido (necessário)"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+"Grupo LDAP removido com sucesso  [ %s ] a partir da função do usuário [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "ações específicas de função de usuário no servidor do katello"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "salvar uma opção na configuração do cliente"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+"nome da opção a ser salva (ex: org, ambiente, provedor, etc) (requerido)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "valor a ser armazenado sob uma opção específica (requerido)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "Com sucesso"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "Opção lembrar senha não foi bem sucedido [ %s ]"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "remover uma opção da config do cliente"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "nome da opção a ser removida (requerida)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "Opção esqueci a senha bem sucedido [ %s ]"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "opções de lista salvas na config do cliente"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "Opções Salvas"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "ações específicas do cliente no servidor do katello"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "lista todas as chaves de ativação"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
 #: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "nome do provedor (requerido)"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "descrição de produto"
-
-#: ../src/katello/client/core/product.py:303
 #: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"url de repositório ex: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "nome da empresa (requerido)"
 
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "pular descoberta de repositório"
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "nome do ambiente ex: dev (padrão: Biblioteca)"
 
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-"presume-se que sim; automaticamente cria repositórios de candidato para as "
-"urls de descoberta (opcional)"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-"atribuir uma chave gpg; esta chave será utilizada para todos os novos "
-"repositórios a não ser que a chave gpg seja especificada para o repo"
-
-#: ../src/katello/client/core/product.py:334
+#: ../src/katello/client/core/activation_key.py:69
 #, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "Produto criado com sucesso [ %s ]"
+msgid "No keys found in organization [ %s ]"
+msgstr "Não foram encontradas nenhuma chave na empresa [ %s ]"
 
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
+#: ../src/katello/client/core/activation_key.py:71
 #, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "Urls de Repositórios  descobertos @ [%s]"
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+"Não foi possível encontrar nenhuma chave na empresa [ %s ] ambiente  [ %s ] "
 
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "atualizar os atributos do produto"
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "Lista de Chave de Ativação"
 
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "mudar a descrição do produto"
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "mostrar informações sobre uma chave de ativação"
 
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "atribuir uma chave gpg ao produto"
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "nome da chave de ativação (requerido)"
 
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "atribuir uma chave gpg também aos repositórios do produto"
-
-#: ../src/katello/client/core/product.py:378
+#: ../src/katello/client/core/activation_key.py:121
 #, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "Produto atualizado com sucesso [ %s ]"
+msgid "Could not find activation key [ %s ]"
+msgstr "Não foi possível encontrar chave de Ativação [ %s ]"
 
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "remover um produto e seu conteúdo"
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "Info da Chave de Ativação"
 
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "listar filtros de um produto"
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "criar uma chave de ativação"
 
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "Filtros de Produto"
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "nome do ambiente ex: dev (requerido)"
 
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "adicionar um filtro à um produto"
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "descrição da chave de ativação"
 
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "remover um filtro de um produto"
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "nome do modelo ex: servidores"
 
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "Não foi possíve encontrar modelo [ %s ] "
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "Chave de Ativação criada com sucesso [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "Não foi possível criar chave de Ativação [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "atualizar uma chave de ativação"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "novo nome do ambiente: ex: dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "novo nome de modelo"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "nova descrição"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "novo nome de modelo ex: servidores"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "adicionar um pool à chave de ativação"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "remover um pool da chave de ativação"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "Chave de Ativação atualizada com sucesso [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "remover uma chave de ativação"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "Chave de Ativação removida com sucesso [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "ações específicas da chave de ativação no servidor katello"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "Formato de Hora é inválido. Requerido: HH:MM:SS[+HH:MM]"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "Formato de Data é inválido. Requerido: YYYY-MM-DD"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "listar todos os filtros"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "nome da empresa (requerido)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "Lista de Filtros"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "criar um filtro"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
 msgid "filter name (required)"
 msgstr "nome do filtro (necessário)"
 
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "Filtro adicionado [ %s ] ao produto [ %s ]"
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "descrição"
 
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "Filtro removido [ %s ] do produto [ %s ]"
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "lista separada por vírgula de nomes/nvres de pacotes"
 
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "ações específicas de produto no servidor katello"
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "Filtro criado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "Não foi possível criar filtro [ %s ]"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "remover um filtro"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "Filtro removido com sucesso [ %s ]"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "informações de filtro"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "Informações de Filtro"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "Adicionar um pacote ao filtro"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "id de pacote (necessário)"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "Pacotes adicionados  [ %s ] ao filtro com sucesso [ %s ]"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "Remover pacotes do filtro"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "Pacotes removidos  [ %s ] do filtro com sucesso [ %s ]"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "ações específicas de filtro no servidor do katello"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "lista distribuições em um repositório"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "id de repositório"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "nome do repositório"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "nome da empresa ex: foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "nome do ambiente ex: produção (padrão: Biblioteca)"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "nome do produto ex: fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "Lista de Distribuição para Repo %s"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "informações de lista sobre uma distribuição"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "id de repositório (necessário)"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "id de distribuição ex: ks-rh-noarch (requerido)"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "Informações de Distribuição"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "ações específicas de repositório no servidor do katello"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "Inserir o conteúdo da chave GPG (finalizar inserção com o CTRL+D):"
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "listar todas as chaves GPG"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "Repositórios"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+"arquivo com chave GPG pública, se não especificado, entrada padrão será "
+"utilizada"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "arquivo com chave GPG pública"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "solicitação de novo conteúdo da chave"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "ações específicas de chave GPG no servidor do katello"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "nome de empresa ex: foo.example.com (requerido)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "Realizando uma ação remota[ %s ]... "
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "Ação remota finalizada:"
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "Ação remota falhou:"
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "lista todos os usuários conhecidos"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "Lista de Usuário"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "criar usuário"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "nome do usuário (necessário)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "senha inicial (requerido)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "email (necessário)"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "conta desabilitada (padrão é 'falso')"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "nome da empresa padrão do usuário"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "nome do ambiente padrão do usuário"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "Usuário criado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "Não foi possível criar usuário [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "listar informações sobre usuário"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "Informações de usuário"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "remover usuário"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "Usuário removido com sucesso [ %s ]"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "atualizar um usuário"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "senha inicial"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "email"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "conta desabilitada"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "Ambiente padrão do usuário é Nenhum"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "Usuário atualizado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "lisar funções de usuaŕio"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "sincronizar funções com os grupos LDAP"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "atribuir uma função a um usuário"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "cancelar atribuição de uma função à um usuário"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "função de usuário (necessário)"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "Função [%s] não foi encontrado"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "reportar usuário"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+"formato do formulário (valores possíveis: 'html', 'text' (default), 'csv', "
+"'pdf')"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "ações específicas de usuário no servidor do katello"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "listar novos changesets de um ambiente"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "nome do ambiente (requerido)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "Lista do Changeset"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "informações detalhadas sobre o changeset"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "nome do changeset (requerido)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "irá exibir pacotes dependentes"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "Info do Changeset"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "criar um  novo changesets para um ambiente"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "descrição do changeset"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "changeset criado com sucesso [ %s ] para ambiente[ %s ]"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "Não foi possível criar changeset [ %s ] para ambiente [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "conteúdo de atualização de um changeset"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s deve ser precedido de %s"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "nome do changeset novo"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "produto a adicionar ao changeset"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "produto para remover do changeset"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "nome de um modelo a ser adicionado ao changeset"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "nome de um modelo a ser removido de um changeset"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+"determina o produto do qual o pacote/errata/repositórios são coletados"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "para adicioanr ao changeset"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "para remover do changeset"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "changeset atualizado com sucesso [ %s ] "
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "remove um changeset"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "Changeset  [ %s ] falha na promoção: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "ações específicas do changeset no servidor do katello"
 
 #: ../src/katello/client/core/system.py:47
 msgid "list systems within an organization"
 msgstr "listar sistemas dentro da empresa"
 
 #: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
 msgid "environment name eg: development"
 msgstr "nome do ambiente: ex: desenvolvimento"
 
@@ -534,33 +1483,35 @@ msgstr "Lista de Sistemas para Org [ %s ]"
 msgid "Systems List For Environment [ %s ] in Org [ %s ]"
 msgstr "Lista de Sistemas para Ambiente [ %s ] na Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:82
+#: ../src/katello/client/core/system.py:83
 #: ../src/katello/client/core/system.py:134
 msgid "Service Level"
 msgstr "Nível do Serviço"
 
-#: ../src/katello/client/core/system.py:89
+#: ../src/katello/client/core/system.py:90
 msgid "display a system within an organization"
 msgstr "exibir um sistema dentro da empresa"
 
-#: ../src/katello/client/core/system.py:95
+#: ../src/katello/client/core/system.py:96
 #: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
 #: ../src/katello/client/core/errata.py:105
 msgid "system name (required)"
 msgstr "nome do sistema (requerido)"
 
-#: ../src/katello/client/core/system.py:97
+#: ../src/katello/client/core/system.py:98
 #: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
 msgid "environment name"
 msgstr "nome do ambiente"
 
@@ -624,12 +1575,12 @@ msgstr ""
 "Você pode especificar no máximo uma instalação/remoção/atualização por "
 "chamada"
 
-#: ../src/katello/client/core/system.py:189
+#: ../src/katello/client/core/system.py:188
 #, python-format
 msgid "Package Information for System [ %s ] in Org [ %s ]"
 msgstr "Informações de pacote para o Sistema [ %s ] na Org [ %s ]"
 
-#: ../src/katello/client/core/system.py:191
+#: ../src/katello/client/core/system.py:190
 #, python-format
 msgid ""
 "Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
@@ -637,138 +1588,104 @@ msgstr ""
 "Informações de pacote para o Sistema [ %s ] no Ambiente [ %s ] na Org [ %s ]"
 " "
 
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "Realizando uma ação remota[ %s ]... "
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "Ação remota finalizada:"
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "Ação remota falhou:"
-
-#: ../src/katello/client/core/system.py:243
+#: ../src/katello/client/core/system.py:242
 msgid "display status of remote tasks"
 msgstr "exibir status das tarefas remotas"
 
-#: ../src/katello/client/core/system.py:249
+#: ../src/katello/client/core/system.py:248
 msgid "system name"
 msgstr "nome do sistema"
 
-#: ../src/katello/client/core/system.py:261
+#: ../src/katello/client/core/system.py:260
 msgid "Remote tasks"
 msgstr "Tarefas remotas"
 
-#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:268
 msgid "Task id"
 msgstr "Id da Tarefa"
 
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
 msgid "System"
 msgstr "Sistema"
 
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
 msgid "Action"
 msgstr "Ação"
 
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
 msgid "Started"
 msgstr "Iniciado"
 
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
 #: ../src/katello/client/core/repo.py:37
 msgid "Finished"
 msgstr "Concluído"
 
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
 msgid "Status"
 msgstr "Status"
 
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
 msgid "Result"
 msgstr "Resultado"
 
-#: ../src/katello/client/core/system.py:283
+#: ../src/katello/client/core/system.py:282
 msgid "display status of remote task"
 msgstr "exibir status das tarefas remotas"
 
-#: ../src/katello/client/core/system.py:287
+#: ../src/katello/client/core/system.py:286
 msgid "UUID of the task"
 msgstr "UUID da tarefa"
 
-#: ../src/katello/client/core/system.py:295
+#: ../src/katello/client/core/system.py:294
 msgid "Remote task"
 msgstr "Tarefa Remota"
 
-#: ../src/katello/client/core/system.py:313
+#: ../src/katello/client/core/system.py:312
 msgid "list releases available for the system"
 msgstr "lista de lançamentos disponíveis para o sistema"
 
-#: ../src/katello/client/core/system.py:319
+#: ../src/katello/client/core/system.py:318
 msgid "system name (if not specified, list all releases in the environment)"
 msgstr ""
 "nome do sistema (caso não seja especificado, listar todos os lançamentos no "
 "ambiente)"
 
-#: ../src/katello/client/core/system.py:341
+#: ../src/katello/client/core/system.py:340
 msgid "Available releases"
 msgstr "Lançamentos Disponíveis"
 
-#: ../src/katello/client/core/system.py:349
+#: ../src/katello/client/core/system.py:348
 msgid "display a the hardware facts of a system"
 msgstr "exibir os fatos do hardware de um sistema"
 
-#: ../src/katello/client/core/system.py:369
+#: ../src/katello/client/core/system.py:367
 #, python-format
 msgid "System Facts For System [ %s ] in Org [ %s ]"
 msgstr "Fatos do Sistemas para o Sistema  [ %s ] na Org  [ %s ] "
 
-#: ../src/katello/client/core/system.py:371
+#: ../src/katello/client/core/system.py:369
 #, python-format
 msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
 msgstr ""
 "Fatos do Sistema para o Sistema [ %s ] no Ambiente [ %s ] na Org [ %s ] "
 
-#: ../src/katello/client/core/system.py:388
+#: ../src/katello/client/core/system.py:386
 msgid "register a system"
 msgstr "registrar um sistema"
 
 #: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "nome da empresa (requerido)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
+#: ../src/katello/client/core/system.py:641
 msgid "service level agreement"
 msgstr "acordo de nível de serviço"
 
-#: ../src/katello/client/core/system.py:396
+#: ../src/katello/client/core/system.py:394
 msgid ""
 "activation key, more keys are separated with comma e.g. "
 "--activationkey=key1,key2"
@@ -776,113 +1693,108 @@ msgstr ""
 "chave de ativação, mais chaves são separadas por uma vírgula ex: "
 "--activationkey=key1,key2"
 
-#: ../src/katello/client/core/system.py:397
+#: ../src/katello/client/core/system.py:395
 msgid "values of $releasever for the system"
 msgstr "valores de $releasever para o sistema"
 
-#: ../src/katello/client/core/system.py:399
+#: ../src/katello/client/core/system.py:397
 msgid "system facts"
 msgstr "fatos do sistema"
 
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "Opção %s não pode ser especificado por %s"
-
-#: ../src/katello/client/core/system.py:429
+#: ../src/katello/client/core/system.py:419
 #, python-format
 msgid "Successfully registered system [ %s ]"
 msgstr "Sistema registrado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/system.py:430
+#: ../src/katello/client/core/system.py:420
 #, python-format
 msgid "Could not register system [ %s ]"
 msgstr "Não foi possível registrar o sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:435
+#: ../src/katello/client/core/system.py:425
 msgid "remove a deletion record for hypervisor"
 msgstr "remover a gravação de remoção para o hypervisor"
 
-#: ../src/katello/client/core/system.py:439
+#: ../src/katello/client/core/system.py:429
 msgid "hypervisor uuid (required"
 msgstr "hypervisor uuid (necessário)"
 
-#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:437
 #, python-format
 msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
 msgstr ""
 "Gravação de remoção para o hypervisor com uuid removida com sucesso  [ %s ]"
 
-#: ../src/katello/client/core/system.py:453
+#: ../src/katello/client/core/system.py:443
 msgid "unregister a system"
 msgstr "cancelar registro de sistema"
 
-#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:470
 #, python-format
 msgid "Successfully unregistered System [ %s ]"
 msgstr "Registro do sistema cancelado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/system.py:486
+#: ../src/katello/client/core/system.py:475
 msgid "subscribe a system to certificate"
 msgstr "subscrever um sistema para certificado"
 
-#: ../src/katello/client/core/system.py:494
+#: ../src/katello/client/core/system.py:483
 msgid "certificate serial to unsubscribe (required)"
 msgstr "série de certificado a cancelar subscrição (requerido)"
 
-#: ../src/katello/client/core/system.py:496
+#: ../src/katello/client/core/system.py:485
 msgid "quantity (default: 1)"
 msgstr "quantidade (padrão:1)"
 
-#: ../src/katello/client/core/system.py:512
+#: ../src/katello/client/core/system.py:499
 #, python-format
 msgid "Successfully subscribed System [ %s ]"
 msgstr "Sistema subscrito com sucesso [ %s ]"
 
-#: ../src/katello/client/core/system.py:517
+#: ../src/katello/client/core/system.py:504
 msgid "list subscriptions for a system"
 msgstr "lista subscrições para um sistema"
 
-#: ../src/katello/client/core/system.py:524
+#: ../src/katello/client/core/system.py:511
 msgid "show available subscriptions"
 msgstr "exibir subscrições disponíveis"
 
-#: ../src/katello/client/core/system.py:542
+#: ../src/katello/client/core/system.py:528
 #, python-format
 msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
 msgstr ""
 "Não foi encontrada nenhuma subscrição para o Sistema [ %s ] na Empresa [ %s "
 "]"
 
-#: ../src/katello/client/core/system.py:554
+#: ../src/katello/client/core/system.py:540
 #, python-format
 msgid "Current Subscriptions for System [ %s ]"
 msgstr "Subscrições Atuais para o Sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:556
+#: ../src/katello/client/core/system.py:542
 msgid "Serial Id"
 msgstr "Id de Série"
 
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
 msgid "Provided products"
 msgstr "Produtos fornecidos"
 
-#: ../src/katello/client/core/system.py:570
+#: ../src/katello/client/core/system.py:556
 #, python-format
 msgid "No Pools found for System [ %s ] in Org [ %s ]"
 msgstr "Nenhum pool foi encontrado para o sistema [ %s ] na Empresa [ %s ]"
 
-#: ../src/katello/client/core/system.py:580
+#: ../src/katello/client/core/system.py:566
 #, python-format
 msgid "Available Subscriptions for System [ %s ]"
 msgstr "Subscrições Disponíveis para o Sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:595
+#: ../src/katello/client/core/system.py:581
 msgid "unsubscribe a system from certificate"
 msgstr "cancelar subscrição para o sistema a partir do certificado"
 
-#: ../src/katello/client/core/system.py:603
+#: ../src/katello/client/core/system.py:589
 msgid ""
 "entitlement id to unsubscribe from (either entitlement or serial or all is "
 "required)"
@@ -890,7 +1802,7 @@ msgstr ""
 "id do serviço para cancelar subscrição de (é necessário tanto o serviço ou a"
 " série ou tudo )"
 
-#: ../src/katello/client/core/system.py:605
+#: ../src/katello/client/core/system.py:591
 msgid ""
 "serial id of a certificate to unsubscribe from (either entitlement or serial"
 " or all is required)"
@@ -898,7 +1810,7 @@ msgstr ""
 "id da série do certificado para cancelar subscrição de (é necessário tanto o"
 " serviço ou a série ou tudo )"
 
-#: ../src/katello/client/core/system.py:607
+#: ../src/katello/client/core/system.py:593
 msgid ""
 "unsubscribe from all currently subscribed certificates (either entitlement "
 "or serial or all is required)"
@@ -906,236 +1818,98 @@ msgstr ""
 "Cancelar registro de todos os certificados atualmente registrados (tanto o "
 "serviço ou série ou tudo)"
 
-#: ../src/katello/client/core/system.py:629
+#: ../src/katello/client/core/system.py:614
 #, python-format
 msgid "Successfully unsubscribed System [ %s ]"
 msgstr "Subscrição do sistema cancelada com sucesso [ %s ]"
 
-#: ../src/katello/client/core/system.py:635
+#: ../src/katello/client/core/system.py:620
 msgid "update a system"
 msgstr "atualizar um sistema"
 
-#: ../src/katello/client/core/system.py:646
+#: ../src/katello/client/core/system.py:631
 msgid "a new name for the system"
 msgstr "um novo nome para o sistema"
 
-#: ../src/katello/client/core/system.py:648
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
 msgid "a description of the system"
 msgstr "uma descrição do sistema"
 
-#: ../src/katello/client/core/system.py:650
+#: ../src/katello/client/core/system.py:637
 msgid "location of the system"
 msgstr "local do sistema"
 
-#: ../src/katello/client/core/system.py:652
+#: ../src/katello/client/core/system.py:639
 msgid "value of $releasever for the system"
 msgstr "valor de $releasever para o sistema"
 
-#: ../src/katello/client/core/system.py:683
+#: ../src/katello/client/core/system.py:674
 #, python-format
 msgid "Successfully updated system [ %s ]"
 msgstr "sistema atualizado com sucesso[ %s ]"
 
-#: ../src/katello/client/core/system.py:684
+#: ../src/katello/client/core/system.py:675
 #, python-format
 msgid "Could not update system [ %s ]"
 msgstr "Não foi possível atualizar sistema [ %s ]"
 
-#: ../src/katello/client/core/system.py:690
+#: ../src/katello/client/core/system.py:681
 msgid "systems report"
 msgstr "formulário dos sistemas"
 
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
 msgstr ""
-"formato do formulário (valores possíveis: 'html', 'text' (default), 'csv', "
-"'pdf')"
 
-#: ../src/katello/client/core/system.py:724
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
 msgid "system specific actions in the katello server"
 msgstr "ações específicas do sistema no servidor do katello"
 
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "listar todos os filtros"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "Lista de Filtros"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "criar um filtro"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "descrição"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "lista separada por vírgula de nomes/nvres de pacotes"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "Filtro criado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "Não foi possível criar filtro [ %s ]"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "remover um filtro"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "Filtro removido com sucesso [ %s ]"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "informações de filtro"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "Informações de Filtro"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "Adicionar um pacote ao filtro"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "id de pacote (necessário)"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "Pacotes adicionados  [ %s ] ao filtro com sucesso [ %s ]"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "Remover pacotes do filtro"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "Pacotes removidos  [ %s ] do filtro com sucesso [ %s ]"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "ações específicas de filtro no servidor do katello"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "lista distribuições em um repositório"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "id de repositório"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "nome do repositório"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "nome da empresa ex: foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "nome do produto ex: fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "Lista de Distribuição para Repo %s"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "informações de lista sobre uma distribuição"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "id de repositório (necessário)"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "id de distribuição ex: ks-rh-noarch (requerido)"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "Informações de Distribuição"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "ações específicas de repositório no servidor do katello"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "obter um status do servidor do katello"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Status do Katello"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "Verificar o status do servidor"
-
-#: ../src/katello/client/core/package.py:40
+#: ../src/katello/client/core/package.py:38
 msgid "list information about a package"
 msgstr "lista informações sobre um pacote"
 
-#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:43
 msgid "package id, string value (required)"
 msgstr "id de pacote, valor de faixa (requerido)"
 
-#: ../src/katello/client/core/package.py:91
+#: ../src/katello/client/core/package.py:87
 msgid "Package Information"
 msgstr "Informações de pacote"
 
-#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/package.py:94
 msgid "list packages in a repository"
 msgstr "lista pacotes em um repositório"
 
-#: ../src/katello/client/core/package.py:123
+#: ../src/katello/client/core/package.py:117
 #, python-format
 msgid "Package List For Repo %s"
 msgstr "Lista de Pacote para Repo %s"
 
-#: ../src/katello/client/core/package.py:154
+#: ../src/katello/client/core/package.py:148
 msgid "search packages in a repository"
 msgstr "buscar pacotes em um repositório"
 
-#: ../src/katello/client/core/package.py:159
+#: ../src/katello/client/core/package.py:153
 msgid ""
 "query string for searching packages, e.g. "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
@@ -1143,1307 +1917,247 @@ msgstr ""
 "analisar faixa para busca de pacotes, ex.: "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
 
-#: ../src/katello/client/core/package.py:170
+#: ../src/katello/client/core/package.py:164
 #, python-format
 msgid "Package List For Repo %s and Query %s"
 msgstr "Lista de Pacotes para Repo  %s e Análise %s"
 
-#: ../src/katello/client/core/package.py:181
+#: ../src/katello/client/core/package.py:175
 msgid "package specific actions in the katello server"
 msgstr "ações específicas do pacote no servidor katello"
 
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "nenhuma descrição disponível"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "não foi dada nenhuma ação: por favor veja -- help"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "ação inválida: por favor veja -- help"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "resultado amigável do grep"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "verbosidade, mais resultado estruturado"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
 msgstr ""
-"delimitador da coluna no resultado amigável do grep, funciona somente com a "
-"opção -g"
 
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "Opção %s é necessária; por favor veja --help"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "Opção %s está colidingo com o %s; por favor veja --help"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "Um dos %s é necessário; por favor veja --help"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "Ao menos um dos  %s foi requerido; por favor veja --help"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "erro: operação falhou"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
 msgstr ""
-"Erro: O hostname do servidor que você configurou no /etc/katello/client.conf"
-" não coincide com o "
 
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "o hostname retornou do servidor katello que você está conectado."
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "executar um cli como uma shell"
 
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "Você possui: [%s] configurado mas possui: [%s] do servidor."
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "nome do provedor (requerido)"
 
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "Por favor, corrija a máquina no arquivo /etc/katello/client.conf"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "Credenciais inválidas ou incapazes de autenticar"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "opção %s: valor booleano inválido: %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "lista todos os usuários conhecidos"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "Lista de Usuário"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "criar usuário"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "nome do usuário (necessário)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "senha inicial (requerido)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "email (necessário)"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "conta desabilitada (padrão é 'falso')"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "nome da empresa padrão do usuário"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "nome do ambiente padrão do usuário"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "Usuário criado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "Não foi possível criar usuário [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "listar informações sobre usuário"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "Informações de usuário"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "remover usuário"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "Usuário removido com sucesso [ %s ]"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "atualizar um usuário"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "senha inicial"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "email"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "conta desabilitada"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "Ambiente padrão do usuário é Nenhum"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "Usuário atualizado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "lisar funções de usuaŕio"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "Lista de funções de Usuários"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "sincronizar funções com os grupos LDAP"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "atribuir uma função a um usuário"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "cancelar atribuição de uma função à um usuário"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "função de usuário (necessário)"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "Função [%s] não foi encontrado"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "reportar usuário"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "ações específicas de usuário no servidor do katello"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "Inserir o conteúdo da chave GPG (finalizar inserção com o CTRL+D):"
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "listar todas as chaves GPG"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "nome da empresa (requerido)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "Não foram encontradas nenhuma chave gpg na empresa [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "Listar Chave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "exibir informações sobre a chave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "nome da chave de ativação (requerido)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "Não foi possíve encontrar chave gpg [ %s ] "
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "Repositórios"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "Info sobre Chave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "criar uma chave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-"arquivo com chave GPG pública, se não especificado, entrada padrão será "
-"utilizada"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "Chave gpg criada com sucesso [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "Não foi possível criar chave gpg [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "atualizar uma chave de ativação"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "novo nome de modelo"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "arquivo com chave GPG pública"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "solicitação de novo conteúdo da chave"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "Chave gpg atualizada com sucesso [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "Não foi possível atualizar chave gpg [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "remover uma chave gpg"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "Chave gpg removida com sucesso [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "ações específicas de chave GPG no servidor do katello"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "lista todas as chaves de ativação"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "nome do ambiente ex: dev (padrão: Biblioteca)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "Não foram encontradas nenhuma chave na empresa [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-"Não foi possível encontrar nenhuma chave na empresa [ %s ] ambiente  [ %s ] "
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "Lista de Chave de Ativação"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "mostrar informações sobre uma chave de ativação"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "Não foi possível encontrar chave de Ativação [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "Info da Chave de Ativação"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "criar uma chave de ativação"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "nome do ambiente ex: dev (requerido)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "descrição da chave de ativação"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "nome do modelo ex: servidores"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "Não foi possíve encontrar modelo [ %s ] "
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "Chave de Ativação criada com sucesso [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "Não foi possível criar chave de Ativação [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "novo nome do ambiente: ex: dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "nova descrição"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "novo nome de modelo ex: servidores"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "adicionar um pool à chave de ativação"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "remover um pool da chave de ativação"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "Chave de Ativação atualizada com sucesso [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "remover uma chave de ativação"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "Chave de Ativação removida com sucesso [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "ações específicas da chave de ativação no servidor katello"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "lista de grupos de pacotes disponíveis"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "id de repositório, valor da faixa (requerido)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "Não foi encontrado nenhum grupo de pacote no repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "Informações de Grupo de Pacote"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "informações de busca para um grupo de pacote"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "id de grupo de pacote, valor da faixa (requerido)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "Grupo de pacote [%s] não foi encontrado no repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "lista as categorias de grupos de pacote disponíveis"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "Nenhuma categoria de grupo de pacote encontrada no repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "Informações de Categoria de Grupo de Pacote"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "id de categoria de grupo de pacote, valor de faixa (requerido)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "Categoria de grupo de pacote [%s] não foi encontrado no repo [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "Informações de Categoria de Grupo de Pacote"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "ações específicas de grupo de pacote no servidor katello"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "listar novos changesets de um ambiente"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "nome do ambiente (requerido)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "Lista do Changeset"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "informações detalhadas sobre o changeset"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "nome do changeset (requerido)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "irá exibir pacotes dependentes"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "Info do Changeset"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "criar um  novo changesets para um ambiente"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "descrição do changeset"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "changeset criado com sucesso [ %s ] para ambiente[ %s ]"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "Não foi possível criar changeset [ %s ] para ambiente [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "conteúdo de atualização de um changeset"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s deve ser precedido de %s"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "nome do changeset novo"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "produto a adicionar ao changeset"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "produto para remover do changeset"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "nome de um modelo a ser adicionado ao changeset"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "nome de um modelo a ser removido de um changeset"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-"determina o produto do qual o pacote/errata/repositórios são coletados"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "para adicioanr ao changeset"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "para remover do changeset"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "changeset atualizado com sucesso [ %s ] "
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "remove um changeset"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "promove um changeset para um próximo ambiente"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "Promovendo o changeset, por favor aguarde..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "Changeset  [ %s ] promovido"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "Changeset  [ %s ] falha na promoção: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "ações específicas do changeset no servidor do katello"
-
-#: ../src/katello/client/core/provider.py:59
+#: ../src/katello/client/core/provider.py:57
 msgid "list all known providers"
 msgstr "lista todos os provedores conhecidos"
 
-#: ../src/katello/client/core/provider.py:81
+#: ../src/katello/client/core/provider.py:79
 msgid "Provider List"
 msgstr "Lista de Provedores"
 
-#: ../src/katello/client/core/provider.py:89
+#: ../src/katello/client/core/provider.py:87
 msgid "list information about a provider"
 msgstr "lista informações sobre um provedor"
 
-#: ../src/katello/client/core/provider.py:104
+#: ../src/katello/client/core/provider.py:102
 msgid "Provider Information"
 msgstr "Informações de Provedor"
 
-#: ../src/katello/client/core/provider.py:116
+#: ../src/katello/client/core/provider.py:114
 msgid "create a provider"
 msgstr "criar um provedor"
 
-#: ../src/katello/client/core/provider.py:118
+#: ../src/katello/client/core/provider.py:116
 msgid "update a provider"
 msgstr "atualizar um provedor"
 
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
 msgid "provider description"
 msgstr "descrição de provedor"
 
-#: ../src/katello/client/core/provider.py:139
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"url de repositório ex: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
 msgid "provider name"
 msgstr "nome do provedor"
 
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "Opção --url precisa começar com http:// ou https://"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "Opção --url não é um formato válido"
-
-#: ../src/katello/client/core/provider.py:159
+#: ../src/katello/client/core/provider.py:147
 #, python-format
 msgid "Successfully created provider [ %s ]"
 msgstr "Provedor criado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/provider.py:160
+#: ../src/katello/client/core/provider.py:148
 #, python-format
 msgid "Could not create provider [ %s ]"
 msgstr "Não foi possível encontrar provedor [ %s ]"
 
-#: ../src/katello/client/core/provider.py:167
+#: ../src/katello/client/core/provider.py:155
 #, python-format
 msgid "Successfully updated provider [ %s ]"
 msgstr "Provedor atualizado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/provider.py:185
+#: ../src/katello/client/core/provider.py:173
 msgid "delete a provider"
 msgstr "remover um provedor"
 
-#: ../src/katello/client/core/provider.py:201
+#: ../src/katello/client/core/provider.py:189
 msgid "synchronize a provider"
 msgstr "sincronizar um provedor"
 
-#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/provider.py:204
 #, python-format
 msgid "Provider [ %s ] failed to sync: %s"
 msgstr "Provedor [ %s ] falha ao sincronizar: %s"
 
-#: ../src/katello/client/core/provider.py:219
+#: ../src/katello/client/core/provider.py:207
 #, python-format
 msgid "Provider [ %s ] synchronization cancelled"
 msgstr "Provedor [ %s ]  sincronização cancelado."
 
-#: ../src/katello/client/core/provider.py:222
+#: ../src/katello/client/core/provider.py:210
 #, python-format
 msgid "Provider [ %s ] synchronized"
 msgstr "Provedor [ %s ] sincronizado"
 
-#: ../src/katello/client/core/provider.py:245
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "cancelar a sincronização em execução no momento"
+
+#: ../src/katello/client/core/provider.py:233
 msgid "status of provider's synchronization"
 msgstr "status da sincronização do provedor"
 
-#: ../src/katello/client/core/provider.py:258
+#: ../src/katello/client/core/provider.py:246
 #, python-format
 msgid "%d%% done (%d of %d packages downloaded)"
 msgstr "%d%% concluído (%d of %d pacotes baixados)"
 
-#: ../src/katello/client/core/provider.py:269
+#: ../src/katello/client/core/provider.py:257
 msgid "Provider Status"
 msgstr "Status do Provedor"
 
-#: ../src/katello/client/core/provider.py:277
+#: ../src/katello/client/core/provider.py:265
 msgid "import a manifest file"
 msgstr "importar um arquivo de manifesto"
 
-#: ../src/katello/client/core/provider.py:283
+#: ../src/katello/client/core/provider.py:271
 msgid "path to the manifest file (required)"
 msgstr "caminho para o arquivo de manifesto (requerido)"
 
-#: ../src/katello/client/core/provider.py:285
+#: ../src/katello/client/core/provider.py:273
 msgid "force reimporting the manifest"
 msgstr "forçar a reimportação do manifesto"
 
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
 #, python-format
 msgid "File %s does not exist"
 msgstr "Arquivo %s não existe"
 
-#: ../src/katello/client/core/provider.py:307
+#: ../src/katello/client/core/provider.py:295
 msgid "Importing manifest, please wait... "
 msgstr "Importando o manifesto, por favor aguarde..."
 
-#: ../src/katello/client/core/provider.py:320
+#: ../src/katello/client/core/provider.py:308
 msgid "refresh provider's products repositories"
 msgstr "atualizar repositórios de produtos de provedores"
 
-#: ../src/katello/client/core/provider.py:329
+#: ../src/katello/client/core/provider.py:317
 #, python-format
 msgid "Provider successfully refreshed [ %s ]"
 msgstr "Provedor atualizado com sucesso  [ %s ]"
 
-#: ../src/katello/client/core/provider.py:336
+#: ../src/katello/client/core/provider.py:324
 msgid "provider specific actions in the katello server"
 msgstr "ações específicas de provedor no servidor katello"
 
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "listar ambientes conhecidos"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "Org"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "Ambiente anterior"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "Lista de Ambiente"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "listar um ambiente específico"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "nome do ambiente: ex: foo.example.com (requerido)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "Info do Ambiente"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "criar um ambiente"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "descrição de ambiente ex: ambiente do foo"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "nome do ambiente anterior (requerido)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "Ambiente criado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "Não foi possível criar ambiente [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "atualizar um ambiente"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "nome do ambiente anterior"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "Ambiente atualizado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "remover um ambiente"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "Ambiente removido com sucesso [ %s ]"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "ações específicas de ambiente no servidor do katello"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "salvar uma opção na configuração do cliente"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-"nome da opção a ser salva (ex: org, ambiente, provedor, etc) (requerido)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "valor a ser armazenado sob uma opção específica (requerido)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "Com sucesso"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "Opção lembrar senha não foi bem sucedido [ %s ]"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "remover uma opção da config do cliente"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "nome da opção a ser removida (requerida)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "Opção esqueci a senha bem sucedido [ %s ]"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "Opção "
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "opções de lista salvas na config do cliente"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "Opções Salvas"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "ações específicas do cliente no servidor do katello"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "lista todos os modelos"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "nome da empresa (requerido se ambiente é especificado)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "Não foi possível encontrar nenhum modelo no ambiente [ %s ] "
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "Lista de Modelos"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "informações de lista sobre um modelo"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "nome do modelo (requerido)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "Info do Modelo"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "criar um arquivo de modelo e dados de importação"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "caminho para o arquivo de modelo (requerido)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "Importando modelos, por favor aguarde..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "exportar o modelo para o arquivo"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "nome do ambiente ex: dev"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "formato da exportação, valores possíveis: %s, default: json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "Não foi possível criar arquivo %s "
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "Exportando modelo, por favor aguarde..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "Modelo foi exportado com sucesso ao arquivo %s"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "criar um arquivo de modelo vazio"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "nome do modelo pai"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "descrição do modelo"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "modelo criado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "Não foi possível criar modelo [ %s ] "
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "nome da atualização e descrição de um modelo"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "cada %s deve ser precedido por um %s"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "nome do nvre do produto (epoch: name-rel.ease-ver.sio.n)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "nome do parâmetro, %s deve seguir"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "valor do parâmetro"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "nome do parâmetro"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "nome do grupo do pacote"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "nome da categoria do grupo do pacote"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "id de distribuição"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "determina o produto do qual os repositórios são coletados"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "Repositório a ser adicionado neste modelo."
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "Repositório a ser removido deste modelo."
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "valor faltando para o parâmetro '%s'"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "Atualizando o modelo, por favor aguarde..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "Modelo atualizado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "remove um modelo"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "nome do ambiente: ex: foo.example.com (padrão: Bilbioteca)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "ações específicas do modelo no servidor do katello"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "executar um cli como uma shell"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "listar planos de sincronização conhecidos"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "Lista de Plano de Sincronização"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "imprimir informações sobre o plano de sinc"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "nome do plano de sinc (necessário)"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "Info sobre o Plano de Sinc"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "criar um plano de sincronização"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "descrição do plano"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-"intervalo de sincronizações recorrentes (escolhas: [%s], default: nenhum)"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "data da primeira sincronização (necessária, formato: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-"tempo da primeira sincronização (formato: HH:MM:SS, default: 00:00:00)"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "Plano de sincronização criado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "Não foi possível criar o Plano de sincronização [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "atualizar um plano de sinc"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "nome do novo plano de sinc"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "data da primeira sincronização (formato: YYYY-MM-DD)"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "tempo da primeira sincronização (formato: HH:MM:SS)"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "Você deve especificar --date e --time"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "Plano de sincronização atualizado com sucesso [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "remover plano de sinc"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "Plano de sincronização removido com sucesso [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr "ações específicas do plano de sincronização no servidor do katello"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "obter a versão do servidor katello"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "Verificar a versão do servidor"
-
-#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "obter um status do servidor do katello"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Status do Katello"
+
+#: ../src/katello/client/core/permission.py:53
 msgid "create a permission for a user role"
 msgstr "criar uma permissão para uma função de usuário"
 
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "nome da função (necessário)"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
 msgid "permission name (required)"
 msgstr "nome da permissão (necessário)"
 
-#: ../src/katello/client/core/permission.py:61
+#: ../src/katello/client/core/permission.py:58
 msgid "permission description"
 msgstr "descrição da permissão"
 
-#: ../src/katello/client/core/permission.py:62
+#: ../src/katello/client/core/permission.py:59
 msgid "organization name"
 msgstr "nome da empresa"
 
-#: ../src/katello/client/core/permission.py:63
+#: ../src/katello/client/core/permission.py:60
 msgid "scope of the permisson (required)"
 msgstr "escopo da permissão (necessário)"
 
-#: ../src/katello/client/core/permission.py:64
+#: ../src/katello/client/core/permission.py:61
 msgid "verbs for the permission"
 msgstr "verbos para a permissão"
 
-#: ../src/katello/client/core/permission.py:65
+#: ../src/katello/client/core/permission.py:62
 msgid "tags for the permission"
 msgstr "abas para a permissão"
 
-#: ../src/katello/client/core/permission.py:81
+#: ../src/katello/client/core/permission.py:76
 #, python-format
 msgid "Invalid scope [ %s ]"
 msgstr "Escopo inválido [ %s ]"
 
-#: ../src/katello/client/core/permission.py:88
+#: ../src/katello/client/core/permission.py:83
 #, python-format
 msgid "Could not find tag [ %s ] in scope of [ %s ]"
 msgstr "Não foi possível encontrar a aba [ %s ] no escopo de  [%s]"
 
-#: ../src/katello/client/core/permission.py:112
+#: ../src/katello/client/core/permission.py:101
 #, python-format
 msgid "Successfully created permission [ %s ] for user role [ %s ]"
 msgstr "Permissão criada com sucesso [ %s ] para função do usuário [ %s ]"
 
-#: ../src/katello/client/core/permission.py:113
+#: ../src/katello/client/core/permission.py:102
 #, python-format
 msgid "Could not create permission [ %s ]"
 msgstr "Não foi possível criar permissão [ %s ]"
 
-#: ../src/katello/client/core/permission.py:119
+#: ../src/katello/client/core/permission.py:108
 msgid "delete a permission"
 msgstr "remover uma permissão"
 
-#: ../src/katello/client/core/permission.py:137
+#: ../src/katello/client/core/permission.py:125
 #, python-format
 msgid "Successfully deleted permission [ %s ] for role [ %s ]"
 msgstr "Permissão removida com sucesso [ %s ] para função [ %s ]"
 
-#: ../src/katello/client/core/permission.py:143
+#: ../src/katello/client/core/permission.py:131
 msgid "list permissions for a user role"
 msgstr "listar permissões para uma função de usuário"
 
-#: ../src/katello/client/core/permission.py:170
+#: ../src/katello/client/core/permission.py:158
 msgid "Permission List"
 msgstr "Lista de Permissão"
 
-#: ../src/katello/client/core/permission.py:177
+#: ../src/katello/client/core/permission.py:165
 msgid "list available scopes, verbs and tags that can be set in a permission"
 msgstr ""
 "listar escopos disponíveis, verbos e abas que possam ser definidos em uma "
 "permissão"
 
-#: ../src/katello/client/core/permission.py:181
+#: ../src/katello/client/core/permission.py:169
 msgid ""
 "organization name eg: foo.example.com,\n"
 "lists organization specific verbs"
@@ -2451,26 +2165,101 @@ msgstr ""
 "nome da empresa ex: foo.example.com\n"
 "lista verbos de empresas específicas"
 
-#: ../src/katello/client/core/permission.py:182
+#: ../src/katello/client/core/permission.py:170
 msgid "filter listed results by scope"
 msgstr "filtrar resultados listados por escopo"
 
-#: ../src/katello/client/core/permission.py:200
+#: ../src/katello/client/core/permission.py:188
 #, python-format
 msgid "Available verbs and tags for permission scope %s"
 msgstr "Verbos e abas disponíveis para o escopo da permissão %s"
 
-#: ../src/katello/client/core/permission.py:202
+#: ../src/katello/client/core/permission.py:190
 msgid "Available verbs"
 msgstr "Verbos disponíveis"
 
-#: ../src/katello/client/core/permission.py:221
+#: ../src/katello/client/core/permission.py:209
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/katello/client/core/permission.py:259
+#: ../src/katello/client/core/permission.py:247
 msgid "permission pecific actions in the katello server"
 msgstr "Ações específicas de permissão no servidor do katello"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "nenhuma descrição disponível"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "não foi dada nenhuma ação: por favor veja -- help"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "ação inválida: por favor veja -- help"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "resultado amigável do grep"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "verbosidade, mais resultado estruturado"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+"delimitador da coluna no resultado amigável do grep, funciona somente com a "
+"opção -g"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+"Erro: O hostname do servidor que você configurou no /etc/katello/client.conf"
+" não coincide com o "
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "o hostname retornou do servidor katello que você está conectado."
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "Você possui: [%s] configurado mas possui: [%s] do servidor."
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "Por favor, corrija a máquina no arquivo /etc/katello/client.conf"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "Credenciais inválidas ou incapazes de autenticar"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "opção %s: valor booleano inválido: %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
 
 #: ../src/katello/client/core/errata.py:42
 msgid "list all errata for a repo"
@@ -2492,26 +2281,116 @@ msgstr "Lista da Errata"
 msgid "list errata for a system"
 msgstr "Errata da lista para um sistema"
 
-#: ../src/katello/client/core/errata.py:125
+#: ../src/katello/client/core/errata.py:124
 #, python-format
 msgid "Errata for system %s in organization %s"
 msgstr "Errata para o sistema %s na empresa %s"
 
-#: ../src/katello/client/core/errata.py:132
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
 msgid "information about an errata"
 msgstr "Informações sobre uma errata"
 
-#: ../src/katello/client/core/errata.py:136
+#: ../src/katello/client/core/errata.py:170
 msgid "errata id, string value (required)"
 msgstr "id da errata, valor da faixa (requerido)"
 
-#: ../src/katello/client/core/errata.py:185
+#: ../src/katello/client/core/errata.py:217
 msgid "Errata Information"
 msgstr "Informações da Errata"
 
-#: ../src/katello/client/core/errata.py:194
+#: ../src/katello/client/core/errata.py:226
 msgid "errata specific actions in the katello server"
 msgstr "ações específicas de errata no servidor do katello"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "obter a versão do servidor katello"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "Verificar a versão do servidor"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "lista de grupos de pacotes disponíveis"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "id de repositório, valor da faixa (requerido)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "Não foi encontrado nenhum grupo de pacote no repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "Informações de Grupo de Pacote"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "informações de busca para um grupo de pacote"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "id de grupo de pacote, valor da faixa (requerido)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "Grupo de pacote [%s] não foi encontrado no repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "lista as categorias de grupos de pacote disponíveis"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "Nenhuma categoria de grupo de pacote encontrada no repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "Informações de Categoria de Grupo de Pacote"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "id de categoria de grupo de pacote, valor de faixa (requerido)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "Categoria de grupo de pacote [%s] não foi encontrado no repo [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "Informações de Categoria de Grupo de Pacote"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "ações específicas de grupo de pacote no servidor katello"
 
 #: ../src/katello/client/core/repo.py:34
 msgid "Waiting"
@@ -2541,20 +2420,27 @@ msgstr "Tempo expirado"
 msgid "Not synced"
 msgstr "Não está em sincronicidade"
 
-#: ../src/katello/client/core/repo.py:116
+#: ../src/katello/client/core/repo.py:114
 msgid "create a repository at a specified URL"
 msgstr "criar um repositório em uma URL especificada"
 
-#: ../src/katello/client/core/repo.py:122
+#: ../src/katello/client/core/repo.py:120
 msgid "repository name to assign (required)"
 msgstr "nome do repositório para atribuir (requerido)"
 
-#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:122
 msgid "url path to the repository (required)"
 msgstr "caminho da url ao repositório (requerido)"
 
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "nome do produto (requerido)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
 msgid ""
 "GPG key to be assigned to the repository; by default, the product's GPG key "
 "will be used."
@@ -2562,29 +2448,29 @@ msgstr ""
 "Chave GPG a ser atribuída ao repositório; por padrão, as chaves GPG de "
 "produto serão utilizadas"
 
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
 msgid "Don't assign a GPG key to the repository."
 msgstr "Não atribua uma chave GPG ao repositório"
 
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
 #, python-format
 msgid "Successfully created repository [ %s ]"
 msgstr "repositório criado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/repo.py:154
+#: ../src/katello/client/core/repo.py:149
 msgid "discovery repositories contained within a URL"
 msgstr "repositórios discovery contidos dentro de uma URL"
 
-#: ../src/katello/client/core/repo.py:160
+#: ../src/katello/client/core/repo.py:155
 msgid ""
 "repository name prefix to add to all the discovered repositories (required)"
 msgstr ""
 "prefixo do nome do repositório a adicionar em todos os repositórios "
 "descobertos (requerido)"
 
-#: ../src/katello/client/core/repo.py:162
+#: ../src/katello/client/core/repo.py:157
 msgid ""
 "root url to perform discovery of repositories eg: "
 "http://porkchop.devel.redhat.com/ (required)"
@@ -2592,16 +2478,31 @@ msgstr ""
 "url root para realizar a descoberta de repositórios ex: "
 "http://porkchop.devel.redhat.com/ (requerido)"
 
-#: ../src/katello/client/core/repo.py:192
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+"presume-se que sim; automaticamente cria repositórios de candidato para as "
+"urls de descoberta (opcional)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "Urls de Repositórios  descobertos @ [%s]"
+
+#: ../src/katello/client/core/repo.py:183
 msgid "Discovering repository urls, this could take some time..."
 msgstr "Descobrindo urls de repositórios, isto pode levar algum tempo..."
 
-#: ../src/katello/client/core/repo.py:196
+#: ../src/katello/client/core/repo.py:187
 #, python-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: ../src/katello/client/core/repo.py:216
+#: ../src/katello/client/core/repo.py:207
 msgid ""
 "\n"
 "Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
@@ -2609,333 +2510,800 @@ msgstr ""
 "¶\n"
 "Selecione urls para o qual os repositórios de candidatos devem ser criados; use o 'y' para confirmar (h para help)"
 
-#: ../src/katello/client/core/repo.py:226
+#: ../src/katello/client/core/repo.py:217
 msgid "Operation aborted upon user request."
 msgstr "Operação abortada até requisição do usuário"
 
-#: ../src/katello/client/core/repo.py:275
+#: ../src/katello/client/core/repo.py:266
 msgid "status information about a repository"
 msgstr "informação de status sobre um repositório"
 
-#: ../src/katello/client/core/repo.py:298
+#: ../src/katello/client/core/repo.py:289
 msgid "Repository Status"
 msgstr "Status do Repositório"
 
-#: ../src/katello/client/core/repo.py:305
+#: ../src/katello/client/core/repo.py:296
 msgid "information about a repository"
 msgstr "Informações sobre um repositório"
 
-#: ../src/katello/client/core/repo.py:319
+#: ../src/katello/client/core/repo.py:310
 msgid "Progress"
 msgstr "Progresso"
 
-#: ../src/katello/client/core/repo.py:322
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "Chave GPG"
+
+#: ../src/katello/client/core/repo.py:313
 #, python-format
 msgid "Information About Repo %s"
 msgstr "Informações sobre repositório %s"
 
-#: ../src/katello/client/core/repo.py:329
+#: ../src/katello/client/core/repo.py:320
 msgid "updates repository attributes"
 msgstr "atributos de repositório de atualizações"
 
-#: ../src/katello/client/core/repo.py:345
+#: ../src/katello/client/core/repo.py:336
 #, python-format
 msgid "Successfully updated repository [ %s ]"
 msgstr "Repositório atualizado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/repo.py:351
+#: ../src/katello/client/core/repo.py:342
 msgid "synchronize a repository"
 msgstr "sincronizar um repositório"
 
-#: ../src/katello/client/core/repo.py:361
+#: ../src/katello/client/core/repo.py:352
 #, python-format
 msgid "Repo [ %s ] synced"
 msgstr "Repo [ %s ] sincronizado"
 
-#: ../src/katello/client/core/repo.py:364
+#: ../src/katello/client/core/repo.py:355
 #, python-format
 msgid "Repo [ %s ] synchronization cancelled"
 msgstr "Repo [ %s ]  Plano de sincronização cancelado."
 
-#: ../src/katello/client/core/repo.py:367
+#: ../src/katello/client/core/repo.py:358
 #, python-format
 msgid "Repo [ %s ] failed to sync: %s"
 msgstr "Repo [ %s ] falha ao sincronizar: %s"
 
-#: ../src/katello/client/core/repo.py:373
+#: ../src/katello/client/core/repo.py:364
 msgid "cancel currently running synchronization of a repository"
 msgstr "cancelar a sincronização em execução atualmente de um repositório"
 
-#: ../src/katello/client/core/repo.py:388
+#: ../src/katello/client/core/repo.py:379
 msgid "enable a repository"
 msgstr "habilitar um repositório"
 
-#: ../src/katello/client/core/repo.py:390
+#: ../src/katello/client/core/repo.py:381
 msgid "disable a repository"
 msgstr "desabilitar um repositório"
 
-#: ../src/katello/client/core/repo.py:409
+#: ../src/katello/client/core/repo.py:400
 msgid "list repos within an organization"
 msgstr "lista repositórios dentro de uma empresa"
 
-#: ../src/katello/client/core/repo.py:413
+#: ../src/katello/client/core/repo.py:404
 msgid "organization name eg: ACME_Corporation (required)"
 msgstr "nome de empresa ex: ACME_Corporation (requerido)"
 
-#: ../src/katello/client/core/repo.py:419
+#: ../src/katello/client/core/repo.py:410
 msgid "list also disabled repositories"
 msgstr "listar também repositórios desabilitados"
 
-#: ../src/katello/client/core/repo.py:439
+#: ../src/katello/client/core/repo.py:430
 #, python-format
 msgid "Repo List For Org %s Environment %s Product %s"
 msgstr "Lista de repo para Org %s Ambiente %s Produto %s"
 
-#: ../src/katello/client/core/repo.py:446
+#: ../src/katello/client/core/repo.py:437
 #, python-format
 msgid "Repo List for Product %s in Org %s "
 msgstr "Lista de Repo para Produto %s na Empresa %s"
 
-#: ../src/katello/client/core/repo.py:453
+#: ../src/katello/client/core/repo.py:444
 #, python-format
 msgid "Repo List For Org %s Environment %s"
 msgstr "Lista de repo para Org %s Ambiente %s"
 
-#: ../src/katello/client/core/repo.py:463
+#: ../src/katello/client/core/repo.py:454
 msgid "delete a repository"
 msgstr "remover um repositório"
 
-#: ../src/katello/client/core/repo.py:476
+#: ../src/katello/client/core/repo.py:467
 msgid "list filters of a repository"
 msgstr "listar filtros de um repositório"
 
-#: ../src/katello/client/core/repo.py:482
+#: ../src/katello/client/core/repo.py:473
 msgid "prints also filters assigned to repository's product."
 msgstr "imprime também filtros atribuídos ao produto do repositório"
 
-#: ../src/katello/client/core/repo.py:492
+#: ../src/katello/client/core/repo.py:483
 msgid "Repository Filters"
 msgstr "Filtros de Repositório"
 
-#: ../src/katello/client/core/repo.py:506
+#: ../src/katello/client/core/repo.py:497
 msgid "add a filter to a repository"
 msgstr "adicionar um filtro ao repositório"
 
-#: ../src/katello/client/core/repo.py:508
+#: ../src/katello/client/core/repo.py:499
 msgid "remove a filter from a repository"
 msgstr "remover um filtro de um repositório"
 
-#: ../src/katello/client/core/repo.py:538
+#: ../src/katello/client/core/repo.py:529
 #, python-format
 msgid "Added filter [ %s ] to repository [ %s ]"
 msgstr "Filtro adicionado [ %s ] ao repositório [ %s ]"
 
-#: ../src/katello/client/core/repo.py:541
+#: ../src/katello/client/core/repo.py:532
 #, python-format
 msgid "Removed filter [ %s ] to repository [ %s ]"
 msgstr "Filtro removido [ %s ] do repositório [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "lista todos as funções dos usuários conhecidos"
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "listar planos de sincronização conhecidos"
 
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "criar função de usuário"
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
 
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "descrição da função"
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "Lista de Plano de Sincronização"
 
-#: ../src/katello/client/core/user_role.py:77
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "imprimir informações sobre o plano de sinc"
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "nome do plano de sinc (necessário)"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "Info sobre o Plano de Sinc"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "criar um plano de sincronização"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "descrição do plano"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
 #, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "Função de usuário criada com sucesso[ %s ]"
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+"intervalo de sincronizações recorrentes (escolhas: [%s], default: nenhum)"
 
-#: ../src/katello/client/core/user_role.py:78
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "data da primeira sincronização (necessária, formato: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+"tempo da primeira sincronização (formato: HH:MM:SS, default: 00:00:00)"
+
+#: ../src/katello/client/core/sync_plan.py:135
 #, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "Não foi possível criar função do usuário [ %s ]"
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "Plano de sincronização criado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "listar informações sobre função do usuário"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "nome da função do usuário(necessário)"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "imprimir detalhes sobre cada permissão de função"
-
-#: ../src/katello/client/core/user_role.py:109
+#: ../src/katello/client/core/sync_plan.py:136
 #, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "Não foi possível criar o Plano de sincronização [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "atualizar um plano de sinc"
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "nome do novo plano de sinc"
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "data da primeira sincronização (formato: YYYY-MM-DD)"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "tempo da primeira sincronização (formato: HH:MM:SS)"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "Plano de sincronização atualizado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "remover plano de sinc"
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "Plano de sincronização removido com sucesso [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr "ações específicas do plano de sincronização no servidor do katello"
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "listar todas as empresas conhecidas"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "Listar as Empresas"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "criar uma empresa"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "descrição do consumidor ex: empresa do foo"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "Empresa criada com sucesso [ %s ]"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "Não foi possível criar empresa [ %s ]"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "Informações da lista sobre uma empresa"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "Níveis de Serviços Disponíveis"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "Informações da Empresa"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "remover uma empresa"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "Removendo a empresa, por favor aguarde..."
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "Empresa removida com sucesso [ %s ]"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "Remoção da empresa [ %s ] falhou: %s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "atualizar uma empresa"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "Empresa atualizada com sucesso [ %s ]"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "gerar e exibir certificado de ueber"
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "regenerar o certificado"
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "Uebercert da Empresa"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "mostrar subscrições"
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "Subscrições de Empresa"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "ações específicas da emrpesa no servidor do katello"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "definir um plano de sincronização"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "nome do plano de sincronização (necessário)"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "cancelar definição de um plano de sincronização"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "lista produtos conhecidos"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "nome do provedor, lista o produto do provedor na Biblioteca"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "Lista de Produto para o Provedor %s"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "Lista de Produto para a Empresa %s, Ambiente '%s'"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "sincronizar um produto"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "Produto [ %s ] falhou na sincronização: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "Produto [ %s ]  sincronização cancelado."
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "Produto [ %s ] sincronizado"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "status da sincronização do produto"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "Status do Produto"
+
+#: ../src/katello/client/core/product.py:249
 msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
 msgstr ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+"promover um produto em um ambiente\n"
+"(cria um changeset temporário com o produto e o promove)"
 
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "Informações de função de usuário"
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "Promovendo o produto, por favor aguarde..."
 
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "remover uma função de usuário"
-
-#: ../src/katello/client/core/user_role.py:152
+#: ../src/katello/client/core/product.py:275
 #, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "Função de usuário removida com sucesso [ %s ]"
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "Produto [ %s ] promovido em ambiente [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "atualizar uma função"
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "Produto  [ %s ] falha na promoção: %s"
 
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "nome da função nova do usuário"
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "criar um novo produto em um provedor padronizado"
 
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "descrição de produto"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "pular descoberta de repositório"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
 msgstr ""
-"Forneça ao menos um parâmetro para atualizar a função do usuário [ %s ]"
+"atribuir uma chave gpg; esta chave será utilizada para todos os novos "
+"repositórios a não ser que a chave gpg seja especificada para o repo"
 
-#: ../src/katello/client/core/user_role.py:180
+#: ../src/katello/client/core/product.py:339
 #, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "Função de usuário atualizada com sucesso[ %s ]"
+msgid "Successfully created product [ %s ]"
+msgstr "Produto criado com sucesso [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "atribuir o grupo LDAP à uma função"
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "atualizar os atributos do produto"
 
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "novo nome de grupo  LDAP (necessário)"
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "mudar a descrição do produto"
 
-#: ../src/katello/client/core/user_role.py:204
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "atribuir uma chave gpg ao produto"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "atribuir uma chave gpg também aos repositórios do produto"
+
+#: ../src/katello/client/core/product.py:383
 #, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgid "Successfully updated product [ %s ]"
+msgstr "Produto atualizado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "remover um produto e seu conteúdo"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "listar filtros de um produto"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "Filtros de Produto"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "adicionar um filtro à um produto"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "remover um filtro de um produto"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "Filtro adicionado [ %s ] ao produto [ %s ]"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "Filtro removido [ %s ] do produto [ %s ]"
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "ações específicas de produto no servidor katello"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "lista todos os modelos"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "nome da empresa (requerido se ambiente é especificado)"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "Não foi possível encontrar nenhum modelo no ambiente [ %s ] "
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "Lista de Modelos"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "informações de lista sobre um modelo"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "nome do modelo (requerido)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "Info do Modelo"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "criar um arquivo de modelo e dados de importação"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "caminho para o arquivo de modelo (requerido)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "Importando modelos, por favor aguarde..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "exportar o modelo para o arquivo"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "nome do ambiente ex: dev"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "formato da exportação, valores possíveis: %s, default: json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "Não foi possível criar arquivo %s "
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "Exportando modelo, por favor aguarde..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "Modelo foi exportado com sucesso ao arquivo %s"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "criar um arquivo de modelo vazio"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "nome do modelo pai"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "descrição do modelo"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "modelo criado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "Não foi possível criar modelo [ %s ] "
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "nome da atualização e descrição de um modelo"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "cada %s deve ser precedido por um %s"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
 msgstr ""
-"Grupo LDAP adicionado com sucesso  [ %s ] para a função do usuário [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "remover o grupo LDAP atribuído à uma função"
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "Nome do grupo LDAP para ser removido (necessário)"
-
-#: ../src/katello/client/core/user_role.py:228
+#: ../src/katello/client/core/template.py:320
 #, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgid "name of the parameter, %s must follow"
+msgstr "nome do parâmetro, %s deve seguir"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "valor do parâmetro"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "nome do parâmetro"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "nome do grupo do pacote"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "nome da categoria do grupo do pacote"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "id de distribuição"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "determina o produto do qual os repositórios são coletados"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "Repositório a ser adicionado neste modelo."
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "Repositório a ser removido deste modelo."
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "valor faltando para o parâmetro '%s'"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "Atualizando o modelo, por favor aguarde..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "Modelo atualizado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "remove um modelo"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "nome do ambiente: ex: foo.example.com (padrão: Bilbioteca)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "ações específicas do modelo no servidor do katello"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "listar ambientes conhecidos"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "Org"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "Ambiente anterior"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "Lista de Ambiente"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "listar um ambiente específico"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "nome do ambiente: ex: foo.example.com (requerido)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "Info do Ambiente"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "criar um ambiente"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "descrição de ambiente ex: ambiente do foo"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "nome do ambiente anterior (requerido)"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "Ambiente criado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "Não foi possível criar ambiente [ %s ]"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "atualizar um ambiente"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "nome do ambiente anterior"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "Ambiente atualizado com sucesso [ %s ]"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "remover um ambiente"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "Ambiente removido com sucesso [ %s ]"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "ações específicas de ambiente no servidor do katello"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "arquivo de certificado %s não existe ou não pode ser lido"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "arquivo de chave %s não existe ou não pode ser lido"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
 msgstr ""
-"Grupo LDAP removido com sucesso  [ %s ] a partir da função do usuário [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "ações específicas de função de usuário no servidor do katello"
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "Não foi possível autenticar via kerberos"
 
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "Formato de Hora é inválido. Requerido: HH:MM:SS[+HH:MM]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "Formato de Data é inválido. Requerido: YYYY-MM-DD"
-
-#. These are a bunch of strings that are marked for translation in optparse,
-#. but not actually translated anywhere. Mark them for translation here,
-#. so we get it picked up. for local translation, and then optparse will
-#. use them.
-#: ../src/katello/client/i18n_optparse.py:48
+#: ../src/katello/client/utils/option_validator.py:86
 #, python-format
-msgid "Usage: %s\n"
-msgstr "Uso: %s"
+msgid "Option %s is required; please see --help"
+msgstr "Opção %s é necessária; por favor veja --help"
 
-#: ../src/katello/client/i18n_optparse.py:49
-msgid "Usage"
-msgstr "Uso: %s"
-
-#: ../src/katello/client/i18n_optparse.py:50
-msgid "%prog [options]"
-msgstr "%prog [options]"
-
-#: ../src/katello/client/i18n_optparse.py:51
-msgid "Options"
-msgstr "Opções"
-
-#. stuff for option value sanity checking
-#: ../src/katello/client/i18n_optparse.py:54
+#: ../src/katello/client/utils/option_validator.py:128
 #, python-format
-msgid "no such option: %s"
-msgstr "não existe tal opção: %s"
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:55
+#: ../src/katello/client/utils/option_validator.py:130
 #, python-format
-msgid "ambiguous option: %s (%s?)"
-msgstr "opção ambígua:  %s (%s?)"
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "Opção %s está colidingo com o %s; por favor veja --help"
 
-#: ../src/katello/client/i18n_optparse.py:56
+#: ../src/katello/client/utils/option_validator.py:133
 #, python-format
-msgid "%s option requires an argument"
-msgstr "%s opção requer um argumento"
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:57
+#: ../src/katello/client/utils/option_validator.py:135
 #, python-format
-msgid "%s option requires %d arguments"
-msgstr "%s opção requer um %d argumento"
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:58
+#: ../src/katello/client/utils/option_validator.py:167
 #, python-format
-msgid "%s option does not take a value"
-msgstr "%s opção não leva um valor"
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
 
-#: ../src/katello/client/i18n_optparse.py:59
-msgid "integer"
-msgstr "inteiro"
-
-#: ../src/katello/client/i18n_optparse.py:60
-msgid "long integer"
-msgstr "longo inteiro"
-
-#: ../src/katello/client/i18n_optparse.py:61
-msgid "floating-point"
-msgstr "ponto flutuante"
-
-#: ../src/katello/client/i18n_optparse.py:62
-msgid "complex"
-msgstr "complexo"
-
-#: ../src/katello/client/i18n_optparse.py:63
+#: ../src/katello/client/utils/option_validator.py:200
 #, python-format
-msgid "option %s: invalid %s value: %r"
-msgstr "opção %s: inválido %s valor: %r"
-
-#: ../src/katello/client/i18n_optparse.py:64
-#, python-format
-msgid "option %s: invalid choice: %r (choose from %s)"
-msgstr "opção %s: escolha inválida: %r (escolha a partir do %s)"
-
-#. default options
-#: ../src/katello/client/i18n_optparse.py:67
-msgid "show this help message and exit"
-msgstr "Mostra esta mensagem de ajuda e sai"
-
-#: ../src/katello/client/i18n_optparse.py:68
-msgid "show program's version number and exit"
-msgstr "mostra o número de versão do programa e sai"
+msgid "At least one of %s is required; please see --help"
+msgstr "Ao menos um dos  %s foi requerido; por favor veja --help"

--- a/cli/po/ru.po
+++ b/cli/po/ru.po
@@ -3,85 +3,64 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # ypoyarko <ypoyarko@redhat.com>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 # ypoyarko <ypoyarko@redhat.com>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2012-05-24 10:22-0400\n"
-"Last-Translator: ypoyarko <ypoyarko@redhat.com>\n"
+"PO-Revision-Date: 2012-08-24 02:24-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "Сертификат %s не может быть прочитан или не существует."
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "Файл %s не может быть прочитан или не существует."
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "Ошибка аутентификации Kerberos"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "вывод версии"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Реквизиты доступа пользователя Katello"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "пользователь"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "пароль"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Информация о сервере Katello"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "имя сервера katello (по умолчанию &mdash; %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "Неверная команда (см. --help)"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "Команда не указана (см. --help)"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "Организация [ %s ] не найдена."
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "Не удалось найти окружение [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "Не удалось найти продукт [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
@@ -90,63 +69,68 @@ msgstr ""
 "Не удалось найти репозиторий [ %s ] в организации [ %s ], продукте [ %s ] и "
 "окружении [ %s ]"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "Не удалось найти провайдера [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "Не удалось найти шаблон [ %s ] в окружении [ %s ]"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "Не удалось найти набор изменений [ %s ]  в окружении [ %s ] "
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "Пользователь [ %s ] не найден"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "Роль  [ %s ] не найдена"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "План синхронизации  [ %s ] не найден"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr "Не удалось найти разрешение  [ %s ] для роли  [ %s ]"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "Фильтр  [ %s ] не найден"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "Не удалось найти систему [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "Неоднозначные системы [ %s ] в окружении [ %s ] организации [ %s ]"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "Не найдена система [ %s ] в окружении [ %s ] организации [ %s ]"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
@@ -155,365 +139,1323 @@ msgstr ""
 "Неоднозначные системы [ %s ] в организации [ %s ]. Необходимо выбрать "
 "окружение."
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "имя"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "показать список организаций"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "Список организаций"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "создать организацию"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "организация (обязательно). Пример:  foo.example.com"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "описание клиента. Пример: my organization"
-
-#: ../src/katello/client/core/organization.py:79
+#. These are a bunch of strings that are marked for translation in optparse,
+#. but not actually translated anywhere. Mark them for translation here,
+#. so we get it picked up. for local translation, and then optparse will
+#. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
+#: ../src/katello/client/i18n_optparse.py:48
 #, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "Создана организация [ %s ]"
+msgid "Usage: %s\n"
+msgstr "Формат: %s\n"
 
-#: ../src/katello/client/core/organization.py:80
+#: ../src/katello/client/i18n_optparse.py:49
+msgid "Usage"
+msgstr "Формат"
+
+#: ../src/katello/client/i18n_optparse.py:50
+msgid "%prog [options]"
+msgstr "%prog [параметры]"
+
+#: ../src/katello/client/i18n_optparse.py:51
+msgid "Options"
+msgstr "Параметры"
+
+#. stuff for option value sanity checking
+# stuff for option value sanity checking
+#: ../src/katello/client/i18n_optparse.py:54
 #, python-format
-msgid "Could not create org [ %s ]"
-msgstr "Не удалось создать организацию [ %s ]"
+msgid "no such option: %s"
+msgstr "нет такого параметра: %s"
 
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "просмотр информации об организации"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "Доступные уровни обслуживания"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "Информация об организации"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "удалить организацию"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "Удаляется организация. Пожалуйста, подождите..."
-
-#: ../src/katello/client/core/organization.py:135
+#: ../src/katello/client/i18n_optparse.py:55
 #, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "Организация [ %s ] удалена"
+msgid "ambiguous option: %s (%s?)"
+msgstr "неоднозначный параметр: %s (%s?)"
 
-#: ../src/katello/client/core/organization.py:138
+#: ../src/katello/client/i18n_optparse.py:56
 #, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "Не удалось удалить организацию [ %s ]: %s"
+msgid "%s option requires an argument"
+msgstr "Параметр %s требует указания аргумента"
 
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "обновить организацию"
-
-#: ../src/katello/client/core/organization.py:162
+#: ../src/katello/client/i18n_optparse.py:57
 #, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "Организация [ %s ] обновлена"
+msgid "%s option requires %d arguments"
+msgstr "Параметр %s требует %d аргумент(а)(ов)"
 
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "создать и показать сертификат ueber"
+#: ../src/katello/client/i18n_optparse.py:58
+#, python-format
+msgid "%s option does not take a value"
+msgstr "Параметр %s не принимает значения"
 
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "заново создать сертификат"
+#: ../src/katello/client/i18n_optparse.py:59
+msgid "integer"
+msgstr "целое"
 
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "Uebercert"
+#: ../src/katello/client/i18n_optparse.py:60
+msgid "long integer"
+msgstr "длинное целое"
 
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "показать подписки"
+#: ../src/katello/client/i18n_optparse.py:61
+msgid "floating-point"
+msgstr "с плавающей точкой"
 
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "Подписки организации"
+#: ../src/katello/client/i18n_optparse.py:62
+msgid "complex"
+msgstr "сложные"
 
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "действия организации на сервере katello"
+#: ../src/katello/client/i18n_optparse.py:63
+#, python-format
+msgid "option %s: invalid %s value: %r"
+msgstr "параметр %s, недопустимое значение %s: %r"
 
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "продукт (обязательно)"
+#: ../src/katello/client/i18n_optparse.py:64
+#, python-format
+msgid "option %s: invalid choice: %r (choose from %s)"
+msgstr "параметр %s, недопустимый выбор %r (выберите из %s)"
 
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
+#. default options
+# default options
+#: ../src/katello/client/i18n_optparse.py:67
+msgid "show this help message and exit"
+msgstr "показать справку и выйти"
+
+#: ../src/katello/client/i18n_optparse.py:68
+msgid "show program's version number and exit"
+msgstr "показать версию программы и выйти"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "показать список ролей"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "Список ролей"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "создать роль"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "название роли (обязательно)"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "описание роли"
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr "Создана роль  [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr "Не удалось создать роль  [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "просмотр информации о роли"
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "название роли (обязательно)"
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "вывод сведений о разрешениях для всех ролей"
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+"%s\n"
+"\tдля: %s\n"
+"\tоперации: %s\n"
+"\tна: %s"
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "Информация о роли"
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "удалить роль"
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr "Роль  [ %s ] удалена"
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "обновить роль"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "новое название роли"
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr "Роль [ %s ] обновлена"
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "назначить группу LDAP роли"
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "имя новой группы LDAP (обязательно)"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr "Группа [ %s ]  добавлена к роли [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "удалить группу LDAP из роли"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "Имя удаляемой группы LDAP (обязательно)"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr "Группа LDAP  [ %s ] удалена из роли  [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "действия роли на сервере katello"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "сохранить параметр в настройки клиента"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr "параметр для сохранения (обязательно)"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "значение сохраняемого параметра (обязательно)"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "Успешно"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "Параметр [ %s ] не сохранен"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "исключить параметр из конфигурации"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "имя параметра для удаления (обязательно)"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "Параметр [ %s ] исключен"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "Не удалось исключить параметр [ %s ]"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "список параметров в конфигурации клиента"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "Сохраненные параметры"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "действия клиентов на сервере katello"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "показать все ключи активации"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "имя организации (обязательно)"
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
 msgstr "имя окружения (по умолчанию &mdash; Library)"
 
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "выбрать план синхронизации"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "название плана синхронизации (обязательно)"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "отменить план синхронизации"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "список известных пакетов"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "имя провайдера, список продуктов в Library"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "Ключ GPG"
-
-#: ../src/katello/client/core/product.py:147
+#: ../src/katello/client/core/activation_key.py:69
 #, python-format
-msgid "Product List For Provider %s"
-msgstr "Список продуктов для провайдера %s"
+msgid "No keys found in organization [ %s ]"
+msgstr "Не найдены ключи в организации [ %s ]"
 
-#: ../src/katello/client/core/product.py:153
+#: ../src/katello/client/core/activation_key.py:71
 #, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "Список продуктов для организации %s в окружении '%s'"
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "Не найдены ключи в организации [ %s ] окружения [ %s ]"
 
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "синхронизация продукта"
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "Список ключей активации"
 
-#: ../src/katello/client/core/product.py:179
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "показать информацию о ключе активации"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "имя ключа активации (обязательно)"
+
+#: ../src/katello/client/core/activation_key.py:121
 #, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "Ошибка синхронизации [ %s ]: %s"
+msgid "Could not find activation key [ %s ]"
+msgstr "Ключ [ %s ] не найден"
 
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "Синхронизация [ %s ] отменена."
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "Информация о ключе активации"
 
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "Продукт [ %s ] синхронизирован."
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "создать ключ активации"
 
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "отменить текущую синхронизацию"
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "имя окружения (обязательно). Пример: dev"
 
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "статус синхронизации"
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "описание ключа активации"
 
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "Статус продукта"
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "имя шаблона. Пример: servers"
 
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
 msgstr ""
-"перенести продукт в окружение\n"
-"(будет создан и перенесён временный набор изменений)"
 
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "Перенос продукта. Пожалуйста, подождите..."
-
-#: ../src/katello/client/core/product.py:268
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
 #, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "Продукт [ %s ] перенесён в окружение [ %s ]"
+msgid "Could not find template [ %s ]"
+msgstr "Не найден шаблон [ %s ]"
 
-#: ../src/katello/client/core/product.py:271
+#: ../src/katello/client/core/activation_key.py:178
 #, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "Не удалось перенести [ %s ]: %s"
+msgid "Successfully created activation key [ %s ]"
+msgstr "Создан ключ [ %s ]"
 
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "создать продукт для провайдера"
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "Не удалось создать ключ [ %s ]"
 
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "провайдер (обязательно)"
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "обновить ключ активации"
 
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "описание продукта"
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "имя нового окружения. Пример: dev"
 
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "имя нового шаблона"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "новое описание"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "имя нового шаблона. Пример: servers"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
 msgstr ""
-"Адрес репозитория (например: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/)"
 
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "пропустить обнаружение репозитория"
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "добавить пул к ключу активации"
 
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "удалить пул из ключа активации"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "Ключ [ %s ] обновлён."
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "удалить ключ активации"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "Ключ [ %s ] удалён"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
 msgstr ""
-"по умолчанию автоматически создавать репозитории кандидатов для обнаруженных"
-" URL (дополнительно)"
 
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
 msgstr ""
-"назначить ключ GPG (будет по умолчанию использоваться для новых "
-"репозиториев)"
 
-#: ../src/katello/client/core/product.py:334
+#: ../src/katello/client/core/activation_key.py:320
 #, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "Создан продукт [ %s ]"
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
 #, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "Обнаружены URL репозиториев: [%s]"
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "обновить атрибуты продукта"
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "операции ключей активации на сервере katello"
 
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "изменить описание продукта"
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "Неверное время. Допустимый формат: ЧЧ:ММ:СС[+ЧЧ:ММ]"
 
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "назначить ключ GPG продукту"
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "Неверная дата. Допустимый формат: ГГГГ-ММ-ДД"
 
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "назначить ключ GPG репозиториям продукта"
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "список фильтров"
 
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "Продукт [ %s ] обновлён."
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "имя организации (обязательно)"
 
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "удалить продукт и его содержимое"
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "Фильтровать список"
 
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "список фильтров для продукта"
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "создать фильтр"
 
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "Фильтры продукта"
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "добавить фильтр для продукта"
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "удалить фильтр продукта"
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
 msgid "filter name (required)"
 msgstr "название фильтра (обязательно)"
 
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "Добавлен фильтр [ %s ] для продукта [ %s ]"
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "описание"
 
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "Удалён фильтр [ %s ] продукта [ %s ]"
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "список имен пакетов или nvres, разделённых запятыми"
 
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "действия продукта на сервере katello"
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "Создан фильтр [%s]"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "Не удалось создать фильтр [ %s ]"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "удалить фильтр"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "Фильтр [ %s ] удалён"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "информация о фильтре"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "Информация о фильтре"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "Добавить пакет в фильтр"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "ID пакета (обязательно)"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "Пакет [ %s ] добавлен в фильтр [ %s ]"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "Удалить пакет из фильтра"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "Пакет [ %s ] удалён из фильтра [ %s ]"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "действия фильтра на сервере katello"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "список дистрибутивов в репозитории"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "ID репозитория"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "имя репозитория"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "имя организации, например foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "имя окружения (по умолчанию &mdash; Library)"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "продукт, например fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "Список дистрибутивов для репозитория %s"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "просмотр информации о дистрибутиве"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "ID репозитория (обязательно)"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "ID дистрибутива (обязательно). Пример: ks-rh-noarch"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "Информация о дистрибутиве"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "действия репозитория на сервере katello"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "Вставьте содержимое GPG (в конце нажмите CTRL+D):"
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "список всех ключей GPG"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "Репозитории"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr "файл открытого ключа GPG (если не задан, будет получен из stdin)"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "файл открытого ключа GPG"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "запрашивать ввод содержимого ключа"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "действия ключа GPG на сервере katello"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "организация (обязательно). Пример:  foo.example.com"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "Выполняется удалённая операция [ %s ]... "
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "Удалённая операция завершена:"
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "Удалённая операция не удалась:"
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "показать список пользователей"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "Пользователи"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "создать пользователя"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "имя пользователя (обязательно)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "исходный пароль (обязателен)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "Email (обязателен)"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "учётная запись отключена (по умолчанию &mdash; 'false')"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "имя стандартной организации пользователя"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "имя стандартного окружения пользователя"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "Создан пользователь [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "Не удалось создать [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "показать информацию о пользователе"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "Информация о пользователе"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "удалить пользователя"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "Пользователь [ %s ] удалён."
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "обновить пользователя"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "исходный пароль"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "Email"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "учетная запись отключена"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "стандартное окружение не определено"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "Пользователь [ %s ] обновлён."
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "показать роли пользователя"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "синхронизация ролей с группами LDAP"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "выбрать роль для пользователя"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "удалить роль пользователя"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "роль пользователя (обязательна)"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "Роль  [ %s ] не найдена"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "отчёт пользователя"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr "формат отчёта ('html', 'text' (по умолчанию), 'csv', 'pdf')"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "действия пользователя на сервере katello"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "список новых наборов изменений для окружения"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "имя окружения (обязательно)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "Список наборов изменений"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "подробно о наборе изменений"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "имя набора изменений (обязательно)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "будут показаны зависимые пакеты"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "Информация о наборе изменений"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "создать набор изменений для окружения"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "описание набора изменений"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "Создан набор изменений [ %s ] для окружения [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "Не удалось создать набор [ %s ] для окружения [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "обновляет содержимое набора изменений"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "перед %s  необходимо указать %s "
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "новое имя набора изменений"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "продукт для добавления в набор изменений"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "продукт для удаления из набора изменений"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "шаблон для добавления в набор изменений"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "шаблон для удаления из набора изменений"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+"определяет продукт, чьи пакеты, репозитории и исправления будут выбраны"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "для добавления в набор"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "для удаления из набора"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "Обновлён набор [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "удаляет набор изменений"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "Не удалось перенести набор [ %s ]: %s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "действия наборов изменений на сервере katello"
 
 #: ../src/katello/client/core/system.py:47
 msgid "list systems within an organization"
 msgstr "список систем в организации"
 
 #: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
 msgid "environment name eg: development"
 msgstr "имя окружения, например \"development\""
 
@@ -531,33 +1473,35 @@ msgstr "Список систем в [ %s ]"
 msgid "Systems List For Environment [ %s ] in Org [ %s ]"
 msgstr "Список систем в окружении [ %s ] организации [ %s ]"
 
-#: ../src/katello/client/core/system.py:82
+#: ../src/katello/client/core/system.py:83
 #: ../src/katello/client/core/system.py:134
 msgid "Service Level"
 msgstr "Уровень обслуживания"
 
-#: ../src/katello/client/core/system.py:89
+#: ../src/katello/client/core/system.py:90
 msgid "display a system within an organization"
 msgstr "показать систему в организации"
 
-#: ../src/katello/client/core/system.py:95
+#: ../src/katello/client/core/system.py:96
 #: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
 #: ../src/katello/client/core/errata.py:105
 msgid "system name (required)"
 msgstr "имя системы (обязательно)"
 
-#: ../src/katello/client/core/system.py:97
+#: ../src/katello/client/core/system.py:98
 #: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
 msgid "environment name"
 msgstr "имя окружения"
 
@@ -612,1799 +1556,572 @@ msgstr ""
 "Вызов может содержать более одной транзакции (установка, удаление, "
 "обновление)"
 
-#: ../src/katello/client/core/system.py:189
+#: ../src/katello/client/core/system.py:188
 #, python-format
 msgid "Package Information for System [ %s ] in Org [ %s ]"
 msgstr "Сведения о пакетах в системе [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/core/system.py:191
+#: ../src/katello/client/core/system.py:190
 #, python-format
 msgid ""
 "Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 "Сведения о пакетах в системе [ %s ] в окружении [ %s ] организации [ %s ]"
 
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "Выполняется удалённая операция [ %s ]... "
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "Удалённая операция завершена:"
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "Удалённая операция не удалась:"
-
-#: ../src/katello/client/core/system.py:243
+#: ../src/katello/client/core/system.py:242
 msgid "display status of remote tasks"
 msgstr "просмотр статуса удалённых задач"
 
-#: ../src/katello/client/core/system.py:249
+#: ../src/katello/client/core/system.py:248
 msgid "system name"
 msgstr "имя системы"
 
-#: ../src/katello/client/core/system.py:261
+#: ../src/katello/client/core/system.py:260
 msgid "Remote tasks"
 msgstr "Удалённые задачи"
 
-#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:268
 msgid "Task id"
 msgstr "ID задачи"
 
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
 msgid "System"
 msgstr "Система"
 
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
 msgid "Action"
 msgstr "Операция"
 
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
 msgid "Started"
 msgstr "Началось"
 
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
 #: ../src/katello/client/core/repo.py:37
 msgid "Finished"
 msgstr "Завершено"
 
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
 msgid "Status"
 msgstr "Статус"
 
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
 msgid "Result"
 msgstr "Результат"
 
-#: ../src/katello/client/core/system.py:283
+#: ../src/katello/client/core/system.py:282
 msgid "display status of remote task"
 msgstr "просмотр статуса удалённой задачи"
 
-#: ../src/katello/client/core/system.py:287
+#: ../src/katello/client/core/system.py:286
 msgid "UUID of the task"
 msgstr "UUID задачи"
 
-#: ../src/katello/client/core/system.py:295
+#: ../src/katello/client/core/system.py:294
 msgid "Remote task"
 msgstr "Удалённая задача"
 
-#: ../src/katello/client/core/system.py:313
+#: ../src/katello/client/core/system.py:312
 msgid "list releases available for the system"
 msgstr "показать выпуски для этой системы"
 
-#: ../src/katello/client/core/system.py:319
+#: ../src/katello/client/core/system.py:318
 msgid "system name (if not specified, list all releases in the environment)"
 msgstr ""
 "имя системы (если не определено, будет показан всех выпусков в окружении)"
 
-#: ../src/katello/client/core/system.py:341
+#: ../src/katello/client/core/system.py:340
 msgid "Available releases"
 msgstr "Доступные выпуски"
 
-#: ../src/katello/client/core/system.py:349
+#: ../src/katello/client/core/system.py:348
 msgid "display a the hardware facts of a system"
 msgstr "показать статистику оборудования"
 
-#: ../src/katello/client/core/system.py:369
+#: ../src/katello/client/core/system.py:367
 #, python-format
 msgid "System Facts For System [ %s ] in Org [ %s ]"
 msgstr "Статистика системы [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/core/system.py:371
+#: ../src/katello/client/core/system.py:369
 #, python-format
 msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
 msgstr "Статистика системы [ %s ] в окружении [ %s ] организации [ %s ]"
 
-#: ../src/katello/client/core/system.py:388
+#: ../src/katello/client/core/system.py:386
 msgid "register a system"
 msgstr "зарегистрировать систему"
 
 #: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "имя организации (обязательно)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
+#: ../src/katello/client/core/system.py:641
 msgid "service level agreement"
 msgstr "соглашение об уровне обслуживания"
 
-#: ../src/katello/client/core/system.py:396
+#: ../src/katello/client/core/system.py:394
 msgid ""
 "activation key, more keys are separated with comma e.g. "
 "--activationkey=key1,key2"
 msgstr "ключи активации через запятую. Пример: --activationkey=key1,key2"
 
-#: ../src/katello/client/core/system.py:397
+#: ../src/katello/client/core/system.py:395
 msgid "values of $releasever for the system"
 msgstr "значения  $releasever для системы"
 
-#: ../src/katello/client/core/system.py:399
+#: ../src/katello/client/core/system.py:397
 msgid "system facts"
 msgstr "статистика системы"
 
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "Параметр %s не может использоваться вместе с %s"
-
-#: ../src/katello/client/core/system.py:429
+#: ../src/katello/client/core/system.py:419
 #, python-format
 msgid "Successfully registered system [ %s ]"
 msgstr "Система [ %s ] зарегистрирована."
 
-#: ../src/katello/client/core/system.py:430
+#: ../src/katello/client/core/system.py:420
 #, python-format
 msgid "Could not register system [ %s ]"
 msgstr "Не удалось зарегистрировать систему [ %s ]"
 
-#: ../src/katello/client/core/system.py:435
+#: ../src/katello/client/core/system.py:425
 msgid "remove a deletion record for hypervisor"
 msgstr "удалить запись удаления для гипервизора"
 
-#: ../src/katello/client/core/system.py:439
+#: ../src/katello/client/core/system.py:429
 msgid "hypervisor uuid (required"
 msgstr "UUID гипервизора (обязательно)"
 
-#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:437
 #, python-format
 msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
 msgstr "Запись удаления успешно удалена для гипервизора c UUID [ %s ]"
 
-#: ../src/katello/client/core/system.py:453
+#: ../src/katello/client/core/system.py:443
 msgid "unregister a system"
 msgstr "отменить регистрацию"
 
-#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:470
 #, python-format
 msgid "Successfully unregistered System [ %s ]"
 msgstr "Удалена регистрация системы [ %s ]"
 
-#: ../src/katello/client/core/system.py:486
+#: ../src/katello/client/core/system.py:475
 msgid "subscribe a system to certificate"
 msgstr "подписать систему на сертификат"
 
-#: ../src/katello/client/core/system.py:494
+#: ../src/katello/client/core/system.py:483
 msgid "certificate serial to unsubscribe (required)"
 msgstr "серийный номер сертификата для удаления подписки (обязательно)"
 
-#: ../src/katello/client/core/system.py:496
+#: ../src/katello/client/core/system.py:485
 msgid "quantity (default: 1)"
 msgstr "количество (по умолчанию 1)"
 
-#: ../src/katello/client/core/system.py:512
+#: ../src/katello/client/core/system.py:499
 #, python-format
 msgid "Successfully subscribed System [ %s ]"
 msgstr "Система [ %s ] зарегистрирована."
 
-#: ../src/katello/client/core/system.py:517
+#: ../src/katello/client/core/system.py:504
 msgid "list subscriptions for a system"
 msgstr "список подписок системы"
 
-#: ../src/katello/client/core/system.py:524
+#: ../src/katello/client/core/system.py:511
 msgid "show available subscriptions"
 msgstr "просмотр доступных подписок"
 
-#: ../src/katello/client/core/system.py:542
+#: ../src/katello/client/core/system.py:528
 #, python-format
 msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
 msgstr "Нет подписок для системы [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/core/system.py:554
+#: ../src/katello/client/core/system.py:540
 #, python-format
 msgid "Current Subscriptions for System [ %s ]"
 msgstr "Текущие подписки для системы [ %s ]"
 
-#: ../src/katello/client/core/system.py:556
+#: ../src/katello/client/core/system.py:542
 msgid "Serial Id"
 msgstr "Серийный ID"
 
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
 msgid "Provided products"
 msgstr "Предоставленные продукты"
 
-#: ../src/katello/client/core/system.py:570
+#: ../src/katello/client/core/system.py:556
 #, python-format
 msgid "No Pools found for System [ %s ] in Org [ %s ]"
 msgstr "Нет пулов для системы [ %s ] в организации [ %s ]"
 
-#: ../src/katello/client/core/system.py:580
+#: ../src/katello/client/core/system.py:566
 #, python-format
 msgid "Available Subscriptions for System [ %s ]"
 msgstr "Доступные подписки для [ %s ]"
 
-#: ../src/katello/client/core/system.py:595
+#: ../src/katello/client/core/system.py:581
 msgid "unsubscribe a system from certificate"
 msgstr "отписать систему от сертификата"
 
-#: ../src/katello/client/core/system.py:603
+#: ../src/katello/client/core/system.py:589
 msgid ""
 "entitlement id to unsubscribe from (either entitlement or serial or all is "
 "required)"
 msgstr "ID отписываемого полномочия (полномочие, серийный или оба)"
 
-#: ../src/katello/client/core/system.py:605
+#: ../src/katello/client/core/system.py:591
 msgid ""
 "serial id of a certificate to unsubscribe from (either entitlement or serial"
 " or all is required)"
 msgstr ""
 "Серийный номер отписываемого сертификата (полномочие, серийный или оба)"
 
-#: ../src/katello/client/core/system.py:607
+#: ../src/katello/client/core/system.py:593
 msgid ""
 "unsubscribe from all currently subscribed certificates (either entitlement "
 "or serial or all is required)"
 msgstr "отписать все сертификаты (полномочие, серийный или оба)"
 
-#: ../src/katello/client/core/system.py:629
+#: ../src/katello/client/core/system.py:614
 #, python-format
 msgid "Successfully unsubscribed System [ %s ]"
 msgstr "Удалена подписка системы [ %s ]"
 
-#: ../src/katello/client/core/system.py:635
+#: ../src/katello/client/core/system.py:620
 msgid "update a system"
 msgstr "обновить систему"
 
-#: ../src/katello/client/core/system.py:646
+#: ../src/katello/client/core/system.py:631
 msgid "a new name for the system"
 msgstr "новое имя для системы"
 
-#: ../src/katello/client/core/system.py:648
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
 msgid "a description of the system"
 msgstr "описание системы"
 
-#: ../src/katello/client/core/system.py:650
+#: ../src/katello/client/core/system.py:637
 msgid "location of the system"
 msgstr "расположение системы"
 
-#: ../src/katello/client/core/system.py:652
+#: ../src/katello/client/core/system.py:639
 msgid "value of $releasever for the system"
 msgstr "значение  $releasever для системы"
 
-#: ../src/katello/client/core/system.py:683
+#: ../src/katello/client/core/system.py:674
 #, python-format
 msgid "Successfully updated system [ %s ]"
 msgstr "Система [ %s ] обновлена."
 
-#: ../src/katello/client/core/system.py:684
+#: ../src/katello/client/core/system.py:675
 #, python-format
 msgid "Could not update system [ %s ]"
 msgstr "Не удалось обновить систему [ %s ]"
 
-#: ../src/katello/client/core/system.py:690
+#: ../src/katello/client/core/system.py:681
 msgid "systems report"
 msgstr "отчёт системы"
 
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr "формат отчёта ('html', 'text' (по умолчанию), 'csv', 'pdf')"
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
 
-#: ../src/katello/client/core/system.py:724
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
 msgid "system specific actions in the katello server"
 msgstr "операции систем на сервере katello"
 
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "список фильтров"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "Фильтровать список"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "создать фильтр"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "описание"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "список имен пакетов или nvres, разделённых запятыми"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "Создан фильтр [%s]"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "Не удалось создать фильтр [ %s ]"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "удалить фильтр"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "Фильтр [ %s ] удалён"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "информация о фильтре"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "Информация о фильтре"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "Добавить пакет в фильтр"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "ID пакета (обязательно)"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "Пакет [ %s ] добавлен в фильтр [ %s ]"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "Удалить пакет из фильтра"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "Пакет [ %s ] удалён из фильтра [ %s ]"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "действия фильтра на сервере katello"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "список дистрибутивов в репозитории"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "ID репозитория"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "имя репозитория"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "имя организации, например foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "продукт, например fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "Список дистрибутивов для репозитория %s"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "просмотр информации о дистрибутиве"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "ID репозитория (обязательно)"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "ID дистрибутива (обязательно). Пример: ks-rh-noarch"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "Информация о дистрибутиве"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "действия репозитория на сервере katello"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "получить статус сервера katello"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Статус Katello"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "Проверить статус сервера"
-
-#: ../src/katello/client/core/package.py:40
+#: ../src/katello/client/core/package.py:38
 msgid "list information about a package"
 msgstr "просмотр информации о пакете"
 
-#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:43
 msgid "package id, string value (required)"
 msgstr "ID пакета (обязательно)"
 
-#: ../src/katello/client/core/package.py:91
+#: ../src/katello/client/core/package.py:87
 msgid "Package Information"
 msgstr "Информация о пакете"
 
-#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/package.py:94
 msgid "list packages in a repository"
 msgstr "список пакетов в репозитории"
 
-#: ../src/katello/client/core/package.py:123
+#: ../src/katello/client/core/package.py:117
 #, python-format
 msgid "Package List For Repo %s"
 msgstr "Список пакетов репозитория %s"
 
-#: ../src/katello/client/core/package.py:154
+#: ../src/katello/client/core/package.py:148
 msgid "search packages in a repository"
 msgstr "поиск пакетов в репозитории"
 
-#: ../src/katello/client/core/package.py:159
+#: ../src/katello/client/core/package.py:153
 msgid ""
 "query string for searching packages, e.g. "
 "'kernel*','kernel-3.3.0-4.el6.x86_64'"
 msgstr "строка поиска, например «kernel*», «kernel-3.3.0-4.el6.x86_64»"
 
-#: ../src/katello/client/core/package.py:170
+#: ../src/katello/client/core/package.py:164
 #, python-format
 msgid "Package List For Repo %s and Query %s"
 msgstr "Список пакетов для репозитория %s по запросу %s"
 
-#: ../src/katello/client/core/package.py:181
+#: ../src/katello/client/core/package.py:175
 msgid "package specific actions in the katello server"
 msgstr "операции пакетов на сервере katello"
 
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "нет описания"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "действие не задано. См. --help"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "недопустимая операция. См. --help"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "вывод в формате grep"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "подробный вывод"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
 msgstr ""
-"разделитель столбцов для вывода grep (используется вместе с параметром -g)"
 
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "Параметр %s является обязательным (см. --help)"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "Конфликт параметров %s и %s (см. --help)"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "Необходимо выбрать одно из %s (см. --help)"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "Необходимо выбрать одно значение из %s (см. --help)"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "ошибка операции"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr "Ошибка. Имя сервера в /etc/katello/client.conf не соответствует "
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "имени сервера, полученного с сервера katello."
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "Настроено [%s], но с сервера получено: [%s]"
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "Исправьте имя узла в /etc/katello/client.conf"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "Неверные реквизиты доступа или ошибка авторизации"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "параметр %s: недопустимое значение %r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "показать список пользователей"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "Пользователи"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "создать пользователя"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "имя пользователя (обязательно)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "исходный пароль (обязателен)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "Email (обязателен)"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "учётная запись отключена (по умолчанию &mdash; 'false')"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "имя стандартной организации пользователя"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "имя стандартного окружения пользователя"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "Создан пользователь [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "Не удалось создать [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "показать информацию о пользователе"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "Информация о пользователе"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "удалить пользователя"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "Пользователь [ %s ] удалён."
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "обновить пользователя"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "исходный пароль"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "Email"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "учетная запись отключена"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "стандартное окружение не определено"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "Пользователь [ %s ] обновлён."
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "показать роли пользователя"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "Список ролей"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "синхронизация ролей с группами LDAP"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "выбрать роль для пользователя"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "удалить роль пользователя"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "роль пользователя (обязательна)"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "Роль  [ %s ] не найдена"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "отчёт пользователя"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "действия пользователя на сервере katello"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "Вставьте содержимое GPG (в конце нажмите CTRL+D):"
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "список всех ключей GPG"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "имя организации (обязательно)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "Не найдены ключи GPG в организации [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "Список ключей GPG"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "показать информацию о ключе GPG"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "имя ключа активации (обязательно)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "Не найден ключ [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "Репозитории"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "Данные ключа GPG"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "создать ключ GPG"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr "файл открытого ключа GPG (если не задан, будет получен из stdin)"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "Создан ключ GPG [ %s ] "
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "Не удалось создать ключ [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "обновить ключ активации"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "имя нового шаблона"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "файл открытого ключа GPG"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "запрашивать ввод содержимого ключа"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "Ключ [ %s ] обновлён."
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "Не удалось обновить ключ [ %s ]."
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "удалить ключ GPG"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "Ключ [ %s ] удалён."
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "действия ключа GPG на сервере katello"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "показать все ключи активации"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "имя окружения (по умолчанию &mdash; Library)"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "Не найдены ключи в организации [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "Не найдены ключи в организации [ %s ] окружения [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "Список ключей активации"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "показать информацию о ключе активации"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "Ключ [ %s ] не найден"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "Информация о ключе активации"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "создать ключ активации"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "имя окружения (обязательно). Пример: dev"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "описание ключа активации"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "имя шаблона. Пример: servers"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "Не найден шаблон [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "Создан ключ [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "Не удалось создать ключ [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "имя нового окружения. Пример: dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "новое описание"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "имя нового шаблона. Пример: servers"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "добавить пул к ключу активации"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "удалить пул из ключа активации"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "Ключ [ %s ] обновлён."
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "удалить ключ активации"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "Ключ [ %s ] удалён"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "операции ключей активации на сервере katello"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "просмотр доступных групп пакетов"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "ID репозитория (обязательно)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "Не найдены группы пакетов в репозитории [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "Информация о группе пакетов"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "поиск информации о группе пакетов"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "ID группы пакетов (обязательно)"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "Группа [%s] не обнаружена в [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "просмотр категорий групп пакетов"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "Нет групп в репозитории [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "Информация о категориях групп пакетов"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "ID категории групп пакетов (обязательно)"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "Категория [%s] не обнаружена в [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "Информация о категориях групп пакетов"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "действия групп пакетов на сервере katello"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "список новых наборов изменений для окружения"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "имя окружения (обязательно)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "Список наборов изменений"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "подробно о наборе изменений"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "имя набора изменений (обязательно)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "будут показаны зависимые пакеты"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "Информация о наборе изменений"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "создать набор изменений для окружения"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "описание набора изменений"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "Создан набор изменений [ %s ] для окружения [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "Не удалось создать набор [ %s ] для окружения [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "обновляет содержимое набора изменений"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "перед %s  необходимо указать %s "
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "новое имя набора изменений"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "продукт для добавления в набор изменений"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "продукт для удаления из набора изменений"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "шаблон для добавления в набор изменений"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "шаблон для удаления из набора изменений"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
 msgstr ""
-"определяет продукт, чьи пакеты, репозитории и исправления будут выбраны"
 
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "для добавления в набор"
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "запуск CLI как оболочки"
 
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "для удаления из набора"
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "провайдер (обязательно)"
 
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "Обновлён набор [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "удаляет набор изменений"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "переносит набор изменений в следующее окружение"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "Перенос набора изменений. Пожалуйста, подождите..."
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "Набор [ %s ] перенесён"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "Не удалось перенести набор [ %s ]: %s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "действия наборов изменений на сервере katello"
-
-#: ../src/katello/client/core/provider.py:59
+#: ../src/katello/client/core/provider.py:57
 msgid "list all known providers"
 msgstr "показать список провайдеров"
 
-#: ../src/katello/client/core/provider.py:81
+#: ../src/katello/client/core/provider.py:79
 msgid "Provider List"
 msgstr "Список провайдеров"
 
-#: ../src/katello/client/core/provider.py:89
+#: ../src/katello/client/core/provider.py:87
 msgid "list information about a provider"
 msgstr "просмотр информации о провайдере"
 
-#: ../src/katello/client/core/provider.py:104
+#: ../src/katello/client/core/provider.py:102
 msgid "Provider Information"
 msgstr "Информация о провайдере"
 
-#: ../src/katello/client/core/provider.py:116
+#: ../src/katello/client/core/provider.py:114
 msgid "create a provider"
 msgstr "создать провайдер"
 
-#: ../src/katello/client/core/provider.py:118
+#: ../src/katello/client/core/provider.py:116
 msgid "update a provider"
 msgstr "обновить провайдер"
 
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
 msgid "provider description"
 msgstr "описание провайдера"
 
-#: ../src/katello/client/core/provider.py:139
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"Адрес репозитория (например: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/)"
+
+#: ../src/katello/client/core/provider.py:137
 msgid "provider name"
 msgstr "имя провайдера"
 
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "\"--url\" должен начинаться с \"http://\" или \"https://\""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "Недопустимый формат параметра \"--url\""
-
-#: ../src/katello/client/core/provider.py:159
+#: ../src/katello/client/core/provider.py:147
 #, python-format
 msgid "Successfully created provider [ %s ]"
 msgstr "Создан провайдер [ %s ]"
 
-#: ../src/katello/client/core/provider.py:160
+#: ../src/katello/client/core/provider.py:148
 #, python-format
 msgid "Could not create provider [ %s ]"
 msgstr "Не удалось создать [ %s ]"
 
-#: ../src/katello/client/core/provider.py:167
+#: ../src/katello/client/core/provider.py:155
 #, python-format
 msgid "Successfully updated provider [ %s ]"
 msgstr "Обновлён провайдер [ %s ]"
 
-#: ../src/katello/client/core/provider.py:185
+#: ../src/katello/client/core/provider.py:173
 msgid "delete a provider"
 msgstr "удалить провайдер"
 
-#: ../src/katello/client/core/provider.py:201
+#: ../src/katello/client/core/provider.py:189
 msgid "synchronize a provider"
 msgstr "синхронизация провайдера"
 
-#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/provider.py:204
 #, python-format
 msgid "Provider [ %s ] failed to sync: %s"
 msgstr "Ошибка синхронизации провайдера [ %s ]: %s"
 
-#: ../src/katello/client/core/provider.py:219
+#: ../src/katello/client/core/provider.py:207
 #, python-format
 msgid "Provider [ %s ] synchronization cancelled"
 msgstr "Синхронизация провайдера [ %s ] отменена"
 
-#: ../src/katello/client/core/provider.py:222
+#: ../src/katello/client/core/provider.py:210
 #, python-format
 msgid "Provider [ %s ] synchronized"
 msgstr "Провайдер [ %s ] синхронизирован."
 
-#: ../src/katello/client/core/provider.py:245
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "отменить текущую синхронизацию"
+
+#: ../src/katello/client/core/provider.py:233
 msgid "status of provider's synchronization"
 msgstr "статус синхронизации провайдера"
 
-#: ../src/katello/client/core/provider.py:258
+#: ../src/katello/client/core/provider.py:246
 #, python-format
 msgid "%d%% done (%d of %d packages downloaded)"
 msgstr "%d%% завершено (загружено пакетов: %d из %d)"
 
-#: ../src/katello/client/core/provider.py:269
+#: ../src/katello/client/core/provider.py:257
 msgid "Provider Status"
 msgstr "Статус провайдера"
 
-#: ../src/katello/client/core/provider.py:277
+#: ../src/katello/client/core/provider.py:265
 msgid "import a manifest file"
 msgstr "импорт файла манифеста"
 
-#: ../src/katello/client/core/provider.py:283
+#: ../src/katello/client/core/provider.py:271
 msgid "path to the manifest file (required)"
 msgstr "путь к файлу манифеста (обязательно)"
 
-#: ../src/katello/client/core/provider.py:285
+#: ../src/katello/client/core/provider.py:273
 msgid "force reimporting the manifest"
 msgstr "принудительно повторить импорт манифеста"
 
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
 #, python-format
 msgid "File %s does not exist"
 msgstr "%s не существует"
 
-#: ../src/katello/client/core/provider.py:307
+#: ../src/katello/client/core/provider.py:295
 msgid "Importing manifest, please wait... "
 msgstr "Импорт манифеста. Пожалуйста, подождите..."
 
-#: ../src/katello/client/core/provider.py:320
+#: ../src/katello/client/core/provider.py:308
 msgid "refresh provider's products repositories"
 msgstr "обновить репозитории провайдера"
 
-#: ../src/katello/client/core/provider.py:329
+#: ../src/katello/client/core/provider.py:317
 #, python-format
 msgid "Provider successfully refreshed [ %s ]"
 msgstr "Провайдер успешно обновлен [ %s ]"
 
-#: ../src/katello/client/core/provider.py:336
+#: ../src/katello/client/core/provider.py:324
 msgid "provider specific actions in the katello server"
 msgstr "действия провайдеров на сервере katello"
 
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "показать окружения"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "Организация"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "Предыдущее окружение"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "Список окружений"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "показать выбранное окружение"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "имя окружения (обязательно). Пример: my.example.com"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "Информация об окружении"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "создать окружение"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "описание окружения. Пример: my environment"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "имя предыдущего окружения (обязательно)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "Создано окружение [ %s ]"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "Не удалось создать окружение [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "обновить окружение"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "имя предыдущего окружения"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "Обновлено окружение [ %s ]"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "удалить окружение"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "Окружение [ %s ] удалено."
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "действия окружения на сервере katello"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "сохранить параметр в настройки клиента"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr "параметр для сохранения (обязательно)"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "значение сохраняемого параметра (обязательно)"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "Успешно"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "Параметр [ %s ] не сохранен"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "исключить параметр из конфигурации"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "имя параметра для удаления (обязательно)"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "Параметр [ %s ] исключен"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "Не удалось исключить параметр [ %s ]"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "список параметров в конфигурации клиента"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "Сохраненные параметры"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "действия клиентов на сервере katello"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "показать все шаблоны"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "имя организации (обязательно при определении окружения)"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "Не найдены шаблоны в окружении [ %s ]"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "Список шаблонов"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "просмотр информации о шаблоне"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "имя шаблона (обязательно)"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "Информация о шаблоне"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "создать файл шаблона и импортировать данные"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "путь к файлу шаблона (обязательно)"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "Импорт шаблона. Пожалуйста, подождите..."
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "экспортировать шаблон в файл"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "имя окружения, например \"dev\""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "формат экспорта (%s). По умолчанию: json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "Не удалось создать файл %s"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "Экспорт шаблона. Пожалуйста, подождите..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "Шаблон сохранён в файл %s"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "создать пустой шаблон"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "имя родительского шаблона"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "описание шаблона"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "Создан шаблон [ %s ]"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "Не удалось создать шаблон [ %s ]"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "название обновлений и описание шаблона"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "перед %s  необходимо указать %s "
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "обозначение продукта (эпоха:имя-выпуск-версия)"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "параметр, следом за которым надо указать %s"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "значение параметра"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "параметр"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "группа пакетов"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "категория групп пакетов"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "ID дистрибутива"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "определяет продукт, чьи репозитории будут выбраны"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "репозиторий для добавления в шаблон"
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "репозиторий для удаления из шаблона"
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "необходимо указать значение параметра '%s'"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "Шаблон обновляется. Пожалуйста, подождите..."
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "Обновлён шаблон [ %s ]"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "удаляет шаблон"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-"имя окружения, например foo.example.com (по умолчанию &mdash; Library)"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "действия шаблонов на сервере katello"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "запуск CLI как оболочки"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "показать sync_plans"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "Список планов синхронизации"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "вывод информации о плане синхронизации"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "название плана синхронизации (обязательно)"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "Информация о плане синхронизации"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "создать план синхронизации"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "описание плана"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr "частота синхронизации ([%s], по умолчанию &mdash; none)"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "дата первой синхронизации (обязательно). Формат: ГГГГ-ММ-ДД"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr "время первой синхронизации. Формат: ЧЧ:ММ:СС, по умолчанию: 00:00:00"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "Создан план [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "Не удалось создать план [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "обновить план"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "название нового плана"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "дата первой синхронизации. Формат: ГГГГ-ММ-ДД"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "время первой синхронизации. Формат: ЧЧ:ММ:СС"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "Необходимо указать --date и --time"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "План [ %s ] обновлён."
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "удалить план"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "План [ %s ] удалён."
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr "действия плана синхронизации на сервере katello"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "получить версию сервера katello"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "Проверить версию сервера"
-
-#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "получить статус сервера katello"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Статус Katello"
+
+#: ../src/katello/client/core/permission.py:53
 msgid "create a permission for a user role"
 msgstr "создать разрешение для роли"
 
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "название роли (обязательно)"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
 msgid "permission name (required)"
 msgstr "имя разрешения (обязательно)"
 
-#: ../src/katello/client/core/permission.py:61
+#: ../src/katello/client/core/permission.py:58
 msgid "permission description"
 msgstr "описание разрешения"
 
-#: ../src/katello/client/core/permission.py:62
+#: ../src/katello/client/core/permission.py:59
 msgid "organization name"
 msgstr "имя организации"
 
-#: ../src/katello/client/core/permission.py:63
+#: ../src/katello/client/core/permission.py:60
 msgid "scope of the permisson (required)"
 msgstr "область действия разрешения (обязательно)"
 
-#: ../src/katello/client/core/permission.py:64
+#: ../src/katello/client/core/permission.py:61
 msgid "verbs for the permission"
 msgstr "действия для разрешения"
 
-#: ../src/katello/client/core/permission.py:65
+#: ../src/katello/client/core/permission.py:62
 msgid "tags for the permission"
 msgstr "теги разрешения"
 
-#: ../src/katello/client/core/permission.py:81
+#: ../src/katello/client/core/permission.py:76
 #, python-format
 msgid "Invalid scope [ %s ]"
 msgstr "Неверно [ %s ]"
 
-#: ../src/katello/client/core/permission.py:88
+#: ../src/katello/client/core/permission.py:83
 #, python-format
 msgid "Could not find tag [ %s ] in scope of [ %s ]"
 msgstr "Не удалось найти тег [ %s ] в области действия для [ %s ]"
 
-#: ../src/katello/client/core/permission.py:112
+#: ../src/katello/client/core/permission.py:101
 #, python-format
 msgid "Successfully created permission [ %s ] for user role [ %s ]"
 msgstr "Создано разрешение [%s] для роли [%s]"
 
-#: ../src/katello/client/core/permission.py:113
+#: ../src/katello/client/core/permission.py:102
 #, python-format
 msgid "Could not create permission [ %s ]"
 msgstr "Не удалось создать разрешение [%s]"
 
-#: ../src/katello/client/core/permission.py:119
+#: ../src/katello/client/core/permission.py:108
 msgid "delete a permission"
 msgstr "удалить разрешение"
 
-#: ../src/katello/client/core/permission.py:137
+#: ../src/katello/client/core/permission.py:125
 #, python-format
 msgid "Successfully deleted permission [ %s ] for role [ %s ]"
 msgstr "Удалено разрешение [%s] для роли [%s]"
 
-#: ../src/katello/client/core/permission.py:143
+#: ../src/katello/client/core/permission.py:131
 msgid "list permissions for a user role"
 msgstr "показать разрешения для роли"
 
-#: ../src/katello/client/core/permission.py:170
+#: ../src/katello/client/core/permission.py:158
 msgid "Permission List"
 msgstr "Список разрешений"
 
-#: ../src/katello/client/core/permission.py:177
+#: ../src/katello/client/core/permission.py:165
 msgid "list available scopes, verbs and tags that can be set in a permission"
 msgstr "показать доступные значения для разрешения"
 
-#: ../src/katello/client/core/permission.py:181
+#: ../src/katello/client/core/permission.py:169
 msgid ""
 "organization name eg: foo.example.com,\n"
 "lists organization specific verbs"
@@ -2412,26 +2129,98 @@ msgstr ""
 "имя организации (например foo.example.com),\n"
 "покажет действия для организации"
 
-#: ../src/katello/client/core/permission.py:182
+#: ../src/katello/client/core/permission.py:170
 msgid "filter listed results by scope"
 msgstr "фильтровать по области применения"
 
-#: ../src/katello/client/core/permission.py:200
+#: ../src/katello/client/core/permission.py:188
 #, python-format
 msgid "Available verbs and tags for permission scope %s"
 msgstr "Доступные действия и теги для %s"
 
-#: ../src/katello/client/core/permission.py:202
+#: ../src/katello/client/core/permission.py:190
 msgid "Available verbs"
 msgstr "Доступные действия"
 
-#: ../src/katello/client/core/permission.py:221
+#: ../src/katello/client/core/permission.py:209
 msgid "None"
 msgstr "Нет"
 
-#: ../src/katello/client/core/permission.py:259
+#: ../src/katello/client/core/permission.py:247
 msgid "permission pecific actions in the katello server"
 msgstr "действия разрешения на сервере katello"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "нет описания"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "действие не задано. См. --help"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "недопустимая операция. См. --help"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "вывод в формате grep"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "подробный вывод"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+"разделитель столбцов для вывода grep (используется вместе с параметром -g)"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr "Ошибка. Имя сервера в /etc/katello/client.conf не соответствует "
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "имени сервера, полученного с сервера katello."
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "Настроено [%s], но с сервера получено: [%s]"
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "Исправьте имя узла в /etc/katello/client.conf"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "Неверные реквизиты доступа или ошибка авторизации"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "параметр %s: недопустимое значение %r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
 
 #: ../src/katello/client/core/errata.py:42
 msgid "list all errata for a repo"
@@ -2453,26 +2242,116 @@ msgstr "Список исправлений"
 msgid "list errata for a system"
 msgstr "список исправлений для системы"
 
-#: ../src/katello/client/core/errata.py:125
+#: ../src/katello/client/core/errata.py:124
 #, python-format
 msgid "Errata for system %s in organization %s"
 msgstr "Исправления для системы %s в организации %s"
 
-#: ../src/katello/client/core/errata.py:132
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
 msgid "information about an errata"
 msgstr "информация об исправлениях"
 
-#: ../src/katello/client/core/errata.py:136
+#: ../src/katello/client/core/errata.py:170
 msgid "errata id, string value (required)"
 msgstr "ID исправления (обязательно)"
 
-#: ../src/katello/client/core/errata.py:185
+#: ../src/katello/client/core/errata.py:217
 msgid "Errata Information"
 msgstr "Информация об исправлении"
 
-#: ../src/katello/client/core/errata.py:194
+#: ../src/katello/client/core/errata.py:226
 msgid "errata specific actions in the katello server"
 msgstr "действия исправлений на сервере katello"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "получить версию сервера katello"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "Проверить версию сервера"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "просмотр доступных групп пакетов"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "ID репозитория (обязательно)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "Не найдены группы пакетов в репозитории [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "Информация о группе пакетов"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "поиск информации о группе пакетов"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "ID группы пакетов (обязательно)"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "Группа [%s] не обнаружена в [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "просмотр категорий групп пакетов"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "Нет групп в репозитории [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "Информация о категориях групп пакетов"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "ID категории групп пакетов (обязательно)"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "Категория [%s] не обнаружена в [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "Информация о категориях групп пакетов"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "действия групп пакетов на сервере katello"
 
 #: ../src/katello/client/core/repo.py:34
 msgid "Waiting"
@@ -2502,47 +2381,54 @@ msgstr "Время ожидания истекло"
 msgid "Not synced"
 msgstr "Не синхронизировано"
 
-#: ../src/katello/client/core/repo.py:116
+#: ../src/katello/client/core/repo.py:114
 msgid "create a repository at a specified URL"
 msgstr "создать репозиторий по адресу"
 
-#: ../src/katello/client/core/repo.py:122
+#: ../src/katello/client/core/repo.py:120
 msgid "repository name to assign (required)"
 msgstr "имя репозитория (обязательно)"
 
-#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:122
 msgid "url path to the repository (required)"
 msgstr "URL репозитория (обязательно)"
 
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "продукт (обязательно)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
 msgid ""
 "GPG key to be assigned to the repository; by default, the product's GPG key "
 "will be used."
 msgstr ""
 "Репозиторию можно назначить GPG. По умолчанию будет выбран ключ продукта."
 
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
 msgid "Don't assign a GPG key to the repository."
 msgstr "Не назначать ключ GPG репозиторию."
 
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
 #, python-format
 msgid "Successfully created repository [ %s ]"
 msgstr "Создан репозиторий [ %s ]"
 
-#: ../src/katello/client/core/repo.py:154
+#: ../src/katello/client/core/repo.py:149
 msgid "discovery repositories contained within a URL"
 msgstr "по этому адресу обнаружены репозитории"
 
-#: ../src/katello/client/core/repo.py:160
+#: ../src/katello/client/core/repo.py:155
 msgid ""
 "repository name prefix to add to all the discovered repositories (required)"
 msgstr "префикс для обнаруженных репозиториев (обязательно)"
 
-#: ../src/katello/client/core/repo.py:162
+#: ../src/katello/client/core/repo.py:157
 msgid ""
 "root url to perform discovery of repositories eg: "
 "http://porkchop.devel.redhat.com/ (required)"
@@ -2550,16 +2436,31 @@ msgstr ""
 "адрес для поиска репозиториев (обязательно). Пример: "
 "http://porkchop.devel.redhat.com/"
 
-#: ../src/katello/client/core/repo.py:192
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+"по умолчанию автоматически создавать репозитории кандидатов для обнаруженных"
+" URL (дополнительно)"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "Обнаружены URL репозиториев: [%s]"
+
+#: ../src/katello/client/core/repo.py:183
 msgid "Discovering repository urls, this could take some time..."
 msgstr "Определение URL репозиториев. Это может занять некоторое время."
 
-#: ../src/katello/client/core/repo.py:196
+#: ../src/katello/client/core/repo.py:187
 #, python-format
 msgid "Error: %s"
 msgstr "Ошибка: %s"
 
-#: ../src/katello/client/core/repo.py:216
+#: ../src/katello/client/core/repo.py:207
 msgid ""
 "\n"
 "Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
@@ -2567,330 +2468,799 @@ msgstr ""
 "\n"
 "Выберите адреса для создания репозиториев. Нажмите \"y\" для подтверждения или \"h\" для получения помощи:"
 
-#: ../src/katello/client/core/repo.py:226
+#: ../src/katello/client/core/repo.py:217
 msgid "Operation aborted upon user request."
 msgstr "Операция прервана по запросу"
 
-#: ../src/katello/client/core/repo.py:275
+#: ../src/katello/client/core/repo.py:266
 msgid "status information about a repository"
 msgstr "информация о состоянии репозитория"
 
-#: ../src/katello/client/core/repo.py:298
+#: ../src/katello/client/core/repo.py:289
 msgid "Repository Status"
 msgstr "Статус репозитория"
 
-#: ../src/katello/client/core/repo.py:305
+#: ../src/katello/client/core/repo.py:296
 msgid "information about a repository"
 msgstr "информация о репозитории"
 
-#: ../src/katello/client/core/repo.py:319
+#: ../src/katello/client/core/repo.py:310
 msgid "Progress"
 msgstr "Прогресс"
 
-#: ../src/katello/client/core/repo.py:322
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "Ключ GPG"
+
+#: ../src/katello/client/core/repo.py:313
 #, python-format
 msgid "Information About Repo %s"
 msgstr "Информация о репозитории %s"
 
-#: ../src/katello/client/core/repo.py:329
+#: ../src/katello/client/core/repo.py:320
 msgid "updates repository attributes"
 msgstr "обновляет атрибуты репозитория"
 
-#: ../src/katello/client/core/repo.py:345
+#: ../src/katello/client/core/repo.py:336
 #, python-format
 msgid "Successfully updated repository [ %s ]"
 msgstr "Репозиторий [ %s ] обновлён."
 
-#: ../src/katello/client/core/repo.py:351
+#: ../src/katello/client/core/repo.py:342
 msgid "synchronize a repository"
 msgstr "синхронизация репозитория"
 
-#: ../src/katello/client/core/repo.py:361
+#: ../src/katello/client/core/repo.py:352
 #, python-format
 msgid "Repo [ %s ] synced"
 msgstr "Синхронизация репозитория [%s] завершена."
 
-#: ../src/katello/client/core/repo.py:364
+#: ../src/katello/client/core/repo.py:355
 #, python-format
 msgid "Repo [ %s ] synchronization cancelled"
 msgstr "Синхронизация репозитория [%s] отменена."
 
-#: ../src/katello/client/core/repo.py:367
+#: ../src/katello/client/core/repo.py:358
 #, python-format
 msgid "Repo [ %s ] failed to sync: %s"
 msgstr "Ошибка синхронизации репозитория [%s]: %s"
 
-#: ../src/katello/client/core/repo.py:373
+#: ../src/katello/client/core/repo.py:364
 msgid "cancel currently running synchronization of a repository"
 msgstr "отменить текущую синхронизацию репозитория"
 
-#: ../src/katello/client/core/repo.py:388
+#: ../src/katello/client/core/repo.py:379
 msgid "enable a repository"
 msgstr "включить репозиторий"
 
-#: ../src/katello/client/core/repo.py:390
+#: ../src/katello/client/core/repo.py:381
 msgid "disable a repository"
 msgstr "отключить репозиторий"
 
-#: ../src/katello/client/core/repo.py:409
+#: ../src/katello/client/core/repo.py:400
 msgid "list repos within an organization"
 msgstr "показать репозитории организации"
 
-#: ../src/katello/client/core/repo.py:413
+#: ../src/katello/client/core/repo.py:404
 msgid "organization name eg: ACME_Corporation (required)"
 msgstr "имя организации (обязательно). Пример: ACME_Corporation"
 
-#: ../src/katello/client/core/repo.py:419
+#: ../src/katello/client/core/repo.py:410
 msgid "list also disabled repositories"
 msgstr "показать отключенные репозитории"
 
-#: ../src/katello/client/core/repo.py:439
+#: ../src/katello/client/core/repo.py:430
 #, python-format
 msgid "Repo List For Org %s Environment %s Product %s"
 msgstr "Список репозиториев для организации %s (окружение %s, продукт %s)"
 
-#: ../src/katello/client/core/repo.py:446
+#: ../src/katello/client/core/repo.py:437
 #, python-format
 msgid "Repo List for Product %s in Org %s "
 msgstr "Список репозиториев для продукта %s в организации %s"
 
-#: ../src/katello/client/core/repo.py:453
+#: ../src/katello/client/core/repo.py:444
 #, python-format
 msgid "Repo List For Org %s Environment %s"
 msgstr "Список репозиториев для организации %s (окружение %s)"
 
-#: ../src/katello/client/core/repo.py:463
+#: ../src/katello/client/core/repo.py:454
 msgid "delete a repository"
 msgstr "удалить репозиторий"
 
-#: ../src/katello/client/core/repo.py:476
+#: ../src/katello/client/core/repo.py:467
 msgid "list filters of a repository"
 msgstr "список фильтров репозитория"
 
-#: ../src/katello/client/core/repo.py:482
+#: ../src/katello/client/core/repo.py:473
 msgid "prints also filters assigned to repository's product."
 msgstr "также покажет фильтры для продукта в репозитории."
 
-#: ../src/katello/client/core/repo.py:492
+#: ../src/katello/client/core/repo.py:483
 msgid "Repository Filters"
 msgstr "Фильтры репозитория"
 
-#: ../src/katello/client/core/repo.py:506
+#: ../src/katello/client/core/repo.py:497
 msgid "add a filter to a repository"
 msgstr "добавить фильтр для репозитория"
 
-#: ../src/katello/client/core/repo.py:508
+#: ../src/katello/client/core/repo.py:499
 msgid "remove a filter from a repository"
 msgstr "удалить фильтр репозитория"
 
-#: ../src/katello/client/core/repo.py:538
+#: ../src/katello/client/core/repo.py:529
 #, python-format
 msgid "Added filter [ %s ] to repository [ %s ]"
 msgstr "Добавлен фильтр [%s] для репозитория [%s]"
 
-#: ../src/katello/client/core/repo.py:541
+#: ../src/katello/client/core/repo.py:532
 #, python-format
 msgid "Removed filter [ %s ] to repository [ %s ]"
 msgstr "Удалён фильтр [ %s ] репозитория [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "показать список ролей"
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "показать sync_plans"
 
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "создать роль"
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "описание роли"
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "Создана роль  [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "Не удалось создать роль  [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "просмотр информации о роли"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "название роли (обязательно)"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "вывод сведений о разрешениях для всех ролей"
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
 msgstr ""
-"%s\n"
-"\tдля: %s\n"
-"\tоперации: %s\n"
-"\tна: %s"
 
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "Информация о роли"
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "Список планов синхронизации"
 
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "удалить роль"
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "вывод информации о плане синхронизации"
 
-#: ../src/katello/client/core/user_role.py:152
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "название плана синхронизации (обязательно)"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "Информация о плане синхронизации"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "создать план синхронизации"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "описание плана"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
 #, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "Роль  [ %s ] удалена"
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr "частота синхронизации ([%s], по умолчанию &mdash; none)"
 
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "обновить роль"
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "дата первой синхронизации (обязательно). Формат: ГГГГ-ММ-ДД"
 
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "новое название роли"
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr "время первой синхронизации. Формат: ЧЧ:ММ:СС, по умолчанию: 00:00:00"
 
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr "Требуется как минимум один параметр для обновления роли"
-
-#: ../src/katello/client/core/user_role.py:180
+#: ../src/katello/client/core/sync_plan.py:135
 #, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "Роль [ %s ] обновлена"
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "Создан план [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "назначить группу LDAP роли"
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "имя новой группы LDAP (обязательно)"
-
-#: ../src/katello/client/core/user_role.py:204
+#: ../src/katello/client/core/sync_plan.py:136
 #, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr "Группа [ %s ]  добавлена к роли [ %s ]"
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "Не удалось создать план [ %s ]"
 
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "удалить группу LDAP из роли"
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "обновить план"
 
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "Имя удаляемой группы LDAP (обязательно)"
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "название нового плана"
 
-#: ../src/katello/client/core/user_role.py:228
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "дата первой синхронизации. Формат: ГГГГ-ММ-ДД"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "время первой синхронизации. Формат: ЧЧ:ММ:СС"
+
+#: ../src/katello/client/core/sync_plan.py:176
 #, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr "Группа LDAP  [ %s ] удалена из роли  [ %s ]"
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "План [ %s ] обновлён."
 
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "действия роли на сервере katello"
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "удалить план"
 
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "Неверное время. Допустимый формат: ЧЧ:ММ:СС[+ЧЧ:ММ]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "Неверная дата. Допустимый формат: ГГГГ-ММ-ДД"
-
-#. These are a bunch of strings that are marked for translation in optparse,
-#. but not actually translated anywhere. Mark them for translation here,
-#. so we get it picked up. for local translation, and then optparse will
-#. use them.
-#: ../src/katello/client/i18n_optparse.py:48
+#: ../src/katello/client/core/sync_plan.py:198
 #, python-format
-msgid "Usage: %s\n"
-msgstr "Формат: %s¶"
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "План [ %s ] удалён."
 
-#: ../src/katello/client/i18n_optparse.py:49
-msgid "Usage"
-msgstr "Формат"
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr "действия плана синхронизации на сервере katello"
 
-#: ../src/katello/client/i18n_optparse.py:50
-msgid "%prog [options]"
-msgstr "%prog [параметры]"
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "показать список организаций"
 
-#: ../src/katello/client/i18n_optparse.py:51
-msgid "Options"
-msgstr "Параметры"
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "Список организаций"
 
-#. stuff for option value sanity checking
-#: ../src/katello/client/i18n_optparse.py:54
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "создать организацию"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "описание клиента. Пример: my organization"
+
+#: ../src/katello/client/core/organization.py:77
 #, python-format
-msgid "no such option: %s"
-msgstr "нет такого параметра: %s"
+msgid "Successfully created org [ %s ]"
+msgstr "Создана организация [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:55
+#: ../src/katello/client/core/organization.py:78
 #, python-format
-msgid "ambiguous option: %s (%s?)"
-msgstr "неоднозначный параметр: %s (%s?)"
+msgid "Could not create org [ %s ]"
+msgstr "Не удалось создать организацию [ %s ]"
 
-#: ../src/katello/client/i18n_optparse.py:56
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "просмотр информации об организации"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "Доступные уровни обслуживания"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "Информация об организации"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "удалить организацию"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "Удаляется организация. Пожалуйста, подождите..."
+
+#: ../src/katello/client/core/organization.py:133
 #, python-format
-msgid "%s option requires an argument"
-msgstr "Параметр %s требует указания аргумента"
+msgid "Successfully deleted org [ %s ]"
+msgstr "Организация [ %s ] удалена"
 
-#: ../src/katello/client/i18n_optparse.py:57
+#: ../src/katello/client/core/organization.py:136
 #, python-format
-msgid "%s option requires %d arguments"
-msgstr "Параметр %s требует %d аргумент(а)(ов)"
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "Не удалось удалить организацию [ %s ]: %s"
 
-#: ../src/katello/client/i18n_optparse.py:58
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "обновить организацию"
+
+#: ../src/katello/client/core/organization.py:160
 #, python-format
-msgid "%s option does not take a value"
-msgstr "Параметр %s не принимает значения"
+msgid "Successfully updated org [ %s ]"
+msgstr "Организация [ %s ] обновлена"
 
-#: ../src/katello/client/i18n_optparse.py:59
-msgid "integer"
-msgstr "целое"
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "создать и показать сертификат ueber"
 
-#: ../src/katello/client/i18n_optparse.py:60
-msgid "long integer"
-msgstr "длинное целое"
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "заново создать сертификат"
 
-#: ../src/katello/client/i18n_optparse.py:61
-msgid "floating-point"
-msgstr "с плавающей точкой"
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "Uebercert"
 
-#: ../src/katello/client/i18n_optparse.py:62
-msgid "complex"
-msgstr "сложные"
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "показать подписки"
 
-#: ../src/katello/client/i18n_optparse.py:63
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "Подписки организации"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "действия организации на сервере katello"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "выбрать план синхронизации"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "название плана синхронизации (обязательно)"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "отменить план синхронизации"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "список известных пакетов"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "имя провайдера, список продуктов в Library"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
 #, python-format
-msgid "option %s: invalid %s value: %r"
-msgstr "параметр %s, недопустимое значение %s: %r"
+msgid "Product List For Provider %s"
+msgstr "Список продуктов для провайдера %s"
 
-#: ../src/katello/client/i18n_optparse.py:64
+#: ../src/katello/client/core/product.py:151
 #, python-format
-msgid "option %s: invalid choice: %r (choose from %s)"
-msgstr "параметр %s, недопустимый выбор %r (выберите из %s)"
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "Список продуктов для организации %s в окружении '%s'"
 
-#. default options
-#: ../src/katello/client/i18n_optparse.py:67
-msgid "show this help message and exit"
-msgstr "показать справку и выйти"
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "синхронизация продукта"
 
-#: ../src/katello/client/i18n_optparse.py:68
-msgid "show program's version number and exit"
-msgstr "показать версию программы и выйти"
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "Ошибка синхронизации [ %s ]: %s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "Синхронизация [ %s ] отменена."
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "Продукт [ %s ] синхронизирован."
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "статус синхронизации"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "Статус продукта"
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+"перенести продукт в окружение\n"
+"(будет создан и перенесён временный набор изменений)"
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "Перенос продукта. Пожалуйста, подождите..."
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "Продукт [ %s ] перенесён в окружение [ %s ]"
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "Не удалось перенести [ %s ]: %s"
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "создать продукт для провайдера"
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "описание продукта"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "пропустить обнаружение репозитория"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+"назначить ключ GPG (будет по умолчанию использоваться для новых "
+"репозиториев)"
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr "Создан продукт [ %s ]"
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "обновить атрибуты продукта"
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "изменить описание продукта"
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "назначить ключ GPG продукту"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "назначить ключ GPG репозиториям продукта"
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr "Продукт [ %s ] обновлён."
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "удалить продукт и его содержимое"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "список фильтров для продукта"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "Фильтры продукта"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "добавить фильтр для продукта"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "удалить фильтр продукта"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "Добавлен фильтр [ %s ] для продукта [ %s ]"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "Удалён фильтр [ %s ] продукта [ %s ]"
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "действия продукта на сервере katello"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "показать все шаблоны"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "имя организации (обязательно при определении окружения)"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "Не найдены шаблоны в окружении [ %s ]"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "Список шаблонов"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "просмотр информации о шаблоне"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "имя шаблона (обязательно)"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "Информация о шаблоне"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "создать файл шаблона и импортировать данные"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "путь к файлу шаблона (обязательно)"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "Импорт шаблона. Пожалуйста, подождите..."
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "экспортировать шаблон в файл"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "имя окружения, например \"dev\""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "формат экспорта (%s). По умолчанию: json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "Не удалось создать файл %s"
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "Экспорт шаблона. Пожалуйста, подождите..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "Шаблон сохранён в файл %s"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "создать пустой шаблон"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "имя родительского шаблона"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "описание шаблона"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "Создан шаблон [ %s ]"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "Не удалось создать шаблон [ %s ]"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "название обновлений и описание шаблона"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "перед %s  необходимо указать %s "
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "параметр, следом за которым надо указать %s"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "значение параметра"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "параметр"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "группа пакетов"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "категория групп пакетов"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "ID дистрибутива"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "определяет продукт, чьи репозитории будут выбраны"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "репозиторий для добавления в шаблон"
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "репозиторий для удаления из шаблона"
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "необходимо указать значение параметра '%s'"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "Шаблон обновляется. Пожалуйста, подождите..."
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "Обновлён шаблон [ %s ]"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "удаляет шаблон"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+"имя окружения, например foo.example.com (по умолчанию &mdash; Library)"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "действия шаблонов на сервере katello"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "показать окружения"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "Организация"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "Предыдущее окружение"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "Список окружений"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "показать выбранное окружение"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "имя окружения (обязательно). Пример: my.example.com"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "Информация об окружении"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "создать окружение"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "описание окружения. Пример: my environment"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "имя предыдущего окружения (обязательно)"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "Создано окружение [ %s ]"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "Не удалось создать окружение [ %s ]"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "обновить окружение"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "имя предыдущего окружения"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "Обновлено окружение [ %s ]"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "удалить окружение"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "Окружение [ %s ] удалено."
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "действия окружения на сервере katello"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "Сертификат %s не может быть прочитан или не существует."
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "Файл %s не может быть прочитан или не существует."
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "Ошибка аутентификации Kerberos"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "Параметр %s является обязательным (см. --help)"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "Конфликт параметров %s и %s (см. --help)"
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "Необходимо выбрать одно значение из %s (см. --help)"

--- a/cli/po/ta.po
+++ b/cli/po/ta.po
@@ -3,2788 +3,145 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # ifelix <ifelix@redhat.com>, 2011. #zanata
+# bkearney <bkearney@fedoraproject.org>, 2012. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-09-02 10:11-0400\n"
-"PO-Revision-Date: 2011-11-25 02:58-0500\n"
-"Last-Translator: ifelix <ifelix@redhat.com>\n"
+"PO-Revision-Date: 2012-08-24 01:49-0400\n"
+"Last-Translator: bkearney <bkearney@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ta-IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "சான்றிதழ் கோப்புe %s இல்லை அல்லது வாசிக்க முடியாது"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "விசை கோப்பு%s இல்லை அல்லது வாசிக்க முடியாது"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "kerberos வழியாக அங்கீகரிக்க முடியவில்லை"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Katello பயனர் கணக்கு சான்றுகள்"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "கணக்கு பயனர்பெயர்"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "கணக்கு கடவுச்சொல்"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello சேவையக தகவல்"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "katello சேவையக புரவலன் பெயர் (முன்னிருப்பு: %s)"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "தவறான கட்டளை; --help-ஐ பார்க்கவும்"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "கட்டளை எதுவும் கொடுக்கப்படவில்லை; --help-ஐ பார்க்கவும்"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "நிறுவனத்தை தேட முடியவில்லை [ %s ]"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "சூழல் [ %s ]-ஐ நிறுவனம் [ %s ]-க்குள் தேட முடியவில்லை"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "தயாரிப்பு [ %s ]-ஐ நிறுவனம் [ %s ]-க்குள் தேட முடியவில்லை"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "வழங்குநர் [ %s ]-ஐ நிறுவனம் [ %s ]-க்குள் தேட முடியவில்லை"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "மாதிரிஉரு [ %s ]-ஐ நிறுவனம் [ %s ]-க்குள் தேட முடியவில்லை"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "நிறுவன பெயர் எடுத்துக்காட்டு: foo.example.com (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "ஒரு நிறுவனத்தை புதுப்பிக்கவும்"
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட நிறுவனம் [ %s ]"
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "நிறுவன Uebercert"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "katello சேவையகத்திலுள்ள நிறுவன குறிப்பிட்ட செயல்கள்"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "தயாரிப்பு பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "தொகுப்பதிவக Urlகள் கண்டுபிடிக்கப்பட்டது @ [%s]"
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr "ஒரு நிறுவனத்திற்குள் சிஸ்டம்களின் பட்டியல்"
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr "சூழல் பெயர் எடுத்துக்காட்டு: வளர்ச்சி"
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr "நிறுவன [ %s ]-க்கான சிஸ்டம்களின் பட்டியல்"
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr "நிறுவனம் [ %s ]-இல்  [ %s ]சூழலுக்கான சிஸ்டம்களின் பட்டியல்"
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr "ஒரு நிறுவனத்திற்குள் ஒரு சிஸ்டத்தை காட்டவும்"
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr "சிஸ்டம் பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "சூழல் பெயர்"
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "முடிந்தது"
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr "ஒரு சிஸ்டத்தில் ஒரு வன்பொருள் அம்சத்தை காட்டவும்"
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "ஒரு சிஸ்டத்தை பதிவுசெய்யவும்"
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "நிறுவனத்தின் பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr "வெற்றிகரமாக பதிவுசெய்யப்பட்ட கணினி [ %s ]"
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr "சிஸ்டம் [ %s ]சை பதிவு செய்ய முடியவில்லை"
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr "ஒரு சிஸ்டத்தை பதிவுநீக்கவும்"
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr "வெற்றிகரமாக பதிவுநீக்கப்பட்ட சிஸ்டம் [ %s ]"
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr "சான்றிதழுக்கு ஒரு சிஸ்டத்தை சந்தாபடுத்தவும்"
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr "சந்தாநீக்குவதற்கான சான்றிதழ் வரிசை (தேவைப்படுகிறது)"
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr "அளவு (முன்னிருப்பு: 1)"
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr "வெற்றிகரமாக சந்தாபடுத்தப்பட்ட கணினி [ %s ]"
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr "ஒரு சிஸ்டத்திற்கான சந்தாக்களின் பட்டியல்"
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr "சான்றிதழிலிருந்து ஒரு சிஸ்டத்தை சந்தாநீக்கவும்"
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr "ஒரு சிஸ்டத்தை புதுப்பிக்கவும்"
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr "சிஸ்டத்திற்கான ஒரு புதிய பெயர்"
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr "சிஸ்டத்திற்கான ஒரு விளக்கம்"
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr "சிஸ்டத்திற்கான  இடம்"
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட சிஸ்டம் [ %s ]"
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr "சிஸ்டம் [ %s ]-ஐ புதுப்பிக்க முடியவில்லை"
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "தொகுப்பதிவக குறியீடு"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "தொகுப்பதிவக பெயர்"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "நிறுவன பெயர் எடுத்துக்காட்டு: foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "தயாரிப்பு பெயர் எடுத்துக்காட்டு: fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr "ஒரு தொகுப்பு பற்றிய தகவலை பட்டியலிடவும்"
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr "தொகுப்பு தகவல்"
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr "ஒரு தொகுப்பதிவகத்தில் தொகுப்புகளை பட்டியலிடவும்"
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "தெரிந்த அனைத்து பயனர்களை பட்டியலிடு"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "பயனர் பட்டியல்"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "பயனரை உருவாக்கு"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "பயனர் பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "தவறான கடவுச்சொல் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "செயல்நீக்கப்பட்ட கணக்கு (முன்னிருப்பு 'தவறாகும்')"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட பயனர் [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "பயனரை உருவாக்க முடியவில்லை [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "பயனரை பற்றிய பட்டியல் தகவல்"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "பயனர் தகவல்"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "பயனரை அழிக்கவும்"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "வெற்றிகரமாக அழிக்கப்பட்ட பயனர் [ %s ]"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "ஒரு பயனரை புதுப்பிக்கவும்"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "துவக்க கடவுச்சொல்"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட பயனர் [ %s ]"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "katello சேவையகத்தில் பயனரின் குறிப்பிட்ட செயல்கள்"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "நிறுவனத்தின் பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "செயல்பாட்டு விசை பெயர் (தேவையானது)"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "ஒரு செயல்பாட்டு விசையை புதுப்பிக்கவும்"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "புதிய மாதிரியுரு பெயர்"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "அனைத்து செயல்பாட்டு விசைகளை பட்டியலிடவும்"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "நிறுவனத்தில் விசைகள் எதுவும் காணப்படவில்லை [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "நிறுவனம் [ %s ] சுழல் [ %s ]-இல் விசைகள் எதுவும் காணப்படவில்லை"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "செயல்பாட்டு விசை பட்டியல்"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "ஒரு செயல்பாட்டு விசையைப் பற்றிய தகவலை காட்டவும்"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "செயல்பாட்டு விசை தகவல்"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "ஒரு செயல்பாட்டு விசையை உருவாக்கு"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "சூழல் பெயர் எகா: dev (தேவையானது)"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "செயல்பாட்டு விசை விவரம்"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "மாதிரியுரு பெயர் எகா: சேவையகங்கள்"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "மாதிரிஉருவை காண முடியவில்லை [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "செயல்பாட்டு விசை [ %s ] வெற்றிகரமாக உருவாக்கப்பட்டது"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "செயல்பாட்டு விசையை உருவாக்க முடியவில்லை [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "புதிய சூழல் பெயர் எகா: dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "புதிய விளக்கம்"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "புதிய மாதிரியுரு பெயர் எகா: சேவையகங்கள்"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "செயல்பாட்டு விசை [ %s ] வெற்றிகரமாக புதுப்பிக்கப்பட்டது"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "ஒரு செயல்பாட்டு விசையை அழிக்கவும்"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "செயல்பாட்டு விசை [ %s ] வெற்றிகரமாக அழிக்கப்பட்டது"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "katello சேவையகத்தினுள் குறிப்பிட்ட செயல்களின் செயல்பாட்டு விசை"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "தொகுப்பதிவக குறியீடு, சர மதிப்பு (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "ஒரு சூழலின் புதிய changesets-ஐ பட்டியலிடவும் "
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "சூழல் பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "Changeset பட்டியல்"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "ஒரு changeset பற்றிய விவரமான தகவல்"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "changeset பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "Changeset தகவல்"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "ஒரு சூழலின் புதிய changesets-ஐ பட்டியலிடவும்"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "changeset [ %s ] க்கான சூழல் [ %s ] வெற்றிகரமாக உருவாக்கப்பட்டது"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "changeset [ %s ] க்கான சூழல் [ %s ] உருவாக்கப்படவில்லை"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "ஒரு changeset-இன் புதுப்பித்தல்களின் உள்ளடக்கம்"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "changeset-க்கு சேர்ப்பதற்கான தயாரிப்பு"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "changeset-இலிருந்து நீக்கவதற்கான தயாரிப்பு"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "changeset-க்கு சேர்ப்பதற்கான ஒரு மாதிரிஉருவின் பெயர்"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "changeset-இலிருந்து நீக்குவதற்கான ஒரு மாதிரிஉருவின் பெயர்"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "இந்த changeset- இலிருந்து இதற்கு நகர்த்தவும்"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட changeset [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "ஒரு changeset-ஐ அழிக்கும்"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "தெரிந்த சூழல்களை பட்டியலிடவும்"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "நிறுவனம்"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "முன் சுற்றுச்சூழல்"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "சுற்றுச்சூழல் பட்டியல்"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "சுற்றுச்சூழல் பெயர் எடுத்துக்காட்டு: foo.example.com (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "சூழல் தகவல்"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "ஒரு சூழலை உருவாக்கவும்"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "சூழல் விளக்க எடுத்துக்காட்டு: foo இன் சூழல்\n"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "முன் சூழலின் பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட சூழல் [ %s ]"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "சூழலை உருவாக்க முடியவில்லை [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "ஒரு சூழலை புதுப்பிக்கவும்"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "முன் சூழலின் பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட சூழல் [ %s ]"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "ஒரு சூழலை அழிக்கவும்"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "வெற்றிகரமாக அழிக்கப்பட்ட சூழல் [ %s ]"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "katello சேவையகத்தின் சூழலிலுள்ள குறிப்பிட்ட செயல்கள்"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "காத்திருத்தல்"
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "இயக்குகிறது"
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "பிழை"
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "ரத்துசெய்யப்பட்டது"
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "நேரம் முடிந்தது"
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr "ஒத்திசைக்கபடவில்லை"
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr "ஒரு குறிப்பிடப்பட்ட URL-இல் ஒரு தொகுப்பதிவகத்தை உருவாக்கவும்"
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr "ஒதுக்குவதற்கு தொகுப்பதிவக பெயர் (தேவைப்பட்டது)"
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr "தொகுப்பதிவகத்திற்கான url பாதை (தேவைப்பட்டது) "
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட தொகுப்பதிவகம் [ %s ] "
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr "ஒரு URL-க்குள் கண்டுபிடிப்பு தொகுப்பதிவகங்களை கொண்டுள்ளன "
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-" urlகளை நொகுப்பதிவகம் கண்டுபிடிக்கிறது, இவற்றிற்கு சில நேரம் எடுக்கும்..."
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "பிழை: %s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr "பயனர் கோரிக்கையின் படி செயல்பாடு ஒதுக்கப்பட்டது. "
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr "ஒரு தொகுப்பதிவகத்தை பற்றிய நிலை தகவல்"
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "தொகுப்பதிவக நிலை"
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "ஒரு தொகுப்பதிவகத்தை பற்றிய நிலை தகவல்"
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "முன்னேற்றம்"
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2803,6 +160,7 @@ msgid "Options"
 msgstr "விருப்பங்கள் "
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2855,6 +213,7 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr "விருப்பம் %s: தவறான தேர்வு: %r (%s-இலிருந்து தேர்ந்தெடு)"
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr "இந்த உதவி செய்தியை காட்டி வெளியேறு"
@@ -2862,3 +221,3014 @@ msgstr "இந்த உதவி செய்தியை காட்டி �
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
 msgstr "நிரலின் பதிப்பு எண்ணை காட்டி வெளியேறு"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "அனைத்து செயல்பாட்டு விசைகளை பட்டியலிடவும்"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "நிறுவனத்தின் பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr "நிறுவனத்தில் விசைகள் எதுவும் காணப்படவில்லை [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "நிறுவனம் [ %s ] சுழல் [ %s ]-இல் விசைகள் எதுவும் காணப்படவில்லை"
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "செயல்பாட்டு விசை பட்டியல்"
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "ஒரு செயல்பாட்டு விசையைப் பற்றிய தகவலை காட்டவும்"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "செயல்பாட்டு விசை பெயர் (தேவையானது)"
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "செயல்பாட்டு விசை தகவல்"
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "ஒரு செயல்பாட்டு விசையை உருவாக்கு"
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "சூழல் பெயர் எகா: dev (தேவையானது)"
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "செயல்பாட்டு விசை விவரம்"
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "மாதிரியுரு பெயர் எகா: சேவையகங்கள்"
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "மாதிரிஉருவை காண முடியவில்லை [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "செயல்பாட்டு விசை [ %s ] வெற்றிகரமாக உருவாக்கப்பட்டது"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "செயல்பாட்டு விசையை உருவாக்க முடியவில்லை [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "ஒரு செயல்பாட்டு விசையை புதுப்பிக்கவும்"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "புதிய சூழல் பெயர் எகா: dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "புதிய மாதிரியுரு பெயர்"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "புதிய விளக்கம்"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "புதிய மாதிரியுரு பெயர் எகா: சேவையகங்கள்"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "செயல்பாட்டு விசை [ %s ] வெற்றிகரமாக புதுப்பிக்கப்பட்டது"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "ஒரு செயல்பாட்டு விசையை அழிக்கவும்"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "செயல்பாட்டு விசை [ %s ] வெற்றிகரமாக அழிக்கப்பட்டது"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "katello சேவையகத்தினுள் குறிப்பிட்ட செயல்களின் செயல்பாட்டு விசை"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "நிறுவனத்தின் பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "தொகுப்பதிவக குறியீடு"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "தொகுப்பதிவக பெயர்"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "நிறுவன பெயர் எடுத்துக்காட்டு: foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "தயாரிப்பு பெயர் எடுத்துக்காட்டு: fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "நிறுவன பெயர் எடுத்துக்காட்டு: foo.example.com (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "தெரிந்த அனைத்து பயனர்களை பட்டியலிடு"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "பயனர் பட்டியல்"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "பயனரை உருவாக்கு"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "பயனர் பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "தவறான கடவுச்சொல் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "செயல்நீக்கப்பட்ட கணக்கு (முன்னிருப்பு 'தவறாகும்')"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட பயனர் [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "பயனரை உருவாக்க முடியவில்லை [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "பயனரை பற்றிய பட்டியல் தகவல்"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "பயனர் தகவல்"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "பயனரை அழிக்கவும்"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "வெற்றிகரமாக அழிக்கப்பட்ட பயனர் [ %s ]"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "ஒரு பயனரை புதுப்பிக்கவும்"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "துவக்க கடவுச்சொல்"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட பயனர் [ %s ]"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "katello சேவையகத்தில் பயனரின் குறிப்பிட்ட செயல்கள்"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "ஒரு சூழலின் புதிய changesets-ஐ பட்டியலிடவும் "
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "சூழல் பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "Changeset பட்டியல்"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "ஒரு changeset பற்றிய விவரமான தகவல்"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "changeset பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "Changeset தகவல்"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "ஒரு சூழலின் புதிய changesets-ஐ பட்டியலிடவும்"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "changeset [ %s ] க்கான சூழல் [ %s ] வெற்றிகரமாக உருவாக்கப்பட்டது"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "changeset [ %s ] க்கான சூழல் [ %s ] உருவாக்கப்படவில்லை"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "ஒரு changeset-இன் புதுப்பித்தல்களின் உள்ளடக்கம்"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "changeset-க்கு சேர்ப்பதற்கான தயாரிப்பு"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "changeset-இலிருந்து நீக்கவதற்கான தயாரிப்பு"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "changeset-க்கு சேர்ப்பதற்கான ஒரு மாதிரிஉருவின் பெயர்"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "changeset-இலிருந்து நீக்குவதற்கான ஒரு மாதிரிஉருவின் பெயர்"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "இந்த changeset- இலிருந்து இதற்கு நகர்த்தவும்"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட changeset [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "ஒரு changeset-ஐ அழிக்கும்"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr "ஒரு நிறுவனத்திற்குள் சிஸ்டம்களின் பட்டியல்"
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr "சூழல் பெயர் எடுத்துக்காட்டு: வளர்ச்சி"
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr "நிறுவன [ %s ]-க்கான சிஸ்டம்களின் பட்டியல்"
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr "நிறுவனம் [ %s ]-இல்  [ %s ]சூழலுக்கான சிஸ்டம்களின் பட்டியல்"
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr "ஒரு நிறுவனத்திற்குள் ஒரு சிஸ்டத்தை காட்டவும்"
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr "சிஸ்டம் பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "சூழல் பெயர்"
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "முடிந்தது"
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr "ஒரு சிஸ்டத்தில் ஒரு வன்பொருள் அம்சத்தை காட்டவும்"
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "ஒரு சிஸ்டத்தை பதிவுசெய்யவும்"
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr "வெற்றிகரமாக பதிவுசெய்யப்பட்ட கணினி [ %s ]"
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr "சிஸ்டம் [ %s ]சை பதிவு செய்ய முடியவில்லை"
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr "ஒரு சிஸ்டத்தை பதிவுநீக்கவும்"
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr "வெற்றிகரமாக பதிவுநீக்கப்பட்ட சிஸ்டம் [ %s ]"
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr "சான்றிதழுக்கு ஒரு சிஸ்டத்தை சந்தாபடுத்தவும்"
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr "சந்தாநீக்குவதற்கான சான்றிதழ் வரிசை (தேவைப்படுகிறது)"
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr "அளவு (முன்னிருப்பு: 1)"
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr "வெற்றிகரமாக சந்தாபடுத்தப்பட்ட கணினி [ %s ]"
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr "ஒரு சிஸ்டத்திற்கான சந்தாக்களின் பட்டியல்"
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr "சான்றிதழிலிருந்து ஒரு சிஸ்டத்தை சந்தாநீக்கவும்"
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr "ஒரு சிஸ்டத்தை புதுப்பிக்கவும்"
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr "சிஸ்டத்திற்கான ஒரு புதிய பெயர்"
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr "சிஸ்டத்திற்கான ஒரு விளக்கம்"
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr "சிஸ்டத்திற்கான  இடம்"
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட சிஸ்டம் [ %s ]"
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr "சிஸ்டம் [ %s ]-ஐ புதுப்பிக்க முடியவில்லை"
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr "ஒரு தொகுப்பு பற்றிய தகவலை பட்டியலிடவும்"
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr "தொகுப்பு தகவல்"
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr "ஒரு தொகுப்பதிவகத்தில் தொகுப்புகளை பட்டியலிடவும்"
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "தொகுப்பதிவக குறியீடு, சர மதிப்பு (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "காத்திருத்தல்"
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "இயக்குகிறது"
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "பிழை"
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "ரத்துசெய்யப்பட்டது"
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "நேரம் முடிந்தது"
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr "ஒத்திசைக்கபடவில்லை"
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr "ஒரு குறிப்பிடப்பட்ட URL-இல் ஒரு தொகுப்பதிவகத்தை உருவாக்கவும்"
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr "ஒதுக்குவதற்கு தொகுப்பதிவக பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr "தொகுப்பதிவகத்திற்கான url பாதை (தேவைப்பட்டது) "
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "தயாரிப்பு பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட தொகுப்பதிவகம் [ %s ] "
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr "ஒரு URL-க்குள் கண்டுபிடிப்பு தொகுப்பதிவகங்களை கொண்டுள்ளன "
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "தொகுப்பதிவக Urlகள் கண்டுபிடிக்கப்பட்டது @ [%s]"
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+" urlகளை நொகுப்பதிவகம் கண்டுபிடிக்கிறது, இவற்றிற்கு சில நேரம் எடுக்கும்..."
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "பிழை: %s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr "பயனர் கோரிக்கையின் படி செயல்பாடு ஒதுக்கப்பட்டது. "
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr "ஒரு தொகுப்பதிவகத்தை பற்றிய நிலை தகவல்"
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "தொகுப்பதிவக நிலை"
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "ஒரு தொகுப்பதிவகத்தை பற்றிய நிலை தகவல்"
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "முன்னேற்றம்"
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "ஒரு நிறுவனத்தை புதுப்பிக்கவும்"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "வெற்றிகரமாக புதுப்பிக்கப்பட்ட நிறுவனம் [ %s ]"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "நிறுவன Uebercert"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "katello சேவையகத்திலுள்ள நிறுவன குறிப்பிட்ட செயல்கள்"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "தெரிந்த சூழல்களை பட்டியலிடவும்"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "நிறுவனம்"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "முன் சுற்றுச்சூழல்"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "சுற்றுச்சூழல் பட்டியல்"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "சுற்றுச்சூழல் பெயர் எடுத்துக்காட்டு: foo.example.com (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "சூழல் தகவல்"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "ஒரு சூழலை உருவாக்கவும்"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "சூழல் விளக்க எடுத்துக்காட்டு: foo இன் சூழல்"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "முன் சூழலின் பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட சூழல் [ %s ]"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "சூழலை உருவாக்க முடியவில்லை [ %s ]"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "ஒரு சூழலை புதுப்பிக்கவும்"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "முன் சூழலின் பெயர் (தேவைப்பட்டது)"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "வெற்றிகரமாக உருவாக்கப்பட்ட சூழல் [ %s ]"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "ஒரு சூழலை அழிக்கவும்"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "வெற்றிகரமாக அழிக்கப்பட்ட சூழல் [ %s ]"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "katello சேவையகத்தின் சூழலிலுள்ள குறிப்பிட்ட செயல்கள்"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "சான்றிதழ் கோப்புe %s இல்லை அல்லது வாசிக்க முடியாது"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "விசை கோப்பு%s இல்லை அல்லது வாசிக்க முடியாது"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "kerberos வழியாக அங்கீகரிக்க முடியவில்லை"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr ""

--- a/cli/po/te.po
+++ b/cli/po/te.po
@@ -15,2774 +15,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: te\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr ""
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr ""
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr ""
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr ""
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
+msgid "Could not find user [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr ""
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr ""
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr ""
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr ""
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr ""
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr ""
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr ""
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr ""
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr ""
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr ""
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr ""
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr ""
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr ""
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr ""
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr ""
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr ""
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr ""
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr ""
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr ""
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr ""
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr ""
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr ""
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr ""
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr ""
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr ""
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2801,6 +158,7 @@ msgid "Options"
 msgstr ""
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2853,10 +211,3021 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr ""
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr ""
 
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr ""
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr ""
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr ""
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr ""
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr ""
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr ""
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr ""
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr ""
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr ""
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr ""
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr ""
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr ""
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
 msgstr ""

--- a/cli/po/zh_CN.po
+++ b/cli/po/zh_CN.po
@@ -17,2788 +17,135 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: zh-Hans-CN\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "证书文件 %s 不存在或者无法读取"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "密钥文件 %s 不存在或者无法读取"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "无法通过 kerberos 认证"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "输出版本信息"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Katello 用户帐户证书"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "帐户用户名"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "帐户密码"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello 服务器信息"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "Katello 服务器主机名（默认为：%s）"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "无效命令，请查看 --help"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "没有给出命令，请查看 --help"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "无法找到机构 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "无法在机构 [ %s ] 中找到环境 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "无法在机构 [ %s ] 中找到产品 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr "无法在机构 [ %s ]、产品 [ %s ] 和环境 [ %s ] 中找到库 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "无法在机构 [ %s ] 中找到供应商 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "无法在环境 [ %s ] 中找到模板 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "无法在环境 [ %s ] 中找到更改集 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "无法找到用户 [ %s ]"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "无法找到用户角色 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "无法找到同步计划 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr "无法找到用户角色 [ %s ] 的权限 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "无法找到过滤器 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "无法在机构 [ %s ] 中找到系统 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "在机构  [ %s ] 的环境  [ %s ] 中发现歧义系统  [ %s ]"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "没有在机构 [ %s ] 的环境 [ %s ] 中发现系统 [ %s ] "
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr "在机构  [ %s ] 发现歧义系统  [ %s ]，您必须指定环境。"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "名称"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "列出所有已知机构"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "机构列表"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "创建一个机构"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "机构名称，例如：foo.example.com（必填项）"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "客户描述，例如：foo 的机构"
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "成功创建机构 [%s]"
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr "无法创建机构 [%s]"
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "列出有关机构的信息"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "可用服务等级"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "机构信息"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "删除机构"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "正在删除机构，请等待......"
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "成功删除机构 [%s]"
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "删除机构 [ %s ] 失败：%s"
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "更新机构"
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "成功更新机构 [%s]"
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "生成并显示 ueber 证书"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "重新生成证书"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "机构 Uebercert"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "显示订阅"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "机构的订阅"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "katello 服务器中的机构具体动作"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "产品名称（必填项）"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "环境名称，例如：production（默认：Library）"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "设定同步计划"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "同步计划名称（必填项）"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "取消设定同步计划"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "列出已知产品"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "供应商名称，列出 Library 中的供应商产品"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "GPG 密钥"
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr "供应商 %s 的产品列表"
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "机构 %s 环境 %s 的产品列表"
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "同步产品"
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "产品 [%s] 同步失败：%s"
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "取消产品 [ %s ] 同步"
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "已同步产品 [%s]"
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "取消目前正在运行的同步"
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "产品同步状态"
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "产品状态"
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-"向环境中推广产品¶\n"
-"（使用产品创建临时更改集并推广它）"
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "推广产品，请等待......"
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "推广到环境 [ %s ] 的产品 [ %s ]"
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "产品 [ %s ] 推广失败：%s"
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "为自定义供应商创建新产品"
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "供应商名称（必填项）"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr " 产品描述"
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr "库 url，例如：http://download.fedoraproject.org/pub/fedora/linux/releases/"
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "跳过库恢复"
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr "假设为是；自动为找到的 url 生成备选库（可选）"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr "分配 gpg 密钥；这个密钥可在每个新库中使用除非为该库指定 gpgkey 或 nogpgkey"
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "成功创建产品 [%s]"
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "[%s] 中找到的库 Url"
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "更新产品属性"
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "更改产品描述"
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "为产品分配 gpgkey"
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "还要为产品的库分配 gpgkey"
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "成功更新产品 [%s]"
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "删除产品及其内容"
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "列出产品的过滤器"
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "产品过滤器"
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "在产品中添加过滤器"
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "从产品中删除过滤器"
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr "过滤器名称（必填项）"
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "在产品 [ %s ] 中添加过滤器 [ %s ]"
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "从产品 [ %s ] 中删除过滤器 [ %s ]"
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "katello 服务器中的产品具体动作"
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr "列出机构中的系统"
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr "环境名称，例如：开发部"
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr "订阅用来过滤系统的池 id"
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr "机构 [ %s ] 的系统列表"
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr "机构 [ %s ] 中环境 [ %s ] 的系统列表"
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr "服务等级"
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr "显示机构中的系统"
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr "系统名称（必填项）"
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "环境名称"
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr "机构 [ %s ] 的系统信息"
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr "机构 [ %s ] 中环境 [ %s ] 的系统信息"
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr "显示系统中安装的软件包清单"
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr "系统中远程安装的软件包，软件包名称使用逗号分开。"
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr "远程从系统中删除的软件包，软件包名称使用逗号分开。"
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr "系统中要更新的软件包，使用 --all 更新所有软件包，软件包名称使用逗号分开。"
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr "系统中远程安装的软件包组，组名称使用逗号分开。"
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr "远程从系统中删除的软件包组，组名称使用逗号分开。"
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr "您在每个调用中最多只能指定一个 安装/删除/更新动作。"
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr "机构 [ %s ] 中系统 [ %s ] 的软件包信息"
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr "机构 [ %s ] 中环境 [ %s ] 的系统 [ %s ] 的软件包信息"
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "执行远程动作 [ %s ]......"
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "完成的远程动作："
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "失败的远程动作："
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr "显示远程任务状态"
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr "系统名称"
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr "远程任务"
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr "任务 id"
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr "系统"
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr "动作"
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr "已开始"
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "已完成"
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr "状态"
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr "结果"
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr "显示远程任务状态"
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr "任务 UUID"
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr "远程任务"
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr "列出该系统可用发行本"
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr "系统名称（如果没有指定，则列出该环境中的所有发行本）"
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr "可用发行本"
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr "显示系统的硬件详情"
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr "机构 [ %s ] 中系统 [ %s ] 的系统详情"
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr "机构 [ %s ] 中环境 [ %s ] 系统 [ %s ] 的系统详情"
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "注册系统"
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "机构名称（必填项）"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr "服务等级协议"
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr "可用密钥，多个密钥可使用逗号分开，例如：--activationkey=key1,key2"
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr "在该系统中使用的 $releasever 值"
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr "系统详情"
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "无法使用 %s 指定选项 %s"
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr "成功注册系统 [ %s ]"
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr "无法注册系统 [ %s ]"
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr "移除 hypervisor 的一个删除记录"
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr "hypervisor uuid（必填项）"
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr "成功为 uuid 为  [ %s ] 的 hypervisor 移除删除记录"
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr "取消注册系统"
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr "成功取消注册系统 [ %s ]"
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr "在证书中订阅系统"
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr "要退订的证书系列（必填项）"
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr "数量（默认为：1）"
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr "成功订阅系统 [ %s ]"
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr "列出系统的订阅"
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr "显示可用订阅"
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr "机构 [ %s ] 中的系统 [ %s ] 没有可用订阅"
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr "系统 [ %s ] 的当前订阅"
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr "序列 id"
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr "提供的产品"
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr "机构 [ %s ] 中的系统 [ %s ] 没有池"
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr "系统 [ %s ] 的可用订阅"
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr "取消订阅证书中的系统"
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr "从中取消订阅的授权 id（可以是授权、序列或全部）"
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr "从中取消订阅的证书序列号（可以是授权、序列或全部）"
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr "取消所欲当前订阅的证书（可以是授权、序列或全部）"
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr "成功取消订阅系统 [ %s ]"
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr "更新系统"
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr "系统的新名称"
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr "系统描述"
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr "系统位置"
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr "该系统的 $releasever 值"
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr "成功更新系统 [ %s ]"
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr "无法更新系统 [ %s ]"
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr "系统报告"
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr "报告格式（可能值：'html'，'text'（默认），'csv'，'pdf'）"
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr "katello 服务器中系统的具体动作"
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "列出所有过滤器"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "过滤器列表"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "创建过滤器"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "描述"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "用逗号分开的软件包名称/nvres 列表"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "成功创建过滤器 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "无法创建过滤器 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "删除过滤器"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "成功删除过滤器 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "过滤器信息"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "过滤器信息"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "在过滤器中添加软件包"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "软件包 id（必填项）"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "在过滤器 [ %s ] 中成功添加软件包 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "从过滤器中删除软件包"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "成功从过滤器 [ %s ] 中删除软件包 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "katello 服务器中过滤器的具体动作"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "列出库中的发行本"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "库 id"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "库名称"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "机构名称，例如：foo.example.com"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "产品名称：例如：fedora-14"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "库 %s 的发行本列表"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "列出有关发行本的信息"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "库 id（必填项）"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "发行本 id，例如：ks-rh-noarch（必填项）"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "发行本信息"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "katello 服务器中库的具体动作"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "获得 katello 服务器的状态"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Katello 状态"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "检查该服务器状态"
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr "列出有关某个软件包的信息"
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr "软件包 id，字符串值（必填项）"
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr "软件包信息"
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr "列出库中的软件包"
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr "库 %s 的软件包列表"
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr "在库中搜索软件包"
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr "搜索软件包时使用的查询字符串，例如：'kernel*'、'kernel-3.3.0-4.el6.x86_64'"
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr "库 %s 和查询 %s 的软件包列表"
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr "katello 服务器中软件包的具体动作"
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "没有描述可用"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "没有任何动作：请查看 --help"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "无效动作：请查看 --help"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "grep 输出结果"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "详细的，更有组织的输出结果"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr "grep 友好输出中的列分隔符，只能在选项 -g 中使用。"
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "需要选项 %s，请查看 --help"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "选项 %s 与 %s 冲突，请查看 --help。"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "需要 %s 之一；请查看 --help"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "至少需要一个 %s；请查看 --help。"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "错误：操作失败"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr "错误：您在 /etc/katello/client.conf 中配置的服务器主机名不匹配"
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "您所连接的 katello 服务器返回的主机名。"
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "您配置了 [%s]，但从服务器中得到的是 [%s]。"
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "请修改 /etc/katello/client.conf 文件中的主机"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "无效证书或者无法认证"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "选项 %s：无效布尔值：%r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "列出所有已知用户"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "用户列表"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "创建用户"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "用户名（必填项）"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "初始密码（必填项）"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "电子邮件（必填项）"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "电子邮件（必填项）"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "用户默认机构名称"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "用户默认环境名称"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "成功创建用户 [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "无法创建用户 [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "列出有关用户信息"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "用户信息"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "删除用户"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "成功删除用户 [ %s ]"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "更新用户"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "初始密码"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "电子邮件"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "禁用的帐户"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "用户默认环境为 None"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "成功更新用户 [ %s ]"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "列出用户角色"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "用户角色列表"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "同步 LDAP 组角色"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "为用户分配角色"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "取消为用户分配的角色"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "用户角色（必填项）"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "没有找到角色 [ %s ]"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "用户报告"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "katello 服务器中用户的具体动作"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "输入 GPG 密钥内容（使用 CTRL+D 完成输入操作）："
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "列出所有 GPG 密钥"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "机构名称（必填项）"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "没有在机构 [ %s ] 中找到密钥"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "GPG 密钥列表"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "显示 gpg 密钥信息"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "激活码名称（必填项）"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "无法找到 gpg 密钥 [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "库"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "GPG 密钥信息"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "生成 gpg 密钥"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr "使用 GPG 公钥的文件，如果没有指定，则使用标准输入"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "成功创建 gpg 密钥 [%s]"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "无法创建 gpg 密钥 [%s]"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "更新激活码"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "新模板名称"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "使用公共 GPG 密钥的文件"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "提示输入密钥的新内容"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "成功更新的 gpg 密钥 [%s]"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "无法更新的 gpg 密钥 [%s]"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "删除 gpg 密钥"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "成功删除 gpg 密钥 [%s]"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "katello 服务器中 GPG 密钥的具体动作"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "列出所有激活密钥"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "环境名称，例如：dev（默认：Library）"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "没有找到机构 [ %s ] 的密钥"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "没有找到机构 [ %s ] 环境 [ %s ] 的密钥"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "激活码列表"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "显示激活码信息"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "无法找到激活码 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "激活码信息"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "生成激活码"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "环境名称，例如：dev（必填项）"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "激活码描述"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "模板名称，例如：servers"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "无法找到模板 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "成功生成激活码 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "无法生成激活码 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "新环境名称，例如：dev"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "新描述"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "新模板名称，例如：servers"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "在激活码中添加池"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "从激活码中删除池"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "已成功更新激活码 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "删除激活码"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "成功删除激活码 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "katello 服务器中激活码的具体动作"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "列出可用软件包组"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "库 id，字符串值（必填项）"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "没有在库 [%s] 中找到软件包组"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "软件包组信息"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "查找软件包组信息"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "软件包组 id，字符串值（必填项）"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "没有在库 [%s] 中找到软件包组 [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "列出可用软件包组分类"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "没有在库 [%s] 中找到软件包组分类"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "软件包组分类信息"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "软件包组分类 id，字符串值（必填项）"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "没有在库 [%s] 中找到软件包组分类 [%s]"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "软件包组分类信息"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "katello 服务器中软件包组的具体动作"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "列出某个环境中的新更改集"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "环境名称（必填项）"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "更改集列表"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "有关更改集的详细信息"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "更改集名称（必填项）"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "将显示依赖软件包"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "更改集信息"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "为某个环境创建新更改集"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "更改集描述"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "成功为环境 [ %s ] 创建更改集 [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "无法为环境 [ %s ] 创建更改集 [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "更新更改集内容"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s 必须在 %s 前面"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "新更改集名称"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "添加到更改集中的产品"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "从更改集中删除的产品"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "要添加到更改集中的模板名称"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "要从更改集中删除的模板名称"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr "决定要在哪个软件包/勘误/库中提取产品"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "添加到更改集"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "从更改集中删除"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "成功更新的更改集 [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "删除更改集"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "将更改集放到下一个环境中"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "正在推广更改集，请等待......"
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "已推广更改集 [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "通过更改集 [ %s ] 失败：%s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "katello 服务器中更改集的具体动作"
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr "列出所有已知供应商"
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr "供应商列表"
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr "列出有关供应商信息"
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr "供应商信息"
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr "创建供应商"
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr "更新供应商"
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr "供应商描述"
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr "供应商名称"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "选项 --url 必须以 http:// 或者 https:// 开始"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "选项 --url 不是有效格式"
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr "成功创建供应商 [%s]"
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr "无法创建供应商 [%s]"
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr "成功更新供应商 [%s]"
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr "删除供应商"
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr "同步供应商"
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr "供应商 [%s] 同步失败：%s"
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr "取消供应商 [ %s ] 同步"
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr "以同步供应商 [%s]"
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr "供应商同步状态"
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr "%d%% 完成（下载 %d 的 %d 软件包）"
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr "供应商状态"
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr "导入清单文件"
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr "导入清单文件的路径（必填项）"
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr "强制重新导入清单"
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr "文件 %s 不存在"
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr "正在导入列表，请等待......"
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr "刷新供应商产品库"
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr "成功刷新供应商 [ %s ]"
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr "katello 服务器中的供应商具体动作"
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "列出已知环境"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "机构"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "上一个环境"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "环境列表"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "列出具体环境"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "环境名称，例如：eg: foo.example.com（必填项）"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "环境信息"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "创建环境"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "环境描述，例如：foo 的环境"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "上一个环境的名称（必填项）"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "成功创建环境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "无法创建环境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "更新环境"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "前一个环境名称"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "成功更新环境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "删除环境"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "成功删除环境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "katello 服务器中环境具体动作"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "在客户端配置文件中保存选项"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr "要保存的选项名称（例如：org、environment、provider 等等）（必填项）"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "要在指定的选项下保存的值（必填项）"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "成功"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "未成功记住的选项 [ %s ]"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "从客户端配置中删除选项"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "要删除的选项名称（必填项）"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "成功忘记选项 [ %s ]"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "未成功忘记选项 [ %s ]"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "列出在客户端配置中保存的选项"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "保存的选项"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "katello 服务器中客户端的具体动作"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "列出所有模板"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "机构名称（如要指定环境则需要）"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "没有在环境 [%s] 中找到模板"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "模板列表"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "列出有关模板的信息"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "模板名称（必填项）"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "模板信息"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "创建模板文件并导入数据"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "到模板文件的路径（必填项）"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "正在导入模板，请等待......"
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "将模板导出为文件"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "环境名称，例如：dev"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "导出格式，可能值为：%s，默认：json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "无法创建文件 %s"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "正在导出模板，请稍侯......"
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "成功将模板导出为文件 %s"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "创建空模板文件"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "上级模板名称"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "模板模式"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "成功创建模板 [%s]"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "无法创建模板 [%s]"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "更新模板名称和描述"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "每个 %s 前面必须有一个 %s"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "产品的名称或 nvre（epoch:name-rel.ease-ver.sio.n）"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "参数名，% 必须跟着"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "参数值"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "参数名"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "软件包组名称"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "软件包组分类名称"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "发行本 id"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "决定要从哪个库中提取产品"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "添加到模板中的库"
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "从模板中删除的库"
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "参数 '%s' 缺少值"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "正在更新模板，请等待......"
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "成功更新模板 [%s]"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "删除模板"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "环境名称，例如：foo.example.com（默认：Library）"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "katello 服务器中模板的具体动作"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "将 cli 作为 shell 运行"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "列出已知 sync_plans"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "同步计划列表"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "输出有关同步计划信息"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "同步计划名称（必填项）"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "同步计划信息"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "生成同步计划"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "计划描述"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr "重复同步间隔（选择：[%s]，默认：none）"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "首次同步日期（必填项，格式：YYYY-MM-DD）"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr "首次同步时间（格式：HH:MM:SS，默认：00:00:00）"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "成功生成同步计划 [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "无法生成同步计划 [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "更新同步计划"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "新同步计划名称"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "首次同步日期（格式：YYYY-MM-DD）"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "首次同步时间（格式：HH:MM:SS）"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "您必须指定 --date 和 --time"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "成功更新的同步计划 [%s]"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "删除同步计划"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "成功删除的同步计划 [%s]"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr "katello 服务器中同步计划的具体动作"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "获得 katello 服务器版本"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "检查该服务器版本"
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr "为用户角色生成权限"
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "角色名称（必填项）"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr "权限名称（必填项）"
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr "权限描述"
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr "机构名称"
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr "权限范围（必填项）"
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr "权限详情"
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr "权限标签"
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr "无效范围 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr "无法在范围 [ %s ] 中找到标签 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr "成功为用户角色 [ %s ] 创建权限 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr "无法创建权限 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr "删除权限"
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr "成功为角色 [ %s ] 删除权限 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr "为用户角色列出权限"
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr "权限列表"
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr "列出在权限中设定的可用范围，详细程序和标签"
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-"机构名称，例如：foo.example.com,\n"
-"列出机构具体详情"
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr "根据范围结果列出过滤器"
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr "权限范围 %s 中使用的可用详细程序和标签"
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr "可用详细程度"
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr "无"
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr "katello 服务器中权限的具体动作"
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr "列出某个库的所有勘误"
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr "根据类型列出过滤器勘误，例如：enhancements"
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr "根据严重程度列出过滤器勘误"
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr "勘误列表"
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr "列出某个系统的勘误"
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr "机构 %s 中系统 %s 的勘误"
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr "勘误信息"
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr "勘误 id，字符串值（必填项）"
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr "勘误信息"
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr "katello 服务器中的勘误具体动作"
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "等待中"
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "运行中"
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "错误"
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "已取消"
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr "已取消。"
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "超时"
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr "没有同步"
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr "在指定 URL 中创建一个库"
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr "要分配的库名称（必填项）"
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr "库的 url 路径（必填项）"
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr "为库分配的 GPG 密钥；默认使用产品的 GPG 密钥。"
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr "不为库分配 GPG 密钥。"
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr "成功创建库 [ %s ]"
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr "在 URL 中找到的库"
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr "在所有找到的库前面添加的库名称前缀（必填项）"
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr "执行库查找的 root url，例如：http://porkchop.devel.redhat.com/ （必填项）"
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr "查找库 url，可能需要一些时间......"
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "错误：%s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-"\n"
-"选择应用来创建备选库的 url；输入‘y’确认（按 h 是帮助）："
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr "根据用户要求取消操作。"
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr "有关库的状态信息"
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "库状态"
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "库信息"
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "进程"
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr "有关库 %s 的信息"
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr "更新库属性"
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr "成功更新库 [ %s ]"
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr "同步库"
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr "已同步库 [%s]"
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr "取消库 [ %s ] 同步"
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr "库 [%s] 同步失败：%s"
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr "取消目前正在运行的库同步"
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr "启用库"
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr "禁用库"
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr "列出机构中的库"
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr "机构名称，例如：ACME_Corporation（必填项）"
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr "列出所有禁用的库"
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr "机构 %s 环境 %s 产品 %s 的库列表"
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr "机构 %s 中产品的库列表"
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr "机构 %s 环境 %s 的库列表"
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr "删除库"
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr "列出库的过滤器"
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr "列出所有为库产品分配的过滤器"
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr "库过滤器"
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr "在库中添加过滤器"
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr "从库中删除过滤器"
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr "在库 [%s] 中添加过滤器 [ %s ]"
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr "从库 [%s] 中删除过滤器 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "列出所有已知用户角色"
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "创建用户角色"
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "角色描述"
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "成功创建用户角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "无法创建用户角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "列出有关用户角色的信息"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "用户角色名称（必填项）"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "输出有关每个角色权限详情"
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "用户角色信息"
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "删除用户角色"
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "成功删除用户角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "更新角色"
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "新用户角色名称"
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr "提供至少一个参数以便更新用户角色"
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "成功更新用户角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "为 LDAP 组分配一个角色"
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "新 LDAP 组名（必填项）"
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr "在用户角色 [ %s ] 中成功添加 LDAP 组 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "删除为角色分配的 LDAP 组"
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "要删除的 LDAP 组名（必填项）"
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr "成功从用户角色 [ %s ] 中删除 LDAP 组 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "katello 服务器中用户角色的具体动作"
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "时间格式无效。所需格式为：HH:MM:SS[+HH:MM]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "日期格式无效。日期格式应为 YYYY-MM-DD"
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
-msgstr "用法：%s¶"
+msgstr "用法：%s\n"
 
 #: ../src/katello/client/i18n_optparse.py:49
 msgid "Usage"
@@ -2813,6 +160,7 @@ msgid "Options"
 msgstr "选项"
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2865,6 +213,7 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr "选项 %s：无效选择：%r（在 %s 中选择）"
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr "显示这个帮助信息并退出"
@@ -2872,3 +221,3023 @@ msgstr "显示这个帮助信息并退出"
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
 msgstr "显示程序版本号并退出"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "列出所有已知用户角色"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "用户角色列表"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "创建用户角色"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "角色名称（必填项）"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "角色描述"
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr "成功创建用户角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr "无法创建用户角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "列出有关用户角色的信息"
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "用户角色名称（必填项）"
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "输出有关每个角色权限详情"
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "用户角色信息"
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "删除用户角色"
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr "成功删除用户角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "更新角色"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "新用户角色名称"
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr "成功更新用户角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "为 LDAP 组分配一个角色"
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "新 LDAP 组名（必填项）"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr "在用户角色 [ %s ] 中成功添加 LDAP 组 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "删除为角色分配的 LDAP 组"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "要删除的 LDAP 组名（必填项）"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr "成功从用户角色 [ %s ] 中删除 LDAP 组 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "katello 服务器中用户角色的具体动作"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "在客户端配置文件中保存选项"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr "要保存的选项名称（例如：org、environment、provider 等等）（必填项）"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "要在指定的选项下保存的值（必填项）"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "成功"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "未成功记住的选项 [ %s ]"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "从客户端配置中删除选项"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "要删除的选项名称（必填项）"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "成功忘记选项 [ %s ]"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "未成功忘记选项 [ %s ]"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "列出在客户端配置中保存的选项"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "保存的选项"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "katello 服务器中客户端的具体动作"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "列出所有激活密钥"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "机构名称（必填项）"
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "环境名称，例如：dev（默认：Library）"
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr "没有找到机构 [ %s ] 的密钥"
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "没有找到机构 [ %s ] 环境 [ %s ] 的密钥"
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "激活码列表"
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "显示激活码信息"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "激活码名称（必填项）"
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr "无法找到激活码 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "激活码信息"
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "生成激活码"
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "环境名称，例如：dev（必填项）"
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "激活码描述"
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "模板名称，例如：servers"
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "无法找到模板 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "成功生成激活码 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "无法生成激活码 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "更新激活码"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "新环境名称，例如：dev"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "新模板名称"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "新描述"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "新模板名称，例如：servers"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "在激活码中添加池"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "从激活码中删除池"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "已成功更新激活码 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "删除激活码"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "成功删除激活码 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "katello 服务器中激活码的具体动作"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "时间格式无效。所需格式为：HH:MM:SS[+HH:MM]"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "日期格式无效。日期格式应为 YYYY-MM-DD"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "列出所有过滤器"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "机构名称（必填项）"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "过滤器列表"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "创建过滤器"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr "过滤器名称（必填项）"
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "描述"
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "用逗号分开的软件包名称/nvres 列表"
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "成功创建过滤器 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "无法创建过滤器 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "删除过滤器"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "成功删除过滤器 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "过滤器信息"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "过滤器信息"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "在过滤器中添加软件包"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "软件包 id（必填项）"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "在过滤器 [ %s ] 中成功添加软件包 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "从过滤器中删除软件包"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "成功从过滤器 [ %s ] 中删除软件包 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "katello 服务器中过滤器的具体动作"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "列出库中的发行本"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "库 id"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "库名称"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "机构名称，例如：foo.example.com"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "环境名称，例如：production（默认：Library）"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "产品名称：例如：fedora-14"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "库 %s 的发行本列表"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "列出有关发行本的信息"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "库 id（必填项）"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "发行本 id，例如：ks-rh-noarch（必填项）"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "发行本信息"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "katello 服务器中库的具体动作"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "输入 GPG 密钥内容（使用 CTRL+D 完成输入操作）："
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "列出所有 GPG 密钥"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "库"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr "使用 GPG 公钥的文件，如果没有指定，则使用标准输入"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "使用公共 GPG 密钥的文件"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "提示输入密钥的新内容"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "katello 服务器中 GPG 密钥的具体动作"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "机构名称，例如：foo.example.com（必填项）"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "执行远程动作 [ %s ]......"
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "完成的远程动作："
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "失败的远程动作："
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "列出所有已知用户"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "用户列表"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "创建用户"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "用户名（必填项）"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "初始密码（必填项）"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "电子邮件（必填项）"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "电子邮件（必填项）"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "用户默认机构名称"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "用户默认环境名称"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "成功创建用户 [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "无法创建用户 [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "列出有关用户信息"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "用户信息"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "删除用户"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "成功删除用户 [ %s ]"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "更新用户"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "初始密码"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "电子邮件"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "禁用的帐户"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "用户默认环境为 None"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "成功更新用户 [ %s ]"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "列出用户角色"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "同步 LDAP 组角色"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "为用户分配角色"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "取消为用户分配的角色"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "用户角色（必填项）"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "没有找到角色 [ %s ]"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "用户报告"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr "报告格式（可能值：'html'，'text'（默认），'csv'，'pdf'）"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "katello 服务器中用户的具体动作"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "列出某个环境中的新更改集"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "环境名称（必填项）"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "更改集列表"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "有关更改集的详细信息"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "更改集名称（必填项）"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "将显示依赖软件包"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "更改集信息"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "为某个环境创建新更改集"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "更改集描述"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "成功为环境 [ %s ] 创建更改集 [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "无法为环境 [ %s ] 创建更改集 [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "更新更改集内容"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s 必须在 %s 前面"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "新更改集名称"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "添加到更改集中的产品"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "从更改集中删除的产品"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "要添加到更改集中的模板名称"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "要从更改集中删除的模板名称"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr "决定要在哪个软件包/勘误/库中提取产品"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "添加到更改集"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "从更改集中删除"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "成功更新的更改集 [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "删除更改集"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "通过更改集 [ %s ] 失败：%s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "katello 服务器中更改集的具体动作"
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr "列出机构中的系统"
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr "环境名称，例如：开发部"
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr "订阅用来过滤系统的池 id"
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr "机构 [ %s ] 的系统列表"
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr "机构 [ %s ] 中环境 [ %s ] 的系统列表"
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr "服务等级"
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr "显示机构中的系统"
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr "系统名称（必填项）"
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "环境名称"
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr "机构 [ %s ] 的系统信息"
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr "机构 [ %s ] 中环境 [ %s ] 的系统信息"
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr "显示系统中安装的软件包清单"
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr "系统中远程安装的软件包，软件包名称使用逗号分开。"
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr "远程从系统中删除的软件包，软件包名称使用逗号分开。"
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr "系统中要更新的软件包，使用 --all 更新所有软件包，软件包名称使用逗号分开。"
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr "系统中远程安装的软件包组，组名称使用逗号分开。"
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr "远程从系统中删除的软件包组，组名称使用逗号分开。"
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr "您在每个调用中最多只能指定一个 安装/删除/更新动作。"
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr "机构 [ %s ] 中系统 [ %s ] 的软件包信息"
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr "机构 [ %s ] 中环境 [ %s ] 的系统 [ %s ] 的软件包信息"
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr "显示远程任务状态"
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr "系统名称"
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr "远程任务"
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr "任务 id"
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr "系统"
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr "动作"
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr "已开始"
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "已完成"
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr "状态"
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr "结果"
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr "显示远程任务状态"
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr "任务 UUID"
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr "远程任务"
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr "列出该系统可用发行本"
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr "系统名称（如果没有指定，则列出该环境中的所有发行本）"
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr "可用发行本"
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr "显示系统的硬件详情"
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr "机构 [ %s ] 中系统 [ %s ] 的系统详情"
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr "机构 [ %s ] 中环境 [ %s ] 系统 [ %s ] 的系统详情"
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "注册系统"
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr "服务等级协议"
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr "可用密钥，多个密钥可使用逗号分开，例如：--activationkey=key1,key2"
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr "在该系统中使用的 $releasever 值"
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr "系统详情"
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr "成功注册系统 [ %s ]"
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr "无法注册系统 [ %s ]"
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr "移除 hypervisor 的一个删除记录"
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr "hypervisor uuid（必填项）"
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr "成功为 uuid 为  [ %s ] 的 hypervisor 移除删除记录"
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr "取消注册系统"
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr "成功取消注册系统 [ %s ]"
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr "在证书中订阅系统"
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr "要退订的证书系列（必填项）"
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr "数量（默认为：1）"
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr "成功订阅系统 [ %s ]"
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr "列出系统的订阅"
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr "显示可用订阅"
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr "机构 [ %s ] 中的系统 [ %s ] 没有可用订阅"
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr "系统 [ %s ] 的当前订阅"
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr "序列 id"
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr "提供的产品"
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr "机构 [ %s ] 中的系统 [ %s ] 没有池"
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr "系统 [ %s ] 的可用订阅"
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr "取消订阅证书中的系统"
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr "从中取消订阅的授权 id（可以是授权、序列或全部）"
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr "从中取消订阅的证书序列号（可以是授权、序列或全部）"
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr "取消所欲当前订阅的证书（可以是授权、序列或全部）"
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr "成功取消订阅系统 [ %s ]"
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr "更新系统"
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr "系统的新名称"
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr "系统描述"
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr "系统位置"
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr "该系统的 $releasever 值"
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr "成功更新系统 [ %s ]"
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr "无法更新系统 [ %s ]"
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr "系统报告"
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr "katello 服务器中系统的具体动作"
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr "列出有关某个软件包的信息"
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr "软件包 id，字符串值（必填项）"
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr "软件包信息"
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr "列出库中的软件包"
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr "库 %s 的软件包列表"
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr "在库中搜索软件包"
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr "搜索软件包时使用的查询字符串，例如：'kernel*'、'kernel-3.3.0-4.el6.x86_64'"
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr "库 %s 和查询 %s 的软件包列表"
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr "katello 服务器中软件包的具体动作"
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "将 cli 作为 shell 运行"
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "供应商名称（必填项）"
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr "列出所有已知供应商"
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr "供应商列表"
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr "列出有关供应商信息"
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr "供应商信息"
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr "创建供应商"
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr "更新供应商"
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr "供应商描述"
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr "库 url，例如：http://download.fedoraproject.org/pub/fedora/linux/releases/"
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr "供应商名称"
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr "成功创建供应商 [%s]"
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr "无法创建供应商 [%s]"
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr "成功更新供应商 [%s]"
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr "删除供应商"
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr "同步供应商"
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr "供应商 [%s] 同步失败：%s"
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr "取消供应商 [ %s ] 同步"
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr "以同步供应商 [%s]"
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "取消目前正在运行的同步"
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr "供应商同步状态"
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr "%d%% 完成（下载 %d 的 %d 软件包）"
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr "供应商状态"
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr "导入清单文件"
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr "导入清单文件的路径（必填项）"
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr "强制重新导入清单"
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr "文件 %s 不存在"
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr "正在导入列表，请等待......"
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr "刷新供应商产品库"
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr "成功刷新供应商 [ %s ]"
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr "katello 服务器中的供应商具体动作"
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "获得 katello 服务器的状态"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Katello 状态"
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr "为用户角色生成权限"
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr "权限名称（必填项）"
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr "权限描述"
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr "机构名称"
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr "权限范围（必填项）"
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr "权限详情"
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr "权限标签"
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr "无效范围 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr "无法在范围 [ %s ] 中找到标签 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr "成功为用户角色 [ %s ] 创建权限 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr "无法创建权限 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr "删除权限"
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr "成功为角色 [ %s ] 删除权限 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr "为用户角色列出权限"
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr "权限列表"
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr "列出在权限中设定的可用范围，详细程序和标签"
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+"机构名称，例如：foo.example.com,\n"
+"列出机构具体详情"
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr "根据范围结果列出过滤器"
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr "权限范围 %s 中使用的可用详细程序和标签"
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr "可用详细程度"
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr "无"
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr "katello 服务器中权限的具体动作"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "没有描述可用"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "没有任何动作：请查看 --help"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "无效动作：请查看 --help"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "grep 输出结果"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "详细的，更有组织的输出结果"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr "grep 友好输出中的列分隔符，只能在选项 -g 中使用。"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr "错误：您在 /etc/katello/client.conf 中配置的服务器主机名不匹配"
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "您所连接的 katello 服务器返回的主机名。"
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "您配置了 [%s]，但从服务器中得到的是 [%s]。"
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "请修改 /etc/katello/client.conf 文件中的主机"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "无效证书或者无法认证"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "选项 %s：无效布尔值：%r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr "列出某个库的所有勘误"
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr "根据类型列出过滤器勘误，例如：enhancements"
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr "根据严重程度列出过滤器勘误"
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr "勘误列表"
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr "列出某个系统的勘误"
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr "机构 %s 中系统 %s 的勘误"
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr "勘误信息"
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr "勘误 id，字符串值（必填项）"
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr "勘误信息"
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr "katello 服务器中的勘误具体动作"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "获得 katello 服务器版本"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "检查该服务器版本"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "列出可用软件包组"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "库 id，字符串值（必填项）"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "没有在库 [%s] 中找到软件包组"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "软件包组信息"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "查找软件包组信息"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "软件包组 id，字符串值（必填项）"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "没有在库 [%s] 中找到软件包组 [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "列出可用软件包组分类"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "没有在库 [%s] 中找到软件包组分类"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "软件包组分类信息"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "软件包组分类 id，字符串值（必填项）"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "没有在库 [%s] 中找到软件包组分类 [%s]"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "软件包组分类信息"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "katello 服务器中软件包组的具体动作"
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "等待中"
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "运行中"
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "错误"
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "已取消"
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr "已取消。"
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "超时"
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr "没有同步"
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr "在指定 URL 中创建一个库"
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr "要分配的库名称（必填项）"
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr "库的 url 路径（必填项）"
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "产品名称（必填项）"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr "为库分配的 GPG 密钥；默认使用产品的 GPG 密钥。"
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr "不为库分配 GPG 密钥。"
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr "成功创建库 [ %s ]"
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr "在 URL 中找到的库"
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr "在所有找到的库前面添加的库名称前缀（必填项）"
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr "执行库查找的 root url，例如：http://porkchop.devel.redhat.com/ （必填项）"
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr "假设为是；自动为找到的 url 生成备选库（可选）"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "[%s] 中找到的库 Url"
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr "查找库 url，可能需要一些时间......"
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "错误：%s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+"\n"
+"选择应用来创建备选库的 url；输入‘y’确认（按 h 是帮助）："
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr "根据用户要求取消操作。"
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr "有关库的状态信息"
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "库状态"
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "库信息"
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "进程"
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "GPG 密钥"
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr "有关库 %s 的信息"
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr "更新库属性"
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr "成功更新库 [ %s ]"
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr "同步库"
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr "已同步库 [%s]"
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr "取消库 [ %s ] 同步"
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr "库 [%s] 同步失败：%s"
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr "取消目前正在运行的库同步"
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr "启用库"
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr "禁用库"
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr "列出机构中的库"
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr "机构名称，例如：ACME_Corporation（必填项）"
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr "列出所有禁用的库"
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr "机构 %s 环境 %s 产品 %s 的库列表"
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr "机构 %s 中产品的库列表 %s"
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr "机构 %s 环境 %s 的库列表"
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr "删除库"
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr "列出库的过滤器"
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr "列出所有为库产品分配的过滤器"
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr "库过滤器"
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr "在库中添加过滤器"
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr "从库中删除过滤器"
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr "在库 [%s] 中添加过滤器 [ %s ]"
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr "从库 [%s] 中删除过滤器 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "列出已知 sync_plans"
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "同步计划列表"
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "输出有关同步计划信息"
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "同步计划名称（必填项）"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "同步计划信息"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "生成同步计划"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "计划描述"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr "重复同步间隔（选择：[%s]，默认：none）"
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "首次同步日期（必填项，格式：YYYY-MM-DD）"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr "首次同步时间（格式：HH:MM:SS，默认：00:00:00）"
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "成功生成同步计划 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "无法生成同步计划 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "更新同步计划"
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "新同步计划名称"
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "首次同步日期（格式：YYYY-MM-DD）"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "首次同步时间（格式：HH:MM:SS）"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "成功更新的同步计划 [%s]"
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "删除同步计划"
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "成功删除的同步计划 [%s]"
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr "katello 服务器中同步计划的具体动作"
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "列出所有已知机构"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "机构列表"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "创建一个机构"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "客户描述，例如：foo 的机构"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "成功创建机构 [%s]"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "无法创建机构 [%s]"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "列出有关机构的信息"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "可用服务等级"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "机构信息"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "删除机构"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "正在删除机构，请等待......"
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "成功删除机构 [%s]"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "删除机构 [ %s ] 失败：%s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "更新机构"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "成功更新机构 [%s]"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "生成并显示 ueber 证书"
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "重新生成证书"
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "机构 Uebercert"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "显示订阅"
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "机构的订阅"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "katello 服务器中的机构具体动作"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "设定同步计划"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "同步计划名称（必填项）"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "取消设定同步计划"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "列出已知产品"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "供应商名称，列出 Library 中的供应商产品"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "供应商 %s 的产品列表"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "机构 %s 环境 %s 的产品列表"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "同步产品"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "产品 [%s] 同步失败：%s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "取消产品 [ %s ] 同步"
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "已同步产品 [%s]"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "产品同步状态"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "产品状态"
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+"向环境中推广产品¶\n"
+"（使用产品创建临时更改集并推广它）"
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "推广产品，请等待......"
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "推广到环境 [ %s ] 的产品 [ %s ]"
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "产品 [ %s ] 推广失败：%s"
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "为自定义供应商创建新产品"
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr " 产品描述"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "跳过库恢复"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr "分配 gpg 密钥；这个密钥可在每个新库中使用除非为该库指定 gpgkey 或 nogpgkey"
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr "成功创建产品 [%s]"
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "更新产品属性"
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "更改产品描述"
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "为产品分配 gpgkey"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "还要为产品的库分配 gpgkey"
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr "成功更新产品 [%s]"
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "删除产品及其内容"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "列出产品的过滤器"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "产品过滤器"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "在产品中添加过滤器"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "从产品中删除过滤器"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "在产品 [ %s ] 中添加过滤器 [ %s ]"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "从产品 [ %s ] 中删除过滤器 [ %s ]"
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "katello 服务器中的产品具体动作"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "列出所有模板"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "机构名称（如要指定环境则需要）"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "没有在环境 [%s] 中找到模板"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "模板列表"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "列出有关模板的信息"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "模板名称（必填项）"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "模板信息"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "创建模板文件并导入数据"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "到模板文件的路径（必填项）"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "正在导入模板，请等待......"
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "将模板导出为文件"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "环境名称，例如：dev"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "导出格式，可能值为：%s，默认：json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "无法创建文件 %s"
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "正在导出模板，请稍侯......"
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "成功将模板导出为文件 %s"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "创建空模板文件"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "上级模板名称"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "模板模式"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "成功创建模板 [%s]"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "无法创建模板 [%s]"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "更新模板名称和描述"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "每个 %s 前面必须有一个 %s"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "参数名，%s 必须跟着"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "参数值"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "参数名"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "软件包组名称"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "软件包组分类名称"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "发行本 id"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "决定要从哪个库中提取产品"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "添加到模板中的库"
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "从模板中删除的库"
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "参数 '%s' 缺少值"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "正在更新模板，请等待......"
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "成功更新模板 [%s]"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "删除模板"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "环境名称，例如：foo.example.com（默认：Library）"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "katello 服务器中模板的具体动作"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "列出已知环境"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "机构"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "上一个环境"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "环境列表"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "列出具体环境"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "环境名称，例如：eg: foo.example.com（必填项）"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "环境信息"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "创建环境"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "环境描述，例如：foo 的环境"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "上一个环境的名称（必填项）"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "成功创建环境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "无法创建环境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "更新环境"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "前一个环境名称"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "成功更新环境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "删除环境"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "成功删除环境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "katello 服务器中环境具体动作"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "证书文件 %s 不存在或者无法读取"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "密钥文件 %s 不存在或者无法读取"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "无法通过 kerberos 认证"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "需要选项 %s，请查看 --help"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "选项 %s 与 %s 冲突，请查看 --help。"
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "至少需要一个 %s；请查看 --help。"

--- a/cli/po/zh_TW.po
+++ b/cli/po/zh_TW.po
@@ -17,2785 +17,131 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: zh-Hant-TW\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"X-Generator: Zanata 1.5.0\n"
+"X-Generator: Zanata 1.6.1\n"
 
-#: ../src/katello/client/server.py:420
-#, python-format
-msgid "certificate file %s does not exist or cannot be read"
-msgstr "認證檔案 %s 不存在或無法讀取"
-
-#: ../src/katello/client/server.py:423
-#, python-format
-msgid "key file %s does not exist or cannot be read"
-msgstr "金鑰檔案 %s 不存在或無法讀取"
-
-#: ../src/katello/client/server.py:436
-msgid "Couldn't authenticate via kerberos"
-msgstr "無法透過 kerberos 認證"
-
-#: ../src/katello/client/cli/base.py:119
+#: ../src/katello/client/cli/base.py:72
 msgid "prints version information"
 msgstr "列印版本資訊"
 
-#: ../src/katello/client/cli/base.py:120
+#: ../src/katello/client/cli/base.py:74
 msgid "Katello User Account Credentials"
 msgstr "Katello 使用者帳號的憑證"
 
-#: ../src/katello/client/cli/base.py:122
+#: ../src/katello/client/cli/base.py:76
 msgid "account username"
 msgstr "帳號的使用者名稱"
 
-#: ../src/katello/client/cli/base.py:124
+#: ../src/katello/client/cli/base.py:78
 msgid "account password"
 msgstr "帳號的密碼"
 
-#: ../src/katello/client/cli/base.py:131
+#: ../src/katello/client/cli/base.py:87
 msgid "Katello Server Information"
 msgstr "Katello 伺服器資訊"
 
-#: ../src/katello/client/cli/base.py:134
+#: ../src/katello/client/cli/base.py:90
 #, python-format
 msgid "katello server host name (default: %s)"
 msgstr "katello 伺服器的主機名稱（預設值：%s）"
 
-#: ../src/katello/client/cli/base.py:200
-msgid "Invalid command; please see --help"
-msgstr "不合乎規定的指令；請參閱「--help」"
-
-#: ../src/katello/client/cli/base.py:224
-msgid "No command given; please see --help"
-msgstr "未給予指令：請參閱「--help」"
-
-#: ../src/katello/client/api/utils.py:46
+#: ../src/katello/client/api/utils.py:57
 #, python-format
 msgid "Could not find organization [ %s ]"
 msgstr "找不到組織 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:61
+#: ../src/katello/client/api/utils.py:72
 #, python-format
 msgid "Could not find environment [ %s ] within organization [ %s ]"
 msgstr "找不到環境 [ %s ] 位於組織 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:75
+#: ../src/katello/client/api/utils.py:86
 #, python-format
 msgid "Could not find product [ %s ] within organization [ %s ]"
 msgstr "找不到產品 [ %s ] 位於組織 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:91
+#: ../src/katello/client/api/utils.py:102
 #, python-format
 msgid ""
 "Could not find repository [ %s ] within organization [ %s ], product [ %s ] "
 "and environment [ %s ]"
 msgstr "找不到軟體庫 [ %s ] 位於組織 [ %s ]、產品 [ %s ] 和環境 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:101
+#: ../src/katello/client/api/utils.py:112
 #, python-format
 msgid "Could not find provider [ %s ] within organization [ %s ]"
 msgstr "找不到供應者 [ %s ] 位於組織 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:112
+#: ../src/katello/client/api/utils.py:123
 #, python-format
 msgid "Could not find template [ %s ] within environment [ %s ]"
 msgstr "找不到範本 [ %s ] 位於組織 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:123
+#: ../src/katello/client/api/utils.py:134
 #, python-format
 msgid "Could not find changeset [ %s ] within environment [ %s ]"
 msgstr "找不到變更集 [ %s ] 位於組織 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:131
+#: ../src/katello/client/api/utils.py:142
 #, python-format
-msgid "Could not fing user [ %s ]"
-msgstr "找不到使用者 [ %s ]"
+msgid "Could not find user [ %s ]"
+msgstr ""
 
-#: ../src/katello/client/api/utils.py:138
-#: ../src/katello/client/core/user_role.py:39
+#: ../src/katello/client/api/utils.py:149
+#: ../src/katello/client/core/user_role.py:37
 #, python-format
 msgid "Cannot find user role [ %s ]"
 msgstr "找不到使用者角色 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:145
+#: ../src/katello/client/api/utils.py:156
 #, python-format
 msgid "Cannot find sync plan [ %s ]"
 msgstr "找不到同步計畫 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:155
+#: ../src/katello/client/api/utils.py:166
 #, python-format
 msgid "Cannot find permission [ %s ] for user role [ %s ]"
 msgstr "找不到權限 [ %s ]（使用者角色 [ %s ]）"
 
-#: ../src/katello/client/api/utils.py:163
+#: ../src/katello/client/api/utils.py:174
 #, python-format
 msgid "Cannot find filter [ %s ]"
 msgstr "找不到篩選器 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:171
+#: ../src/katello/client/api/utils.py:182
+#, python-format
+msgid "Could not find system group [ %s ] within organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/api/utils.py:190
 #, python-format
 msgid "Could not find System [ %s ] in Org [ %s ]"
 msgstr "找不到系統 [ %s ]，於組織 [ %s ]"
 
-#: ../src/katello/client/api/utils.py:173
+#: ../src/katello/client/api/utils.py:192
 #, python-format
 msgid "Found ambiguous Systems [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "找到了定義不明的系統 [%s] 於環境 [%s] 中（組織 [%s]）"
 
-#: ../src/katello/client/api/utils.py:179
+#: ../src/katello/client/api/utils.py:198
 #, python-format
 msgid "Could not find System [ %s ] in Environment [ %s ] in Org [ %s ]"
 msgstr "找不到系統 [%s] 於環境 [%s] 中（組織 [%s]）"
 
-#: ../src/katello/client/api/utils.py:182
+#: ../src/katello/client/api/utils.py:201
 #, python-format
 msgid ""
 "Found ambiguous Systems [ %s ] in Org [ %s ], you have to specify the "
 "environment"
 msgstr "找到了定義不明的系統 [%s] 於組織 [%s] 中，您必須指定環境"
 
-#: ../src/katello/client/utils/printer.py:144
-msgid "name"
-msgstr "名稱"
-
-#: ../src/katello/client/core/organization.py:44
-msgid "list all known organizations"
-msgstr "列出所有已知組織"
-
-#: ../src/katello/client/core/organization.py:53
-msgid "Organization List"
-msgstr "組織清單"
-
-#: ../src/katello/client/core/organization.py:61
-msgid "create an organization"
-msgstr "建立組織"
-
-#: ../src/katello/client/core/organization.py:66
-#: ../src/katello/client/core/organization.py:93
-#: ../src/katello/client/core/organization.py:121
-#: ../src/katello/client/core/organization.py:150
-#: ../src/katello/client/core/organization.py:173
-#: ../src/katello/client/core/organization.py:205
-#: ../src/katello/client/core/product.py:59
-#: ../src/katello/client/core/product.py:120
-#: ../src/katello/client/core/product.py:295
-#: ../src/katello/client/core/system.py:51
-#: ../src/katello/client/core/system.py:93
-#: ../src/katello/client/core/system.py:149
-#: ../src/katello/client/core/system.py:247
-#: ../src/katello/client/core/system.py:317
-#: ../src/katello/client/core/system.py:353
-#: ../src/katello/client/core/system.py:694
-#: ../src/katello/client/core/environment.py:51
-#: ../src/katello/client/core/environment.py:78
-#: ../src/katello/client/core/environment.py:112
-#: ../src/katello/client/core/environment.py:151
-#: ../src/katello/client/core/environment.py:189
-#: ../src/katello/client/core/sync_plan.py:58
-#: ../src/katello/client/core/repo.py:120
-#: ../src/katello/client/core/repo.py:158
-msgid "organization name eg: foo.example.com (required)"
-msgstr "組織名稱，例如 foo.example.com（必填）"
-
-#: ../src/katello/client/core/organization.py:68
-#: ../src/katello/client/core/organization.py:152
-msgid "consumer description eg: foo's organization"
-msgstr "消耗者的描述，例如「foo 的組織」"
-
-#: ../src/katello/client/core/organization.py:79
-#, python-format
-msgid "Successfully created org [ %s ]"
-msgstr "已成功建立組織 [ %s ]"
-
-#: ../src/katello/client/core/organization.py:80
-#, python-format
-msgid "Could not create org [ %s ]"
-msgstr "無法建立組織 [ %s ]"
-
-#: ../src/katello/client/core/organization.py:88
-msgid "list information about an organization"
-msgstr "列出組織資訊"
-
-#: ../src/katello/client/core/organization.py:106
-msgid "Available Service Levels"
-msgstr "可用服務等級"
-
-#: ../src/katello/client/core/organization.py:108
-msgid "Organization Information"
-msgstr "組織資訊"
-
-#: ../src/katello/client/core/organization.py:116
-msgid "delete an organization"
-msgstr "刪除組織"
-
-#: ../src/katello/client/core/organization.py:132
-msgid "Deleting the organization, please wait... "
-msgstr "正在刪除組織，請稍候..."
-
-#: ../src/katello/client/core/organization.py:135
-#, python-format
-msgid "Successfully deleted org [ %s ]"
-msgstr "已成功刪除組織 [ %s ]"
-
-#: ../src/katello/client/core/organization.py:138
-#, python-format
-msgid "Organization [ %s ] deletion failed: %s"
-msgstr "組織 [ %s ] 刪除失敗：%s"
-
-#: ../src/katello/client/core/organization.py:145
-msgid "update an organization"
-msgstr "更新組織"
-
-#: ../src/katello/client/core/organization.py:162
-#, python-format
-msgid "Successfully updated org [ %s ]"
-msgstr "已成功更新組織 [ %s ]"
-
-#: ../src/katello/client/core/organization.py:169
-msgid "generate and show ueber certificate"
-msgstr "產生並顯示 ueber 憑證"
-
-#: ../src/katello/client/core/organization.py:175
-msgid "regenerate the certificate"
-msgstr "重新產生憑證"
-
-#: ../src/katello/client/core/organization.py:188
-msgid "Organization Uebercert"
-msgstr "組織的 Uebercert"
-
-#: ../src/katello/client/core/organization.py:197
-msgid "show subscriptions"
-msgstr "顯示訂閱"
-
-#: ../src/katello/client/core/organization.py:228
-msgid "Organization's Subscriptions"
-msgstr "組織訂閱"
-
-#: ../src/katello/client/core/organization.py:257
-msgid "organization specific actions in the katello server"
-msgstr "katello 伺服器中，與組織相關的特定動作"
-
-#: ../src/katello/client/core/product.py:60
-#: ../src/katello/client/core/product.py:299
-#: ../src/katello/client/core/repo.py:126
-#: ../src/katello/client/core/repo.py:166
-msgid "product name (required)"
-msgstr "產品名稱（必填）"
-
-#: ../src/katello/client/core/product.py:62
-#: ../src/katello/client/core/product.py:122
-#: ../src/katello/client/core/distribution.py:51
-#: ../src/katello/client/core/package.py:53
-#: ../src/katello/client/core/package.py:108
-#: ../src/katello/client/core/errata.py:52
-#: ../src/katello/client/core/errata.py:144
-#: ../src/katello/client/core/repo.py:84
-#: ../src/katello/client/core/repo.py:415
-msgid "environment name eg: production (default: Library)"
-msgstr "環境名稱，例如 production（預設值：Library）"
-
-#: ../src/katello/client/core/product.py:74
-msgid "set a synchronization plan"
-msgstr "設定同步計畫"
-
-#: ../src/katello/client/core/product.py:79
-msgid "synchronization plan name (required)"
-msgstr "同步計畫名稱（必填）"
-
-#: ../src/katello/client/core/product.py:101
-msgid "unset a synchronization plan"
-msgstr "取消同步計畫設定"
-
-#: ../src/katello/client/core/product.py:116
-msgid "list known products"
-msgstr "列出已知產品"
-
-#: ../src/katello/client/core/product.py:124
-msgid "provider name, lists provider's product in the Library"
-msgstr "供應方名稱、列出函式庫中，供應方的產品"
-
-#: ../src/katello/client/core/product.py:142
-#: ../src/katello/client/core/repo.py:320
-msgid "GPG key"
-msgstr "GPP 金鑰"
-
-#: ../src/katello/client/core/product.py:147
-#, python-format
-msgid "Product List For Provider %s"
-msgstr "供應方 %s 的產品清單"
-
-#: ../src/katello/client/core/product.py:153
-#, python-format
-msgid "Product List For Organization %s, Environment '%s'"
-msgstr "組織 %s、環境 %s 的產品清單"
-
-#: ../src/katello/client/core/product.py:163
-msgid "synchronize a product"
-msgstr "同步一項產品"
-
-#: ../src/katello/client/core/product.py:179
-#, python-format
-msgid "Product [ %s ] failed to sync: %s"
-msgstr "同步產品 [ %s ] 失敗：%s"
-
-#: ../src/katello/client/core/product.py:182
-#, python-format
-msgid "Product [ %s ] synchronization cancelled"
-msgstr "已取消產品 [ %s ] 的同步作業"
-
-#: ../src/katello/client/core/product.py:185
-#, python-format
-msgid "Product [ %s ] synchronized"
-msgstr "已同步產品 [ %s ]"
-
-#: ../src/katello/client/core/product.py:191
-#: ../src/katello/client/core/provider.py:228
-msgid "cancel currently running synchronization"
-msgstr "取消目前執行中的同步作業"
-
-#: ../src/katello/client/core/product.py:208
-msgid "status of product's synchronization"
-msgstr "產品的同步狀態"
-
-#: ../src/katello/client/core/product.py:234
-msgid "Product Status"
-msgstr "產品狀態"
-
-#: ../src/katello/client/core/product.py:242
-msgid ""
-"promote a product to an environment\n"
-"(creates a temporary changeset with the product and promotes it)"
-msgstr ""
-"將產品推送至某環境\n"
-"（建立暫時性的產品 changeset，並將它推送）"
-
-#: ../src/katello/client/core/product.py:265
-msgid "Promoting the product, please wait... "
-msgstr "推送產品中，請稍候……"
-
-#: ../src/katello/client/core/product.py:268
-#, python-format
-msgid "Product [ %s ] promoted to environment [ %s ] "
-msgstr "產品 [ %s ] 已推送至環境 [ %s ]"
-
-#: ../src/katello/client/core/product.py:271
-#, python-format
-msgid "Product [ %s ] promotion failed: %s"
-msgstr "產品 [ %s ] 推送失敗：%s"
-
-#: ../src/katello/client/core/product.py:291
-msgid "create new product to a custom provider"
-msgstr "新建產品至自訂供應方"
-
-#: ../src/katello/client/core/product.py:297
-#: ../src/katello/client/core/provider.py:46
-#: ../src/katello/client/core/provider.py:129
-msgid "provider name (required)"
-msgstr "供應方名稱（必須）"
-
-#: ../src/katello/client/core/product.py:301
-msgid "product description"
-msgstr "產品描述"
-
-#: ../src/katello/client/core/product.py:303
-#: ../src/katello/client/core/provider.py:133
-msgid ""
-"repository url eg: "
-"http://download.fedoraproject.org/pub/fedora/linux/releases/"
-msgstr ""
-"軟體庫 URL，例如「http://download.fedoraproject.org/pub/fedora/linux/releases/」"
-
-#: ../src/katello/client/core/product.py:305
-msgid "skip repository discovery"
-msgstr "跳過軟體庫搜尋"
-
-#: ../src/katello/client/core/product.py:307
-#: ../src/katello/client/core/repo.py:164
-msgid ""
-"assume yes; automatically create candidate repositories for discovered urls "
-"(optional)"
-msgstr "假定為「yes」（是），自動為找到的 URL 建立候選軟體庫（選用）"
-
-#: ../src/katello/client/core/product.py:309
-msgid ""
-"assign a gpg key; this key will be used for every new repository unless "
-"gpgkey or nogpgkey is specified for the repo"
-msgstr "指定一組 gpg 金鑰；此金鑰將會使用於所有新軟體庫，除非軟體庫指定了 gpgkey 或是 nogpgkey"
-
-#: ../src/katello/client/core/product.py:334
-#, python-format
-msgid "Successfully created product [ %s ]"
-msgstr "已成功建立產品 [ %s ]"
-
-#: ../src/katello/client/core/product.py:341
-#: ../src/katello/client/core/repo.py:182
-#, python-format
-msgid "Repository Urls discovered @ [%s]"
-msgstr "找到的軟體庫 URL @ [%s]"
-
-#: ../src/katello/client/core/product.py:350
-msgid "update a product's attributes"
-msgstr "更新產品的屬性"
-
-#: ../src/katello/client/core/product.py:355
-msgid "change description of the product"
-msgstr "更改產品描述"
-
-#: ../src/katello/client/core/product.py:357
-#: ../src/katello/client/core/product.py:359
-msgid "assign a gpgkey to the product"
-msgstr "為產品指定 gpgkey"
-
-#: ../src/katello/client/core/product.py:361
-msgid "assign the gpgpkey also to the product's repositories"
-msgstr "同時為產品的軟體庫指定 gpgkey"
-
-#: ../src/katello/client/core/product.py:378
-#, python-format
-msgid "Successfully updated product [ %s ]"
-msgstr "已成功更新了產品 [ %s ]"
-
-#: ../src/katello/client/core/product.py:384
-msgid "delete a product and its content"
-msgstr "刪除產品及其內容"
-
-#: ../src/katello/client/core/product.py:399
-msgid "list filters of a product"
-msgstr "列出產品的篩選器"
-
-#: ../src/katello/client/core/product.py:410
-msgid "Product Filters"
-msgstr "產品篩選器"
-
-#: ../src/katello/client/core/product.py:425
-msgid "add a filter to a product"
-msgstr "為產品新增篩選器"
-
-#: ../src/katello/client/core/product.py:427
-msgid "remove a filter from a product"
-msgstr "移除產品的篩選器"
-
-#: ../src/katello/client/core/product.py:436
-#: ../src/katello/client/core/filters.py:67
-#: ../src/katello/client/core/filters.py:101
-#: ../src/katello/client/core/filters.py:122
-#: ../src/katello/client/core/filters.py:152
-#: ../src/katello/client/core/filters.py:179
-#: ../src/katello/client/core/repo.py:516
-msgid "filter name (required)"
-msgstr "篩選器名稱（必填）"
-
-#: ../src/katello/client/core/product.py:458
-#, python-format
-msgid "Added filter [ %s ] to product [ %s ]"
-msgstr "已將篩選器 [ %s ] 新增至產品 [ %s ]"
-
-#: ../src/katello/client/core/product.py:461
-#, python-format
-msgid "Removed filter [ %s ] to product [ %s ]"
-msgstr "已將篩選器 [ %s ] 由產品 [ %s ] 中移除"
-
-#: ../src/katello/client/core/product.py:472
-msgid "product specific actions in the katello server"
-msgstr "katello 伺服器中，與產品相關的特定動作"
-
-#: ../src/katello/client/core/system.py:47
-msgid "list systems within an organization"
-msgstr "列出組織中的系統"
-
-#: ../src/katello/client/core/system.py:53
-#: ../src/katello/client/core/system.py:321
-#: ../src/katello/client/core/system.py:393
-#: ../src/katello/client/core/system.py:461
-#: ../src/katello/client/core/system.py:696
-msgid "environment name eg: development"
-msgstr "環境名稱，例如：development（開發部）"
-
-#: ../src/katello/client/core/system.py:55
-msgid "pool id to filter systems by subscriptions"
-msgstr "透過集區 id 來以訂閱篩選系統"
-
-#: ../src/katello/client/core/system.py:76
-#, python-format
-msgid "Systems List For Org [ %s ]"
-msgstr "組織的系統清單 [ %s ]"
-
-#: ../src/katello/client/core/system.py:78
-#, python-format
-msgid "Systems List For Environment [ %s ] in Org [ %s ]"
-msgstr "環境 [ %s ] 的系統清單，位於組織 [ %s ]"
-
-#: ../src/katello/client/core/system.py:82
-#: ../src/katello/client/core/system.py:134
-msgid "Service Level"
-msgstr "服務等級"
-
-#: ../src/katello/client/core/system.py:89
-msgid "display a system within an organization"
-msgstr "顯示組織中的某台系統"
-
-#: ../src/katello/client/core/system.py:95
-#: ../src/katello/client/core/system.py:151
-#: ../src/katello/client/core/system.py:355
-#: ../src/katello/client/core/system.py:391
-#: ../src/katello/client/core/system.py:459
-#: ../src/katello/client/core/system.py:492
-#: ../src/katello/client/core/system.py:521
-#: ../src/katello/client/core/system.py:601
-#: ../src/katello/client/core/system.py:641
-#: ../src/katello/client/core/errata.py:105
-msgid "system name (required)"
-msgstr "系統名稱（必填）"
-
-#: ../src/katello/client/core/system.py:97
-#: ../src/katello/client/core/system.py:153
-#: ../src/katello/client/core/system.py:251
-#: ../src/katello/client/core/system.py:357
-#: ../src/katello/client/core/system.py:643
-msgid "environment name"
-msgstr "環境名稱"
-
-#: ../src/katello/client/core/system.py:109
-#, python-format
-msgid "System Information For Org [ %s ]"
-msgstr "組織 [ %s ] 的系統資訊"
-
-#: ../src/katello/client/core/system.py:111
-#, python-format
-msgid "System Information For Environment [ %s ] in Org [ %s ]"
-msgstr "環境 [ %s ] 的系統資訊，位於組織 [ %s ]"
-
-#: ../src/katello/client/core/system.py:145
-msgid "display and manipulate with the installed packages of a system"
-msgstr "顯示並操作系統的已安裝套件"
-
-#: ../src/katello/client/core/system.py:155
-msgid ""
-"packages to be installed remotely on the system, package names are separated"
-" with comma"
-msgstr "將遠端安裝在系統上的套件，套件名稱將以逗號區隔開"
-
-#: ../src/katello/client/core/system.py:157
-msgid ""
-"packages to be removed remotely from the system, package names are separated"
-" with comma"
-msgstr "將由系統上遠端移除的套件，套件名稱將以逗號區隔開"
-
-#: ../src/katello/client/core/system.py:159
-msgid ""
-"packages to be updated on the system, use --all to update all packages, "
-"package names are separated with comma"
-msgstr "系統上即將更新的套件，請使用 --all 以更新所有套件，套件名稱將以逗號區隔開"
-
-#: ../src/katello/client/core/system.py:161
-msgid ""
-"package groups to be installed remotely on the system, group names are "
-"separated with comma"
-msgstr "將遠端安裝在系統上的套件群組，群組名稱將以逗號區隔開"
-
-#: ../src/katello/client/core/system.py:163
-msgid ""
-"package groups to be removed remotely from the system, group names are "
-"separated with comma"
-msgstr "即將由系統上遠端移除的套件群組，群組名稱將以逗號區隔開"
-
-#: ../src/katello/client/core/system.py:170
-msgid "You can specify at most one install/remove/update action per call"
-msgstr "您一次調用最多僅能指定一項安裝/移除/更新動作"
-
-#: ../src/katello/client/core/system.py:189
-#, python-format
-msgid "Package Information for System [ %s ] in Org [ %s ]"
-msgstr "系統 [ %s ] 的套件資訊，位於組織 [ %s ]"
-
-#: ../src/katello/client/core/system.py:191
-#, python-format
-msgid ""
-"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
-msgstr "系統 [ %s ] 的套件資訊，位於環境 [ %s ]，於組織 [ %s ]"
-
-#: ../src/katello/client/core/system.py:213
-#, python-format
-msgid "Performing remote action [ %s ]... "
-msgstr "正在執行遠端動作 [ %s ]..."
-
-#: ../src/katello/client/core/system.py:217
-msgid "Remote action finished:"
-msgstr "遠端動作已完成："
-
-#: ../src/katello/client/core/system.py:221
-msgid "Remote action failed:"
-msgstr "遠端動作失敗："
-
-#: ../src/katello/client/core/system.py:243
-msgid "display status of remote tasks"
-msgstr "顯示遠端工作的狀態"
-
-#: ../src/katello/client/core/system.py:249
-msgid "system name"
-msgstr "系統名稱"
-
-#: ../src/katello/client/core/system.py:261
-msgid "Remote tasks"
-msgstr "遠端工作"
-
-#: ../src/katello/client/core/system.py:269
-msgid "Task id"
-msgstr "工作 id"
-
-#: ../src/katello/client/core/system.py:270
-#: ../src/katello/client/core/system.py:300
-msgid "System"
-msgstr "系統"
-
-#: ../src/katello/client/core/system.py:271
-#: ../src/katello/client/core/system.py:301
-msgid "Action"
-msgstr "動作"
-
-#: ../src/katello/client/core/system.py:272
-#: ../src/katello/client/core/system.py:302
-msgid "Started"
-msgstr "已開始"
-
-#: ../src/katello/client/core/system.py:273
-#: ../src/katello/client/core/system.py:303
-#: ../src/katello/client/core/repo.py:37
-msgid "Finished"
-msgstr "已完成"
-
-#: ../src/katello/client/core/system.py:274
-#: ../src/katello/client/core/system.py:304
-msgid "Status"
-msgstr "狀態"
-
-#: ../src/katello/client/core/system.py:275
-#: ../src/katello/client/core/system.py:305
-msgid "Result"
-msgstr "結果"
-
-#: ../src/katello/client/core/system.py:283
-msgid "display status of remote task"
-msgstr "顯示遠端工作的狀態"
-
-#: ../src/katello/client/core/system.py:287
-msgid "UUID of the task"
-msgstr "工作的 UUID"
-
-#: ../src/katello/client/core/system.py:295
-msgid "Remote task"
-msgstr "遠端工作"
-
-#: ../src/katello/client/core/system.py:313
-msgid "list releases available for the system"
-msgstr "列出系統可使用的發行版"
-
-#: ../src/katello/client/core/system.py:319
-msgid "system name (if not specified, list all releases in the environment)"
-msgstr "系統名稱（若未指定，將列出環境中的所有發行版）"
-
-#: ../src/katello/client/core/system.py:341
-msgid "Available releases"
-msgstr "可用發行版"
-
-#: ../src/katello/client/core/system.py:349
-msgid "display a the hardware facts of a system"
-msgstr "顯示系統的硬體資訊"
-
-#: ../src/katello/client/core/system.py:369
-#, python-format
-msgid "System Facts For System [ %s ] in Org [ %s ]"
-msgstr "系統 [ %s ] 的系統資訊，位於組織 [ %s ]"
-
-#: ../src/katello/client/core/system.py:371
-#, python-format
-msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
-msgstr "系統 [ %s ] 的系統資訊，位於環境 [ %s]，於組織 [ %s ]"
-
-#: ../src/katello/client/core/system.py:388
-msgid "register a system"
-msgstr "註冊系統"
-
-#: ../src/katello/client/core/system.py:392
-#: ../src/katello/client/core/system.py:457
-#: ../src/katello/client/core/system.py:490
-#: ../src/katello/client/core/system.py:520
-#: ../src/katello/client/core/system.py:599
-#: ../src/katello/client/core/system.py:639
-#: ../src/katello/client/core/filters.py:42
-#: ../src/katello/client/core/filters.py:65
-#: ../src/katello/client/core/filters.py:99
-#: ../src/katello/client/core/filters.py:120
-#: ../src/katello/client/core/filters.py:150
-#: ../src/katello/client/core/filters.py:177
-#: ../src/katello/client/core/provider.py:64
-#: ../src/katello/client/core/sync_plan.py:85
-#: ../src/katello/client/core/sync_plan.py:115
-#: ../src/katello/client/core/sync_plan.py:153
-#: ../src/katello/client/core/sync_plan.py:194
-#: ../src/katello/client/core/errata.py:103
-msgid "organization name (required)"
-msgstr "組織名稱（必填）"
-
-#: ../src/katello/client/core/system.py:394
-#: ../src/katello/client/core/system.py:654
-msgid "service level agreement"
-msgstr "服務等級協議"
-
-#: ../src/katello/client/core/system.py:396
-msgid ""
-"activation key, more keys are separated with comma e.g. "
-"--activationkey=key1,key2"
-msgstr "啟動金鑰，超過一組金鑰可以逗號隔開，例如「--activationkey=key1,key2」"
-
-#: ../src/katello/client/core/system.py:397
-msgid "values of $releasever for the system"
-msgstr "系統的 $releasever 值"
-
-#: ../src/katello/client/core/system.py:399
-msgid "system facts"
-msgstr "系統詳情"
-
-#: ../src/katello/client/core/system.py:407
-#, python-format
-msgid "Option %s can not be specified with %s"
-msgstr "選項 %s 無法以 %s 指定"
-
-#: ../src/katello/client/core/system.py:429
-#, python-format
-msgid "Successfully registered system [ %s ]"
-msgstr "已成功註冊系統 [ %s ]"
-
-#: ../src/katello/client/core/system.py:430
-#, python-format
-msgid "Could not register system [ %s ]"
-msgstr "無法註冊系統 [ %s ]"
-
-#: ../src/katello/client/core/system.py:435
-msgid "remove a deletion record for hypervisor"
-msgstr "移除 hypervisor 的刪除紀錄"
-
-#: ../src/katello/client/core/system.py:439
-msgid "hypervisor uuid (required"
-msgstr "hypervisor uuid（必提供）"
-
-#: ../src/katello/client/core/system.py:447
-#, python-format
-msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
-msgstr "已成功移除 uuid 為 [%s] 的 hypervisor 的刪除紀錄"
-
-#: ../src/katello/client/core/system.py:453
-msgid "unregister a system"
-msgstr "取消註冊系統"
-
-#: ../src/katello/client/core/system.py:481
-#, python-format
-msgid "Successfully unregistered System [ %s ]"
-msgstr "已成功取消註冊系統 [ %s ]"
-
-#: ../src/katello/client/core/system.py:486
-msgid "subscribe a system to certificate"
-msgstr "透過認證訂閱系統"
-
-#: ../src/katello/client/core/system.py:494
-msgid "certificate serial to unsubscribe (required)"
-msgstr "要取消訂閱的認證序號（必填）"
-
-#: ../src/katello/client/core/system.py:496
-msgid "quantity (default: 1)"
-msgstr "數量（預設值：1）"
-
-#: ../src/katello/client/core/system.py:512
-#, python-format
-msgid "Successfully subscribed System [ %s ]"
-msgstr "已成功取消訂閱系統 [ %s ]"
-
-#: ../src/katello/client/core/system.py:517
-msgid "list subscriptions for a system"
-msgstr "列出一台系統的訂閱服務"
-
-#: ../src/katello/client/core/system.py:524
-msgid "show available subscriptions"
-msgstr "顯示可用訂閱"
-
-#: ../src/katello/client/core/system.py:542
-#, python-format
-msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
-msgstr "找不到系統 [ %s ] 的訂閱（於組織 [ %s ] 中）"
-
-#: ../src/katello/client/core/system.py:554
-#, python-format
-msgid "Current Subscriptions for System [ %s ]"
-msgstr "系統 [ %s ] 目前的訂閱"
-
-#: ../src/katello/client/core/system.py:556
-msgid "Serial Id"
-msgstr "序列 ID"
-
-#: ../src/katello/client/core/system.py:563
-#: ../src/katello/client/core/system.py:588
-msgid "Provided products"
-msgstr "提供的產品"
-
-#: ../src/katello/client/core/system.py:570
-#, python-format
-msgid "No Pools found for System [ %s ] in Org [ %s ]"
-msgstr "找不到系統 [ %s ] 的集池（於組織 [ %s ] 中）"
-
-#: ../src/katello/client/core/system.py:580
-#, python-format
-msgid "Available Subscriptions for System [ %s ]"
-msgstr "系統 [ %s ] 的可用訂閱"
-
-#: ../src/katello/client/core/system.py:595
-msgid "unsubscribe a system from certificate"
-msgstr "從認證取消訂閱系統"
-
-#: ../src/katello/client/core/system.py:603
-msgid ""
-"entitlement id to unsubscribe from (either entitlement or serial or all is "
-"required)"
-msgstr "欲取消訂閱之權利 ID（必須提供權利或序列或兩者）"
-
-#: ../src/katello/client/core/system.py:605
-msgid ""
-"serial id of a certificate to unsubscribe from (either entitlement or serial"
-" or all is required)"
-msgstr "欲取消訂閱之憑證的序列 ID（必須提供權利或序列或兩者）"
-
-#: ../src/katello/client/core/system.py:607
-msgid ""
-"unsubscribe from all currently subscribed certificates (either entitlement "
-"or serial or all is required)"
-msgstr "欲取目前訂閱的所有認證（必須提供權利或序列或兩者）"
-
-#: ../src/katello/client/core/system.py:629
-#, python-format
-msgid "Successfully unsubscribed System [ %s ]"
-msgstr "已成功取消訂閱系統 [ %s ]"
-
-#: ../src/katello/client/core/system.py:635
-msgid "update a system"
-msgstr "更新系統"
-
-#: ../src/katello/client/core/system.py:646
-msgid "a new name for the system"
-msgstr "系統的新名稱"
-
-#: ../src/katello/client/core/system.py:648
-msgid "a description of the system"
-msgstr "系統描述"
-
-#: ../src/katello/client/core/system.py:650
-msgid "location of the system"
-msgstr "系統位置"
-
-#: ../src/katello/client/core/system.py:652
-msgid "value of $releasever for the system"
-msgstr "系統的 $releasever 值"
-
-#: ../src/katello/client/core/system.py:683
-#, python-format
-msgid "Successfully updated system [ %s ]"
-msgstr "已成功更新系統 [ %s ]"
-
-#: ../src/katello/client/core/system.py:684
-#, python-format
-msgid "Could not update system [ %s ]"
-msgstr "無法更新系統 [ %s ]"
-
-#: ../src/katello/client/core/system.py:690
-msgid "systems report"
-msgstr "系統報告"
-
-#: ../src/katello/client/core/system.py:698
-#: ../src/katello/client/core/user.py:294
-msgid ""
-"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
-msgstr "報告格式（可用的值：html、text（預設值）、csv、pdf）"
-
-#: ../src/katello/client/core/system.py:724
-msgid "system specific actions in the katello server"
-msgstr "katello 伺服器中，與系統相關的特定動作"
-
-#: ../src/katello/client/core/filters.py:38
-msgid "list all filters"
-msgstr "列出所有篩選器"
-
-#: ../src/katello/client/core/filters.py:55
-msgid "Filter List"
-msgstr "篩選器清單"
-
-#: ../src/katello/client/core/filters.py:61
-msgid "create a filter"
-msgstr "建立篩選器"
-
-#: ../src/katello/client/core/filters.py:69
-msgid "description"
-msgstr "描述"
-
-#: ../src/katello/client/core/filters.py:71
-msgid "comma-separated list of package names/nvres"
-msgstr "逗號區隔開的套件名稱/nvres 清單"
-
-#: ../src/katello/client/core/filters.py:87
-#, python-format
-msgid "Successfully created filter [ %s ]"
-msgstr "已成功建立篩選器 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:88
-#, python-format
-msgid "Could not create filter [ %s ]"
-msgstr "無法建立篩選器 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:95
-msgid "delete a filter"
-msgstr "刪除篩選器"
-
-#: ../src/katello/client/core/filters.py:112
-#, python-format
-msgid "Successfully deleted filter [ %s ]"
-msgstr "已成功刪除篩選器 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:116
-msgid "filter info"
-msgstr "篩選器資訊"
-
-#: ../src/katello/client/core/filters.py:138
-msgid "Filter Information"
-msgstr "篩選器資訊"
-
-#: ../src/katello/client/core/filters.py:146
-msgid "Add a package to filter"
-msgstr "新增套件至篩選器"
-
-#: ../src/katello/client/core/filters.py:154
-#: ../src/katello/client/core/filters.py:181
-msgid "package id (required)"
-msgstr "套件 id（必填）"
-
-#: ../src/katello/client/core/filters.py:169
-#, python-format
-msgid "Successfully added package [ %s ] to filter [ %s ]"
-msgstr "已成功新增套件 [ %s ] 至篩選器 [ %s ]"
-
-#: ../src/katello/client/core/filters.py:173
-msgid "Remove a package from filter"
-msgstr "由篩選器移除套件"
-
-#: ../src/katello/client/core/filters.py:199
-#, python-format
-msgid "Successfully removed package [ %s ] from filter [ %s ]"
-msgstr "已成功移除套件 [ %s ]（由篩選器 [ %s ]）"
-
-#: ../src/katello/client/core/filters.py:205
-msgid "filter specific actions in the katello server"
-msgstr "katello 伺服器中，與篩選器相關的特定動作"
-
-#: ../src/katello/client/core/distribution.py:41
-msgid "list distributions in a repository"
-msgstr "列出軟體庫的散佈版本"
-
-#: ../src/katello/client/core/distribution.py:45
-#: ../src/katello/client/core/package.py:47
-#: ../src/katello/client/core/package.py:102
-#: ../src/katello/client/core/errata.py:46
-#: ../src/katello/client/core/errata.py:138
-#: ../src/katello/client/core/repo.py:79
-msgid "repository id"
-msgstr "軟體庫 ID"
-
-#: ../src/katello/client/core/distribution.py:47
-#: ../src/katello/client/core/package.py:49
-#: ../src/katello/client/core/package.py:104
-#: ../src/katello/client/core/errata.py:48
-#: ../src/katello/client/core/errata.py:140
-#: ../src/katello/client/core/repo.py:80
-msgid "repository name"
-msgstr "軟體庫名稱"
-
-#: ../src/katello/client/core/distribution.py:49
-#: ../src/katello/client/core/package.py:51
-#: ../src/katello/client/core/package.py:106
-#: ../src/katello/client/core/errata.py:50
-#: ../src/katello/client/core/errata.py:142
-#: ../src/katello/client/core/repo.py:81
-msgid "organization name eg: foo.example.com"
-msgstr "組織名稱，例如「foo.example.com」"
-
-#: ../src/katello/client/core/distribution.py:53
-#: ../src/katello/client/core/package.py:55
-#: ../src/katello/client/core/package.py:110
-#: ../src/katello/client/core/errata.py:54
-#: ../src/katello/client/core/errata.py:146
-#: ../src/katello/client/core/repo.py:82
-#: ../src/katello/client/core/repo.py:417
-msgid "product name eg: fedora-14"
-msgstr "產品名稱，例如「fedora-14」"
-
-#: ../src/katello/client/core/distribution.py:76
-#, python-format
-msgid "Distribution List For Repo %s"
-msgstr "軟體庫 %s 的散佈清單"
-
-#: ../src/katello/client/core/distribution.py:88
-msgid "list information about a distribution"
-msgstr "列出關於散佈版本的資訊"
-
-#: ../src/katello/client/core/distribution.py:93
-msgid "repository id (required)"
-msgstr "軟體庫 ID（必填）"
-
-#: ../src/katello/client/core/distribution.py:95
-msgid "distribution id eg: ks-rh-noarch (required)"
-msgstr "發行版 ID，例如「ks-rh-noarch」（必填）"
-
-#: ../src/katello/client/core/distribution.py:114
-msgid "Distribution Information"
-msgstr "發行版資訊"
-
-#: ../src/katello/client/core/distribution.py:124
-#: ../src/katello/client/core/repo.py:552
-msgid "repo specific actions in the katello server"
-msgstr "katello 伺服器中，與軟體庫相關的特定動作"
-
-#: ../src/katello/client/core/ping.py:39
-msgid "get the status of the katello server"
-msgstr "取得 katello 伺服器的狀態"
-
-#: ../src/katello/client/core/ping.py:58
-msgid "Katello Status"
-msgstr "Katello 的狀態"
-
-#: ../src/katello/client/core/ping.py:122
-msgid "Check the status of the server"
-msgstr "檢查伺服器的狀態"
-
-#: ../src/katello/client/core/package.py:40
-msgid "list information about a package"
-msgstr "列出套件資訊"
-
-#: ../src/katello/client/core/package.py:45
-msgid "package id, string value (required)"
-msgstr "套件 ID，字串值（必填）"
-
-#: ../src/katello/client/core/package.py:91
-msgid "Package Information"
-msgstr "套件資訊"
-
-#: ../src/katello/client/core/package.py:98
-msgid "list packages in a repository"
-msgstr "列出軟體庫的套件"
-
-#: ../src/katello/client/core/package.py:123
-#, python-format
-msgid "Package List For Repo %s"
-msgstr "軟體庫 %s 的套件清單"
-
-#: ../src/katello/client/core/package.py:154
-msgid "search packages in a repository"
-msgstr "在軟體庫中搜尋套件"
-
-#: ../src/katello/client/core/package.py:159
-msgid ""
-"query string for searching packages, e.g. "
-"'kernel*','kernel-3.3.0-4.el6.x86_64'"
-msgstr "查詢字串以搜尋套件，例如「kernel*」、「kernel-3.3.0-4.el6.x86_64」"
-
-#: ../src/katello/client/core/package.py:170
-#, python-format
-msgid "Package List For Repo %s and Query %s"
-msgstr "Repo %s 和 Query %s 的套件清單"
-
-#: ../src/katello/client/core/package.py:181
-msgid "package specific actions in the katello server"
-msgstr "katello 伺服器中，與套件相關的特定動作"
-
-#: ../src/katello/client/core/base.py:95
-#: ../src/katello/client/core/base.py:204
-msgid "no description available"
-msgstr "找不到描述"
-
-#: ../src/katello/client/core/base.py:123
-msgid "no action given: please see --help"
-msgstr "未給予動作：請參閱「--help」"
-
-#: ../src/katello/client/core/base.py:130
-msgid "invalid action: please see --help"
-msgstr "動作不合乎規定：請參閱「--help」"
-
-#: ../src/katello/client/core/base.py:177
-msgid "grep friendly output"
-msgstr "適用於「grep」指令的輸出"
-
-#: ../src/katello/client/core/base.py:180
-msgid "verbose, more structured output"
-msgstr "verbose，更結構化的輸出"
-
-#: ../src/katello/client/core/base.py:183
-msgid "column delimiter in grep friendly output, works only with option -g"
-msgstr "適合 grep 輸出的欄位分隔符號，僅能與選項 -g 搭配使用"
-
-#: ../src/katello/client/core/base.py:253
-#, python-format
-msgid "Option %s is required; please see --help"
-msgstr "選項 %s 必填；請參閱「--help」"
-
-#: ../src/katello/client/core/base.py:265
-#, python-format
-msgid "Option %s is colliding with %s; please see --help"
-msgstr "選項 %s 與 %s 互相衝突；請查看 --help"
-
-#: ../src/katello/client/core/base.py:287
-#, python-format
-msgid "One of %s is required; please see --help"
-msgstr "需提供其中一個 %s；請查看 --help"
-
-#: ../src/katello/client/core/base.py:307
-#, python-format
-msgid "At least one of %s is required; please see --help"
-msgstr "需要至少一個 %s；請查看 --help"
-
-#: ../src/katello/client/core/base.py:386
-msgid "error: operation failed"
-msgstr "錯誤：操作失敗"
-
-#: ../src/katello/client/core/base.py:403
-msgid ""
-"ERROR: The server hostname you have configured in /etc/katello/client.conf "
-"does not match the"
-msgstr "錯誤：/etc/katello/client.conf 檔案中配置的伺服器主機名稱並不符合"
-
-#: ../src/katello/client/core/base.py:404
-msgid "hostname returned from the katello server you are connecting to.  "
-msgstr "從您想連接的 ketello 伺服器之主機名稱。"
-
-#: ../src/katello/client/core/base.py:406
-#, python-format
-msgid "You have: [%s] configured but got: [%s] from the server."
-msgstr "您有：[%s] 已配置，但從伺服器上取得：[%s]"
-
-#: ../src/katello/client/core/base.py:408
-msgid "Please correct the host in the /etc/katello/client.conf file"
-msgstr "請修正 /etc/katello/client.conf 檔案中的主機"
-
-#: ../src/katello/client/core/base.py:420
-msgid "Invalid credentials or unable to authenticate"
-msgstr "不正確的身份認證，或無法通過認證"
-
-#: ../src/katello/client/core/base.py:459
-#, python-format
-msgid "option %s: invalid boolean value: %r"
-msgstr "選項 %s：不正確的布林值：%r"
-
-#: ../src/katello/client/core/user.py:42
-msgid "list all known users"
-msgstr "列出所有已知使用者"
-
-#: ../src/katello/client/core/user.py:54
-msgid "User List"
-msgstr "使用者清單"
-
-#: ../src/katello/client/core/user.py:62
-msgid "create user"
-msgstr "建立使用者"
-
-#: ../src/katello/client/core/user.py:65
-#: ../src/katello/client/core/user.py:108
-#: ../src/katello/client/core/user.py:136
-#: ../src/katello/client/core/user.py:157
-#: ../src/katello/client/core/user.py:209
-#: ../src/katello/client/core/user.py:260
-msgid "user name (required)"
-msgstr "使用者名稱（必填）"
-
-#: ../src/katello/client/core/user.py:66
-msgid "initial password (required)"
-msgstr "初始密碼（必填）"
-
-#: ../src/katello/client/core/user.py:67
-msgid "email (required)"
-msgstr "電子郵件（必填）"
-
-#: ../src/katello/client/core/user.py:68
-msgid "disabled account (default is 'false')"
-msgstr "已停用的帳號（預設值為「false」）"
-
-#: ../src/katello/client/core/user.py:70
-#: ../src/katello/client/core/user.py:162
-msgid "user's default organization name"
-msgstr "使用者的預設組織名稱"
-
-#: ../src/katello/client/core/user.py:72
-#: ../src/katello/client/core/user.py:164
-msgid "user's default environment name"
-msgstr "使用者的預設環境名稱"
-
-#: ../src/katello/client/core/user.py:97
-#, python-format
-msgid "Successfully created user [ %s ]"
-msgstr "已成功建立使用者 [ %s ]"
-
-#: ../src/katello/client/core/user.py:98
-#, python-format
-msgid "Could not create user [ %s ]"
-msgstr "無法建立使用者 [ %s ]"
-
-#: ../src/katello/client/core/user.py:105
-msgid "list information about user"
-msgstr "列出使用者資訊"
-
-#: ../src/katello/client/core/user.py:125
-msgid "User Information"
-msgstr "使用者資訊"
-
-#: ../src/katello/client/core/user.py:133
-msgid "delete user"
-msgstr "刪除使用者"
-
-#: ../src/katello/client/core/user.py:147
-#, python-format
-msgid "Successfully deleted user [ %s ]"
-msgstr "已成功刪除使用者 [ %s ]"
-
-#: ../src/katello/client/core/user.py:154
-msgid "update an user"
-msgstr "更新使用者"
-
-#: ../src/katello/client/core/user.py:158
-msgid "initial password"
-msgstr "初始密碼"
-
-#: ../src/katello/client/core/user.py:159
-msgid "email"
-msgstr "電子郵件"
-
-#: ../src/katello/client/core/user.py:160
-msgid "disabled account"
-msgstr "已停用的帳號"
-
-#: ../src/katello/client/core/user.py:166
-msgid "user's default environment is None"
-msgstr "使用者的預設環境為 None"
-
-#: ../src/katello/client/core/user.py:199
-#, python-format
-msgid "Successfully updated user [ %s ]"
-msgstr "已成功更新使用者 [ %s ]"
-
-#: ../src/katello/client/core/user.py:206
-msgid "list user's roles"
-msgstr "列出使用者的角色"
-
-#: ../src/katello/client/core/user.py:223
-#: ../src/katello/client/core/user_role.py:54
-msgid "User Role List"
-msgstr "使用者角色清單"
-
-#: ../src/katello/client/core/user.py:232
-msgid "synchronise roles with LDAP groups"
-msgstr "與 LDAP 群組同步角色"
-
-#: ../src/katello/client/core/user.py:246
-msgid "assign role to a user"
-msgstr "指定使用者角色"
-
-#: ../src/katello/client/core/user.py:248
-msgid "unassign role to a user"
-msgstr "取消使用者角色的指定"
-
-#: ../src/katello/client/core/user.py:261
-msgid "user role (required)"
-msgstr "使用者角色（必填）"
-
-#: ../src/katello/client/core/user.py:275
-#, python-format
-msgid "Role [ %s ] not found"
-msgstr "找不到角色 [ %s ]"
-
-#: ../src/katello/client/core/user.py:291
-msgid "user report"
-msgstr "使用者報告"
-
-#: ../src/katello/client/core/user.py:312
-msgid "user specific actions in the katello server"
-msgstr "katello 伺服器中，與使用者相關的特定動作"
-
-#: ../src/katello/client/core/gpg_key.py:41
-msgid "Enter content of the GPG key (finish input with CTRL+D):"
-msgstr "輸入 GPG 金鑰的內容（請以 CTRL+D 完成輸入）："
-
-#: ../src/katello/client/core/gpg_key.py:61
-msgid "list all GPG keys"
-msgstr "列出所有 GPG 金鑰"
-
-#: ../src/katello/client/core/gpg_key.py:65
-#: ../src/katello/client/core/gpg_key.py:95
-#: ../src/katello/client/core/gpg_key.py:132
-#: ../src/katello/client/core/gpg_key.py:165
-#: ../src/katello/client/core/gpg_key.py:209
-#: ../src/katello/client/core/activation_key.py:53
-#: ../src/katello/client/core/activation_key.py:100
-#: ../src/katello/client/core/activation_key.py:139
-#: ../src/katello/client/core/activation_key.py:183
-#: ../src/katello/client/core/activation_key.py:251
-#: ../src/katello/client/core/changeset.py:44
-#: ../src/katello/client/core/changeset.py:78
-#: ../src/katello/client/core/changeset.py:143
-#: ../src/katello/client/core/changeset.py:310
-#: ../src/katello/client/core/changeset.py:395
-#: ../src/katello/client/core/changeset.py:424
-#: ../src/katello/client/core/provider.py:48
-#: ../src/katello/client/core/provider.py:135
-#: ../src/katello/client/core/template.py:91
-#: ../src/katello/client/core/template.py:155
-#: ../src/katello/client/core/template.py:198
-#: ../src/katello/client/core/template.py:251
-#: ../src/katello/client/core/template.py:316
-#: ../src/katello/client/core/template.py:493
-msgid "name of organization (required)"
-msgstr "組織名稱（必填）"
-
-#: ../src/katello/client/core/gpg_key.py:76
-#, python-format
-msgid "No gpg keys found in organization [ %s ]"
-msgstr "組織 [ %s ] 中找不到 gpg 金鑰"
-
-#: ../src/katello/client/core/gpg_key.py:82
-msgid "Gpg Key List"
-msgstr "GPG 金鑰清單"
-
-#: ../src/katello/client/core/gpg_key.py:89
-msgid "show information about a gpg key"
-msgstr "顯示有關於一組 gpg 金鑰的資訊"
-
-#: ../src/katello/client/core/gpg_key.py:93
-#: ../src/katello/client/core/gpg_key.py:130
-#: ../src/katello/client/core/gpg_key.py:163
-#: ../src/katello/client/core/gpg_key.py:207
-#: ../src/katello/client/core/activation_key.py:98
-#: ../src/katello/client/core/activation_key.py:137
-#: ../src/katello/client/core/activation_key.py:181
-#: ../src/katello/client/core/activation_key.py:249
-msgid "activation key name (required)"
-msgstr "啟動金鑰名稱（必填）"
-
-#: ../src/katello/client/core/gpg_key.py:105
-#: ../src/katello/client/core/gpg_key.py:191
-#: ../src/katello/client/core/gpg_key.py:220
-#, python-format
-msgid "Could not find gpg key [ %s ]"
-msgstr "找不到 gpg 金鑰 [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:117
-msgid "Repositories"
-msgstr "軟體庫"
-
-#: ../src/katello/client/core/gpg_key.py:119
-msgid "Gpg Key Info"
-msgstr "GPG 金鑰資訊"
-
-#: ../src/katello/client/core/gpg_key.py:126
-msgid "create a gpg key"
-msgstr "建立一組 gpg 金鑰"
-
-#: ../src/katello/client/core/gpg_key.py:134
-msgid ""
-"file with public GPG key, if not                                 specified, "
-"standard input will be used"
-msgstr "含有公用 GPG 金鑰的檔案，若未指定的話，將會使用標準輸入"
-
-#: ../src/katello/client/core/gpg_key.py:152
-#, python-format
-msgid "Successfully created gpg key [ %s ]"
-msgstr "已成功建立 gpg 金鑰 [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:153
-#, python-format
-msgid "Could not create gpg key [ %s ]"
-msgstr "無法建立 gpg 金鑰 [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:159
-#: ../src/katello/client/core/activation_key.py:177
-msgid "update an activation key"
-msgstr "更新啟動金鑰"
-
-#: ../src/katello/client/core/gpg_key.py:167
-#: ../src/katello/client/core/activation_key.py:187
-#: ../src/katello/client/core/template.py:317
-msgid "new template name"
-msgstr "新範本名稱"
-
-#: ../src/katello/client/core/gpg_key.py:169
-msgid "file with public GPG key"
-msgstr "含有公用 gpg 金鑰的檔案"
-
-#: ../src/katello/client/core/gpg_key.py:171
-msgid "prompt for new content of the key"
-msgstr "提示金鑰的新內容"
-
-#: ../src/katello/client/core/gpg_key.py:196
-#, python-format
-msgid "Successfully updated gpg key [ %s ]"
-msgstr "已成功更新 gpg 金鑰 [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:197
-#, python-format
-msgid "Could not updated gpg key [ %s ]"
-msgstr "無法更新 gpg 金鑰 [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:203
-msgid "delete an gpg key"
-msgstr "刪除一組 gpg 金鑰"
-
-#: ../src/katello/client/core/gpg_key.py:224
-#, python-format
-msgid "Successfully deleted gpg key [ %s ]"
-msgstr "已成功移除 gpg 金鑰 [ %s ]"
-
-#: ../src/katello/client/core/gpg_key.py:228
-msgid "GPG key specific actions in the katello server"
-msgstr "katello 伺服器中，與 GPG 金鑰相關的特定動作"
-
-#: ../src/katello/client/core/activation_key.py:49
-msgid "list all activation keys"
-msgstr "列出所有啟動金鑰"
-
-#: ../src/katello/client/core/activation_key.py:55
-#: ../src/katello/client/core/template.py:56
-#: ../src/katello/client/core/template.py:93
-msgid "environment name eg: dev (default: Library)"
-msgstr "環境名稱，例如：dev（預設值：Library）"
-
-#: ../src/katello/client/core/activation_key.py:68
-#, python-format
-msgid "No keys found in organization [ %s ]"
-msgstr "組織 [ %s ] 中找不到金鑰"
-
-#: ../src/katello/client/core/activation_key.py:70
-#, python-format
-msgid "No keys found in organization [ %s ] environment [ %s ]"
-msgstr "組織 [ %s ] 中找不到金鑰，位於環境 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:80
-msgid "Activation Key List"
-msgstr "啟動金鑰清單"
-
-#: ../src/katello/client/core/activation_key.py:94
-msgid "show information about an activation key"
-msgstr "顯示啟動金鑰的資訊"
-
-#: ../src/katello/client/core/activation_key.py:114
-#, python-format
-msgid "Could not find activation key [ %s ]"
-msgstr "找不到啟動金鑰 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:126
-msgid "Activation Key Info"
-msgstr "啟動金鑰資訊"
-
-#: ../src/katello/client/core/activation_key.py:133
-msgid "create an activation key"
-msgstr "建立啟動金鑰"
-
-#: ../src/katello/client/core/activation_key.py:141
-msgid "environment name eg: dev (required)"
-msgstr "環境名稱，例如「dev」（必填）"
-
-#: ../src/katello/client/core/activation_key.py:143
-msgid "activation key description"
-msgstr "啟動金鑰的描述"
-
-#: ../src/katello/client/core/activation_key.py:145
-msgid "template name eg: servers"
-msgstr "範本名稱，例如「servers」"
-
-#: ../src/katello/client/core/activation_key.py:164
-#: ../src/katello/client/core/activation_key.py:227
-#, python-format
-msgid "Could not find template [ %s ]"
-msgstr "找不到範本 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:169
-#, python-format
-msgid "Successfully created activation key [ %s ]"
-msgstr "已成功建立啟動金鑰 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:170
-#, python-format
-msgid "Could not create activation key [ %s ]"
-msgstr "無法建立啟動金鑰 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:185
-msgid "new environment name eg: dev"
-msgstr "新環境名稱，例如「dev」"
-
-#: ../src/katello/client/core/activation_key.py:189
-msgid "new description"
-msgstr "新描述"
-
-#: ../src/katello/client/core/activation_key.py:191
-msgid "new template name eg: servers"
-msgstr "新範本名稱，例如「servers」"
-
-#: ../src/katello/client/core/activation_key.py:194
-msgid "add a pool to the activation key"
-msgstr "新增集池至啟動金鑰"
-
-#: ../src/katello/client/core/activation_key.py:196
-msgid "remove a pool from the activation key"
-msgstr "由啟動金鑰移除集池"
-
-#: ../src/katello/client/core/activation_key.py:237
-#, python-format
-msgid "Successfully updated activation key [ %s ]"
-msgstr "已成功更新啟動金鑰 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:245
-msgid "delete an activation key"
-msgstr "刪除啟動金鑰"
-
-#: ../src/katello/client/core/activation_key.py:269
-#, python-format
-msgid "Successfully deleted activation key [ %s ]"
-msgstr "已成功刪除啟動金鑰 [ %s ]"
-
-#: ../src/katello/client/core/activation_key.py:273
-msgid "activation key specific actions in the katello server"
-msgstr "katello 伺服器中，與啟動金鑰相關的特定動作"
-
-#: ../src/katello/client/core/packagegroup.py:20
-msgid "list available package groups"
-msgstr "列出可用的套件群組"
-
-#: ../src/katello/client/core/packagegroup.py:24
-#: ../src/katello/client/core/packagegroup.py:53
-#: ../src/katello/client/core/packagegroup.py:89
-#: ../src/katello/client/core/packagegroup.py:117
-msgid "repository id, string value (required)"
-msgstr "軟體庫 ID，字串值（必填）"
-
-#: ../src/katello/client/core/packagegroup.py:34
-#, python-format
-msgid "No package groups found in repo [%s]"
-msgstr "軟體庫 [%s] 裡找不到套件群組"
-
-#: ../src/katello/client/core/packagegroup.py:35
-#: ../src/katello/client/core/packagegroup.py:71
-msgid "Package Group Information"
-msgstr "套件群組資訊"
-
-#: ../src/katello/client/core/packagegroup.py:49
-#: ../src/katello/client/core/packagegroup.py:113
-msgid "lookup information for a package group"
-msgstr "套件群組的查詢資訊"
-
-#: ../src/katello/client/core/packagegroup.py:55
-msgid "package group id, string value (required)"
-msgstr "套件群組 ID，字串值（必填）"
-
-#: ../src/katello/client/core/packagegroup.py:67
-#, python-format
-msgid "Package group [%s] not found in repo [%s]"
-msgstr "套件群組 [%s] 不存在於軟體庫 [%s] 中"
-
-#: ../src/katello/client/core/packagegroup.py:85
-msgid "list available package groups categories"
-msgstr "列出可用的套件群組類別"
-
-#: ../src/katello/client/core/packagegroup.py:99
-#, python-format
-msgid "No package group categories found in repo [%s]"
-msgstr "軟體庫 [%s] 裡找不到套件群組類別"
-
-#: ../src/katello/client/core/packagegroup.py:100
-msgid "Package Group Cateogory Information"
-msgstr "套件群組類別的資訊"
-
-#: ../src/katello/client/core/packagegroup.py:119
-msgid "package group category id, string value (required)"
-msgstr "套件群組類別 ID，字串值（必填）"
-
-#: ../src/katello/client/core/packagegroup.py:131
-#, python-format
-msgid "Package group category [%s] not found in repo [%s]"
-msgstr "套件群組類別 [%s] 在軟體庫 [%s] 中找不到。"
-
-#: ../src/katello/client/core/packagegroup.py:133
-msgid "Package Group Category Information"
-msgstr "套件群組類別的資訊"
-
-#: ../src/katello/client/core/packagegroup.py:143
-msgid "package group specific actions in the katello server"
-msgstr "katello 伺服器中，與套件群組相關的特定動作"
-
-#: ../src/katello/client/core/changeset.py:40
-msgid "list new changesets of an environment"
-msgstr "列出環境的新變更集"
-
-#: ../src/katello/client/core/changeset.py:46
-#: ../src/katello/client/core/changeset.py:79
-#: ../src/katello/client/core/changeset.py:145
-#: ../src/katello/client/core/changeset.py:312
-#: ../src/katello/client/core/changeset.py:397
-#: ../src/katello/client/core/changeset.py:426
-#: ../src/katello/client/core/environment.py:114
-#: ../src/katello/client/core/environment.py:155
-msgid "environment name (required)"
-msgstr "環境名稱（必填）"
-
-#: ../src/katello/client/core/changeset.py:68
-msgid "Changeset List"
-msgstr "變更集清單"
-
-#: ../src/katello/client/core/changeset.py:75
-msgid "detailed information about a changeset"
-msgstr "變更集的詳細資訊"
-
-#: ../src/katello/client/core/changeset.py:80
-#: ../src/katello/client/core/changeset.py:147
-#: ../src/katello/client/core/changeset.py:308
-#: ../src/katello/client/core/changeset.py:393
-#: ../src/katello/client/core/changeset.py:422
-msgid "changeset name (required)"
-msgstr "變更集名稱（必填）"
-
-#: ../src/katello/client/core/changeset.py:82
-msgid "will display dependent packages"
-msgstr "將顯示相依套件"
-
-#: ../src/katello/client/core/changeset.py:131
-msgid "Changeset Info"
-msgstr "變更集資訊"
-
-#: ../src/katello/client/core/changeset.py:139
-msgid "create a new changeset for an environment"
-msgstr "建立環境的變更集"
-
-#: ../src/katello/client/core/changeset.py:149
-#: ../src/katello/client/core/changeset.py:314
-msgid "changeset description"
-msgstr "變更集描述"
-
-#: ../src/katello/client/core/changeset.py:165
-#, python-format
-msgid "Successfully created changeset [ %s ] for environment [ %s ]"
-msgstr "已成功建立變更集 [ %s ] 位於環境 [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:166
-#, python-format
-msgid "Could not create changeset [ %s ] for environment [ %s ]"
-msgstr "無法建立變更集 [ %s ] 位於環境 [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:286
-msgid "updates content of a changeset"
-msgstr "更新變更集的內容"
-
-#: ../src/katello/client/core/changeset.py:299
-#: ../src/katello/client/core/template.py:310
-#, python-format
-msgid "%s must be preceded by %s"
-msgstr "%s 的前面必須是 %s"
-
-#: ../src/katello/client/core/changeset.py:316
-msgid "new changeset name"
-msgstr "新變更集名稱"
-
-#: ../src/katello/client/core/changeset.py:319
-msgid "product to add to the changeset"
-msgstr "要加入變更集的產品"
-
-#: ../src/katello/client/core/changeset.py:322
-msgid "product to remove from the changeset"
-msgstr "要從變更集移除的產品"
-
-#: ../src/katello/client/core/changeset.py:325
-msgid "name of a template to be added to the changeset"
-msgstr "要加入變更集的範本名稱"
-
-#: ../src/katello/client/core/changeset.py:328
-msgid "name of a template to be removed from the changeset"
-msgstr "要從變更集移除的範本名稱"
-
-#: ../src/katello/client/core/changeset.py:331
-msgid ""
-"determines product from which the packages/errata/repositories are picked"
-msgstr "從選取的套件 / 勘誤 / 軟體庫決定產品"
-
-#: ../src/katello/client/core/changeset.py:336
-msgid " to add to the changeset"
-msgstr "要新增至變更集"
-
-#: ../src/katello/client/core/changeset.py:339
-msgid " to remove from the changeset"
-msgstr "要從變更集移除"
-
-#: ../src/katello/client/core/changeset.py:373
-#, python-format
-msgid "Successfully updated changeset [ %s ]"
-msgstr "已成功更新變更集 [ %s ]"
-
-#: ../src/katello/client/core/changeset.py:389
-msgid "deletes a changeset"
-msgstr "刪除變更集"
-
-#: ../src/katello/client/core/changeset.py:418
-msgid "promotes a changeset to the next environment"
-msgstr "將變更集送至下一個環境中"
-
-#: ../src/katello/client/core/changeset.py:443
-msgid "Promoting the changeset, please wait... "
-msgstr "正在發送變更集，請稍候……"
-
-#: ../src/katello/client/core/changeset.py:446
-#, python-format
-msgid "Changeset [ %s ] promoted"
-msgstr "變更集 [ %s ] 已發送"
-
-#: ../src/katello/client/core/changeset.py:449
-#, python-format
-msgid "Changeset [ %s ] promotion failed: %s"
-msgstr "發送變更集 [ %s ] 失敗：%s"
-
-#: ../src/katello/client/core/changeset.py:455
-msgid "changeset specific actions in the katello server"
-msgstr "katello 伺服器中，與變更集相關的特定動作"
-
-#: ../src/katello/client/core/provider.py:59
-msgid "list all known providers"
-msgstr "列出所有已知供應方"
-
-#: ../src/katello/client/core/provider.py:81
-msgid "Provider List"
-msgstr "供應方清單"
-
-#: ../src/katello/client/core/provider.py:89
-msgid "list information about a provider"
-msgstr "列出關於供應方的資訊"
-
-#: ../src/katello/client/core/provider.py:104
-msgid "Provider Information"
-msgstr "供應方資訊"
-
-#: ../src/katello/client/core/provider.py:116
-msgid "create a provider"
-msgstr "建立供應方"
-
-#: ../src/katello/client/core/provider.py:118
-msgid "update a provider"
-msgstr "更新供應方"
-
-#: ../src/katello/client/core/provider.py:131
-#: ../src/katello/client/core/template.py:159
-msgid "provider description"
-msgstr "供應方的描述"
-
-#: ../src/katello/client/core/provider.py:139
-msgid "provider name"
-msgstr "供應方名稱"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:151
-msgid "Option --url has to start with http:// or https://"
-msgstr "選項「--url」必須以「http://」或「https://」開始"
-
-#. pylint: disable=E1101
-#: ../src/katello/client/core/provider.py:153
-msgid "Option --url is not in a valid format"
-msgstr "選項「--url」並非正確的格式"
-
-#: ../src/katello/client/core/provider.py:159
-#, python-format
-msgid "Successfully created provider [ %s ]"
-msgstr "已成功建立供應方 [ %s ]"
-
-#: ../src/katello/client/core/provider.py:160
-#, python-format
-msgid "Could not create provider [ %s ]"
-msgstr "無法建立供應方 [ %s ]"
-
-#: ../src/katello/client/core/provider.py:167
-#, python-format
-msgid "Successfully updated provider [ %s ]"
-msgstr "已成功更新供應方 [ %s ]"
-
-#: ../src/katello/client/core/provider.py:185
-msgid "delete a provider"
-msgstr "刪除供應方"
-
-#: ../src/katello/client/core/provider.py:201
-msgid "synchronize a provider"
-msgstr "同步供應方"
-
-#: ../src/katello/client/core/provider.py:216
-#, python-format
-msgid "Provider [ %s ] failed to sync: %s"
-msgstr "同步供應方 [ %s ] 失敗：%s"
-
-#: ../src/katello/client/core/provider.py:219
-#, python-format
-msgid "Provider [ %s ] synchronization cancelled"
-msgstr "供應方 [ %s ] 的同步程序已取消"
-
-#: ../src/katello/client/core/provider.py:222
-#, python-format
-msgid "Provider [ %s ] synchronized"
-msgstr "已同步供應方 [ %s ]"
-
-#: ../src/katello/client/core/provider.py:245
-msgid "status of provider's synchronization"
-msgstr "供應方的同步狀態"
-
-#: ../src/katello/client/core/provider.py:258
-#, python-format
-msgid "%d%% done (%d of %d packages downloaded)"
-msgstr "%d%% 已完成（已下載了 %d 個套件，總共有 %d 個套件）"
-
-#: ../src/katello/client/core/provider.py:269
-msgid "Provider Status"
-msgstr "供應方狀態"
-
-#: ../src/katello/client/core/provider.py:277
-msgid "import a manifest file"
-msgstr "匯入清單檔案"
-
-#: ../src/katello/client/core/provider.py:283
-msgid "path to the manifest file (required)"
-msgstr "清單檔案的路徑（必填）"
-
-#: ../src/katello/client/core/provider.py:285
-msgid "force reimporting the manifest"
-msgstr "強制重新匯入清單"
-
-#: ../src/katello/client/core/provider.py:302
-#: ../src/katello/client/core/template.py:177
-#, python-format
-msgid "File %s does not exist"
-msgstr "檔案 %s 不存在"
-
-#: ../src/katello/client/core/provider.py:307
-msgid "Importing manifest, please wait... "
-msgstr "匯入清單檔案中，請稍候……"
-
-#: ../src/katello/client/core/provider.py:320
-msgid "refresh provider's products repositories"
-msgstr "更新供應方的產品軟體庫"
-
-#: ../src/katello/client/core/provider.py:329
-#, python-format
-msgid "Provider successfully refreshed [ %s ]"
-msgstr "供應方已成功更新 [%s]"
-
-#: ../src/katello/client/core/provider.py:336
-msgid "provider specific actions in the katello server"
-msgstr "katello 伺服器中，與供應方相關的特定動作"
-
-#: ../src/katello/client/core/environment.py:47
-msgid "list known environments"
-msgstr "列出已知環境"
-
-#: ../src/katello/client/core/environment.py:64
-#: ../src/katello/client/core/environment.py:95
-msgid "Org"
-msgstr "組織"
-
-#: ../src/katello/client/core/environment.py:65
-#: ../src/katello/client/core/environment.py:96
-msgid "Prior Environment"
-msgstr "之前的環境"
-
-#: ../src/katello/client/core/environment.py:67
-msgid "Environment List"
-msgstr "環境清單"
-
-#: ../src/katello/client/core/environment.py:74
-msgid "list a specific environment"
-msgstr "列出特定環境"
-
-#: ../src/katello/client/core/environment.py:80
-#: ../src/katello/client/core/environment.py:187
-msgid "environment name eg: foo.example.com (required)"
-msgstr "環境名稱，例如 foo.example.com（必填）"
-
-#: ../src/katello/client/core/environment.py:98
-msgid "Environment Info"
-msgstr "環境資訊"
-
-#: ../src/katello/client/core/environment.py:106
-msgid "create an environment"
-msgstr "建立環境"
-
-#: ../src/katello/client/core/environment.py:110
-#: ../src/katello/client/core/environment.py:149
-msgid "environment description eg: foo's environment"
-msgstr "環境的描述，例如：foo 的環境"
-
-#: ../src/katello/client/core/environment.py:116
-msgid "name of prior environment (required)"
-msgstr "之前的環境名稱（必填）"
-
-#: ../src/katello/client/core/environment.py:136
-#, python-format
-msgid "Successfully created environment [ %s ]"
-msgstr "已成功建立環境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:137
-#, python-format
-msgid "Could not create environment [ %s ]"
-msgstr "無法建立環境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:144
-msgid "update an environment"
-msgstr "更新環境"
-
-#: ../src/katello/client/core/environment.py:153
-msgid "name of prior environment"
-msgstr "之前的環境名稱"
-
-#: ../src/katello/client/core/environment.py:176
-#, python-format
-msgid "Successfully updated environment [ %s ]"
-msgstr "已成功更新環境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:183
-msgid "delete an environment"
-msgstr "刪除環境"
-
-#: ../src/katello/client/core/environment.py:203
-#, python-format
-msgid "Successfully deleted environment [ %s ]"
-msgstr "已成功刪除環境 [ %s ]"
-
-#: ../src/katello/client/core/environment.py:212
-msgid "environment specific actions in the katello server"
-msgstr "katello 伺服器中，與環境相關的特定動作"
-
-#: ../src/katello/client/core/client.py:38
-msgid "save an option to the client config"
-msgstr "將選項儲存至用戶端配置中"
-
-#: ../src/katello/client/core/client.py:42
-msgid ""
-"name of the option to be saved (e.g. org, environment, provider, etc) "
-"(required)"
-msgstr "要儲存的選項之名稱（例如 org、environment、provider 等）（必填）"
-
-#: ../src/katello/client/core/client.py:44
-msgid "value to be store under specified option (required)"
-msgstr "特定選項之下要儲存的值（必填）"
-
-#: ../src/katello/client/core/client.py:63
-msgid "Successfully "
-msgstr "成功"
-
-#: ../src/katello/client/core/client.py:65
-#, python-format
-msgid "Unsuccessfully remembered option [ %s ]"
-msgstr "未成功記得選項 [ %s ]"
-
-#: ../src/katello/client/core/client.py:72
-msgid "remove an option from the client config"
-msgstr "從用戶端配置移除選項"
-
-#: ../src/katello/client/core/client.py:76
-msgid "name of the option to be deleted (required)"
-msgstr "要移除的選項名稱（必填）"
-
-#: ../src/katello/client/core/client.py:87
-#, python-format
-msgid "Successfully forgot option [ %s ]"
-msgstr "已成功忘記選項 [ %s ]"
-
-#: ../src/katello/client/core/client.py:89
-#, python-format
-msgid "Unsuccessfully forgot option [ %s ]"
-msgstr "未成功忘記選項 [ %s ]"
-
-#: ../src/katello/client/core/client.py:96
-msgid "list options saved in the client config"
-msgstr "列出儲存於用戶端配置的選項"
-
-#: ../src/katello/client/core/client.py:105
-msgid "Saved Options"
-msgstr "已儲存的選項"
-
-#: ../src/katello/client/core/client.py:120
-msgid "client specific actions in the katello server"
-msgstr "katello 伺服器中，與用戶端相關的特定動作"
-
-#: ../src/katello/client/core/template.py:50
-msgid "list all templates"
-msgstr "列出所有範本"
-
-#: ../src/katello/client/core/template.py:54
-msgid "name of organization (required if specifying environment)"
-msgstr "組織名稱（指定環境時必填）"
-
-#: ../src/katello/client/core/template.py:69
-#, python-format
-msgid "No templates found in environment [ %s ]"
-msgstr "環境 [ %s ] 中找不到範本"
-
-#: ../src/katello/client/core/template.py:77
-msgid "Template List"
-msgstr "範本清單"
-
-#: ../src/katello/client/core/template.py:85
-msgid "list information about a template"
-msgstr "列出關於範本的資訊"
-
-#: ../src/katello/client/core/template.py:89
-#: ../src/katello/client/core/template.py:196
-#: ../src/katello/client/core/template.py:247
-#: ../src/katello/client/core/template.py:314
-#: ../src/katello/client/core/template.py:491
-msgid "template name (required)"
-msgstr "範本名稱（必填）"
-
-#: ../src/katello/client/core/template.py:127
-msgid "Template Info"
-msgstr "範本資訊"
-
-#: ../src/katello/client/core/template.py:150
-msgid "create a template file and import data"
-msgstr "建立範本檔案，並匯入資料"
-
-#: ../src/katello/client/core/template.py:157
-#: ../src/katello/client/core/template.py:202
-msgid "path to the template file (required)"
-msgstr "範本檔案的路徑（必填）"
-
-#: ../src/katello/client/core/template.py:180
-msgid "Importing template, please wait... "
-msgstr "匯入範本中，請稍候……"
-
-#: ../src/katello/client/core/template.py:191
-msgid "export the template into the file"
-msgstr "將範本匯出至檔案中"
-
-#: ../src/katello/client/core/template.py:200
-msgid "environment name eg: dev"
-msgstr "環境名稱，例如 dev"
-
-#: ../src/katello/client/core/template.py:204
-#, python-format
-msgid "format of the export, possible values: %s, default: json"
-msgstr "匯出的格式，可用的值：%s、預設值為 json"
-
-#: ../src/katello/client/core/template.py:225
-#, python-format
-msgid "Could not create file %s"
-msgstr "無法建立檔案 %s"
-
-#: ../src/katello/client/core/template.py:229
-msgid "Exporting template, please wait... "
-msgstr "正在匯出範本，請稍候..."
-
-#: ../src/katello/client/core/template.py:232
-#, python-format
-msgid "Template was exported successfully to file %s"
-msgstr "範本已成功匯出至檔案 %s"
-
-#: ../src/katello/client/core/template.py:242
-msgid "create an empty template file"
-msgstr "建立空白的範本檔案"
-
-#: ../src/katello/client/core/template.py:249
-#: ../src/katello/client/core/template.py:315
-msgid "name of the parent template"
-msgstr "父範本的名稱"
-
-#: ../src/katello/client/core/template.py:253
-#: ../src/katello/client/core/template.py:318
-msgid "template description"
-msgstr "範本的描述"
-
-#: ../src/katello/client/core/template.py:276
-#, python-format
-msgid "Successfully created template [ %s ]"
-msgstr "已成功建立範本 [ %s ]"
-
-#: ../src/katello/client/core/template.py:277
-#, python-format
-msgid "Could not create template [ %s ]"
-msgstr "無法建立範本 [ %s ]"
-
-#: ../src/katello/client/core/template.py:285
-msgid "updates name and description of a template"
-msgstr "更新範本的名稱與描述"
-
-#: ../src/katello/client/core/template.py:299
-#, python-format
-msgid "each %s must be preceeded by %s"
-msgstr "每個 %s 之前都必須有 %s"
-
-#. bz 799149
-#. self.parser.add_option('--add_product', dest='add_products',
-#. action="append", help=_("name of the product"))
-#. self.parser.add_option('--remove_product', dest='remove_products',
-#. action="append", help=_("name of the product"))
-#: ../src/katello/client/core/template.py:324
-#: ../src/katello/client/core/template.py:325
-msgid "name or nvre of the product (epoch:name-rel.ease-ver.sio.n)"
-msgstr "產品的名稱或 nvre（epoch:name-rel.ease-ver.sio.n）"
-
-#: ../src/katello/client/core/template.py:328
-#, python-format
-msgid "name of the parameter, %s must follow"
-msgstr "參數的名稱，%s 必須接在其後"
-
-#: ../src/katello/client/core/template.py:329
-msgid "value of the parameter"
-msgstr "參數的值"
-
-#: ../src/katello/client/core/template.py:330
-msgid "name of the parameter"
-msgstr "參數名稱"
-
-#: ../src/katello/client/core/template.py:332
-#: ../src/katello/client/core/template.py:333
-msgid "name of the package group"
-msgstr "套件群組的名稱"
-
-#: ../src/katello/client/core/template.py:335
-#: ../src/katello/client/core/template.py:336
-msgid "name of the package group category"
-msgstr "套件群組類別的名稱"
-
-#: ../src/katello/client/core/template.py:338
-#: ../src/katello/client/core/template.py:339
-msgid "distribution id"
-msgstr "發行版 id"
-
-#: ../src/katello/client/core/template.py:342
-msgid "determines product from which the repositories are picked"
-msgstr "判斷要由哪個產品選擇軟體庫"
-
-#: ../src/katello/client/core/template.py:344
-msgid "repository to be added to the template"
-msgstr "欲新增至範本的軟體庫"
-
-#: ../src/katello/client/core/template.py:346
-msgid "repository to be removed from the template"
-msgstr "欲由範本中移除的軟體庫"
-
-#: ../src/katello/client/core/template.py:357
-#, python-format
-msgid "missing value for parameter '%s'"
-msgstr "參數「%s」缺少必要的值"
-
-#: ../src/katello/client/core/template.py:417
-#: ../src/katello/client/core/template.py:418
-msgid "Updating the template, please wait... "
-msgstr "更新範本中，請稍候……"
-
-#: ../src/katello/client/core/template.py:419
-#, python-format
-msgid "Successfully updated template [ %s ]"
-msgstr "已成功更新範本 [ %s ]"
-
-#: ../src/katello/client/core/template.py:487
-msgid "deletes a template"
-msgstr "刪除範本"
-
-#: ../src/katello/client/core/template.py:495
-msgid "environment name eg: foo.example.com (default: Library)"
-msgstr "環境名稱，例如 foo.example.com（預設值：Library）"
-
-#: ../src/katello/client/core/template.py:516
-msgid "template specific actions in the katello server"
-msgstr "katello 伺服器中，與範本相關的特定動作"
-
-#: ../src/katello/client/core/shell_command.py:30
-msgid "run the cli as a shell"
-msgstr "以 shell 方式執行命令列指令"
-
-#: ../src/katello/client/core/sync_plan.py:55
-msgid "list known sync_plans"
-msgstr "列出已知的同步計畫(_P)"
-
-#: ../src/katello/client/core/sync_plan.py:74
-msgid "Sync Plan List"
-msgstr "同步計畫清單"
-
-#: ../src/katello/client/core/sync_plan.py:81
-msgid "print info about a sync plan"
-msgstr "印出有關於同步計畫的資訊"
-
-#: ../src/katello/client/core/sync_plan.py:84
-#: ../src/katello/client/core/sync_plan.py:114
-#: ../src/katello/client/core/sync_plan.py:151
-#: ../src/katello/client/core/sync_plan.py:193
-msgid "name of the sync plan (required)"
-msgstr "同步計畫的名稱（必填）"
-
-#: ../src/katello/client/core/sync_plan.py:103
-msgid "Sync Plan Info"
-msgstr "同步計畫資訊"
-
-#: ../src/katello/client/core/sync_plan.py:111
-msgid "create a synchronization plan"
-msgstr "建立同步計畫"
-
-#: ../src/katello/client/core/sync_plan.py:116
-#: ../src/katello/client/core/sync_plan.py:154
-msgid "plan description"
-msgstr "計畫詳述"
-
-#: ../src/katello/client/core/sync_plan.py:118
-#: ../src/katello/client/core/sync_plan.py:156
-#, python-format
-msgid "interval of recurring synchronizations (choices: [%s], default: none)"
-msgstr "重複的同步間隔（選項：[%s]，預設值：none）"
-
-#: ../src/katello/client/core/sync_plan.py:120
-msgid "date of first synchronization (required, format: YYYY-MM-DD)"
-msgstr "第一次同步的日期（必填，格式：YYYY-MM-DD）"
-
-#: ../src/katello/client/core/sync_plan.py:121
-msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
-msgstr "第一次同步的時間（格式：HH:MM:SS，預設值：00:00:00）"
-
-#: ../src/katello/client/core/sync_plan.py:141
-#, python-format
-msgid "Successfully created synchronization plan [ %s ]"
-msgstr "已成功建立同步計畫 [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:142
-#, python-format
-msgid "Could not create synchronization plan [ %s ]"
-msgstr "無法建立同步計畫 [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:148
-msgid "update a sync plan"
-msgstr "更新同步計畫"
-
-#: ../src/katello/client/core/sync_plan.py:152
-msgid "new sync plan name"
-msgstr "新同步計畫名稱"
-
-#: ../src/katello/client/core/sync_plan.py:158
-msgid "date of first synchronization (format: YYYY-MM-DD)"
-msgstr "第一次同步的日期（格式：YYYY-MM-DD）"
-
-#: ../src/katello/client/core/sync_plan.py:159
-msgid "time of first synchronization (format: HH:MM:SS)"
-msgstr "第一次同步的時間（格式：HH:MM:SS）"
-
-#: ../src/katello/client/core/sync_plan.py:165
-msgid "You have to specify both --date and --time"
-msgstr "您必須指定 --date 與 --time"
-
-#: ../src/katello/client/core/sync_plan.py:184
-#, python-format
-msgid "Successfully updated sync plan [ %s ]"
-msgstr "已成功更新了同步計畫 [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:190
-msgid "delete a sync plan"
-msgstr "刪除同步計畫"
-
-#: ../src/katello/client/core/sync_plan.py:207
-#, python-format
-msgid "Successfully deleted sync plan [ %s ]"
-msgstr "已成功刪除同步計畫 [ %s ]"
-
-#: ../src/katello/client/core/sync_plan.py:215
-msgid "synchronization plan specific actions in the katello server"
-msgstr "katello 伺服器中，與同步計畫相關的特定動作"
-
-#: ../src/katello/client/core/version.py:39
-msgid "get the version of the katello server"
-msgstr "取得 katello 伺服器的版本"
-
-#: ../src/katello/client/core/version.py:54
-msgid "Check the version of the server"
-msgstr "檢查伺服器的版本"
-
-#: ../src/katello/client/core/permission.py:56
-msgid "create a permission for a user role"
-msgstr "為使用者角色建立權限"
-
-#: ../src/katello/client/core/permission.py:59
-#: ../src/katello/client/core/permission.py:122
-#: ../src/katello/client/core/permission.py:146
-#: ../src/katello/client/core/user_role.py:65
-msgid "role name (required)"
-msgstr "角色名稱（必填）"
-
-#: ../src/katello/client/core/permission.py:60
-#: ../src/katello/client/core/permission.py:123
-msgid "permission name (required)"
-msgstr "權限名稱（必填）"
-
-#: ../src/katello/client/core/permission.py:61
-msgid "permission description"
-msgstr "權限描述"
-
-#: ../src/katello/client/core/permission.py:62
-msgid "organization name"
-msgstr "組織名稱"
-
-#: ../src/katello/client/core/permission.py:63
-msgid "scope of the permisson (required)"
-msgstr "權限規格（必填）"
-
-#: ../src/katello/client/core/permission.py:64
-msgid "verbs for the permission"
-msgstr "權限動詞"
-
-#: ../src/katello/client/core/permission.py:65
-msgid "tags for the permission"
-msgstr "權限標籤"
-
-#: ../src/katello/client/core/permission.py:81
-#, python-format
-msgid "Invalid scope [ %s ]"
-msgstr "無效的規格 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:88
-#, python-format
-msgid "Could not find tag [ %s ] in scope of [ %s ]"
-msgstr "找不到標籤 [ %s ] 於規格 [ %s ] 中"
-
-#: ../src/katello/client/core/permission.py:112
-#, python-format
-msgid "Successfully created permission [ %s ] for user role [ %s ]"
-msgstr "已成功建立權限 [ %s ]，使用者角色為 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:113
-#, python-format
-msgid "Could not create permission [ %s ]"
-msgstr "無法建立權限 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:119
-msgid "delete a permission"
-msgstr "刪除權限"
-
-#: ../src/katello/client/core/permission.py:137
-#, python-format
-msgid "Successfully deleted permission [ %s ] for role [ %s ]"
-msgstr "已成功刪除權限 [ %s ]，角色為 [ %s ]"
-
-#: ../src/katello/client/core/permission.py:143
-msgid "list permissions for a user role"
-msgstr "列出使用者角色的權限"
-
-#: ../src/katello/client/core/permission.py:170
-msgid "Permission List"
-msgstr "權限清單"
-
-#: ../src/katello/client/core/permission.py:177
-msgid "list available scopes, verbs and tags that can be set in a permission"
-msgstr "列出可設置在權限中的可用規格、動詞與標籤"
-
-#: ../src/katello/client/core/permission.py:181
-msgid ""
-"organization name eg: foo.example.com,\n"
-"lists organization specific verbs"
-msgstr ""
-"組織名稱，例如 foo.example.com，\n"
-"列出組織相關的動詞"
-
-#: ../src/katello/client/core/permission.py:182
-msgid "filter listed results by scope"
-msgstr "以規格篩選列出的結果"
-
-#: ../src/katello/client/core/permission.py:200
-#, python-format
-msgid "Available verbs and tags for permission scope %s"
-msgstr "權限規格 %s 的可用動詞與標籤"
-
-#: ../src/katello/client/core/permission.py:202
-msgid "Available verbs"
-msgstr "可用動詞"
-
-#: ../src/katello/client/core/permission.py:221
-msgid "None"
-msgstr "無"
-
-#: ../src/katello/client/core/permission.py:259
-msgid "permission pecific actions in the katello server"
-msgstr "katello 伺服器中，與權限相關的特定動作"
-
-#: ../src/katello/client/core/errata.py:42
-msgid "list all errata for a repo"
-msgstr "列出軟體庫的所有勘誤"
-
-#: ../src/katello/client/core/errata.py:58
-msgid "filter errata by type eg: enhancements"
-msgstr "以類型篩選勘誤，例如 enhancements"
-
-#: ../src/katello/client/core/errata.py:60
-msgid "filter errata by severity"
-msgstr "以嚴重性篩選勘誤"
-
-#: ../src/katello/client/core/errata.py:94
-msgid "Errata List"
-msgstr "勘誤清單"
-
-#: ../src/katello/client/core/errata.py:99
-msgid "list errata for a system"
-msgstr "列出系統的勘誤"
-
-#: ../src/katello/client/core/errata.py:125
-#, python-format
-msgid "Errata for system %s in organization %s"
-msgstr "系統 %s 的勘誤，位於組織 %s 中"
-
-#: ../src/katello/client/core/errata.py:132
-msgid "information about an errata"
-msgstr "勘誤的資訊"
-
-#: ../src/katello/client/core/errata.py:136
-msgid "errata id, string value (required)"
-msgstr "勘誤 ID，字串值（必填）"
-
-#: ../src/katello/client/core/errata.py:185
-msgid "Errata Information"
-msgstr "勘誤資訊"
-
-#: ../src/katello/client/core/errata.py:194
-msgid "errata specific actions in the katello server"
-msgstr "katello 伺服器中，與勘誤相關的特定動作"
-
-#: ../src/katello/client/core/repo.py:34
-msgid "Waiting"
-msgstr "等待中"
-
-#: ../src/katello/client/core/repo.py:35
-msgid "Running"
-msgstr "執行中"
-
-#: ../src/katello/client/core/repo.py:36
-msgid "Error"
-msgstr "錯誤"
-
-#: ../src/katello/client/core/repo.py:38
-msgid "Cancelled"
-msgstr "已取消"
-
-#: ../src/katello/client/core/repo.py:39
-msgid "Canceled"
-msgstr "已取消"
-
-#: ../src/katello/client/core/repo.py:40
-msgid "Timed out"
-msgstr "逾時"
-
-#: ../src/katello/client/core/repo.py:41
-msgid "Not synced"
-msgstr "未同步"
-
-#: ../src/katello/client/core/repo.py:116
-msgid "create a repository at a specified URL"
-msgstr "在特定 URL 上建立軟體庫"
-
-#: ../src/katello/client/core/repo.py:122
-msgid "repository name to assign (required)"
-msgstr "要指定的軟體庫名稱（必填）"
-
-#: ../src/katello/client/core/repo.py:124
-msgid "url path to the repository (required)"
-msgstr "軟體庫的 URL 路徑（必填）"
-
-#: ../src/katello/client/core/repo.py:128
-#: ../src/katello/client/core/repo.py:335
-msgid ""
-"GPG key to be assigned to the repository; by default, the product's GPG key "
-"will be used."
-msgstr "欲指定給軟體庫的 GPG 金鑰；就預設值，將會使用產品的 GPG 金鑰。"
-
-#: ../src/katello/client/core/repo.py:130
-#: ../src/katello/client/core/repo.py:337
-msgid "Don't assign a GPG key to the repository."
-msgstr "不指定一組 GPG 金鑰至軟體庫。"
-
-#: ../src/katello/client/core/repo.py:148
-#: ../src/katello/client/core/repo.py:253
-#, python-format
-msgid "Successfully created repository [ %s ]"
-msgstr "已成功建立軟體庫 [ %s ]"
-
-#: ../src/katello/client/core/repo.py:154
-msgid "discovery repositories contained within a URL"
-msgstr "尋找包含於 URL 中的軟體庫"
-
-#: ../src/katello/client/core/repo.py:160
-msgid ""
-"repository name prefix to add to all the discovered repositories (required)"
-msgstr "要新增至尋找到的軟體庫名稱之前的前綴（必填）"
-
-#: ../src/katello/client/core/repo.py:162
-msgid ""
-"root url to perform discovery of repositories eg: "
-"http://porkchop.devel.redhat.com/ (required)"
-msgstr "要尋找軟體庫的 root URL，例如「http://porkchop.devel.redhat.com/」（必填）"
-
-#: ../src/katello/client/core/repo.py:192
-msgid "Discovering repository urls, this could take some time..."
-msgstr "正在尋找軟體庫 URL，這可能會花上一點時間……"
-
-#: ../src/katello/client/core/repo.py:196
-#, python-format
-msgid "Error: %s"
-msgstr "錯誤：%s"
-
-#: ../src/katello/client/core/repo.py:216
-msgid ""
-"\n"
-"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
-msgstr ""
-"\n"
-"為要建立的候選軟體庫選擇 URL；請按下「y」確認（按下「h」求助）："
-
-#: ../src/katello/client/core/repo.py:226
-msgid "Operation aborted upon user request."
-msgstr "應使用者要求放棄操作。"
-
-#: ../src/katello/client/core/repo.py:275
-msgid "status information about a repository"
-msgstr "關於軟體庫的狀態資訊"
-
-#: ../src/katello/client/core/repo.py:298
-msgid "Repository Status"
-msgstr "軟體庫狀態"
-
-#: ../src/katello/client/core/repo.py:305
-msgid "information about a repository"
-msgstr "關於軟體庫的資訊"
-
-#: ../src/katello/client/core/repo.py:319
-msgid "Progress"
-msgstr "進度"
-
-#: ../src/katello/client/core/repo.py:322
-#, python-format
-msgid "Information About Repo %s"
-msgstr "關於軟體庫 %s 的資訊"
-
-#: ../src/katello/client/core/repo.py:329
-msgid "updates repository attributes"
-msgstr "更新軟體庫項目"
-
-#: ../src/katello/client/core/repo.py:345
-#, python-format
-msgid "Successfully updated repository [ %s ]"
-msgstr "已成功更新了軟體庫 [ %s ]"
-
-#: ../src/katello/client/core/repo.py:351
-msgid "synchronize a repository"
-msgstr "同步軟體庫"
-
-#: ../src/katello/client/core/repo.py:361
-#, python-format
-msgid "Repo [ %s ] synced"
-msgstr "已同步軟體庫 [%s]"
-
-#: ../src/katello/client/core/repo.py:364
-#, python-format
-msgid "Repo [ %s ] synchronization cancelled"
-msgstr "已取消軟體庫 [ %s ] 的同步"
-
-#: ../src/katello/client/core/repo.py:367
-#, python-format
-msgid "Repo [ %s ] failed to sync: %s"
-msgstr "同步軟體庫 [%s] 失敗：%s"
-
-#: ../src/katello/client/core/repo.py:373
-msgid "cancel currently running synchronization of a repository"
-msgstr "取消軟體庫目前進行中的同步程序"
-
-#: ../src/katello/client/core/repo.py:388
-msgid "enable a repository"
-msgstr "啟用軟體庫"
-
-#: ../src/katello/client/core/repo.py:390
-msgid "disable a repository"
-msgstr "停用軟體庫"
-
-#: ../src/katello/client/core/repo.py:409
-msgid "list repos within an organization"
-msgstr "列出組織中的軟體庫"
-
-#: ../src/katello/client/core/repo.py:413
-msgid "organization name eg: ACME_Corporation (required)"
-msgstr "組織名稱，例如「ACME_Corporation 」（必填）"
-
-#: ../src/katello/client/core/repo.py:419
-msgid "list also disabled repositories"
-msgstr "亦列出已停用的軟體庫"
-
-#: ../src/katello/client/core/repo.py:439
-#, python-format
-msgid "Repo List For Org %s Environment %s Product %s"
-msgstr "組織 %s、環境 %s、產品 %s 的軟體庫清單"
-
-#: ../src/katello/client/core/repo.py:446
-#, python-format
-msgid "Repo List for Product %s in Org %s "
-msgstr "產品 %s 的軟體庫清單，位於組織 %s"
-
-#: ../src/katello/client/core/repo.py:453
-#, python-format
-msgid "Repo List For Org %s Environment %s"
-msgstr "組織 %s 的軟體庫清單，位於環境 %s"
-
-#: ../src/katello/client/core/repo.py:463
-msgid "delete a repository"
-msgstr "刪除軟體庫"
-
-#: ../src/katello/client/core/repo.py:476
-msgid "list filters of a repository"
-msgstr "列出軟體庫篩選器"
-
-#: ../src/katello/client/core/repo.py:482
-msgid "prints also filters assigned to repository's product."
-msgstr "亦列出指定至軟體庫產品的篩選器"
-
-#: ../src/katello/client/core/repo.py:492
-msgid "Repository Filters"
-msgstr "軟體庫篩選器"
-
-#: ../src/katello/client/core/repo.py:506
-msgid "add a filter to a repository"
-msgstr "新增篩選器至軟體庫"
-
-#: ../src/katello/client/core/repo.py:508
-msgid "remove a filter from a repository"
-msgstr "移除軟體庫的篩選器"
-
-#: ../src/katello/client/core/repo.py:538
-#, python-format
-msgid "Added filter [ %s ] to repository [ %s ]"
-msgstr "新增篩選器 [ %s ] 至軟體庫 [ %s ]"
-
-#: ../src/katello/client/core/repo.py:541
-#, python-format
-msgid "Removed filter [ %s ] to repository [ %s ]"
-msgstr "移除篩選器 [ %s ] 由軟體庫 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:46
-msgid "list all known user roles"
-msgstr "列出所有已知的使用者角色"
-
-#: ../src/katello/client/core/user_role.py:62
-msgid "create user role"
-msgstr "建立使用者角色"
-
-#: ../src/katello/client/core/user_role.py:66
-#: ../src/katello/client/core/user_role.py:165
-msgid "role description"
-msgstr "角色描述"
-
-#: ../src/katello/client/core/user_role.py:77
-#, python-format
-msgid "Successfully created user role [ %s ]"
-msgstr "已成功建立使用者角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:78
-#, python-format
-msgid "Could not create user role [ %s ]"
-msgstr "無法建立使用者角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:86
-msgid "list information about user role"
-msgstr "列出有關於使用者角色的資訊"
-
-#: ../src/katello/client/core/user_role.py:89
-#: ../src/katello/client/core/user_role.py:141
-#: ../src/katello/client/core/user_role.py:163
-#: ../src/katello/client/core/user_role.py:190
-#: ../src/katello/client/core/user_role.py:214
-msgid "user role name (required)"
-msgstr "使用者角色名稱（必填）"
-
-#: ../src/katello/client/core/user_role.py:90
-msgid "print details about each of role's permissions"
-msgstr "印出有關於各角色之權限的詳細資料"
-
-#: ../src/katello/client/core/user_role.py:109
-#, python-format
-msgid ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-msgstr ""
-"%s\n"
-"\tfor: %s\n"
-"\tverbs: %s\n"
-"\ton: %s"
-
-#: ../src/katello/client/core/user_role.py:130
-msgid "User Role Information"
-msgstr "使用者角色資訊"
-
-#: ../src/katello/client/core/user_role.py:138
-msgid "delete a user role"
-msgstr "刪除使用者角色"
-
-#: ../src/katello/client/core/user_role.py:152
-#, python-format
-msgid "Successfully deleted user role [ %s ]"
-msgstr "已成功刪除了使用者角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:160
-msgid "update a role"
-msgstr "更新角色"
-
-#: ../src/katello/client/core/user_role.py:164
-msgid "new user role name"
-msgstr "新使用者角色名稱"
-
-#: ../src/katello/client/core/user_role.py:170
-msgid "Provide at least one parameter to update the user role"
-msgstr "提供至少一個參數，以更新使用者角色"
-
-#: ../src/katello/client/core/user_role.py:180
-#, python-format
-msgid "Successfully updated user role [ %s ]"
-msgstr "已成功更新了使用者角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:187
-msgid "assign LDAP group to a role"
-msgstr "為角色指定 LDAP 群組"
-
-#: ../src/katello/client/core/user_role.py:191
-msgid "new LDAP group name (required)"
-msgstr "新 LDAP 群組名稱（必提供）"
-
-#: ../src/katello/client/core/user_role.py:204
-#, python-format
-msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
-msgstr "已成功新增了 LDAP 群組 [ %s ] 至使用者角色 [ %s ]"
-
-#: ../src/katello/client/core/user_role.py:211
-msgid "remove LDAP group assigned to a role"
-msgstr "移除為某角色指定的 LDAP 群組"
-
-#: ../src/katello/client/core/user_role.py:215
-msgid "LDAP group name to be removed (required)"
-msgstr "欲移除之 LDAP 群組的名稱（必提供）"
-
-#: ../src/katello/client/core/user_role.py:228
-#, python-format
-msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
-msgstr "已成功移除了 LDAP 群組 [ %s ]（由使用者角色 [ %s ]）"
-
-#: ../src/katello/client/core/user_role.py:235
-msgid "user role specific actions in the katello server"
-msgstr "katello 伺服器中，與使用者角色相關的特定動作"
-
-#: ../src/katello/client/core/datetime_formatter.py:45
-msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
-msgstr "時間格式無效。所需格式為：HH:MM:SS[+HH:MM]"
-
-#: ../src/katello/client/core/datetime_formatter.py:47
-msgid "Date format is invalid. Required: YYYY-MM-DD"
-msgstr "日期格式無效。所需格式為：YYYY-MM-DD"
-
 #. These are a bunch of strings that are marked for translation in optparse,
 #. but not actually translated anywhere. Mark them for translation here,
 #. so we get it picked up. for local translation, and then optparse will
 #. use them.
+# These are a bunch of strings that are marked for translation in optparse,
+# but not actually translated anywhere. Mark them for translation here,
+# so we get it picked up. for local translation, and then optparse will
+# use them.
 #: ../src/katello/client/i18n_optparse.py:48
 #, python-format
 msgid "Usage: %s\n"
@@ -2814,6 +160,7 @@ msgid "Options"
 msgstr "選項"
 
 #. stuff for option value sanity checking
+# stuff for option value sanity checking
 #: ../src/katello/client/i18n_optparse.py:54
 #, python-format
 msgid "no such option: %s"
@@ -2866,6 +213,7 @@ msgid "option %s: invalid choice: %r (choose from %s)"
 msgstr "選項 %s：無效的選擇：%r（由 %s 選擇）"
 
 #. default options
+# default options
 #: ../src/katello/client/i18n_optparse.py:67
 msgid "show this help message and exit"
 msgstr "顯示此協助訊息並退出"
@@ -2873,3 +221,3024 @@ msgstr "顯示此協助訊息並退出"
 #: ../src/katello/client/i18n_optparse.py:68
 msgid "show program's version number and exit"
 msgstr "顯示程式的版本號碼並退出"
+
+#: ../src/katello/client/core/user_role.py:44
+msgid "list all known user roles"
+msgstr "列出所有已知的使用者角色"
+
+#: ../src/katello/client/core/user_role.py:52
+#: ../src/katello/client/core/user.py:230
+msgid "User Role List"
+msgstr "使用者角色清單"
+
+#: ../src/katello/client/core/user_role.py:60
+msgid "create user role"
+msgstr "建立使用者角色"
+
+#: ../src/katello/client/core/user_role.py:63
+#: ../src/katello/client/core/permission.py:56
+#: ../src/katello/client/core/permission.py:111
+#: ../src/katello/client/core/permission.py:134
+msgid "role name (required)"
+msgstr "角色名稱（必填）"
+
+#: ../src/katello/client/core/user_role.py:64
+#: ../src/katello/client/core/user_role.py:163
+msgid "role description"
+msgstr "角色描述"
+
+#: ../src/katello/client/core/user_role.py:75
+#, python-format
+msgid "Successfully created user role [ %s ]"
+msgstr "已成功建立使用者角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:76
+#, python-format
+msgid "Could not create user role [ %s ]"
+msgstr "無法建立使用者角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:84
+msgid "list information about user role"
+msgstr "列出有關於使用者角色的資訊"
+
+#: ../src/katello/client/core/user_role.py:87
+#: ../src/katello/client/core/user_role.py:139
+#: ../src/katello/client/core/user_role.py:161
+#: ../src/katello/client/core/user_role.py:187
+#: ../src/katello/client/core/user_role.py:210
+msgid "user role name (required)"
+msgstr "使用者角色名稱（必填）"
+
+#: ../src/katello/client/core/user_role.py:88
+msgid "print details about each of role's permissions"
+msgstr "印出有關於各角色之權限的詳細資料"
+
+#: ../src/katello/client/core/user_role.py:107
+#, python-format
+msgid ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+msgstr ""
+"%s\n"
+"\tfor: %s\n"
+"\tverbs: %s\n"
+"\ton: %s"
+
+#: ../src/katello/client/core/user_role.py:128
+msgid "User Role Information"
+msgstr "使用者角色資訊"
+
+#: ../src/katello/client/core/user_role.py:136
+msgid "delete a user role"
+msgstr "刪除使用者角色"
+
+#: ../src/katello/client/core/user_role.py:150
+#, python-format
+msgid "Successfully deleted user role [ %s ]"
+msgstr "已成功刪除了使用者角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:158
+msgid "update a role"
+msgstr "更新角色"
+
+#: ../src/katello/client/core/user_role.py:162
+msgid "new user role name"
+msgstr "新使用者角色名稱"
+
+#: ../src/katello/client/core/user_role.py:177
+#, python-format
+msgid "Successfully updated user role [ %s ]"
+msgstr "已成功更新了使用者角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:184
+msgid "assign LDAP group to a role"
+msgstr "為角色指定 LDAP 群組"
+
+#: ../src/katello/client/core/user_role.py:188
+msgid "new LDAP group name (required)"
+msgstr "新 LDAP 群組名稱（必提供）"
+
+#: ../src/katello/client/core/user_role.py:200
+#, python-format
+msgid "Successfully added LDAP group [ %s ] to the user role [ %s ]"
+msgstr "已成功新增了 LDAP 群組 [ %s ] 至使用者角色 [ %s ]"
+
+#: ../src/katello/client/core/user_role.py:207
+msgid "remove LDAP group assigned to a role"
+msgstr "移除為某角色指定的 LDAP 群組"
+
+#: ../src/katello/client/core/user_role.py:211
+msgid "LDAP group name to be removed (required)"
+msgstr "欲移除之 LDAP 群組的名稱（必提供）"
+
+#: ../src/katello/client/core/user_role.py:223
+#, python-format
+msgid "Successfully removed LDAP group [ %s ] from the user role [ %s ]"
+msgstr "已成功移除了 LDAP 群組 [ %s ]（由使用者角色 [ %s ]）"
+
+#: ../src/katello/client/core/user_role.py:230
+msgid "user role specific actions in the katello server"
+msgstr "katello 伺服器中，與使用者角色相關的特定動作"
+
+#: ../src/katello/client/core/client.py:37
+msgid "save an option to the client config"
+msgstr "將選項儲存至用戶端配置中"
+
+#: ../src/katello/client/core/client.py:41
+msgid ""
+"name of the option to be saved (e.g. org, environment, provider, etc) "
+"(required)"
+msgstr "要儲存的選項之名稱（例如 org、environment、provider 等）（必填）"
+
+#: ../src/katello/client/core/client.py:43
+msgid "value to be store under specified option (required)"
+msgstr "特定選項之下要儲存的值（必填）"
+
+#: ../src/katello/client/core/client.py:62
+msgid "Successfully "
+msgstr "成功"
+
+#: ../src/katello/client/core/client.py:64
+#, python-format
+msgid "Unsuccessfully remembered option [ %s ]"
+msgstr "未成功記得選項 [ %s ]"
+
+#: ../src/katello/client/core/client.py:71
+msgid "remove an option from the client config"
+msgstr "從用戶端配置移除選項"
+
+#: ../src/katello/client/core/client.py:75
+msgid "name of the option to be deleted (required)"
+msgstr "要移除的選項名稱（必填）"
+
+#: ../src/katello/client/core/client.py:87
+#, python-format
+msgid "Successfully forgot option [ %s ]"
+msgstr "已成功忘記選項 [ %s ]"
+
+#: ../src/katello/client/core/client.py:89
+#, python-format
+msgid "Unsuccessfully forgot option [ %s ]"
+msgstr "未成功忘記選項 [ %s ]"
+
+#: ../src/katello/client/core/client.py:96
+msgid "list options saved in the client config"
+msgstr "列出儲存於用戶端配置的選項"
+
+#: ../src/katello/client/core/client.py:105
+msgid "Saved Options"
+msgstr "已儲存的選項"
+
+#: ../src/katello/client/core/client.py:121
+msgid "client specific actions in the katello server"
+msgstr "katello 伺服器中，與用戶端相關的特定動作"
+
+#: ../src/katello/client/core/activation_key.py:50
+msgid "list all activation keys"
+msgstr "列出所有啟動金鑰"
+
+#: ../src/katello/client/core/activation_key.py:54
+#: ../src/katello/client/core/activation_key.py:108
+#: ../src/katello/client/core/activation_key.py:147
+#: ../src/katello/client/core/activation_key.py:192
+#: ../src/katello/client/core/activation_key.py:262
+#: ../src/katello/client/core/activation_key.py:291
+#: ../src/katello/client/core/activation_key.py:334
+#: ../src/katello/client/core/gpg_key.py:65
+#: ../src/katello/client/core/gpg_key.py:95
+#: ../src/katello/client/core/gpg_key.py:131
+#: ../src/katello/client/core/gpg_key.py:163
+#: ../src/katello/client/core/gpg_key.py:206
+#: ../src/katello/client/core/system_group.py:75
+#: ../src/katello/client/core/system_group.py:110
+#: ../src/katello/client/core/system_group.py:256
+#: ../src/katello/client/core/system_group.py:294
+#: ../src/katello/client/core/system_group.py:356
+#: ../src/katello/client/core/system_group.py:387
+#: ../src/katello/client/core/changeset.py:42
+#: ../src/katello/client/core/changeset.py:76
+#: ../src/katello/client/core/changeset.py:140
+#: ../src/katello/client/core/changeset.py:324
+#: ../src/katello/client/core/changeset.py:407
+#: ../src/katello/client/core/changeset.py:434
+#: ../src/katello/client/core/system.py:721
+#: ../src/katello/client/core/system.py:764
+#: ../src/katello/client/core/provider.py:46
+#: ../src/katello/client/core/provider.py:133
+#: ../src/katello/client/core/template.py:89
+#: ../src/katello/client/core/template.py:152
+#: ../src/katello/client/core/template.py:194
+#: ../src/katello/client/core/template.py:244
+#: ../src/katello/client/core/template.py:308
+#: ../src/katello/client/core/template.py:481
+msgid "name of organization (required)"
+msgstr "組織名稱（必填）"
+
+#: ../src/katello/client/core/activation_key.py:56
+#: ../src/katello/client/core/template.py:54
+#: ../src/katello/client/core/template.py:91
+msgid "environment name eg: dev (default: Library)"
+msgstr "環境名稱，例如：dev（預設值：Library）"
+
+#: ../src/katello/client/core/activation_key.py:69
+#, python-format
+msgid "No keys found in organization [ %s ]"
+msgstr "組織 [ %s ] 中找不到金鑰"
+
+#: ../src/katello/client/core/activation_key.py:71
+#, python-format
+msgid "No keys found in organization [ %s ] environment [ %s ]"
+msgstr "組織 [ %s ] 中找不到金鑰，位於環境 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:88
+msgid "Activation Key List"
+msgstr "啟動金鑰清單"
+
+#: ../src/katello/client/core/activation_key.py:102
+msgid "show information about an activation key"
+msgstr "顯示啟動金鑰的資訊"
+
+#: ../src/katello/client/core/activation_key.py:106
+#: ../src/katello/client/core/activation_key.py:145
+#: ../src/katello/client/core/activation_key.py:190
+#: ../src/katello/client/core/activation_key.py:260
+#: ../src/katello/client/core/activation_key.py:289
+#: ../src/katello/client/core/activation_key.py:332
+msgid "activation key name (required)"
+msgstr "啟動金鑰名稱（必填）"
+
+#: ../src/katello/client/core/activation_key.py:121
+#, python-format
+msgid "Could not find activation key [ %s ]"
+msgstr "找不到啟動金鑰 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:134
+msgid "Activation Key Info"
+msgstr "啟動金鑰資訊"
+
+#: ../src/katello/client/core/activation_key.py:141
+msgid "create an activation key"
+msgstr "建立啟動金鑰"
+
+#: ../src/katello/client/core/activation_key.py:149
+msgid "environment name eg: dev (required)"
+msgstr "環境名稱，例如「dev」（必填）"
+
+#: ../src/katello/client/core/activation_key.py:151
+msgid "activation key description"
+msgstr "啟動金鑰的描述"
+
+#: ../src/katello/client/core/activation_key.py:153
+msgid "template name eg: servers"
+msgstr "範本名稱，例如「servers」"
+
+#: ../src/katello/client/core/activation_key.py:155
+msgid "usage limit (unlimited by default)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:173
+#: ../src/katello/client/core/activation_key.py:238
+#, python-format
+msgid "Could not find template [ %s ]"
+msgstr "找不到範本 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:178
+#, python-format
+msgid "Successfully created activation key [ %s ]"
+msgstr "已成功建立啟動金鑰 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:179
+#, python-format
+msgid "Could not create activation key [ %s ]"
+msgstr "無法建立啟動金鑰 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:186
+msgid "update an activation key"
+msgstr "更新啟動金鑰"
+
+#: ../src/katello/client/core/activation_key.py:194
+msgid "new environment name eg: dev"
+msgstr "新環境名稱，例如「dev」"
+
+#: ../src/katello/client/core/activation_key.py:196
+#: ../src/katello/client/core/gpg_key.py:165
+#: ../src/katello/client/core/template.py:309
+msgid "new template name"
+msgstr "新範本名稱"
+
+#: ../src/katello/client/core/activation_key.py:198
+#: ../src/katello/client/core/system_group.py:262
+msgid "new description"
+msgstr "新描述"
+
+#: ../src/katello/client/core/activation_key.py:200
+msgid "new template name eg: servers"
+msgstr "新範本名稱，例如「servers」"
+
+#: ../src/katello/client/core/activation_key.py:202
+msgid "usage limit (set -1 for no limit)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:205
+msgid "add a pool to the activation key"
+msgstr "新增集池至啟動金鑰"
+
+#: ../src/katello/client/core/activation_key.py:207
+msgid "remove a pool from the activation key"
+msgstr "由啟動金鑰移除集池"
+
+#: ../src/katello/client/core/activation_key.py:248
+#, python-format
+msgid "Successfully updated activation key [ %s ]"
+msgstr "已成功更新啟動金鑰 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:256
+msgid "delete an activation key"
+msgstr "刪除啟動金鑰"
+
+#: ../src/katello/client/core/activation_key.py:279
+#, python-format
+msgid "Successfully deleted activation key [ %s ]"
+msgstr "已成功刪除啟動金鑰 [ %s ]"
+
+#: ../src/katello/client/core/activation_key.py:285
+msgid "add system group to an activation key"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:293
+#: ../src/katello/client/core/activation_key.py:336
+#: ../src/katello/client/core/system_group.py:73
+#: ../src/katello/client/core/system_group.py:144
+#: ../src/katello/client/core/system_group.py:176
+#: ../src/katello/client/core/system_group.py:215
+#: ../src/katello/client/core/system_group.py:254
+#: ../src/katello/client/core/system_group.py:292
+#: ../src/katello/client/core/system_group.py:324
+#: ../src/katello/client/core/system_group.py:354
+#: ../src/katello/client/core/system_group.py:385
+#: ../src/katello/client/core/system_group.py:417
+#: ../src/katello/client/core/system_group.py:495
+#: ../src/katello/client/core/errata.py:134
+msgid "system group name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:320
+#, python-format
+msgid "Successfully added system group to activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:328
+#: ../src/katello/client/core/system.py:758
+msgid "remove system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:363
+#, python-format
+msgid "Successfully removed system group from activation key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/activation_key.py:370
+msgid "activation key specific actions in the katello server"
+msgstr "katello 伺服器中，與啟動金鑰相關的特定動作"
+
+#: ../src/katello/client/core/datetime_formatter.py:45
+msgid "Time format is invalid. Required: HH:MM:SS[+HH:MM]"
+msgstr "時間格式無效。所需格式為：HH:MM:SS[+HH:MM]"
+
+#: ../src/katello/client/core/datetime_formatter.py:47
+msgid "Date format is invalid. Required: YYYY-MM-DD"
+msgstr "日期格式無效。所需格式為：YYYY-MM-DD"
+
+#: ../src/katello/client/core/filters.py:36
+msgid "list all filters"
+msgstr "列出所有篩選器"
+
+#: ../src/katello/client/core/filters.py:40
+#: ../src/katello/client/core/filters.py:63
+#: ../src/katello/client/core/filters.py:96
+#: ../src/katello/client/core/filters.py:116
+#: ../src/katello/client/core/filters.py:145
+#: ../src/katello/client/core/filters.py:170
+#: ../src/katello/client/core/system.py:390
+#: ../src/katello/client/core/system.py:447
+#: ../src/katello/client/core/system.py:479
+#: ../src/katello/client/core/system.py:507
+#: ../src/katello/client/core/system.py:585
+#: ../src/katello/client/core/system.py:624
+#: ../src/katello/client/core/provider.py:62
+#: ../src/katello/client/core/errata.py:103
+#: ../src/katello/client/core/errata.py:133
+#: ../src/katello/client/core/sync_plan.py:83
+#: ../src/katello/client/core/sync_plan.py:112
+#: ../src/katello/client/core/sync_plan.py:147
+#: ../src/katello/client/core/sync_plan.py:186
+msgid "organization name (required)"
+msgstr "組織名稱（必填）"
+
+#: ../src/katello/client/core/filters.py:53
+msgid "Filter List"
+msgstr "篩選器清單"
+
+#: ../src/katello/client/core/filters.py:59
+msgid "create a filter"
+msgstr "建立篩選器"
+
+#: ../src/katello/client/core/filters.py:65
+#: ../src/katello/client/core/filters.py:98
+#: ../src/katello/client/core/filters.py:118
+#: ../src/katello/client/core/filters.py:147
+#: ../src/katello/client/core/filters.py:172
+#: ../src/katello/client/core/repo.py:507
+#: ../src/katello/client/core/product.py:441
+msgid "filter name (required)"
+msgstr "篩選器名稱（必填）"
+
+#: ../src/katello/client/core/filters.py:67
+msgid "description"
+msgstr "描述"
+
+#: ../src/katello/client/core/filters.py:69
+msgid "comma-separated list of package names/nvres"
+msgstr "逗號區隔開的套件名稱/nvres 清單"
+
+#: ../src/katello/client/core/filters.py:84
+#, python-format
+msgid "Successfully created filter [ %s ]"
+msgstr "已成功建立篩選器 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:85
+#, python-format
+msgid "Could not create filter [ %s ]"
+msgstr "無法建立篩選器 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:92
+msgid "delete a filter"
+msgstr "刪除篩選器"
+
+#: ../src/katello/client/core/filters.py:108
+#, python-format
+msgid "Successfully deleted filter [ %s ]"
+msgstr "已成功刪除篩選器 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:112
+msgid "filter info"
+msgstr "篩選器資訊"
+
+#: ../src/katello/client/core/filters.py:133
+msgid "Filter Information"
+msgstr "篩選器資訊"
+
+#: ../src/katello/client/core/filters.py:141
+msgid "Add a package to filter"
+msgstr "新增套件至篩選器"
+
+#: ../src/katello/client/core/filters.py:149
+#: ../src/katello/client/core/filters.py:174
+msgid "package id (required)"
+msgstr "套件 id（必填）"
+
+#: ../src/katello/client/core/filters.py:162
+#, python-format
+msgid "Successfully added package [ %s ] to filter [ %s ]"
+msgstr "已成功新增套件 [ %s ] 至篩選器 [ %s ]"
+
+#: ../src/katello/client/core/filters.py:166
+msgid "Remove a package from filter"
+msgstr "由篩選器移除套件"
+
+#: ../src/katello/client/core/filters.py:190
+#, python-format
+msgid "Successfully removed package [ %s ] from filter [ %s ]"
+msgstr "已成功移除套件 [ %s ]（由篩選器 [ %s ]）"
+
+#: ../src/katello/client/core/filters.py:196
+msgid "filter specific actions in the katello server"
+msgstr "katello 伺服器中，與篩選器相關的特定動作"
+
+#: ../src/katello/client/core/distribution.py:39
+msgid "list distributions in a repository"
+msgstr "列出軟體庫的散佈版本"
+
+#: ../src/katello/client/core/distribution.py:43
+#: ../src/katello/client/core/package.py:45
+#: ../src/katello/client/core/package.py:98
+#: ../src/katello/client/core/errata.py:46
+#: ../src/katello/client/core/errata.py:172
+#: ../src/katello/client/core/repo.py:79
+msgid "repository id"
+msgstr "軟體庫 ID"
+
+#: ../src/katello/client/core/distribution.py:45
+#: ../src/katello/client/core/package.py:47
+#: ../src/katello/client/core/package.py:100
+#: ../src/katello/client/core/errata.py:48
+#: ../src/katello/client/core/errata.py:174
+#: ../src/katello/client/core/repo.py:80
+msgid "repository name"
+msgstr "軟體庫名稱"
+
+#: ../src/katello/client/core/distribution.py:47
+#: ../src/katello/client/core/package.py:49
+#: ../src/katello/client/core/package.py:102
+#: ../src/katello/client/core/errata.py:50
+#: ../src/katello/client/core/errata.py:176
+#: ../src/katello/client/core/repo.py:81
+msgid "organization name eg: foo.example.com"
+msgstr "組織名稱，例如「foo.example.com」"
+
+#: ../src/katello/client/core/distribution.py:49
+#: ../src/katello/client/core/package.py:51
+#: ../src/katello/client/core/package.py:104
+#: ../src/katello/client/core/errata.py:52
+#: ../src/katello/client/core/errata.py:178
+#: ../src/katello/client/core/repo.py:84
+#: ../src/katello/client/core/repo.py:406
+#: ../src/katello/client/core/product.py:60
+#: ../src/katello/client/core/product.py:119
+msgid "environment name eg: production (default: Library)"
+msgstr "環境名稱，例如 production（預設值：Library）"
+
+#: ../src/katello/client/core/distribution.py:51
+#: ../src/katello/client/core/package.py:53
+#: ../src/katello/client/core/package.py:106
+#: ../src/katello/client/core/errata.py:54
+#: ../src/katello/client/core/errata.py:180
+#: ../src/katello/client/core/repo.py:82
+#: ../src/katello/client/core/repo.py:408
+msgid "product name eg: fedora-14"
+msgstr "產品名稱，例如「fedora-14」"
+
+#: ../src/katello/client/core/distribution.py:72
+#, python-format
+msgid "Distribution List For Repo %s"
+msgstr "軟體庫 %s 的散佈清單"
+
+#: ../src/katello/client/core/distribution.py:84
+msgid "list information about a distribution"
+msgstr "列出關於散佈版本的資訊"
+
+#: ../src/katello/client/core/distribution.py:89
+msgid "repository id (required)"
+msgstr "軟體庫 ID（必填）"
+
+#: ../src/katello/client/core/distribution.py:91
+msgid "distribution id eg: ks-rh-noarch (required)"
+msgstr "發行版 ID，例如「ks-rh-noarch」（必填）"
+
+#: ../src/katello/client/core/distribution.py:109
+msgid "Distribution Information"
+msgstr "發行版資訊"
+
+#: ../src/katello/client/core/distribution.py:119
+#: ../src/katello/client/core/repo.py:543
+msgid "repo specific actions in the katello server"
+msgstr "katello 伺服器中，與軟體庫相關的特定動作"
+
+#: ../src/katello/client/core/gpg_key.py:41
+msgid "Enter content of the GPG key (finish input with CTRL+D):"
+msgstr "輸入 GPG 金鑰的內容（請以 CTRL+D 完成輸入）："
+
+#: ../src/katello/client/core/gpg_key.py:61
+msgid "list all GPG keys"
+msgstr "列出所有 GPG 金鑰"
+
+#: ../src/katello/client/core/gpg_key.py:76
+#, python-format
+msgid "No GPG keys found in organization [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:82
+msgid "GPG Key List"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:89
+msgid "show information about a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:93
+#: ../src/katello/client/core/gpg_key.py:129
+#: ../src/katello/client/core/gpg_key.py:161
+#: ../src/katello/client/core/gpg_key.py:204
+msgid "GPG key name (required)"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:104
+#: ../src/katello/client/core/gpg_key.py:188
+#: ../src/katello/client/core/gpg_key.py:216
+#, python-format
+msgid "Could not find GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:116
+msgid "Repositories"
+msgstr "軟體庫"
+
+#: ../src/katello/client/core/gpg_key.py:118
+msgid "GPG Key Info"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:125
+msgid "create a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:133
+msgid ""
+"file with public GPG key, if not                                 specified, "
+"standard input will be used"
+msgstr "含有公用 GPG 金鑰的檔案，若未指定的話，將會使用標準輸入"
+
+#: ../src/katello/client/core/gpg_key.py:150
+#, python-format
+msgid "Successfully created GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:151
+#, python-format
+msgid "Could not create GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:157
+msgid "update a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:167
+msgid "file with public GPG key"
+msgstr "含有公用 gpg 金鑰的檔案"
+
+#: ../src/katello/client/core/gpg_key.py:169
+msgid "prompt for new content of the key"
+msgstr "提示金鑰的新內容"
+
+#: ../src/katello/client/core/gpg_key.py:193
+#, python-format
+msgid "Successfully updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:194
+#, python-format
+msgid "Could not updated GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:200
+msgid "delete a GPG key"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:220
+#, python-format
+msgid "Successfully deleted GPG key [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/gpg_key.py:224
+msgid "GPG key specific actions in the katello server"
+msgstr "katello 伺服器中，與 GPG 金鑰相關的特定動作"
+
+#: ../src/katello/client/core/system_group.py:30
+msgid "system group specific actions in the katello server"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:44
+msgid "list system groups within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:48
+#: ../src/katello/client/core/system_group.py:142
+#: ../src/katello/client/core/system_group.py:174
+#: ../src/katello/client/core/system_group.py:213
+#: ../src/katello/client/core/system_group.py:322
+#: ../src/katello/client/core/system_group.py:415
+#: ../src/katello/client/core/system_group.py:493
+#: ../src/katello/client/core/system.py:51
+#: ../src/katello/client/core/system.py:94
+#: ../src/katello/client/core/system.py:149
+#: ../src/katello/client/core/system.py:246
+#: ../src/katello/client/core/system.py:316
+#: ../src/katello/client/core/system.py:352
+#: ../src/katello/client/core/system.py:685
+#: ../src/katello/client/core/repo.py:118
+#: ../src/katello/client/core/repo.py:153
+#: ../src/katello/client/core/sync_plan.py:56
+#: ../src/katello/client/core/organization.py:64
+#: ../src/katello/client/core/organization.py:91
+#: ../src/katello/client/core/organization.py:119
+#: ../src/katello/client/core/organization.py:148
+#: ../src/katello/client/core/organization.py:171
+#: ../src/katello/client/core/organization.py:203
+#: ../src/katello/client/core/product.py:57
+#: ../src/katello/client/core/product.py:117
+#: ../src/katello/client/core/product.py:302
+#: ../src/katello/client/core/environment.py:47
+#: ../src/katello/client/core/environment.py:74
+#: ../src/katello/client/core/environment.py:107
+#: ../src/katello/client/core/environment.py:144
+#: ../src/katello/client/core/environment.py:181
+msgid "organization name eg: foo.example.com (required)"
+msgstr "組織名稱，例如 foo.example.com（必填）"
+
+#: ../src/katello/client/core/system_group.py:60
+#, python-format
+msgid "System Groups List For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:69
+msgid "create a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:77
+#: ../src/katello/client/core/system_group.py:114
+msgid "maximum number of systems in this group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:79
+msgid "system group description"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:96
+#, python-format
+msgid "Successfully created system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:97
+#: ../src/katello/client/core/system_group.py:133
+#, python-format
+msgid "Could not create system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:102
+msgid "Copy a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:106
+msgid "original system group name.  source of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:108
+msgid "new system group name.  destination of the copy (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:112
+msgid "system group description for new group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:131
+#, python-format
+msgid "Successfully copied system group [ %s ] to [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:138
+msgid "display a system group within an organization"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:153
+#, python-format
+msgid "System Group Information For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:170
+msgid "display the list of jobs for the specified system group."
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:185
+#, python-format
+msgid "System Group History For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:209
+msgid "display job information including individual system tasks"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:217
+msgid "Job ID to list tasks for (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:227
+#, python-format
+msgid "System Group Job tasks For [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:234
+#, python-format
+msgid "Could not find job [ %s ] for system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:250
+msgid "update a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:258
+msgid "new system group name"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:260
+msgid "maximum number of systems in this group (enter -1 for unlimited)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:280
+#, python-format
+msgid "Successfully updated system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:288
+msgid "delete a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:296
+msgid "delete the systems along with the system group (optional)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:318
+msgid "display the systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:340
+#, python-format
+msgid "Systems within System Group [ %s ] For Org [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:350
+msgid "add systems to a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:358
+#: ../src/katello/client/core/system_group.py:389
+msgid "comma separated list of system uuids (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:373
+#, python-format
+msgid "Successfully added systems to system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:381
+msgid "remove systems from a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:404
+#, python-format
+msgid "Successfully removed systems from system group [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:411
+msgid "manipulate the installed packages for systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:419
+msgid ""
+"packages to be installed remotely on the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:421
+msgid ""
+"packages to be removed remotely from the systems, package names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:423
+msgid ""
+"packages to be updated on the systems, use --all to update all packages, "
+"package names are separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:425
+msgid ""
+"package groups to be installed remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:427
+msgid ""
+"package groups to be removed remotely from the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:429
+msgid ""
+"package groups to be updated remotely on the systems, group names are "
+"separated with comma"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:473
+#: ../src/katello/client/core/system_group.py:517
+#: ../src/katello/client/core/system.py:212
+#, python-format
+msgid "Performing remote action [ %s ]... "
+msgstr "正在執行遠端動作 [ %s ]..."
+
+#: ../src/katello/client/core/system_group.py:477
+#: ../src/katello/client/core/system_group.py:521
+#: ../src/katello/client/core/system.py:216
+msgid "Remote action finished:"
+msgstr "遠端動作已完成："
+
+#: ../src/katello/client/core/system_group.py:481
+#: ../src/katello/client/core/system_group.py:525
+#: ../src/katello/client/core/system.py:220
+msgid "Remote action failed:"
+msgstr "遠端動作失敗："
+
+#: ../src/katello/client/core/system_group.py:489
+msgid "install errata on systems in a system group"
+msgstr ""
+
+#: ../src/katello/client/core/system_group.py:497
+msgid ""
+"errata to be installed remotely on the systems, errata IDs separated with "
+"comma (required)"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:40
+msgid "list all known users"
+msgstr "列出所有已知使用者"
+
+#: ../src/katello/client/core/user.py:52
+msgid "User List"
+msgstr "使用者清單"
+
+#: ../src/katello/client/core/user.py:60
+msgid "create user"
+msgstr "建立使用者"
+
+#: ../src/katello/client/core/user.py:63
+#: ../src/katello/client/core/user.py:105
+#: ../src/katello/client/core/user.py:141
+#: ../src/katello/client/core/user.py:162
+#: ../src/katello/client/core/user.py:216
+#: ../src/katello/client/core/user.py:267
+msgid "user name (required)"
+msgstr "使用者名稱（必填）"
+
+#: ../src/katello/client/core/user.py:64
+msgid "initial password (required)"
+msgstr "初始密碼（必填）"
+
+#: ../src/katello/client/core/user.py:65
+msgid "email (required)"
+msgstr "電子郵件（必填）"
+
+#: ../src/katello/client/core/user.py:66
+msgid "disabled account (default is 'false')"
+msgstr "已停用的帳號（預設值為「false」）"
+
+#: ../src/katello/client/core/user.py:68
+#: ../src/katello/client/core/user.py:167
+msgid "user's default organization name"
+msgstr "使用者的預設組織名稱"
+
+#: ../src/katello/client/core/user.py:70
+#: ../src/katello/client/core/user.py:169
+msgid "user's default environment name"
+msgstr "使用者的預設環境名稱"
+
+#: ../src/katello/client/core/user.py:72
+#: ../src/katello/client/core/user.py:173
+msgid "user's default locale"
+msgstr ""
+
+#: ../src/katello/client/core/user.py:94
+#, python-format
+msgid "Successfully created user [ %s ]"
+msgstr "已成功建立使用者 [ %s ]"
+
+#: ../src/katello/client/core/user.py:95
+#, python-format
+msgid "Could not create user [ %s ]"
+msgstr "無法建立使用者 [ %s ]"
+
+#: ../src/katello/client/core/user.py:102
+msgid "list information about user"
+msgstr "列出使用者資訊"
+
+#: ../src/katello/client/core/user.py:123
+msgid "User Information"
+msgstr "使用者資訊"
+
+#: ../src/katello/client/core/user.py:138
+msgid "delete user"
+msgstr "刪除使用者"
+
+#: ../src/katello/client/core/user.py:152
+#, python-format
+msgid "Successfully deleted user [ %s ]"
+msgstr "已成功刪除使用者 [ %s ]"
+
+#: ../src/katello/client/core/user.py:159
+msgid "update an user"
+msgstr "更新使用者"
+
+#: ../src/katello/client/core/user.py:163
+msgid "initial password"
+msgstr "初始密碼"
+
+#: ../src/katello/client/core/user.py:164
+msgid "email"
+msgstr "電子郵件"
+
+#: ../src/katello/client/core/user.py:165
+msgid "disabled account"
+msgstr "已停用的帳號"
+
+#: ../src/katello/client/core/user.py:171
+msgid "user's default environment is None"
+msgstr "使用者的預設環境為 None"
+
+#: ../src/katello/client/core/user.py:206
+#, python-format
+msgid "Successfully updated user [ %s ]"
+msgstr "已成功更新使用者 [ %s ]"
+
+#: ../src/katello/client/core/user.py:213
+msgid "list user's roles"
+msgstr "列出使用者的角色"
+
+#: ../src/katello/client/core/user.py:239
+msgid "synchronise roles with LDAP groups"
+msgstr "與 LDAP 群組同步角色"
+
+#: ../src/katello/client/core/user.py:253
+msgid "assign role to a user"
+msgstr "指定使用者角色"
+
+#: ../src/katello/client/core/user.py:255
+msgid "unassign role to a user"
+msgstr "取消使用者角色的指定"
+
+#: ../src/katello/client/core/user.py:268
+msgid "user role (required)"
+msgstr "使用者角色（必填）"
+
+#: ../src/katello/client/core/user.py:281
+#, python-format
+msgid "Role [ %s ] not found"
+msgstr "找不到角色 [ %s ]"
+
+#: ../src/katello/client/core/user.py:297
+msgid "user report"
+msgstr "使用者報告"
+
+#: ../src/katello/client/core/user.py:300
+#: ../src/katello/client/core/system.py:689
+msgid ""
+"report format (possible values: 'html', 'text' (default), 'csv', 'pdf')"
+msgstr "報告格式（可用的值：html、text（預設值）、csv、pdf）"
+
+#: ../src/katello/client/core/user.py:318
+msgid "user specific actions in the katello server"
+msgstr "katello 伺服器中，與使用者相關的特定動作"
+
+#: ../src/katello/client/core/changeset.py:38
+msgid "list new changesets of an environment"
+msgstr "列出環境的新變更集"
+
+#: ../src/katello/client/core/changeset.py:44
+#: ../src/katello/client/core/changeset.py:77
+#: ../src/katello/client/core/changeset.py:142
+#: ../src/katello/client/core/changeset.py:326
+#: ../src/katello/client/core/changeset.py:409
+#: ../src/katello/client/core/changeset.py:436
+#: ../src/katello/client/core/environment.py:109
+#: ../src/katello/client/core/environment.py:148
+msgid "environment name (required)"
+msgstr "環境名稱（必填）"
+
+#: ../src/katello/client/core/changeset.py:66
+msgid "Changeset List"
+msgstr "變更集清單"
+
+#: ../src/katello/client/core/changeset.py:73
+msgid "detailed information about a changeset"
+msgstr "變更集的詳細資訊"
+
+#: ../src/katello/client/core/changeset.py:78
+#: ../src/katello/client/core/changeset.py:144
+#: ../src/katello/client/core/changeset.py:322
+#: ../src/katello/client/core/changeset.py:405
+#: ../src/katello/client/core/changeset.py:432
+msgid "changeset name (required)"
+msgstr "變更集名稱（必填）"
+
+#: ../src/katello/client/core/changeset.py:80
+msgid "will display dependent packages"
+msgstr "將顯示相依套件"
+
+#: ../src/katello/client/core/changeset.py:128
+msgid "Changeset Info"
+msgstr "變更集資訊"
+
+#: ../src/katello/client/core/changeset.py:136
+msgid "create a new changeset for an environment"
+msgstr "建立環境的變更集"
+
+#: ../src/katello/client/core/changeset.py:146
+#: ../src/katello/client/core/changeset.py:328
+msgid "changeset description"
+msgstr "變更集描述"
+
+#: ../src/katello/client/core/changeset.py:148
+msgid ""
+"changeset type promotion: pushes changes to the next environment [DEFAULT]"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:150
+msgid ""
+"changeset type deletion: deletes items in changeset from current environment"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:166
+msgid "specify either --promotion or --deletion but not both"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:175
+#, python-format
+msgid "Successfully created changeset [ %s ] for environment [ %s ]"
+msgstr "已成功建立變更集 [ %s ] 位於環境 [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:176
+#, python-format
+msgid "Could not create changeset [ %s ] for environment [ %s ]"
+msgstr "無法建立變更集 [ %s ] 位於環境 [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:300
+msgid "updates content of a changeset"
+msgstr "更新變更集的內容"
+
+#: ../src/katello/client/core/changeset.py:313
+#: ../src/katello/client/core/template.py:302
+#, python-format
+msgid "%s must be preceded by %s"
+msgstr "%s 的前面必須是 %s"
+
+#: ../src/katello/client/core/changeset.py:330
+msgid "new changeset name"
+msgstr "新變更集名稱"
+
+#: ../src/katello/client/core/changeset.py:333
+msgid "product to add to the changeset"
+msgstr "要加入變更集的產品"
+
+#: ../src/katello/client/core/changeset.py:336
+msgid "product to remove from the changeset"
+msgstr "要從變更集移除的產品"
+
+#: ../src/katello/client/core/changeset.py:339
+msgid "name of a template to be added to the changeset"
+msgstr "要加入變更集的範本名稱"
+
+#: ../src/katello/client/core/changeset.py:342
+msgid "name of a template to be removed from the changeset"
+msgstr "要從變更集移除的範本名稱"
+
+#: ../src/katello/client/core/changeset.py:345
+msgid ""
+"determines product from which the packages/errata/repositories are picked"
+msgstr "從選取的套件 / 勘誤 / 軟體庫決定產品"
+
+#: ../src/katello/client/core/changeset.py:350
+msgid " to add to the changeset"
+msgstr "要新增至變更集"
+
+#: ../src/katello/client/core/changeset.py:353
+msgid " to remove from the changeset"
+msgstr "要從變更集移除"
+
+#: ../src/katello/client/core/changeset.py:385
+#, python-format
+msgid "Successfully updated changeset [ %s ]"
+msgstr "已成功更新變更集 [ %s ]"
+
+#: ../src/katello/client/core/changeset.py:401
+msgid "deletes a changeset"
+msgstr "刪除變更集"
+
+#: ../src/katello/client/core/changeset.py:428
+msgid "applies a changeset based on the type (promotion, deletion)"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:451
+msgid "Applying the changeset, please wait... "
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:454
+#, python-format
+msgid "Changeset [ %s ] applied"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:457
+#, python-format
+msgid "Changeset [ %s ] promotion failed: %s"
+msgstr "發送變更集 [ %s ] 失敗：%s"
+
+#: ../src/katello/client/core/changeset.py:462
+msgid "promotes a changeset to the next environment - DEPRECATED"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:472
+msgid "This is a deletion changeset and does not support promotion"
+msgstr ""
+
+#: ../src/katello/client/core/changeset.py:481
+msgid "changeset specific actions in the katello server"
+msgstr "katello 伺服器中，與變更集相關的特定動作"
+
+#: ../src/katello/client/core/system.py:47
+msgid "list systems within an organization"
+msgstr "列出組織中的系統"
+
+#: ../src/katello/client/core/system.py:53
+#: ../src/katello/client/core/system.py:320
+#: ../src/katello/client/core/system.py:391
+#: ../src/katello/client/core/system.py:451
+#: ../src/katello/client/core/system.py:687
+msgid "environment name eg: development"
+msgstr "環境名稱，例如：development（開發部）"
+
+#: ../src/katello/client/core/system.py:55
+msgid "pool id to filter systems by subscriptions"
+msgstr "透過集區 id 來以訂閱篩選系統"
+
+#: ../src/katello/client/core/system.py:76
+#, python-format
+msgid "Systems List For Org [ %s ]"
+msgstr "組織的系統清單 [ %s ]"
+
+#: ../src/katello/client/core/system.py:78
+#, python-format
+msgid "Systems List For Environment [ %s ] in Org [ %s ]"
+msgstr "環境 [ %s ] 的系統清單，位於組織 [ %s ]"
+
+#: ../src/katello/client/core/system.py:83
+#: ../src/katello/client/core/system.py:134
+msgid "Service Level"
+msgstr "服務等級"
+
+#: ../src/katello/client/core/system.py:90
+msgid "display a system within an organization"
+msgstr "顯示組織中的某台系統"
+
+#: ../src/katello/client/core/system.py:96
+#: ../src/katello/client/core/system.py:151
+#: ../src/katello/client/core/system.py:354
+#: ../src/katello/client/core/system.py:389
+#: ../src/katello/client/core/system.py:449
+#: ../src/katello/client/core/system.py:481
+#: ../src/katello/client/core/system.py:508
+#: ../src/katello/client/core/system.py:587
+#: ../src/katello/client/core/system.py:626
+#: ../src/katello/client/core/system.py:719
+#: ../src/katello/client/core/system.py:762
+#: ../src/katello/client/core/errata.py:105
+msgid "system name (required)"
+msgstr "系統名稱（必填）"
+
+#: ../src/katello/client/core/system.py:98
+#: ../src/katello/client/core/system.py:153
+#: ../src/katello/client/core/system.py:250
+#: ../src/katello/client/core/system.py:356
+#: ../src/katello/client/core/system.py:628
+msgid "environment name"
+msgstr "環境名稱"
+
+#: ../src/katello/client/core/system.py:109
+#, python-format
+msgid "System Information For Org [ %s ]"
+msgstr "組織 [ %s ] 的系統資訊"
+
+#: ../src/katello/client/core/system.py:111
+#, python-format
+msgid "System Information For Environment [ %s ] in Org [ %s ]"
+msgstr "環境 [ %s ] 的系統資訊，位於組織 [ %s ]"
+
+#: ../src/katello/client/core/system.py:145
+msgid "display and manipulate with the installed packages of a system"
+msgstr "顯示並操作系統的已安裝套件"
+
+#: ../src/katello/client/core/system.py:155
+msgid ""
+"packages to be installed remotely on the system, package names are separated"
+" with comma"
+msgstr "將遠端安裝在系統上的套件，套件名稱將以逗號區隔開"
+
+#: ../src/katello/client/core/system.py:157
+msgid ""
+"packages to be removed remotely from the system, package names are separated"
+" with comma"
+msgstr "將由系統上遠端移除的套件，套件名稱將以逗號區隔開"
+
+#: ../src/katello/client/core/system.py:159
+msgid ""
+"packages to be updated on the system, use --all to update all packages, "
+"package names are separated with comma"
+msgstr "系統上即將更新的套件，請使用 --all 以更新所有套件，套件名稱將以逗號區隔開"
+
+#: ../src/katello/client/core/system.py:161
+msgid ""
+"package groups to be installed remotely on the system, group names are "
+"separated with comma"
+msgstr "將遠端安裝在系統上的套件群組，群組名稱將以逗號區隔開"
+
+#: ../src/katello/client/core/system.py:163
+msgid ""
+"package groups to be removed remotely from the system, group names are "
+"separated with comma"
+msgstr "即將由系統上遠端移除的套件群組，群組名稱將以逗號區隔開"
+
+#: ../src/katello/client/core/system.py:170
+msgid "You can specify at most one install/remove/update action per call"
+msgstr "您一次調用最多僅能指定一項安裝/移除/更新動作"
+
+#: ../src/katello/client/core/system.py:188
+#, python-format
+msgid "Package Information for System [ %s ] in Org [ %s ]"
+msgstr "系統 [ %s ] 的套件資訊，位於組織 [ %s ]"
+
+#: ../src/katello/client/core/system.py:190
+#, python-format
+msgid ""
+"Package Information for System [ %s ] in Environment [ %s ] in Org [ %s ]"
+msgstr "系統 [ %s ] 的套件資訊，位於環境 [ %s ]，於組織 [ %s ]"
+
+#: ../src/katello/client/core/system.py:242
+msgid "display status of remote tasks"
+msgstr "顯示遠端工作的狀態"
+
+#: ../src/katello/client/core/system.py:248
+msgid "system name"
+msgstr "系統名稱"
+
+#: ../src/katello/client/core/system.py:260
+msgid "Remote tasks"
+msgstr "遠端工作"
+
+#: ../src/katello/client/core/system.py:268
+msgid "Task id"
+msgstr "工作 id"
+
+#: ../src/katello/client/core/system.py:269
+#: ../src/katello/client/core/system.py:299
+msgid "System"
+msgstr "系統"
+
+#: ../src/katello/client/core/system.py:270
+#: ../src/katello/client/core/system.py:300
+msgid "Action"
+msgstr "動作"
+
+#: ../src/katello/client/core/system.py:271
+#: ../src/katello/client/core/system.py:301
+msgid "Started"
+msgstr "已開始"
+
+#: ../src/katello/client/core/system.py:272
+#: ../src/katello/client/core/system.py:302
+#: ../src/katello/client/core/repo.py:37
+msgid "Finished"
+msgstr "已完成"
+
+#: ../src/katello/client/core/system.py:273
+#: ../src/katello/client/core/system.py:303
+msgid "Status"
+msgstr "狀態"
+
+#: ../src/katello/client/core/system.py:274
+#: ../src/katello/client/core/system.py:304
+msgid "Result"
+msgstr "結果"
+
+#: ../src/katello/client/core/system.py:282
+msgid "display status of remote task"
+msgstr "顯示遠端工作的狀態"
+
+#: ../src/katello/client/core/system.py:286
+msgid "UUID of the task"
+msgstr "工作的 UUID"
+
+#: ../src/katello/client/core/system.py:294
+msgid "Remote task"
+msgstr "遠端工作"
+
+#: ../src/katello/client/core/system.py:312
+msgid "list releases available for the system"
+msgstr "列出系統可使用的發行版"
+
+#: ../src/katello/client/core/system.py:318
+msgid "system name (if not specified, list all releases in the environment)"
+msgstr "系統名稱（若未指定，將列出環境中的所有發行版）"
+
+#: ../src/katello/client/core/system.py:340
+msgid "Available releases"
+msgstr "可用發行版"
+
+#: ../src/katello/client/core/system.py:348
+msgid "display a the hardware facts of a system"
+msgstr "顯示系統的硬體資訊"
+
+#: ../src/katello/client/core/system.py:367
+#, python-format
+msgid "System Facts For System [ %s ] in Org [ %s ]"
+msgstr "系統 [ %s ] 的系統資訊，位於組織 [ %s ]"
+
+#: ../src/katello/client/core/system.py:369
+#, python-format
+msgid "System Facts For System [ %s ] in Environment [ %s]  in Org [ %s ]"
+msgstr "系統 [ %s ] 的系統資訊，位於環境 [ %s]，於組織 [ %s ]"
+
+#: ../src/katello/client/core/system.py:386
+msgid "register a system"
+msgstr "註冊系統"
+
+#: ../src/katello/client/core/system.py:392
+#: ../src/katello/client/core/system.py:641
+msgid "service level agreement"
+msgstr "服務等級協議"
+
+#: ../src/katello/client/core/system.py:394
+msgid ""
+"activation key, more keys are separated with comma e.g. "
+"--activationkey=key1,key2"
+msgstr "啟動金鑰，超過一組金鑰可以逗號隔開，例如「--activationkey=key1,key2」"
+
+#: ../src/katello/client/core/system.py:395
+msgid "values of $releasever for the system"
+msgstr "系統的 $releasever 值"
+
+#: ../src/katello/client/core/system.py:397
+msgid "system facts"
+msgstr "系統詳情"
+
+#: ../src/katello/client/core/system.py:419
+#, python-format
+msgid "Successfully registered system [ %s ]"
+msgstr "已成功註冊系統 [ %s ]"
+
+#: ../src/katello/client/core/system.py:420
+#, python-format
+msgid "Could not register system [ %s ]"
+msgstr "無法註冊系統 [ %s ]"
+
+#: ../src/katello/client/core/system.py:425
+msgid "remove a deletion record for hypervisor"
+msgstr "移除 hypervisor 的刪除紀錄"
+
+#: ../src/katello/client/core/system.py:429
+msgid "hypervisor uuid (required"
+msgstr "hypervisor uuid（必提供）"
+
+#: ../src/katello/client/core/system.py:437
+#, python-format
+msgid "Successfully removed deletion record for hypervisor with uuid [ %s ]"
+msgstr "已成功移除 uuid 為 [%s] 的 hypervisor 的刪除紀錄"
+
+#: ../src/katello/client/core/system.py:443
+msgid "unregister a system"
+msgstr "取消註冊系統"
+
+#: ../src/katello/client/core/system.py:470
+#, python-format
+msgid "Successfully unregistered System [ %s ]"
+msgstr "已成功取消註冊系統 [ %s ]"
+
+#: ../src/katello/client/core/system.py:475
+msgid "subscribe a system to certificate"
+msgstr "透過認證訂閱系統"
+
+#: ../src/katello/client/core/system.py:483
+msgid "certificate serial to unsubscribe (required)"
+msgstr "要取消訂閱的認證序號（必填）"
+
+#: ../src/katello/client/core/system.py:485
+msgid "quantity (default: 1)"
+msgstr "數量（預設值：1）"
+
+#: ../src/katello/client/core/system.py:499
+#, python-format
+msgid "Successfully subscribed System [ %s ]"
+msgstr "已成功取消訂閱系統 [ %s ]"
+
+#: ../src/katello/client/core/system.py:504
+msgid "list subscriptions for a system"
+msgstr "列出一台系統的訂閱服務"
+
+#: ../src/katello/client/core/system.py:511
+msgid "show available subscriptions"
+msgstr "顯示可用訂閱"
+
+#: ../src/katello/client/core/system.py:528
+#, python-format
+msgid "No Subscriptions found for System [ %s ] in Org [ %s ]"
+msgstr "找不到系統 [ %s ] 的訂閱（於組織 [ %s ] 中）"
+
+#: ../src/katello/client/core/system.py:540
+#, python-format
+msgid "Current Subscriptions for System [ %s ]"
+msgstr "系統 [ %s ] 目前的訂閱"
+
+#: ../src/katello/client/core/system.py:542
+msgid "Serial Id"
+msgstr "序列 ID"
+
+#: ../src/katello/client/core/system.py:549
+#: ../src/katello/client/core/system.py:574
+msgid "Provided products"
+msgstr "提供的產品"
+
+#: ../src/katello/client/core/system.py:556
+#, python-format
+msgid "No Pools found for System [ %s ] in Org [ %s ]"
+msgstr "找不到系統 [ %s ] 的集池（於組織 [ %s ] 中）"
+
+#: ../src/katello/client/core/system.py:566
+#, python-format
+msgid "Available Subscriptions for System [ %s ]"
+msgstr "系統 [ %s ] 的可用訂閱"
+
+#: ../src/katello/client/core/system.py:581
+msgid "unsubscribe a system from certificate"
+msgstr "從認證取消訂閱系統"
+
+#: ../src/katello/client/core/system.py:589
+msgid ""
+"entitlement id to unsubscribe from (either entitlement or serial or all is "
+"required)"
+msgstr "欲取消訂閱之權利 ID（必須提供權利或序列或兩者）"
+
+#: ../src/katello/client/core/system.py:591
+msgid ""
+"serial id of a certificate to unsubscribe from (either entitlement or serial"
+" or all is required)"
+msgstr "欲取消訂閱之憑證的序列 ID（必須提供權利或序列或兩者）"
+
+#: ../src/katello/client/core/system.py:593
+msgid ""
+"unsubscribe from all currently subscribed certificates (either entitlement "
+"or serial or all is required)"
+msgstr "欲取目前訂閱的所有認證（必須提供權利或序列或兩者）"
+
+#: ../src/katello/client/core/system.py:614
+#, python-format
+msgid "Successfully unsubscribed System [ %s ]"
+msgstr "已成功取消訂閱系統 [ %s ]"
+
+#: ../src/katello/client/core/system.py:620
+msgid "update a system"
+msgstr "更新系統"
+
+#: ../src/katello/client/core/system.py:631
+msgid "a new name for the system"
+msgstr "系統的新名稱"
+
+#: ../src/katello/client/core/system.py:633
+msgid "a new environment name for the system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:635
+msgid "a description of the system"
+msgstr "系統描述"
+
+#: ../src/katello/client/core/system.py:637
+msgid "location of the system"
+msgstr "系統位置"
+
+#: ../src/katello/client/core/system.py:639
+msgid "value of $releasever for the system"
+msgstr "系統的 $releasever 值"
+
+#: ../src/katello/client/core/system.py:674
+#, python-format
+msgid "Successfully updated system [ %s ]"
+msgstr "已成功更新系統 [ %s ]"
+
+#: ../src/katello/client/core/system.py:675
+#, python-format
+msgid "Could not update system [ %s ]"
+msgstr "無法更新系統 [ %s ]"
+
+#: ../src/katello/client/core/system.py:681
+msgid "systems report"
+msgstr "系統報告"
+
+#: ../src/katello/client/core/system.py:715
+msgid "add system groups to a system"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:723
+#: ../src/katello/client/core/system.py:766
+msgid "comma separated list of system group names (required)"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:750
+#, python-format
+msgid "Successfully added system groups to system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:793
+#, python-format
+msgid "Successfully removed system groups from system [ %s ]"
+msgstr ""
+
+#: ../src/katello/client/core/system.py:802
+msgid "system specific actions in the katello server"
+msgstr "katello 伺服器中，與系統相關的特定動作"
+
+#: ../src/katello/client/core/package.py:38
+msgid "list information about a package"
+msgstr "列出套件資訊"
+
+#: ../src/katello/client/core/package.py:43
+msgid "package id, string value (required)"
+msgstr "套件 ID，字串值（必填）"
+
+#: ../src/katello/client/core/package.py:87
+msgid "Package Information"
+msgstr "套件資訊"
+
+#: ../src/katello/client/core/package.py:94
+msgid "list packages in a repository"
+msgstr "列出軟體庫的套件"
+
+#: ../src/katello/client/core/package.py:117
+#, python-format
+msgid "Package List For Repo %s"
+msgstr "軟體庫 %s 的套件清單"
+
+#: ../src/katello/client/core/package.py:148
+msgid "search packages in a repository"
+msgstr "在軟體庫中搜尋套件"
+
+#: ../src/katello/client/core/package.py:153
+msgid ""
+"query string for searching packages, e.g. "
+"'kernel*','kernel-3.3.0-4.el6.x86_64'"
+msgstr "查詢字串以搜尋套件，例如「kernel*」、「kernel-3.3.0-4.el6.x86_64」"
+
+#: ../src/katello/client/core/package.py:164
+#, python-format
+msgid "Package List For Repo %s and Query %s"
+msgstr "Repo %s 和 Query %s 的套件清單"
+
+#: ../src/katello/client/core/package.py:175
+msgid "package specific actions in the katello server"
+msgstr "katello 伺服器中，與套件相關的特定動作"
+
+#: ../src/katello/client/core/admin.py:38
+msgid "re-generate certificate revocation lists"
+msgstr ""
+
+#: ../src/katello/client/core/admin.py:49
+msgid "various administrative actions"
+msgstr ""
+
+#: ../src/katello/client/core/shell_command.py:28
+msgid "run the cli as a shell"
+msgstr "以 shell 方式執行命令列指令"
+
+#: ../src/katello/client/core/provider.py:44
+#: ../src/katello/client/core/provider.py:127
+#: ../src/katello/client/core/product.py:304
+msgid "provider name (required)"
+msgstr "供應方名稱（必須）"
+
+#: ../src/katello/client/core/provider.py:57
+msgid "list all known providers"
+msgstr "列出所有已知供應方"
+
+#: ../src/katello/client/core/provider.py:79
+msgid "Provider List"
+msgstr "供應方清單"
+
+#: ../src/katello/client/core/provider.py:87
+msgid "list information about a provider"
+msgstr "列出關於供應方的資訊"
+
+#: ../src/katello/client/core/provider.py:102
+msgid "Provider Information"
+msgstr "供應方資訊"
+
+#: ../src/katello/client/core/provider.py:114
+msgid "create a provider"
+msgstr "建立供應方"
+
+#: ../src/katello/client/core/provider.py:116
+msgid "update a provider"
+msgstr "更新供應方"
+
+#: ../src/katello/client/core/provider.py:129
+#: ../src/katello/client/core/template.py:156
+msgid "provider description"
+msgstr "供應方的描述"
+
+#: ../src/katello/client/core/provider.py:131
+#: ../src/katello/client/core/product.py:310
+msgid ""
+"repository url eg: "
+"http://download.fedoraproject.org/pub/fedora/linux/releases/"
+msgstr ""
+"軟體庫 URL，例如「http://download.fedoraproject.org/pub/fedora/linux/releases/」"
+
+#: ../src/katello/client/core/provider.py:137
+msgid "provider name"
+msgstr "供應方名稱"
+
+#: ../src/katello/client/core/provider.py:147
+#, python-format
+msgid "Successfully created provider [ %s ]"
+msgstr "已成功建立供應方 [ %s ]"
+
+#: ../src/katello/client/core/provider.py:148
+#, python-format
+msgid "Could not create provider [ %s ]"
+msgstr "無法建立供應方 [ %s ]"
+
+#: ../src/katello/client/core/provider.py:155
+#, python-format
+msgid "Successfully updated provider [ %s ]"
+msgstr "已成功更新供應方 [ %s ]"
+
+#: ../src/katello/client/core/provider.py:173
+msgid "delete a provider"
+msgstr "刪除供應方"
+
+#: ../src/katello/client/core/provider.py:189
+msgid "synchronize a provider"
+msgstr "同步供應方"
+
+#: ../src/katello/client/core/provider.py:204
+#, python-format
+msgid "Provider [ %s ] failed to sync: %s"
+msgstr "同步供應方 [ %s ] 失敗：%s"
+
+#: ../src/katello/client/core/provider.py:207
+#, python-format
+msgid "Provider [ %s ] synchronization cancelled"
+msgstr "供應方 [ %s ] 的同步程序已取消"
+
+#: ../src/katello/client/core/provider.py:210
+#, python-format
+msgid "Provider [ %s ] synchronized"
+msgstr "已同步供應方 [ %s ]"
+
+#: ../src/katello/client/core/provider.py:216
+#: ../src/katello/client/core/product.py:198
+msgid "cancel currently running synchronization"
+msgstr "取消目前執行中的同步作業"
+
+#: ../src/katello/client/core/provider.py:233
+msgid "status of provider's synchronization"
+msgstr "供應方的同步狀態"
+
+#: ../src/katello/client/core/provider.py:246
+#, python-format
+msgid "%d%% done (%d of %d packages downloaded)"
+msgstr "%d%% 已完成（已下載了 %d 個套件，總共有 %d 個套件）"
+
+#: ../src/katello/client/core/provider.py:257
+msgid "Provider Status"
+msgstr "供應方狀態"
+
+#: ../src/katello/client/core/provider.py:265
+msgid "import a manifest file"
+msgstr "匯入清單檔案"
+
+#: ../src/katello/client/core/provider.py:271
+msgid "path to the manifest file (required)"
+msgstr "清單檔案的路徑（必填）"
+
+#: ../src/katello/client/core/provider.py:273
+msgid "force reimporting the manifest"
+msgstr "強制重新匯入清單"
+
+#: ../src/katello/client/core/provider.py:290
+#: ../src/katello/client/core/template.py:173
+#, python-format
+msgid "File %s does not exist"
+msgstr "檔案 %s 不存在"
+
+#: ../src/katello/client/core/provider.py:295
+msgid "Importing manifest, please wait... "
+msgstr "匯入清單檔案中，請稍候……"
+
+#: ../src/katello/client/core/provider.py:308
+msgid "refresh provider's products repositories"
+msgstr "更新供應方的產品軟體庫"
+
+#: ../src/katello/client/core/provider.py:317
+#, python-format
+msgid "Provider successfully refreshed [ %s ]"
+msgstr "供應方已成功更新 [%s]"
+
+#: ../src/katello/client/core/provider.py:324
+msgid "provider specific actions in the katello server"
+msgstr "katello 伺服器中，與供應方相關的特定動作"
+
+#: ../src/katello/client/core/ping.py:37
+msgid "get the status of the katello server"
+msgstr "取得 katello 伺服器的狀態"
+
+#: ../src/katello/client/core/ping.py:50
+msgid "Katello Status"
+msgstr "Katello 的狀態"
+
+#: ../src/katello/client/core/permission.py:53
+msgid "create a permission for a user role"
+msgstr "為使用者角色建立權限"
+
+#: ../src/katello/client/core/permission.py:57
+#: ../src/katello/client/core/permission.py:112
+msgid "permission name (required)"
+msgstr "權限名稱（必填）"
+
+#: ../src/katello/client/core/permission.py:58
+msgid "permission description"
+msgstr "權限描述"
+
+#: ../src/katello/client/core/permission.py:59
+msgid "organization name"
+msgstr "組織名稱"
+
+#: ../src/katello/client/core/permission.py:60
+msgid "scope of the permisson (required)"
+msgstr "權限規格（必填）"
+
+#: ../src/katello/client/core/permission.py:61
+msgid "verbs for the permission"
+msgstr "權限動詞"
+
+#: ../src/katello/client/core/permission.py:62
+msgid "tags for the permission"
+msgstr "權限標籤"
+
+#: ../src/katello/client/core/permission.py:76
+#, python-format
+msgid "Invalid scope [ %s ]"
+msgstr "無效的規格 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:83
+#, python-format
+msgid "Could not find tag [ %s ] in scope of [ %s ]"
+msgstr "找不到標籤 [ %s ] 於規格 [ %s ] 中"
+
+#: ../src/katello/client/core/permission.py:101
+#, python-format
+msgid "Successfully created permission [ %s ] for user role [ %s ]"
+msgstr "已成功建立權限 [ %s ]，使用者角色為 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:102
+#, python-format
+msgid "Could not create permission [ %s ]"
+msgstr "無法建立權限 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:108
+msgid "delete a permission"
+msgstr "刪除權限"
+
+#: ../src/katello/client/core/permission.py:125
+#, python-format
+msgid "Successfully deleted permission [ %s ] for role [ %s ]"
+msgstr "已成功刪除權限 [ %s ]，角色為 [ %s ]"
+
+#: ../src/katello/client/core/permission.py:131
+msgid "list permissions for a user role"
+msgstr "列出使用者角色的權限"
+
+#: ../src/katello/client/core/permission.py:158
+msgid "Permission List"
+msgstr "權限清單"
+
+#: ../src/katello/client/core/permission.py:165
+msgid "list available scopes, verbs and tags that can be set in a permission"
+msgstr "列出可設置在權限中的可用規格、動詞與標籤"
+
+#: ../src/katello/client/core/permission.py:169
+msgid ""
+"organization name eg: foo.example.com,\n"
+"lists organization specific verbs"
+msgstr ""
+"組織名稱，例如 foo.example.com，\n"
+"列出組織相關的動詞"
+
+#: ../src/katello/client/core/permission.py:170
+msgid "filter listed results by scope"
+msgstr "以規格篩選列出的結果"
+
+#: ../src/katello/client/core/permission.py:188
+#, python-format
+msgid "Available verbs and tags for permission scope %s"
+msgstr "權限規格 %s 的可用動詞與標籤"
+
+#: ../src/katello/client/core/permission.py:190
+msgid "Available verbs"
+msgstr "可用動詞"
+
+#: ../src/katello/client/core/permission.py:209
+msgid "None"
+msgstr "無"
+
+#: ../src/katello/client/core/permission.py:247
+msgid "permission pecific actions in the katello server"
+msgstr "katello 伺服器中，與權限相關的特定動作"
+
+#: ../src/katello/client/core/base.py:129
+msgid "no description available"
+msgstr "找不到描述"
+
+#: ../src/katello/client/core/base.py:202
+msgid "operation failed"
+msgstr ""
+
+#: ../src/katello/client/core/base.py:275
+msgid "no action given: please see --help"
+msgstr "未給予動作：請參閱「--help」"
+
+#: ../src/katello/client/core/base.py:280
+msgid "invalid action: please see --help"
+msgstr "動作不合乎規定：請參閱「--help」"
+
+#: ../src/katello/client/core/base.py:317
+msgid "grep friendly output"
+msgstr "適用於「grep」指令的輸出"
+
+#: ../src/katello/client/core/base.py:320
+msgid "verbose, more structured output"
+msgstr "verbose，更結構化的輸出"
+
+#: ../src/katello/client/core/base.py:323
+msgid "column delimiter in grep friendly output, works only with option -g"
+msgstr "適合 grep 輸出的欄位分隔符號，僅能與選項 -g 搭配使用"
+
+#: ../src/katello/client/core/base.py:326
+msgid "Suppress any heading output. Useful if grepping the output."
+msgstr ""
+
+#: ../src/katello/client/core/base.py:372
+msgid ""
+"ERROR: The server hostname you have configured in /etc/katello/client.conf "
+"does not match the"
+msgstr "錯誤：/etc/katello/client.conf 檔案中配置的伺服器主機名稱並不符合"
+
+#: ../src/katello/client/core/base.py:373
+msgid "hostname returned from the katello server you are connecting to.  "
+msgstr "從您想連接的 ketello 伺服器之主機名稱。"
+
+#: ../src/katello/client/core/base.py:375
+#, python-format
+msgid "You have: [%s] configured but got: [%s] from the server."
+msgstr "您有：[%s] 已配置，但從伺服器上取得：[%s]"
+
+#: ../src/katello/client/core/base.py:377
+msgid "Please correct the host in the /etc/katello/client.conf file"
+msgstr "請修正 /etc/katello/client.conf 檔案中的主機"
+
+#: ../src/katello/client/core/base.py:389
+msgid "Invalid credentials or unable to authenticate"
+msgstr "不正確的身份認證，或無法通過認證"
+
+#: ../src/katello/client/core/base.py:435
+#, python-format
+msgid "option %s: invalid boolean value: %r"
+msgstr "選項 %s：不正確的布林值：%r"
+
+#: ../src/katello/client/core/base.py:456
+#, python-format
+msgid "option %s: has to start with %s"
+msgstr ""
+
+#. pylint: disable=E1101
+#: ../src/katello/client/core/base.py:458
+#, python-format
+msgid "option %s: invalid format"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:42
+msgid "list all errata for a repo"
+msgstr "列出軟體庫的所有勘誤"
+
+#: ../src/katello/client/core/errata.py:58
+msgid "filter errata by type eg: enhancements"
+msgstr "以類型篩選勘誤，例如 enhancements"
+
+#: ../src/katello/client/core/errata.py:60
+msgid "filter errata by severity"
+msgstr "以嚴重性篩選勘誤"
+
+#: ../src/katello/client/core/errata.py:94
+msgid "Errata List"
+msgstr "勘誤清單"
+
+#: ../src/katello/client/core/errata.py:99
+msgid "list errata for a system"
+msgstr "列出系統的勘誤"
+
+#: ../src/katello/client/core/errata.py:124
+#, python-format
+msgid "Errata for system %s in organization %s"
+msgstr "系統 %s 的勘誤，位於組織 %s 中"
+
+#: ../src/katello/client/core/errata.py:130
+msgid "list errata for a system group"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:135
+msgid "filter errata by type eg: bug, enhancement or security"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:155
+msgid "# Systems"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:158
+#, python-format
+msgid "Errata for system group %s in organization %s"
+msgstr ""
+
+#: ../src/katello/client/core/errata.py:166
+msgid "information about an errata"
+msgstr "勘誤的資訊"
+
+#: ../src/katello/client/core/errata.py:170
+msgid "errata id, string value (required)"
+msgstr "勘誤 ID，字串值（必填）"
+
+#: ../src/katello/client/core/errata.py:217
+msgid "Errata Information"
+msgstr "勘誤資訊"
+
+#: ../src/katello/client/core/errata.py:226
+msgid "errata specific actions in the katello server"
+msgstr "katello 伺服器中，與勘誤相關的特定動作"
+
+#: ../src/katello/client/core/version.py:38
+msgid "get the version of the katello server"
+msgstr "取得 katello 伺服器的版本"
+
+#: ../src/katello/client/core/version.py:54
+msgid "Check the version of the server"
+msgstr "檢查伺服器的版本"
+
+#: ../src/katello/client/core/packagegroup.py:17
+msgid "list available package groups"
+msgstr "列出可用的套件群組"
+
+#: ../src/katello/client/core/packagegroup.py:21
+#: ../src/katello/client/core/packagegroup.py:50
+#: ../src/katello/client/core/packagegroup.py:85
+#: ../src/katello/client/core/packagegroup.py:113
+msgid "repository id, string value (required)"
+msgstr "軟體庫 ID，字串值（必填）"
+
+#: ../src/katello/client/core/packagegroup.py:31
+#, python-format
+msgid "No package groups found in repo [%s]"
+msgstr "軟體庫 [%s] 裡找不到套件群組"
+
+#: ../src/katello/client/core/packagegroup.py:32
+#: ../src/katello/client/core/packagegroup.py:67
+msgid "Package Group Information"
+msgstr "套件群組資訊"
+
+#: ../src/katello/client/core/packagegroup.py:46
+#: ../src/katello/client/core/packagegroup.py:109
+msgid "lookup information for a package group"
+msgstr "套件群組的查詢資訊"
+
+#: ../src/katello/client/core/packagegroup.py:52
+msgid "package group id, string value (required)"
+msgstr "套件群組 ID，字串值（必填）"
+
+#: ../src/katello/client/core/packagegroup.py:63
+#, python-format
+msgid "Package group [%s] not found in repo [%s]"
+msgstr "套件群組 [%s] 不存在於軟體庫 [%s] 中"
+
+#: ../src/katello/client/core/packagegroup.py:81
+msgid "list available package groups categories"
+msgstr "列出可用的套件群組類別"
+
+#: ../src/katello/client/core/packagegroup.py:95
+#, python-format
+msgid "No package group categories found in repo [%s]"
+msgstr "軟體庫 [%s] 裡找不到套件群組類別"
+
+#: ../src/katello/client/core/packagegroup.py:96
+msgid "Package Group Cateogory Information"
+msgstr "套件群組類別的資訊"
+
+#: ../src/katello/client/core/packagegroup.py:115
+msgid "package group category id, string value (required)"
+msgstr "套件群組類別 ID，字串值（必填）"
+
+#: ../src/katello/client/core/packagegroup.py:126
+#, python-format
+msgid "Package group category [%s] not found in repo [%s]"
+msgstr "套件群組類別 [%s] 在軟體庫 [%s] 中找不到。"
+
+#: ../src/katello/client/core/packagegroup.py:128
+msgid "Package Group Category Information"
+msgstr "套件群組類別的資訊"
+
+#: ../src/katello/client/core/packagegroup.py:138
+msgid "package group specific actions in the katello server"
+msgstr "katello 伺服器中，與套件群組相關的特定動作"
+
+#: ../src/katello/client/core/repo.py:34
+msgid "Waiting"
+msgstr "等待中"
+
+#: ../src/katello/client/core/repo.py:35
+msgid "Running"
+msgstr "執行中"
+
+#: ../src/katello/client/core/repo.py:36
+msgid "Error"
+msgstr "錯誤"
+
+#: ../src/katello/client/core/repo.py:38
+msgid "Cancelled"
+msgstr "已取消"
+
+#: ../src/katello/client/core/repo.py:39
+msgid "Canceled"
+msgstr "已取消"
+
+#: ../src/katello/client/core/repo.py:40
+msgid "Timed out"
+msgstr "逾時"
+
+#: ../src/katello/client/core/repo.py:41
+msgid "Not synced"
+msgstr "未同步"
+
+#: ../src/katello/client/core/repo.py:114
+msgid "create a repository at a specified URL"
+msgstr "在特定 URL 上建立軟體庫"
+
+#: ../src/katello/client/core/repo.py:120
+msgid "repository name to assign (required)"
+msgstr "要指定的軟體庫名稱（必填）"
+
+#: ../src/katello/client/core/repo.py:122
+msgid "url path to the repository (required)"
+msgstr "軟體庫的 URL 路徑（必填）"
+
+#: ../src/katello/client/core/repo.py:124
+#: ../src/katello/client/core/repo.py:161
+#: ../src/katello/client/core/product.py:58
+#: ../src/katello/client/core/product.py:306
+msgid "product name (required)"
+msgstr "產品名稱（必填）"
+
+#: ../src/katello/client/core/repo.py:126
+#: ../src/katello/client/core/repo.py:326
+msgid ""
+"GPG key to be assigned to the repository; by default, the product's GPG key "
+"will be used."
+msgstr "欲指定給軟體庫的 GPG 金鑰；就預設值，將會使用產品的 GPG 金鑰。"
+
+#: ../src/katello/client/core/repo.py:128
+#: ../src/katello/client/core/repo.py:328
+msgid "Don't assign a GPG key to the repository."
+msgstr "不指定一組 GPG 金鑰至軟體庫。"
+
+#: ../src/katello/client/core/repo.py:143
+#: ../src/katello/client/core/repo.py:244
+#, python-format
+msgid "Successfully created repository [ %s ]"
+msgstr "已成功建立軟體庫 [ %s ]"
+
+#: ../src/katello/client/core/repo.py:149
+msgid "discovery repositories contained within a URL"
+msgstr "尋找包含於 URL 中的軟體庫"
+
+#: ../src/katello/client/core/repo.py:155
+msgid ""
+"repository name prefix to add to all the discovered repositories (required)"
+msgstr "要新增至尋找到的軟體庫名稱之前的前綴（必填）"
+
+#: ../src/katello/client/core/repo.py:157
+msgid ""
+"root url to perform discovery of repositories eg: "
+"http://porkchop.devel.redhat.com/ (required)"
+msgstr "要尋找軟體庫的 root URL，例如「http://porkchop.devel.redhat.com/」（必填）"
+
+#: ../src/katello/client/core/repo.py:159
+#: ../src/katello/client/core/product.py:314
+msgid ""
+"assume yes; automatically create candidate repositories for discovered urls "
+"(optional)"
+msgstr "假定為「yes」（是），自動為找到的 URL 建立候選軟體庫（選用）"
+
+#: ../src/katello/client/core/repo.py:174
+#: ../src/katello/client/core/product.py:346
+#, python-format
+msgid "Repository Urls discovered @ [%s]"
+msgstr "找到的軟體庫 URL @ [%s]"
+
+#: ../src/katello/client/core/repo.py:183
+msgid "Discovering repository urls, this could take some time..."
+msgstr "正在尋找軟體庫 URL，這可能會花上一點時間……"
+
+#: ../src/katello/client/core/repo.py:187
+#, python-format
+msgid "Error: %s"
+msgstr "錯誤：%s"
+
+#: ../src/katello/client/core/repo.py:207
+msgid ""
+"\n"
+"Select urls for which candidate repos should be created; use `y` to confirm (h for help):"
+msgstr ""
+"\n"
+"為要建立的候選軟體庫選擇 URL；請按下「y」確認（按下「h」求助）："
+
+#: ../src/katello/client/core/repo.py:217
+msgid "Operation aborted upon user request."
+msgstr "應使用者要求放棄操作。"
+
+#: ../src/katello/client/core/repo.py:266
+msgid "status information about a repository"
+msgstr "關於軟體庫的狀態資訊"
+
+#: ../src/katello/client/core/repo.py:289
+msgid "Repository Status"
+msgstr "軟體庫狀態"
+
+#: ../src/katello/client/core/repo.py:296
+msgid "information about a repository"
+msgstr "關於軟體庫的資訊"
+
+#: ../src/katello/client/core/repo.py:310
+msgid "Progress"
+msgstr "進度"
+
+#: ../src/katello/client/core/repo.py:311
+#: ../src/katello/client/core/product.py:140
+msgid "GPG key"
+msgstr "GPP 金鑰"
+
+#: ../src/katello/client/core/repo.py:313
+#, python-format
+msgid "Information About Repo %s"
+msgstr "關於軟體庫 %s 的資訊"
+
+#: ../src/katello/client/core/repo.py:320
+msgid "updates repository attributes"
+msgstr "更新軟體庫項目"
+
+#: ../src/katello/client/core/repo.py:336
+#, python-format
+msgid "Successfully updated repository [ %s ]"
+msgstr "已成功更新了軟體庫 [ %s ]"
+
+#: ../src/katello/client/core/repo.py:342
+msgid "synchronize a repository"
+msgstr "同步軟體庫"
+
+#: ../src/katello/client/core/repo.py:352
+#, python-format
+msgid "Repo [ %s ] synced"
+msgstr "已同步軟體庫 [%s]"
+
+#: ../src/katello/client/core/repo.py:355
+#, python-format
+msgid "Repo [ %s ] synchronization cancelled"
+msgstr "已取消軟體庫 [ %s ] 的同步"
+
+#: ../src/katello/client/core/repo.py:358
+#, python-format
+msgid "Repo [ %s ] failed to sync: %s"
+msgstr "同步軟體庫 [%s] 失敗：%s"
+
+#: ../src/katello/client/core/repo.py:364
+msgid "cancel currently running synchronization of a repository"
+msgstr "取消軟體庫目前進行中的同步程序"
+
+#: ../src/katello/client/core/repo.py:379
+msgid "enable a repository"
+msgstr "啟用軟體庫"
+
+#: ../src/katello/client/core/repo.py:381
+msgid "disable a repository"
+msgstr "停用軟體庫"
+
+#: ../src/katello/client/core/repo.py:400
+msgid "list repos within an organization"
+msgstr "列出組織中的軟體庫"
+
+#: ../src/katello/client/core/repo.py:404
+msgid "organization name eg: ACME_Corporation (required)"
+msgstr "組織名稱，例如「ACME_Corporation 」（必填）"
+
+#: ../src/katello/client/core/repo.py:410
+msgid "list also disabled repositories"
+msgstr "亦列出已停用的軟體庫"
+
+#: ../src/katello/client/core/repo.py:430
+#, python-format
+msgid "Repo List For Org %s Environment %s Product %s"
+msgstr "組織 %s、環境 %s、產品 %s 的軟體庫清單"
+
+#: ../src/katello/client/core/repo.py:437
+#, python-format
+msgid "Repo List for Product %s in Org %s "
+msgstr "產品 %s 的軟體庫清單，位於組織 %s"
+
+#: ../src/katello/client/core/repo.py:444
+#, python-format
+msgid "Repo List For Org %s Environment %s"
+msgstr "組織 %s 的軟體庫清單，位於環境 %s"
+
+#: ../src/katello/client/core/repo.py:454
+msgid "delete a repository"
+msgstr "刪除軟體庫"
+
+#: ../src/katello/client/core/repo.py:467
+msgid "list filters of a repository"
+msgstr "列出軟體庫篩選器"
+
+#: ../src/katello/client/core/repo.py:473
+msgid "prints also filters assigned to repository's product."
+msgstr "亦列出指定至軟體庫產品的篩選器"
+
+#: ../src/katello/client/core/repo.py:483
+msgid "Repository Filters"
+msgstr "軟體庫篩選器"
+
+#: ../src/katello/client/core/repo.py:497
+msgid "add a filter to a repository"
+msgstr "新增篩選器至軟體庫"
+
+#: ../src/katello/client/core/repo.py:499
+msgid "remove a filter from a repository"
+msgstr "移除軟體庫的篩選器"
+
+#: ../src/katello/client/core/repo.py:529
+#, python-format
+msgid "Added filter [ %s ] to repository [ %s ]"
+msgstr "新增篩選器 [ %s ] 至軟體庫 [ %s ]"
+
+#: ../src/katello/client/core/repo.py:532
+#, python-format
+msgid "Removed filter [ %s ] to repository [ %s ]"
+msgstr "移除篩選器 [ %s ] 由軟體庫 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:53
+msgid "list known sync_plans"
+msgstr "列出已知的同步計畫(_P)"
+
+#: ../src/katello/client/core/sync_plan.py:69
+#: ../src/katello/client/core/sync_plan.py:97
+msgid "Start date"
+msgstr ""
+
+#: ../src/katello/client/core/sync_plan.py:72
+msgid "Sync Plan List"
+msgstr "同步計畫清單"
+
+#: ../src/katello/client/core/sync_plan.py:79
+msgid "print info about a sync plan"
+msgstr "印出有關於同步計畫的資訊"
+
+#: ../src/katello/client/core/sync_plan.py:82
+#: ../src/katello/client/core/sync_plan.py:111
+#: ../src/katello/client/core/sync_plan.py:145
+#: ../src/katello/client/core/sync_plan.py:185
+msgid "name of the sync plan (required)"
+msgstr "同步計畫的名稱（必填）"
+
+#: ../src/katello/client/core/sync_plan.py:100
+msgid "Sync Plan Info"
+msgstr "同步計畫資訊"
+
+#: ../src/katello/client/core/sync_plan.py:108
+msgid "create a synchronization plan"
+msgstr "建立同步計畫"
+
+#: ../src/katello/client/core/sync_plan.py:113
+#: ../src/katello/client/core/sync_plan.py:148
+msgid "plan description"
+msgstr "計畫詳述"
+
+#: ../src/katello/client/core/sync_plan.py:115
+#: ../src/katello/client/core/sync_plan.py:150
+#, python-format
+msgid "interval of recurring synchronizations (choices: [%s], default: none)"
+msgstr "重複的同步間隔（選項：[%s]，預設值：none）"
+
+#: ../src/katello/client/core/sync_plan.py:117
+msgid "date of first synchronization (required, format: YYYY-MM-DD)"
+msgstr "第一次同步的日期（必填，格式：YYYY-MM-DD）"
+
+#: ../src/katello/client/core/sync_plan.py:118
+msgid "time of first synchronization (format: HH:MM:SS, default: 00:00:00)"
+msgstr "第一次同步的時間（格式：HH:MM:SS，預設值：00:00:00）"
+
+#: ../src/katello/client/core/sync_plan.py:135
+#, python-format
+msgid "Successfully created synchronization plan [ %s ]"
+msgstr "已成功建立同步計畫 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:136
+#, python-format
+msgid "Could not create synchronization plan [ %s ]"
+msgstr "無法建立同步計畫 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:142
+msgid "update a sync plan"
+msgstr "更新同步計畫"
+
+#: ../src/katello/client/core/sync_plan.py:146
+msgid "new sync plan name"
+msgstr "新同步計畫名稱"
+
+#: ../src/katello/client/core/sync_plan.py:152
+msgid "date of first synchronization (format: YYYY-MM-DD)"
+msgstr "第一次同步的日期（格式：YYYY-MM-DD）"
+
+#: ../src/katello/client/core/sync_plan.py:153
+msgid "time of first synchronization (format: HH:MM:SS)"
+msgstr "第一次同步的時間（格式：HH:MM:SS）"
+
+#: ../src/katello/client/core/sync_plan.py:176
+#, python-format
+msgid "Successfully updated sync plan [ %s ]"
+msgstr "已成功更新了同步計畫 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:182
+msgid "delete a sync plan"
+msgstr "刪除同步計畫"
+
+#: ../src/katello/client/core/sync_plan.py:198
+#, python-format
+msgid "Successfully deleted sync plan [ %s ]"
+msgstr "已成功刪除同步計畫 [ %s ]"
+
+#: ../src/katello/client/core/sync_plan.py:206
+msgid "synchronization plan specific actions in the katello server"
+msgstr "katello 伺服器中，與同步計畫相關的特定動作"
+
+#: ../src/katello/client/core/organization.py:42
+msgid "list all known organizations"
+msgstr "列出所有已知組織"
+
+#: ../src/katello/client/core/organization.py:51
+msgid "Organization List"
+msgstr "組織清單"
+
+#: ../src/katello/client/core/organization.py:59
+msgid "create an organization"
+msgstr "建立組織"
+
+#: ../src/katello/client/core/organization.py:66
+#: ../src/katello/client/core/organization.py:150
+msgid "consumer description eg: foo's organization"
+msgstr "消耗者的描述，例如「foo 的組織」"
+
+#: ../src/katello/client/core/organization.py:77
+#, python-format
+msgid "Successfully created org [ %s ]"
+msgstr "已成功建立組織 [ %s ]"
+
+#: ../src/katello/client/core/organization.py:78
+#, python-format
+msgid "Could not create org [ %s ]"
+msgstr "無法建立組織 [ %s ]"
+
+#: ../src/katello/client/core/organization.py:86
+msgid "list information about an organization"
+msgstr "列出組織資訊"
+
+#: ../src/katello/client/core/organization.py:104
+msgid "Available Service Levels"
+msgstr "可用服務等級"
+
+#: ../src/katello/client/core/organization.py:106
+msgid "Organization Information"
+msgstr "組織資訊"
+
+#: ../src/katello/client/core/organization.py:114
+msgid "delete an organization"
+msgstr "刪除組織"
+
+#: ../src/katello/client/core/organization.py:130
+msgid "Deleting the organization, please wait... "
+msgstr "正在刪除組織，請稍候..."
+
+#: ../src/katello/client/core/organization.py:133
+#, python-format
+msgid "Successfully deleted org [ %s ]"
+msgstr "已成功刪除組織 [ %s ]"
+
+#: ../src/katello/client/core/organization.py:136
+#, python-format
+msgid "Organization [ %s ] deletion failed: %s"
+msgstr "組織 [ %s ] 刪除失敗：%s"
+
+#: ../src/katello/client/core/organization.py:143
+msgid "update an organization"
+msgstr "更新組織"
+
+#: ../src/katello/client/core/organization.py:160
+#, python-format
+msgid "Successfully updated org [ %s ]"
+msgstr "已成功更新組織 [ %s ]"
+
+#: ../src/katello/client/core/organization.py:167
+msgid "generate and show ueber certificate"
+msgstr "產生並顯示 ueber 憑證"
+
+#: ../src/katello/client/core/organization.py:173
+msgid "regenerate the certificate"
+msgstr "重新產生憑證"
+
+#: ../src/katello/client/core/organization.py:186
+msgid "Organization Uebercert"
+msgstr "組織的 Uebercert"
+
+#: ../src/katello/client/core/organization.py:195
+msgid "show subscriptions"
+msgstr "顯示訂閱"
+
+#: ../src/katello/client/core/organization.py:226
+msgid "Organization's Subscriptions"
+msgstr "組織訂閱"
+
+#: ../src/katello/client/core/organization.py:255
+msgid "organization specific actions in the katello server"
+msgstr "katello 伺服器中，與組織相關的特定動作"
+
+#: ../src/katello/client/core/product.py:71
+msgid "set a synchronization plan"
+msgstr "設定同步計畫"
+
+#: ../src/katello/client/core/product.py:76
+msgid "synchronization plan name (required)"
+msgstr "同步計畫名稱（必填）"
+
+#: ../src/katello/client/core/product.py:98
+msgid "unset a synchronization plan"
+msgstr "取消同步計畫設定"
+
+#: ../src/katello/client/core/product.py:113
+msgid "list known products"
+msgstr "列出已知產品"
+
+#: ../src/katello/client/core/product.py:121
+msgid "provider name, lists provider's product in the Library"
+msgstr "供應方名稱、列出函式庫中，供應方的產品"
+
+#: ../src/katello/client/core/product.py:123
+msgid "list marketing products (hidden by default)"
+msgstr ""
+
+#: ../src/katello/client/core/product.py:145
+#, python-format
+msgid "Product List For Provider %s"
+msgstr "供應方 %s 的產品清單"
+
+#: ../src/katello/client/core/product.py:151
+#, python-format
+msgid "Product List For Organization %s, Environment '%s'"
+msgstr "組織 %s、環境 %s 的產品清單"
+
+#: ../src/katello/client/core/product.py:170
+msgid "synchronize a product"
+msgstr "同步一項產品"
+
+#: ../src/katello/client/core/product.py:186
+#, python-format
+msgid "Product [ %s ] failed to sync: %s"
+msgstr "同步產品 [ %s ] 失敗：%s"
+
+#: ../src/katello/client/core/product.py:189
+#, python-format
+msgid "Product [ %s ] synchronization cancelled"
+msgstr "已取消產品 [ %s ] 的同步作業"
+
+#: ../src/katello/client/core/product.py:192
+#, python-format
+msgid "Product [ %s ] synchronized"
+msgstr "已同步產品 [ %s ]"
+
+#: ../src/katello/client/core/product.py:215
+msgid "status of product's synchronization"
+msgstr "產品的同步狀態"
+
+#: ../src/katello/client/core/product.py:241
+msgid "Product Status"
+msgstr "產品狀態"
+
+#: ../src/katello/client/core/product.py:249
+msgid ""
+"promote a product to an environment\n"
+"(creates a temporary changeset with the product and promotes it)"
+msgstr ""
+"將產品推送至某環境\n"
+"（建立暫時性的產品 changeset，並將它推送）"
+
+#: ../src/katello/client/core/product.py:272
+msgid "Promoting the product, please wait... "
+msgstr "推送產品中，請稍候……"
+
+#: ../src/katello/client/core/product.py:275
+#, python-format
+msgid "Product [ %s ] promoted to environment [ %s ] "
+msgstr "產品 [ %s ] 已推送至環境 [ %s ]"
+
+#: ../src/katello/client/core/product.py:278
+#, python-format
+msgid "Product [ %s ] promotion failed: %s"
+msgstr "產品 [ %s ] 推送失敗：%s"
+
+#: ../src/katello/client/core/product.py:298
+msgid "create new product to a custom provider"
+msgstr "新建產品至自訂供應方"
+
+#: ../src/katello/client/core/product.py:308
+msgid "product description"
+msgstr "產品描述"
+
+#: ../src/katello/client/core/product.py:312
+msgid "skip repository discovery"
+msgstr "跳過軟體庫搜尋"
+
+#: ../src/katello/client/core/product.py:316
+msgid ""
+"assign a gpg key; this key will be used for every new repository unless "
+"gpgkey or nogpgkey is specified for the repo"
+msgstr "指定一組 gpg 金鑰；此金鑰將會使用於所有新軟體庫，除非軟體庫指定了 gpgkey 或是 nogpgkey"
+
+#: ../src/katello/client/core/product.py:339
+#, python-format
+msgid "Successfully created product [ %s ]"
+msgstr "已成功建立產品 [ %s ]"
+
+#: ../src/katello/client/core/product.py:355
+msgid "update a product's attributes"
+msgstr "更新產品的屬性"
+
+#: ../src/katello/client/core/product.py:360
+msgid "change description of the product"
+msgstr "更改產品描述"
+
+#: ../src/katello/client/core/product.py:362
+#: ../src/katello/client/core/product.py:364
+msgid "assign a gpgkey to the product"
+msgstr "為產品指定 gpgkey"
+
+#: ../src/katello/client/core/product.py:366
+msgid "assign the gpgpkey also to the product's repositories"
+msgstr "同時為產品的軟體庫指定 gpgkey"
+
+#: ../src/katello/client/core/product.py:383
+#, python-format
+msgid "Successfully updated product [ %s ]"
+msgstr "已成功更新了產品 [ %s ]"
+
+#: ../src/katello/client/core/product.py:389
+msgid "delete a product and its content"
+msgstr "刪除產品及其內容"
+
+#: ../src/katello/client/core/product.py:404
+msgid "list filters of a product"
+msgstr "列出產品的篩選器"
+
+#: ../src/katello/client/core/product.py:415
+msgid "Product Filters"
+msgstr "產品篩選器"
+
+#: ../src/katello/client/core/product.py:430
+msgid "add a filter to a product"
+msgstr "為產品新增篩選器"
+
+#: ../src/katello/client/core/product.py:432
+msgid "remove a filter from a product"
+msgstr "移除產品的篩選器"
+
+#: ../src/katello/client/core/product.py:463
+#, python-format
+msgid "Added filter [ %s ] to product [ %s ]"
+msgstr "已將篩選器 [ %s ] 新增至產品 [ %s ]"
+
+#: ../src/katello/client/core/product.py:466
+#, python-format
+msgid "Removed filter [ %s ] to product [ %s ]"
+msgstr "已將篩選器 [ %s ] 由產品 [ %s ] 中移除"
+
+#: ../src/katello/client/core/product.py:477
+msgid "product specific actions in the katello server"
+msgstr "katello 伺服器中，與產品相關的特定動作"
+
+#: ../src/katello/client/core/template.py:48
+msgid "list all templates"
+msgstr "列出所有範本"
+
+#: ../src/katello/client/core/template.py:52
+msgid "name of organization (required if specifying environment)"
+msgstr "組織名稱（指定環境時必填）"
+
+#: ../src/katello/client/core/template.py:67
+#, python-format
+msgid "No templates found in environment [ %s ]"
+msgstr "環境 [ %s ] 中找不到範本"
+
+#: ../src/katello/client/core/template.py:75
+msgid "Template List"
+msgstr "範本清單"
+
+#: ../src/katello/client/core/template.py:83
+msgid "list information about a template"
+msgstr "列出關於範本的資訊"
+
+#: ../src/katello/client/core/template.py:87
+#: ../src/katello/client/core/template.py:192
+#: ../src/katello/client/core/template.py:240
+#: ../src/katello/client/core/template.py:306
+#: ../src/katello/client/core/template.py:479
+msgid "template name (required)"
+msgstr "範本名稱（必填）"
+
+#: ../src/katello/client/core/template.py:124
+msgid "Template Info"
+msgstr "範本資訊"
+
+#: ../src/katello/client/core/template.py:147
+msgid "create a template file and import data"
+msgstr "建立範本檔案，並匯入資料"
+
+#: ../src/katello/client/core/template.py:154
+#: ../src/katello/client/core/template.py:198
+msgid "path to the template file (required)"
+msgstr "範本檔案的路徑（必填）"
+
+#: ../src/katello/client/core/template.py:176
+msgid "Importing template, please wait... "
+msgstr "匯入範本中，請稍候……"
+
+#: ../src/katello/client/core/template.py:187
+msgid "export the template into the file"
+msgstr "將範本匯出至檔案中"
+
+#: ../src/katello/client/core/template.py:196
+msgid "environment name eg: dev"
+msgstr "環境名稱，例如 dev"
+
+#: ../src/katello/client/core/template.py:200
+#, python-format
+msgid "format of the export, possible values: %s, default: json"
+msgstr "匯出的格式，可用的值：%s、預設值為 json"
+
+#: ../src/katello/client/core/template.py:218
+#, python-format
+msgid "Could not create file %s"
+msgstr "無法建立檔案 %s"
+
+#: ../src/katello/client/core/template.py:222
+msgid "Exporting template, please wait... "
+msgstr "正在匯出範本，請稍候..."
+
+#: ../src/katello/client/core/template.py:225
+#, python-format
+msgid "Template was exported successfully to file %s"
+msgstr "範本已成功匯出至檔案 %s"
+
+#: ../src/katello/client/core/template.py:235
+msgid "create an empty template file"
+msgstr "建立空白的範本檔案"
+
+#: ../src/katello/client/core/template.py:242
+#: ../src/katello/client/core/template.py:307
+msgid "name of the parent template"
+msgstr "父範本的名稱"
+
+#: ../src/katello/client/core/template.py:246
+#: ../src/katello/client/core/template.py:310
+msgid "template description"
+msgstr "範本的描述"
+
+#: ../src/katello/client/core/template.py:268
+#, python-format
+msgid "Successfully created template [ %s ]"
+msgstr "已成功建立範本 [ %s ]"
+
+#: ../src/katello/client/core/template.py:269
+#, python-format
+msgid "Could not create template [ %s ]"
+msgstr "無法建立範本 [ %s ]"
+
+#: ../src/katello/client/core/template.py:277
+msgid "updates name and description of a template"
+msgstr "更新範本的名稱與描述"
+
+#: ../src/katello/client/core/template.py:291
+#, python-format
+msgid "each %s must be preceeded by %s"
+msgstr "每個 %s 之前都必須有 %s"
+
+#. bz 799149
+#. parser.add_option('--add_product', dest='add_products', action="append",
+#. help=_("name of the product"))
+#. parser.add_option('--remove_product', dest='remove_products',
+#. action="append", help=_("name of the product"))
+#: ../src/katello/client/core/template.py:316
+#: ../src/katello/client/core/template.py:317
+msgid "name of the package"
+msgstr ""
+
+#: ../src/katello/client/core/template.py:320
+#, python-format
+msgid "name of the parameter, %s must follow"
+msgstr "參數的名稱，%s 必須接在其後"
+
+#: ../src/katello/client/core/template.py:321
+msgid "value of the parameter"
+msgstr "參數的值"
+
+#: ../src/katello/client/core/template.py:322
+msgid "name of the parameter"
+msgstr "參數名稱"
+
+#: ../src/katello/client/core/template.py:324
+#: ../src/katello/client/core/template.py:325
+msgid "name of the package group"
+msgstr "套件群組的名稱"
+
+#: ../src/katello/client/core/template.py:327
+#: ../src/katello/client/core/template.py:328
+msgid "name of the package group category"
+msgstr "套件群組類別的名稱"
+
+#: ../src/katello/client/core/template.py:330
+#: ../src/katello/client/core/template.py:331
+msgid "distribution id"
+msgstr "發行版 id"
+
+#: ../src/katello/client/core/template.py:334
+msgid "determines product from which the repositories are picked"
+msgstr "判斷要由哪個產品選擇軟體庫"
+
+#: ../src/katello/client/core/template.py:336
+msgid "repository to be added to the template"
+msgstr "欲新增至範本的軟體庫"
+
+#: ../src/katello/client/core/template.py:338
+msgid "repository to be removed from the template"
+msgstr "欲由範本中移除的軟體庫"
+
+#: ../src/katello/client/core/template.py:348
+#, python-format
+msgid "missing value for parameter '%s'"
+msgstr "參數「%s」缺少必要的值"
+
+#: ../src/katello/client/core/template.py:408
+#: ../src/katello/client/core/template.py:409
+msgid "Updating the template, please wait... "
+msgstr "更新範本中，請稍候……"
+
+#: ../src/katello/client/core/template.py:410
+#, python-format
+msgid "Successfully updated template [ %s ]"
+msgstr "已成功更新範本 [ %s ]"
+
+#: ../src/katello/client/core/template.py:475
+msgid "deletes a template"
+msgstr "刪除範本"
+
+#: ../src/katello/client/core/template.py:483
+msgid "environment name eg: foo.example.com (default: Library)"
+msgstr "環境名稱，例如 foo.example.com（預設值：Library）"
+
+#: ../src/katello/client/core/template.py:503
+msgid "template specific actions in the katello server"
+msgstr "katello 伺服器中，與範本相關的特定動作"
+
+#: ../src/katello/client/core/environment.py:43
+msgid "list known environments"
+msgstr "列出已知環境"
+
+#: ../src/katello/client/core/environment.py:60
+#: ../src/katello/client/core/environment.py:90
+msgid "Org"
+msgstr "組織"
+
+#: ../src/katello/client/core/environment.py:61
+#: ../src/katello/client/core/environment.py:91
+msgid "Prior Environment"
+msgstr "之前的環境"
+
+#: ../src/katello/client/core/environment.py:63
+msgid "Environment List"
+msgstr "環境清單"
+
+#: ../src/katello/client/core/environment.py:70
+msgid "list a specific environment"
+msgstr "列出特定環境"
+
+#: ../src/katello/client/core/environment.py:76
+#: ../src/katello/client/core/environment.py:179
+msgid "environment name eg: foo.example.com (required)"
+msgstr "環境名稱，例如 foo.example.com（必填）"
+
+#: ../src/katello/client/core/environment.py:93
+msgid "Environment Info"
+msgstr "環境資訊"
+
+#: ../src/katello/client/core/environment.py:101
+msgid "create an environment"
+msgstr "建立環境"
+
+#: ../src/katello/client/core/environment.py:105
+#: ../src/katello/client/core/environment.py:142
+msgid "environment description eg: foo's environment"
+msgstr "環境的描述，例如：foo 的環境"
+
+#: ../src/katello/client/core/environment.py:111
+msgid "name of prior environment (required)"
+msgstr "之前的環境名稱（必填）"
+
+#: ../src/katello/client/core/environment.py:129
+#, python-format
+msgid "Successfully created environment [ %s ]"
+msgstr "已成功建立環境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:130
+#, python-format
+msgid "Could not create environment [ %s ]"
+msgstr "無法建立環境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:137
+msgid "update an environment"
+msgstr "更新環境"
+
+#: ../src/katello/client/core/environment.py:146
+msgid "name of prior environment"
+msgstr "之前的環境名稱"
+
+#: ../src/katello/client/core/environment.py:168
+#, python-format
+msgid "Successfully updated environment [ %s ]"
+msgstr "已成功更新環境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:175
+msgid "delete an environment"
+msgstr "刪除環境"
+
+#: ../src/katello/client/core/environment.py:194
+#, python-format
+msgid "Successfully deleted environment [ %s ]"
+msgstr "已成功刪除環境 [ %s ]"
+
+#: ../src/katello/client/core/environment.py:203
+msgid "environment specific actions in the katello server"
+msgstr "katello 伺服器中，與環境相關的特定動作"
+
+#: ../src/katello/client/server.py:96
+#, python-format
+msgid "certificate file %s does not exist or cannot be read"
+msgstr "認證檔案 %s 不存在或無法讀取"
+
+#: ../src/katello/client/server.py:99
+#, python-format
+msgid "key file %s does not exist or cannot be read"
+msgstr "金鑰檔案 %s 不存在或無法讀取"
+
+#: ../src/katello/client/server.py:104
+msgid "can't authenticate via certificate when not using https connection"
+msgstr ""
+
+#: ../src/katello/client/server.py:126
+msgid "Couldn't authenticate via kerberos"
+msgstr "無法透過 kerberos 認證"
+
+#: ../src/katello/client/utils/option_validator.py:86
+#, python-format
+msgid "Option %s is required; please see --help"
+msgstr "選項 %s 必填；請參閱「--help」"
+
+#: ../src/katello/client/utils/option_validator.py:128
+#, python-format
+msgid "Options %s are colliding with %s; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:130
+#, python-format
+msgid "Option %s is colliding with %s; please see --help"
+msgstr "選項 %s 與 %s 互相衝突；請查看 --help"
+
+#: ../src/katello/client/utils/option_validator.py:133
+#, python-format
+msgid "Options %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:135
+#, python-format
+msgid "Option %s can't be used in this command; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:167
+#, python-format
+msgid "Exactly one of %s is required; please see --help"
+msgstr ""
+
+#: ../src/katello/client/utils/option_validator.py:200
+#, python-format
+msgid "At least one of %s is required; please see --help"
+msgstr "需要至少一個 %s；請查看 --help"

--- a/cli/src/katello/client/main.py
+++ b/cli/src/katello/client/main.py
@@ -17,6 +17,20 @@
 
 import sys
 import codecs
+import locale
+import gettext
+
+# Localization domain:
+APP = 'katello'
+# Directory where translations are deployed:
+DIR = '/usr/share/locale/'
+try:
+    locale.setlocale(locale.LC_ALL, '')
+except locale.Error:
+    locale.setlocale(locale.LC_ALL, 'C')
+gettext.bindtextdomain(APP, DIR)
+gettext.textdomain(APP)
+
 
 from katello.client.core import (
   activation_key,


### PR DESCRIPTION
To get this to work the installation work was moved to the makefile, and new strings
had to be brought in since bad translations will now break the build. In addition, the
gettext context needed to be set up to actually make use of the translations.
