### PR TITLE
798679 - Read correct argument

### DIFF
--- a/cli/src/katello/client/core/product.py
+++ b/cli/src/katello/client/core/product.py
@@ -127,7 +127,7 @@ class List(ProductAction):
 
     def run(self):
         org_name = self.get_option('org')
-        env_name = self.get_option('env')
+        env_name = self.get_option('environment')
         prov_name = self.get_option('prov')
         all = self.get_option('all')
 

--- a/cli/src/katello/client/core/repo.py
+++ b/cli/src/katello/client/core/repo.py
@@ -408,7 +408,7 @@ class List(RepoAction):
 
     def run(self):
         orgName = self.get_option('org')
-        envName = self.get_option('env')
+        envName = self.get_option('environment')
         prodName = self.get_option('product')
         listDisabled = self.has_option('disabled')
 


### PR DESCRIPTION
This opt_arg variable has been renamed in 85bafb2 and this is left over.

addressing:
  File "/usr/lib/python2.6/site-packages/mock-0.8.0rc1-py2.6.egg/mock.py", line 857, in assert_called_with
    raise AssertionError(msg)
AssertionError: Expected call: mock('ACME_Corporation', 'Library')
Actual call: mock('ACME_Corporation', None)
