### PR TITLE
845995 - fix syntax error

### DIFF
--- a/src/app/controllers/api/activation_keys_controller.rb
+++ b/src/app/controllers/api/activation_keys_controller.rb
@@ -150,7 +150,7 @@ class Api::ActivationKeysController < Api::ApiController
     ids = params[:activation_key][:system_group_ids] if params[:activation_key]
     @system_groups = []
     if ids
-      for group_id in ids:
+      for group_id in ids
         group = SystemGroup.find(group_id)
         raise HttpErrors::NotFound, _("Couldn't find system group '#{group_id}'") if group.nil?
         @system_groups << group


### PR DESCRIPTION
Ruby is not Python :)

addressing:

```
** Execute apipie:static
rake aborted!
/builddir/build/BUILD/katello-git-25.8372cd6/app/controllers/api/activation_keys_controller.rb:153: syntax error, unexpected ':', expecting keyword_do_cond or ';' or '\n'
/builddir/build/BUILD/katello-git-25.8372cd6/app/controllers/api/activation_keys_controller.rb:165: syntax error, unexpected keyword_end, expecting $end
/usr/share/gems/gems/activesupport-3.0.11/lib/active_support/dependencies.rb:235:in `load'
/usr/share/gems/gems/activesupport-3.0.11/lib/active_support/dependencies.rb:235:in `block in load'
/usr/share/gems/gems/activesupport-3.0.11/lib/active_support/dependencies.rb:227:in `load_dependency'
/usr/share/gems/gems/activesupport-3.0.11/lib/active_support/dependencies.rb:235:in `load'
/usr/share/gems/gems/apipie-rails-0.0.11/lib/tasks/apipie.rake:117:in `block in with_loaded_documentation'
/usr/share/gems/gems/apipie-rails-0.0.11/lib/tasks/apipie.rake:117:in `each'
/usr/share/gems/gems/apipie-rails-0.0.11/lib/tasks/apipie.rake:117:in `with_loaded_documentation'
/usr/share/gems/gems/apipie-rails-0.0.11/lib/tasks/apipie.rake:21:in `block (2 levels) in <top (required)>'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
/usr/share/ruby/monitor.rb:211:in `mon_synchronize'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/task.rb:144:in `invoke'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:116:in `invoke_task'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block (2 levels) in top_level'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `each'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block in top_level'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:88:in `top_level'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:66:in `block in run'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/usr/share/gems/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
/usr/bin/rake:32:in `<main>'
Tasks: TOP => apipie:static
```
