### PR TITLE
rubygem-hashr is now in EPEL 6

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -58,7 +58,6 @@
        <packagereq type="default">rubygem-gettext_i18n_rails</packagereq>
        <packagereq type="default">rubygem-haml</packagereq>
        <packagereq type="default">rubygem-haml-rails</packagereq>
-       <packagereq type="default">rubygem-hashr</packagereq>
        <packagereq type="default">rubygem-hoe</packagereq>
        <packagereq type="default">rubygem-i18n</packagereq>
        <packagereq type="default">rubygem-i18n_data</packagereq>


### PR DESCRIPTION
https://admin.fedoraproject.org/updates/FEDORA-EPEL-2012-6677/rubygem-hashr-0.0.21-3.el6
