### PR TITLE
rubygem-transaction-simple is now in Fedora

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -52,7 +52,6 @@
        <packagereq type="default">rubygem-ruport</packagereq>
        <packagereq type="default">rubygem-simple-navigation</packagereq>
        <packagereq type="default">rubygem-tire</packagereq>
-       <packagereq type="default">rubygem-transaction-simple</packagereq>
        <packagereq type="default">rubygem-yui-compressor</packagereq>
     </packagelist>
   </group>

--- a/rel-eng/comps/comps-katello-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-server-fedora17.xml
@@ -46,7 +46,6 @@
        <packagereq type="default">rubygem-rcov</packagereq>
        <packagereq type="default">rubygem-ruport</packagereq>
        <packagereq type="default">rubygem-tire</packagereq>
-       <packagereq type="default">rubygem-transaction-simple</packagereq>
        <packagereq type="default">rubygem-yui-compressor</packagereq>
     </packagelist>
   </group>


### PR DESCRIPTION
https://admin.fedoraproject.org/updates/FEDORA-2012-12160/rubygem-transaction-simple-1.4.0.2-3.fc16
https://admin.fedoraproject.org/updates/FEDORA-2012-12136/rubygem-transaction-simple-1.4.0.2-3.fc17
