### PR TITLE
845668 - removing console.log usage from js, which cause FF3.6 failures

### DIFF
--- a/src/public/javascripts/content_search.js
+++ b/src/public/javascripts/content_search.js
@@ -223,9 +223,6 @@ KT.content_search = function(paths_in){
         else if (search_pages[search_params.content_type] ){
             main_search(search_params);
         }
-        else{
-            console.log(search_params);
-        }
     },
     main_search = function(search_params){
         var options = {};

--- a/src/public/javascripts/system_groups.js
+++ b/src/public/javascripts/system_groups.js
@@ -323,7 +323,6 @@ KT.system_groups = (function(){
             $.get(KT.routes.auto_complete_systems_path(), {term:string}, function(data){
                 var found = false;
                 $.each(data, function(index, element){
-                    console.log(element.label);
                     if (element.label === string){
                         found = element.id;
 

--- a/src/public/javascripts/system_subscriptions.js
+++ b/src/public/javascripts/system_subscriptions.js
@@ -60,7 +60,6 @@ $(document).ready(function() {
                 name            :  element.attr('name'),
                 data            :  element.data('options'),
                 onsuccess       :  function(result, status, xhr){
-                    console.log(xhr.responseText);
                     element.select(xhr.responseText);
                     notices.checkNotices();
                 }


### PR DESCRIPTION
Firefox 3.6 notoriously does not play nice with console.log.  In the case
of 845668, it caused the behavior of adding a system to a system
group to fail without any noticable errors.

The katello js had 3 instances of console.log actively included.  Since
each of those cases looks more to be there for 'debugging' purposes, I have
removed them.

If they are _really_ needed, we can add them back with some protection
around them.  An example might be:

if ( typeof console !== "undefined" && console.error && console.warn ) {
  console.log(element.label);
}
