### PR TITLE
katello - add bundler patch to prefer rpm-gems

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,6 +1,6 @@
-# set environment variable BUNDLER_DISABLE_PATCH to 'true' to disable bundler patch
+# set environment variable BUNDLER_ENABLE_RPM_PREFERRING to 'true' to enable bundler patch
 # if enabled bundler prefers rpm-gems even if they are older version then gems in gem-repo
-unless ENV['BUNDLER_DISABLE_PATCH'] == 'true'
+if ENV['BUNDLER_ENABLE_RPM_PREFERRING'] == 'true'
   require File.join(File.dirname(__FILE__), 'lib', 'bundler_patch_rpm-gems_preferred')
 end
 

--- a/src/lib/bundler_patch_rpm-gems_preferred.rb
+++ b/src/lib/bundler_patch_rpm-gems_preferred.rb
@@ -1,3 +1,15 @@
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
 module Bundler
 
   unless defined? PREFER_RPM_GEMS
@@ -35,7 +47,8 @@ module Bundler
         end
 
         def rpm_full_name
-          return nil if !self.class.rpm_command_available? || @rpm_full_name == false
+          return nil unless self.class.rpm_command_available?
+          return @rpm_full_name || nil unless @rpm_full_name.nil?
 
           name = `rpm -q #{rpm_name} 2>&1`
           if $?.exitstatus == 0


### PR DESCRIPTION
I also updated gem-repo with missing development gems, so you can now:
- use `bundle install` to get development environment on rpm-based machine after katello installation, already installed gems as rpms are used, no newer gem is installed unless it is missing as rpm
- use `bundle install` to get development environment on non-rpm-bases machine without using rubygems.org
- deployment is not affected 
- set environment variable `BUNDLER_ENABLE_RPM_PREFERRING` to `true` to enable bundler patch
