### PR TITLE
794901 - correcting URLs in install manifests

### DIFF
--- a/puppet/modules/apache2/manifests/install.pp
+++ b/puppet/modules/apache2/manifests/install.pp
@@ -1,19 +1,14 @@
 class apache2::install {
-  package { "httpd": ensure => installed}
-  package { [ "mod_ssl" ]:
-    ensure => present, require => Package["httpd"],
+  package { "httpd":
+    ensure => installed
+  }
+
+  package { "mod_ssl":
+    ensure => present,
+    require => Package["httpd"],
     notify => Service["httpd"]
   }
-  group { $apache2::params::group: ensure => present }
-  user  { $apache2::params::user:
-    ensure => present,
-    home => $apache2::params::home,
-    managehome => false,
-    membership => minimum,
-    groups => [],
-    shell => "/sbin/nologin",
-    require => Package["httpd"],
-  }
+
   Package["httpd"] -> File["/etc/httpd/conf/httpd.conf"]
   Package["httpd"] -> File["/etc/httpd/conf.d"]
   Package["httpd"] ~> Service["httpd"]

--- a/puppet/modules/candlepin/manifests/install.pp
+++ b/puppet/modules/candlepin/manifests/install.pp
@@ -1,20 +1,18 @@
 class candlepin::install {
-  $os_type = $operatingsystem ? {
-    "Fedora" => "fedora",
-    default  => "epel"
+  $os = $operatingsystem ? {
+    "RedHat" => "RHEL",
+    default  => "Fedora"
   }
-  yumrepo { "candlepin":
-    descr    => 'Candlepin Repo',
-    baseurl  => "http://repos.fedorapeople.org/repos/candlepin/candlepin/$os_type-\$releasever/\$basearch",
+
+  yumrepo { "katello-candlepin":
+    name     => "katello-candlepin",
+    baseurl  => "http://fedorapeople.org/groups/katello/releases/yum/katello-candlepin/${os}/${lsbmajdistrelease}/x86_64/",
     enabled  => "1",
     gpgcheck => "0"
   }
 
-	package{"candlepin-tomcat6":
-    require => Yumrepo["candlepin"],
+	package {"candlepin-tomcat6":
+    require => Yumrepo["katello-candlepin"],
     ensure  => installed
   }
-
-  Class["candlepin::install"] -> Exec["cpsetup"]
-  Class["postgres::install"] -> Exec["cpsetup"]
 }

--- a/puppet/modules/pulp/manifests/install.pp
+++ b/puppet/modules/pulp/manifests/install.pp
@@ -1,26 +1,20 @@
 class pulp::install {
   include mongodb::install
 
-  $os_type = $operatingsystem ? {
-    "Fedora" => "fedora-${operatingsystemrelease}",
-    default  => "\$releasever"
+  $os = $operatingsystem ? {
+    "RedHat" => "RHEL",
+    default  => "Fedora"
   }
 
-  yumrepo {
-    "fedora-pulp":
-      enabled  => "0",
-      gpgcheck => "0",
-      descr    => "Pulp Community Releases",
-      baseurl  => "http://repos.fedorapeople.org/repos/pulp/pulp/${os_type}//\$basearch/";
-    "testing-fedora-pulp":
-      enabled  => "1",
-      gpgcheck => "0",
-      descr    => "Pulp Community Releases",
-      baseurl  => "http://repos.fedorapeople.org/repos/pulp/pulp/testing/${os_type}/\$basearch/";
+  yumrepo { "katello-pulp":
+    name     => "katello-pulp",
+    baseurl  => "http://fedorapeople.org/groups/katello/releases/yum/katello-pulp/${os}/${lsbmajdistrelease}/x86_64/",
+    enabled  => "1",
+    gpgcheck => "0"
   }
 
   package{"pulp":
     ensure => installed,
-    require => Yumrepo["fedora-pulp","testing-fedora-pulp"]
+    require => Yumrepo["katello-pulp"]
   }
 }

--- a/puppet/modules/thumbslug/manifests/install.pp
+++ b/puppet/modules/thumbslug/manifests/install.pp
@@ -1,17 +1,8 @@
 class thumbslug::install {
-  $os_type = $operatingsystem ? {
-    "Fedora" => "fedora",
-    default  => "epel"
-  }
-  yumrepo { "thumbslug":
-    descr    => 'Thumbslug Repo',
-    baseurl  => "http://repos.fedorapeople.org/repos/candlepin/thumbslug/$os_type-\$releasever/\$basearch",
-    enabled  => "1",
-    gpgcheck => "0"
-  }
+  include candlepin::install
 
-	package{"thumbslug":
-    require => Yumrepo["thumbslug"],
+	package {"katello-thumbslug":
+    require => Yumrepo["candlepin::install:katello-candlepin"],
     ensure  => installed
   }
 }


### PR DESCRIPTION
These are not used, only for pure Puppet installation:

https://fedorahosted.org/katello/wiki/InstallViaPuppet

Also removed creation of apache user (that is already there).
