### PR TITLE
cdn-var-substitutor - isolate the logic to separate class

### DIFF
--- a/src/app/models/glue/provider.rb
+++ b/src/app/models/glue/provider.rb
@@ -215,7 +215,7 @@ module Glue::Provider
     def import_products_from_cp
       product_in_katello_ids = self.organization.library.products.all(:select => "cp_id").map(&:cp_id)
       products_in_candlepin_ids = []
-      Resources::CDN::CdnVarSubstitutor.with_cache do
+      Util::CdnVarSubstitutor.with_cache do
         marketing_to_enginnering_product_ids_mapping.each do |marketing_product_id, engineering_product_ids|
           engineering_product_ids = engineering_product_ids.uniq
           products_in_candlepin_ids << marketing_product_id

--- a/src/app/models/glue/pulp/repos.rb
+++ b/src/app/models/glue/pulp/repos.rb
@@ -409,9 +409,9 @@ module Glue::Pulp::Repos
 
     def set_repos
       content_urls = self.productContent.map { |pc| pc.content.contentUrl }
-      cdn_var_substitutor = Resources::CDN::CdnVarSubstitutor.new(self.provider[:repository_url],
+      cdn_var_substitutor = Resources::CDN::CdnResource.new(self.provider[:repository_url],
                                                        :ssl_client_cert => OpenSSL::X509::Certificate.new(self.certificate),
-                                                       :ssl_client_key => OpenSSL::PKey::RSA.new(self.key))
+                                                       :ssl_client_key => OpenSSL::PKey::RSA.new(self.key)).substitutor
       cdn_var_substitutor.precalculate(content_urls)
 
       self.productContent.collect do |pc|

--- a/src/app/models/provider.rb
+++ b/src/app/models/provider.rb
@@ -211,11 +211,11 @@ class Provider < ActiveRecord::Base
   def available_releases
     releases = []
     begin
-      Resources::CDN::CdnVarSubstitutor.with_cache do
+      Util::CdnVarSubstitutor.with_cache do
         self.products.engineering.each do |product|
-          cdn_var_substitutor = Resources::CDN::CdnVarSubstitutor.new(product.provider[:repository_url],
+          cdn_var_substitutor = Resources::CDN::CdnResource.new(product.provider[:repository_url],
                                                            :ssl_client_cert => OpenSSL::X509::Certificate.new(product.certificate),
-                                                           :ssl_client_key => OpenSSL::PKey::RSA.new(product.key))
+                                                           :ssl_client_key => OpenSSL::PKey::RSA.new(product.key)).substitutor
           product.productContent.each do |pc|
             if url_to_releases = pc.content.contentUrl[/^.*\$releasever/]
               cdn_var_substitutor.substitute_vars(url_to_releases).each do |(substitutions, path)|

--- a/src/lib/resources/cdn.rb
+++ b/src/lib/resources/cdn.rb
@@ -32,6 +32,10 @@ module Resources
       attr_reader :url
       attr_accessor :proxy_host, :proxy_port, :proxy_user, :proxy_password
 
+      def substitutor
+        Util::CdnVarSubstitutor.new(self)
+      end
+
       def initialize url, options = {}
         options.reverse_merge!(:verify_ssl => 9)
         options.assert_valid_keys(:ssl_client_key, :ssl_client_cert, :ssl_ca_file, :verify_ssl)
@@ -122,108 +126,6 @@ module Resources
       def parse_host(host_or_url)
         uri = URI.parse(host_or_url)
         return uri.host || uri.path
-      end
-
-   end
-
-    class CdnVarSubstitutor
-      def initialize url, options
-        @url = url
-        @options = options
-        @resource = CdnResource.new(@url, @options)
-        @substitutions = Thread.current[:cdn_var_substitutor_cache] || {}
-      end
-
-      def self.with_cache(&block)
-        Thread.current[:cdn_var_substitutor_cache] = {}
-        yield
-      ensure
-        Thread.current[:cdn_var_substitutor_cache] = nil
-      end
-
-      # precalcuclate all paths at once - let's you discover errors and stop
-      # before it causes more pain
-      def precalculate(paths_with_vars)
-        paths_with_vars.uniq.reduce({}) do |ret, path_with_vars|
-          ret[path_with_vars] = substitute_vars(path_with_vars); ret
-        end
-      end
-
-    # takes path e.g. "/rhel/server/5/$releasever/$basearch/os"
-    # returns hash substituting variables:
-    #
-    #  { {"releasever" => "6Server", "basearch" => "i386"} =>  "/rhel/server/5/6Server/i386/os",
-    #    {"releasever" => "6Server", "basearch" => "x86_64"} =>  "/rhel/server/5/6Server/x84_64/os"}
-    #
-    # values are loaded from CDN
-      def substitute_vars(path_with_vars)
-        if path_with_vars =~ /^(.*\$\w+)(.*)$/
-          prefix_with_vars, suffix_witout_vars =  $1, $2
-        else
-          prefix_with_vars, suffix_witout_vars = "", path_with_vars
-        end
-
-        prefixes_without_vars = substitute_vars_in_prefix(prefix_with_vars)
-        paths_without_vars = prefixes_without_vars.reduce({}) do |h, (substitutions, prefix_without_vars)|
-          h[substitutions] = prefix_without_vars + suffix_witout_vars; h
-        end
-        return paths_without_vars
-      end
-
-      # prefix_with_vars is the part of url containing some vars. We can cache
-      # calcualted values for this parts. So for example for:
-      #   "/a/$b/$c/d"
-      #   "/a/$b/$c/e"
-      # prefix_with_vars is "/a/$b/$c" and we store the result after resolving
-      # for the first path.
-      def substitute_vars_in_prefix(prefix_with_vars)
-        paths_with_vars = { {} => prefix_with_vars}
-        prefixes_without_vars = @substitutions[prefix_with_vars]
-
-        unless prefixes_without_vars
-          prefixes_without_vars = {}
-          while not paths_with_vars.empty?
-            substitutions, path = paths_with_vars.shift
-
-            if is_substituable path
-              for_each_substitute_of_next_var substitutions, path do |new_substitution, new_path|
-                paths_with_vars[new_substitution] = new_path
-              end
-            else
-              prefixes_without_vars[substitutions] = path
-            end
-          end
-          @substitutions[prefix_with_vars] = prefixes_without_vars
-        end
-        return prefixes_without_vars
-      end
-
-      def is_substituable path
-        path.include?("$")
-      end
-
-      def is_substitute_of(substituted_url, original_url)
-        substitutions = self.substitute_vars(original_url).values
-        substitutions.include? substituted_url
-      end
-
-      protected
-
-      def for_each_substitute_of_next_var(substitutions, path)
-        if path =~ /^(.*?)\$([^\/]*)/
-          base_path, var = $1, $2
-          get_substitutions_from(base_path).each do |value|
-
-            new_substitutions = substitutions.merge(var => value)
-            new_path = path.sub("$#{var}",value)
-
-            yield new_substitutions, new_path
-          end
-        end
-      end
-
-      def get_substitutions_from(base_path)
-        @resource.get(File.join(base_path,"listing")).split("\n")
       end
 
     end

--- a/src/lib/util/cdn_var_substitutor.rb
+++ b/src/lib/util/cdn_var_substitutor.rb
@@ -1,0 +1,120 @@
+#
+# Copyright 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Util
+
+  class CdnVarSubstitutor
+
+    # cdn_resource - an object providing access to CDN. It has to
+    # provide a get method that takes a path (e.g.
+    # /content/rhel/6.2/listing) and returns the body response)
+    def initialize cdn_resource
+      @resource = cdn_resource
+      @substitutions = Thread.current[:cdn_var_substitutor_cache] || {}
+    end
+
+    # using substitutor from whithin the block makes sure that every
+    # request is made only once.
+    def self.with_cache(&block)
+      Thread.current[:cdn_var_substitutor_cache] = {}
+      yield
+    ensure
+      Thread.current[:cdn_var_substitutor_cache] = nil
+    end
+
+    # precalcuclate all paths at once - let's you discover errors and stop
+    # before it causes more pain
+    def precalculate(paths_with_vars)
+      paths_with_vars.uniq.reduce({}) do |ret, path_with_vars|
+        ret[path_with_vars] = substitute_vars(path_with_vars); ret
+      end
+    end
+
+    # takes path e.g. "/rhel/server/5/$releasever/$basearch/os"
+    # returns hash substituting variables:
+    #
+    #  { {"releasever" => "6Server", "basearch" => "i386"} =>  "/rhel/server/5/6Server/i386/os",
+    #    {"releasever" => "6Server", "basearch" => "x86_64"} =>  "/rhel/server/5/6Server/x84_64/os"}
+    #
+    # values are loaded from CDN
+    def substitute_vars(path_with_vars)
+      if path_with_vars =~ /^(.*\$\w+)(.*)$/
+        prefix_with_vars, suffix_witout_vars =  $1, $2
+      else
+        prefix_with_vars, suffix_witout_vars = "", path_with_vars
+      end
+
+      prefixes_without_vars = substitute_vars_in_prefix(prefix_with_vars)
+      paths_without_vars = prefixes_without_vars.reduce({}) do |h, (substitutions, prefix_without_vars)|
+        h[substitutions] = prefix_without_vars + suffix_witout_vars; h
+      end
+      return paths_without_vars
+    end
+
+    # prefix_with_vars is the part of url containing some vars. We can cache
+    # calcualted values for this parts. So for example for:
+    #   "/a/$b/$c/d"
+    #   "/a/$b/$c/e"
+    # prefix_with_vars is "/a/$b/$c" and we store the result after resolving
+    # for the first path.
+    def substitute_vars_in_prefix(prefix_with_vars)
+      paths_with_vars = { {} => prefix_with_vars}
+      prefixes_without_vars = @substitutions[prefix_with_vars]
+
+      unless prefixes_without_vars
+        prefixes_without_vars = {}
+        while not paths_with_vars.empty?
+          substitutions, path = paths_with_vars.shift
+
+          if is_substituable path
+            for_each_substitute_of_next_var substitutions, path do |new_substitution, new_path|
+              paths_with_vars[new_substitution] = new_path
+            end
+          else
+            prefixes_without_vars[substitutions] = path
+          end
+        end
+        @substitutions[prefix_with_vars] = prefixes_without_vars
+      end
+      return prefixes_without_vars
+    end
+
+    def is_substituable path
+      path.include?("$")
+    end
+
+    def is_substitute_of(substituted_url, original_url)
+      substitutions = self.substitute_vars(original_url).values
+      substitutions.include? substituted_url
+    end
+
+    protected
+
+    def for_each_substitute_of_next_var(substitutions, path)
+      if path =~ /^(.*?)\$([^\/]*)/
+        base_path, var = $1, $2
+        get_substitutions_from(base_path).each do |value|
+
+          new_substitutions = substitutions.merge(var => value)
+          new_path = path.sub("$#{var}",value)
+
+          yield new_substitutions, new_path
+        end
+      end
+    end
+
+    def get_substitutions_from(base_path)
+      @resource.get(File.join(base_path,"listing")).split("\n")
+    end
+
+  end
+end

--- a/src/spec/lib/cdn_spec.rb
+++ b/src/spec/lib/cdn_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Resources::CDN::CdnVarSubstitutor do
+describe Resources::CDN::CdnResource do
 
   let(:provider_url) { "https://cdn.redhat.com" }
   let(:path_with_variables) { "/content/dist/rhel/server/5/$releasever/$basearch/os" }
@@ -10,7 +10,7 @@ describe Resources::CDN::CdnVarSubstitutor do
   end
 
   subject do
-    Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options)
+    Resources::CDN::CdnResource.new(provider_url, connect_options).substitutor
   end
 
   it "should substitute all variables with values in listings" do
@@ -72,9 +72,9 @@ describe Resources::CDN::CdnVarSubstitutor do
     stub_successful_cdn_requests(["6","61"],["i386", "x86_64"])
 
     @net_mock.should_receive(:start).exactly(3).times
-    Resources::CDN::CdnVarSubstitutor.with_cache do
-      Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
-      Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
+    Util::CdnVarSubstitutor.with_cache do
+      Resources::CDN::CdnResource.new(provider_url, connect_options).substitutor.substitute_vars(path_with_variables)
+      Resources::CDN::CdnResource.new(provider_url, connect_options).substitutor.substitute_vars(path_with_variables)
     end
   end
 
@@ -82,10 +82,10 @@ describe Resources::CDN::CdnVarSubstitutor do
     stub_successful_cdn_requests(["6","61"],["i386", "x86_64"])
 
     @net_mock.should_receive(:start).exactly(6).times
-    Resources::CDN::CdnVarSubstitutor.with_cache do
-      Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
+    Util::CdnVarSubstitutor.with_cache do
+      Resources::CDN::CdnResource.new(provider_url, connect_options).substitutor.substitute_vars(path_with_variables)
     end
-    Resources::CDN::CdnVarSubstitutor.new(provider_url, connect_options).substitute_vars(path_with_variables)
+    Resources::CDN::CdnResource.new(provider_url, connect_options).substitutor.substitute_vars(path_with_variables)
   end
 
 

--- a/src/spec/models/product_spec.rb
+++ b/src/spec/models/product_spec.rb
@@ -26,13 +26,15 @@ describe Product, :katello => true do
 
     @organization = Organization.create!(:name => ProductTestData::ORG_ID, :cp_key => 'admin-org-37070')
     @provider     = @organization.redhat_provider
-    @substitutor_mock = Resources::CDN::CdnVarSubstitutor.new("https://cdn.redhat.com", {:ssl_client_cert => "456",:ssl_ca_file => "fake-ca.pem", :ssl_client_key => "123"})
+    @cdn_mock = Resources::CDN::CdnResource.new("https://cdn.redhat.com", {:ssl_client_cert => "456",:ssl_ca_file => "fake-ca.pem", :ssl_client_key => "123"})
+    @substitutor_mock = Util::CdnVarSubstitutor.new(@cdn_mock)
     @substitutor_mock.stub!(:precalculate).and_return do |paths|
       # we pretend, that all paths are substituted to themseves
       @substitutor_mock.instance_variable_set("@substitutions", Hash.new {|h,k| {{} => k} })
     end
+    @cdn_mock.stub(:substitutor => @substitutor_mock)
 
-    Resources::CDN::CdnVarSubstitutor.stub(:new => @substitutor_mock)
+    Resources::CDN::CdnResource.stub(:new => @cdn_mock)
     disable_cdn
 
     ProductTestData::SIMPLE_PRODUCT.merge!({:provider => @provider, :environments => [@organization.library]})


### PR DESCRIPTION
It's possible now to use the CdnVarSubstitutor without the rest of the
Rails code, e.g.:

```
require 'lib/util/cdn_var_substitutor.rb'
class CDN
  def get(path)
    {"/server/listing" => "6.1\n6.2",
     "/server/6.1/listing" => "x86_64\ni386",
     "/server/6.2/listing" => "x86_64"}[path]
  end
end
substitutor = Util::CdnVarSubstitutor.new(CDN.new)
substitutor.substitute_vars("/server/$releasever/$basearch/os")
```

All it requires is an object with a method get, taking path inside a
CDN and returning the body for the path.
