### PR TITLE
fix unit tests

### DIFF
--- a/cli/test/katello/__init__.py
+++ b/cli/test/katello/__init__.py
@@ -1,2 +1,5 @@
 
 __path__.append('../src/katello')
+
+from katello.client.i18n import configure_i18n
+configure_i18n()


### PR DESCRIPTION
addressing:

```
======================================================================
ERROR: Failure: NameError (name '_' is not defined)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/nose/loader.py", line 364, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.6/site-packages/nose/importer.py", line 39, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.6/site-packages/nose/importer.py", line 84, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/root/test/katello/tests/core/user/user_role_remove_ldap_group_test.py", line 8, in <module>
    import katello.client.core.user_role
  File "/usr/lib/python2.6/site-packages/katello/client/core/user_role.py", line 41, in <module>
    class List(UserRoleAction):
  File "/usr/lib/python2.6/site-packages/katello/client/core/user_role.py", line 43, in List
    description = _('list all known user roles')
NameError: name '_' is not defined
```
