### PR TITLE
843462 - system group search indexing should not include pulp content

### DIFF
--- a/src/app/models/system_group.rb
+++ b/src/app/models/system_group.rb
@@ -18,7 +18,7 @@ class SystemGroup < ActiveRecord::Base
   include IndexedModel
 
   index_options :extended_json=>:extended_index_attrs,
-                :json=>{},
+                :json=>{:only=>[:id, :organization_id, :name, :description, :max_systems]},
                 :display_attrs=>[:name, :description, :system]
 
   mapping do


### PR DESCRIPTION
Bugzilla 843462 raises an issue where a system (consumer) that is
a member of a system group, is not properly unregistered using
subscription-manager.  When attempting to do so, the user would
see something like "Invalid credentials" returned; however, the
system was partially unregistered on the server (e.g. system record gone).

The reason for this was that Katello was attempting to index
content in pulp for the system group.  The basic flow was:
- delete the system
- update the system group indexes (including info from pulp).
  The problem with this was that the request to pulp was sent
  after the consumer/system was destroyed; therefore, the authorization
  credentials were invalid.

Since there really is no need to index the content in pulp
for the system groups, this commit updates the system group
model to only include the information we need/want.
