### PR TITLE
evironment is now stored to environment variable instead env

### DIFF
--- a/cli/src/katello/client/core/changeset.py
+++ b/cli/src/katello/client/core/changeset.py
@@ -43,7 +43,7 @@ class List(ChangesetAction):
         opt_parser_add_environment(parser, required=1)
 
     def check_options(self, validator):
-        validator.require(('org', 'env'))
+        validator.require(('org', 'environment'))
 
     def run(self):
         orgName = self.get_option('org')


### PR DESCRIPTION
This is left over from 85bafb23

addressing:
2012-08-29 02:28:43,527 [ERROR][MainThread] error() @ base.py:183 - Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/katello/client/cli/base.py", line 193, in main
    ret_code = super(KatelloCLI, self).main(args, command_name, parent_usage)
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 294, in main
    return subcommand.main(self.args[1:], self.args[0], self._get_usage_line(command_name, parent_usage))
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 294, in main
    return subcommand.main(self.args[1:], self.args[0], self._get_usage_line(command_name, parent_usage))
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 368, in main
    self.setup_action(args, command_name, parent_usage)
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 354, in setup_action
    self.process_options(parser, args)
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 212, in process_options
    self.check_options(validator)
  File "/usr/lib/python2.6/site-packages/katello/client/core/changeset.py", line 47, in check_options
    validator.require(('org', 'env'))
  File "/usr/lib/python2.6/site-packages/katello/client/utils/option_validator.py", line 81, in require
    if not self.exists(opt_dest):
  File "/usr/lib/python2.6/site-packages/katello/client/utils/option_validator.py", line 44, in exists
    return (not getattr(self.options, opt_dest) is None)
AttributeError: Values instance has no attribute 'env'
