### PR TITLE
841289 - perform cleanup on failed registration with activation key

### DIFF
--- a/src/app/models/glue/candlepin/consumer.rb
+++ b/src/app/models/glue/candlepin/consumer.rb
@@ -20,6 +20,7 @@ module Glue::Candlepin::Consumer
     base.class_eval do
       before_save :save_candlepin_orchestration
       before_destroy :destroy_candlepin_orchestration
+      after_rollback :rollback_on_candlepin_create, :on => :create
 
       lazy_accessor :href, :facts, :cp_type, :href, :idCert, :owner, :lastCheckin, :created, :guestIds, :installedProducts, :autoheal, :releaseVer, :serviceLevel,
         :initializer => lambda {
@@ -200,6 +201,11 @@ module Glue::Candlepin::Consumer
 
     def destroy_candlepin_orchestration
       pre_queue.create(:name => "delete candlepin consumer: #{self.name}", :priority => 3, :action => [self, :del_candlepin_consumer])
+    end
+
+    # A rollback occurred while attempting to create the consumer; therefore, perform necessary cleanup.
+    def rollback_on_candlepin_create
+      del_candlepin_consumer
     end
 
     def hostname


### PR DESCRIPTION
When a client/system/consumer registers with katello, the
creation of the system in katello is handled using a single db
transaction.  In supporting this, it will assign the system
to the activation key, environment, subscriptions, system groups...etc.
In addition, it will create the appropriate records in pulp,
candlepin and elasticsearch.

If an error occurs when creating the katello records (e.g.
system group max members validation error), a DB rollback will
be performed on the transaction.  While this cleans up the
katello DB, it does not affect pulp, candlepin and elasticsearch.

This commit is to addresses that by introducing the after_rollback
callback on the system, candlepin consumer and pulp consumer,
performing the appropriate cleanup in each handler.
