### PR TITLE
package rubygem-transaction-simple is now in EPEL6

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -90,7 +90,6 @@
        <packagereq type="default">rubygem-text-format</packagereq>
        <packagereq type="default">rubygem-thor</packagereq>
        <packagereq type="default">rubygem-tire</packagereq>
-       <packagereq type="default">rubygem-transaction-simple</packagereq>
        <packagereq type="default">rubygem-tzinfo</packagereq>
        <packagereq type="default">rubygem-warden</packagereq>
        <packagereq type="default">rubygem-yui-compressor</packagereq>


### PR DESCRIPTION
https://admin.fedoraproject.org/updates/FEDORA-EPEL-2012-6752/rubygem-transaction-simple-1.4.0.2-3.el6
