### PR TITLE
758651 - check if thin port is free before starting thin

### DIFF
--- a/src/deploy/common/katello.init
+++ b/src/deploy/common/katello.init
@@ -27,10 +27,13 @@ KATELLO_PIDS=${KATELLO_PIDS:-${KATELLO_HOME}/tmp/pids/thin.*.pid}
 export KATELLO_LOGGING=${KATELLO_LOGGING:-warn}
 export KATELLO_LOGGING_SQL=${KATELLO_LOGGING_SQL:-warn}
 export RAILS_RELATIVE_URL_ROOT=$KATELLO_PREFIX
+THIN_SERVERS=$( awk '/^servers:/ {print $2}' < /etc/katello/thin.yml )
+THIN_PORT=$( awk '/^port:/ {print $2}' < /etc/katello/thin.yml )
+PID_DIR=$( dirname $( echo $KATELLO_PIDS | awk '{print $1}' ) )
 
 check_privilege() {
     runuser -s /bin/sh ${KATELLO_USER} -c "echo x > /dev/null" 2> /dev/null || RETVAL=4
-    if [ $RETVAL = 4 ]; then
+    if [ 0$RETVAL -eq 4 ]; then
         echo "User had insufficient privilege";
         exit $RETVAL
     fi
@@ -78,13 +81,21 @@ start() {
         # delete Gemfile.lock (it will be regenerated)
         rm -f $KATELLO_DATA_DIR/Gemfile.lock
         export HOME=
-        $THIN start --user ${KATELLO_USER} \
-            --environment $KATELLO_ENV \
-            --group ${KATELLO_GROUP} \
-            --config /etc/katello/thin.yml \
-            --rackup "${KATELLO_HOME}/config.ru"
-        RETVAL=$?
-        if [ $RETVAL = 0 ]; then
+        RETVAL=0
+        for P in $( seq $THIN_PORT $(( $THIN_PORT + $THIN_SERVERS - 1)) ); do
+            /usr/sbin/lsof -t -i TCP:$P > /dev/null && \
+            echo "Something is blocking port $P. THIN could not start." && \
+            RETVAL=1;
+        done
+        if [ 0$RETVAL -eq 0 ]; then
+            $THIN start --user ${KATELLO_USER} \
+                --environment $KATELLO_ENV \
+                --group ${KATELLO_GROUP} \
+                --config /etc/katello/thin.yml \
+                --rackup "${KATELLO_HOME}/config.ru" >/dev/null
+            RETVAL=$?
+        fi
+        if [ 0$RETVAL -eq 0 ]; then
             echo_success
         else
             echo_failure
@@ -96,7 +107,14 @@ start() {
 }
 
 stop() {
-    $THIN --config /etc/katello/thin.yml stop
+    echo -n $"Stopping $prog: "
+    $THIN --config /etc/katello/thin.yml stop >/dev/null
+    for P in $( seq $THIN_PORT $(( $THIN_PORT + $THIN_SERVERS - 1)) ); do
+        if [ -f $PID_DIR/thin.$P.pid ]; then
+            killproc -p $PID_DIR/thin.$P.pid
+        fi
+    done
+    echo
 }
 
 restart() {

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -76,6 +76,7 @@ Requires:       rubygem(tire) >= 0.3.0
 Requires:       rubygem(tire) < 0.4
 Requires:       rubygem(ldap_fluff)
 Requires:       rubygem(apipie-rails)
+Requires:       lsof
 
 %if 0%{?rhel} == 6
 Requires:       redhat-logos >= 60.0.14


### PR DESCRIPTION
This does not check if 'thin' really use specified port (although it can be
done by similar for-loop after thin start), because I find it redundant.
It just check if those ports are free, just before thin is started.

As side effect, the init script is not so verbose. And pid files are
correctly deleted when script finish and in case "thin stop" will not work
(which happen sometime), it is killed by sending SIGTERM and SIGKILL.
