### PR TITLE
841300 - Zoom out on 2-Pane page causes rendering error

### DIFF
--- a/src/app/stylesheets/katello.scss
+++ b/src/app/stylesheets/katello.scss
@@ -626,6 +626,7 @@ fieldset {
         @include border-right-radius(5px);
         background-color: $lightergrey_color;
         margin-top: 79px;
+        margin-right: 5px;
         position: relative;
         .panel_action {
             .disabled {
@@ -886,6 +887,7 @@ fieldset {
   border-top: 1px solid #D1D1D2;
   z-index: 0;
   top: 0;
+  @include box-shadow(0 0 20px #ddd inset);
 
   .subnav {
     border: 0;

--- a/src/public/javascripts/panel.js
+++ b/src/public/javascripts/panel.js
@@ -26,7 +26,7 @@ $(document).ready(function () {
         panelLeft = $(this).width();
         $('.block').not('#new').width(panelLeft - 17);
         apanel.width(940 - panelLeft);
-        $('.right').width(898 - panelLeft);
+        $('.right').width(885 - panelLeft);
         if (apanel.hasClass('opened')) {
             apanel.css({
                 "left": (panelLeft)


### PR DESCRIPTION
This fixes rendering error on zoomed-out two pane. I added little gap between left and right pane, I hope this is acceptable solution.
