### PR TITLE
workaround for bz 854263

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -154,6 +154,9 @@ Requires:       candlepin-selinux
 # the following backend engine deps are required by <katello-configure>
 Requires:       mongodb mongodb-server
 Requires:       qpid-cpp-server qpid-cpp-client qpid-cpp-client-ssl qpid-cpp-server-ssl
+%if 0%{?fedora}
+Requires:       /etc/rc.d/init.d/qpidd
+%endif
 Requires:       foreman foreman-postgresql
 # </katello-configure>
 


### PR DESCRIPTION
This file is provided by
qpid-cpp-server-daemon on F16 + updates, F17 + updates
qpid-cpp-server on F16 Gold, F17 Gold

we are leaving out RHEL as there it is always in package qpid-cpp-server
