### PR TITLE
gather up all packages for katello-debug

### DIFF
--- a/src/script/katello-debug
+++ b/src/script/katello-debug
@@ -150,7 +150,7 @@ output = `katello-debug-certificates >> #{File.join(target_dir, "certificates")}
 output = `find /root/ssl-build -ls | sort -k 11 > #{File.join(target_dir, "ssl_build_dir")}`
 
 # Below are custom system calls to get more info
-ouput = `rpm -qa | egrep "katello|candlepin|pulp|thumbslug|qpid" >> #{File.join(target_dir, "packages")}`
+ouput = `rpm -qa" >> #{File.join(target_dir, "packages")}`
 
 
 if (options[:archive])


### PR DESCRIPTION
Filtering out packages not specific to Katello hides issues with other
packages on the system that may be interacting with Katello like the JVM
version, ruby packages, redhat-release and others.
