### PR TITLE
843529 - cleanup task_statuses and job_tasks on system deletion

### DIFF
--- a/src/app/models/system.rb
+++ b/src/app/models/system.rb
@@ -56,7 +56,7 @@ class System < ActiveRecord::Base
   belongs_to :environment, :class_name => "KTEnvironment", :inverse_of => :systems
   belongs_to :system_template
 
-  has_many :task_statuses, :as => :task_owner
+  has_many :task_statuses, :as => :task_owner, :dependent => :destroy
 
   has_many :system_activation_keys, :dependent => :destroy
   has_many :activation_keys, :through => :system_activation_keys

--- a/src/app/models/task_status.rb
+++ b/src/app/models/task_status.rb
@@ -36,6 +36,11 @@ class TaskStatus < ActiveRecord::Base
   # adding belongs_to :system allows us to perform joins with the owning system, if there is one
   belongs_to :system, :foreign_key => :task_owner_id, :class_name => "System"
 
+  # a task may be optionally associated with a job, but it is not required
+  # an example scenario would be a job that is created by performing an action on a system group
+  has_one :job_task, :dependent => :destroy
+  has_one :job, :through => :job_task
+
   before_save :setup_task_type
 
   before_save do |status|

--- a/src/app/views/system_groups/events/_system_items.html.haml
+++ b/src/app/views/system_groups/events/_system_items.html.haml
@@ -2,25 +2,26 @@
   - cssclass = cycle("alt", "")
   <tr class = "#{cssclass}">
 
-%td.event_name{"data-pending-task-id" => (t.id if t.pending?)}
-  - if t.pending?
-    = image_tag("embed/icons/spinner.gif")
-    = t.system.name
-
-  - else
-    %span.icon_wrap.fl.status_icons
-      %span.fl{:class=>(t.state=="error" ? "error_icon" : "check_icon")}
-        &nbsp;&nbsp;
-    .event_status
+- unless t.system.nil?
+  %td.event_name{"data-pending-task-id" => (t.id if t.pending?)}
+    - if t.pending?
+      = image_tag("embed/icons/spinner.gif")
       = t.system.name
-      %span.tipsy-icon.info.task-info{"data-result" => t.result_description}
 
-%td.event_date
-  - if t.pending?
-    = image_tag("embed/icons/spinner.gif")
-    = t.message
-  - else
-    = t.finish_time
+    - else
+      %span.icon_wrap.fl.status_icons
+        %span.fl{:class=>(t.state=="error" ? "error_icon" : "check_icon")}
+          &nbsp;&nbsp;
+      .event_status
+        = t.system.name
+        %span.tipsy-icon.info.task-info{"data-result" => t.result_description}
 
-- if include_tr
-  </tr>
+  %td.event_date
+    - if t.pending?
+      = image_tag("embed/icons/spinner.gif")
+      = t.message
+    - else
+      = t.finish_time
+
+  - if include_tr
+    </tr>


### PR DESCRIPTION
This request addresses the following general issue:
- systemA exists
- systemA is a member of a system group
- an action is performed on the system group
  - performing this action creates a job along with a set of tasks
    (1 for each system in the group), joined together by job_tasks
- systemA is deleted
- when user attempts to access a System Group Event History item
  that involved systemA, they get an error... the issue is that
  the DB was not cleaned up properly when the system was deleted...
  the system is gone, but the task_statuses and job_tasks records
  remain...

With this change, the entries in the task_statuses and job_tasks
will now be deleted when the system is deleted.  In addition, in
the off chance that record wasn't cleaned in the DB, the UI view
was updated to handle the error cleanly.
