### PR TITLE
852631 - system group - update to raise exception when no groups exist

### DIFF
--- a/src/app/controllers/system_group_errata_controller.rb
+++ b/src/app/controllers/system_group_errata_controller.rb
@@ -61,8 +61,14 @@ class SystemGroupErrataController < ApplicationController
     errata_ids = params[:errata_ids]
     job = @group.install_errata(errata_ids)
     
-    notify.success _("Errata scheduled for install.")
+    notify.success _("Install of Errata '%s' scheduled for System Group '%s'.") % [params[:errata_ids], @group.name]
     render :text => job.id
+
+  rescue Errors::SystemGroupEmptyException => e
+    notify.error _("Install of Errata '%s' scheduled for System Group '%s' failed.  Reason: %s") %
+                 [params[:errata_ids], @group.name, e.message]
+
+    render :text => '' and return
   end
 
   def status

--- a/src/app/controllers/system_group_packages_controller.rb
+++ b/src/app/controllers/system_group_packages_controller.rb
@@ -75,6 +75,15 @@ class SystemGroupPackagesController < ApplicationController
                         :group_id           => @group.id,
                         :job                => job,
                         :include_tr_shading => false }
+  rescue Errors::SystemGroupEmptyException => e
+    if !params[:packages].blank?
+      notify.error _("Install of Packages '%s' scheduled for System Group '%s' failed.  Reason: %s") %
+                   [params[:packages], @group.name, e.message]
+    elsif !params[:groups].blank?
+      notify.error _("Install of Package Groups '%s' scheduled for System Group '%s' failed.  Reason: %s") %
+                   [params[:groups], @group.name, e.message]
+    end
+    render :text => '' and return
   end
 
   def remove
@@ -106,6 +115,15 @@ class SystemGroupPackagesController < ApplicationController
     render :partial => 'system_groups/packages/items', :locals => {:editable => @group.systems_editable?,
                                                                    :group_id => @group.id, :job => job,
                                                                    :include_tr_shading => false}
+  rescue Errors::SystemGroupEmptyException => e
+    if !params[:packages].blank?
+      notify.error _("Uninstall of Packages '%s' scheduled for System Group '%s' failed.  Reason: %s") %
+                   [params[:packages], @group.name, e.message]
+    elsif !params[:groups].blank?
+      notify.error _("Uninstall of Package Groups '%s' scheduled for System Group '%s' failed.  Reason: %s") %
+                   [params[:groups], @group.name, e.message]
+    end
+    render :text => '' and return
   end
 
   def update
@@ -138,6 +156,16 @@ class SystemGroupPackagesController < ApplicationController
                          :group_id           => @group.id,
                          :job                => job,
                          :include_tr_shading => false }
+
+  rescue Errors::SystemGroupEmptyException => e
+    if !params[:packages].blank?
+      notify.error _("Update of Packages '%s' scheduled for System Group '%s' failed.  Reason: %s") %
+                   [params[:packages], @group.name, e.message]
+    elsif !params[:groups].blank?
+      notify.error _("Update of Package Groups '%s' scheduled for System Group '%s' failed.  Reason: %s") %
+                   [params[:groups], @group.name, e.message]
+    end
+    render :text => '' and return
   end
 
   def status

--- a/src/app/models/errors.rb
+++ b/src/app/models/errors.rb
@@ -42,6 +42,12 @@ module Errors
 
   class ConflictException < StandardError; end
 
+  class SystemGroupEmptyException < StandardError
+    def message
+      _("System group is empty.")
+    end
+  end
+
   class UsageLimitExhaustedException < StandardError; end
 
   class UnsupportedActionException < StandardError

--- a/src/app/models/system_group.rb
+++ b/src/app/models/system_group.rb
@@ -157,32 +157,38 @@ class SystemGroup < ActiveRecord::Base
   end
 
   def install_packages packages
+    raise Errors::SystemGroupEmptyException if self.systems.empty?
     pulp_job = self.install_package(packages)
     job = save_job(pulp_job, :package_install, :packages, packages)
   end
 
   def uninstall_packages packages
+    raise Errors::SystemGroupEmptyException if self.systems.empty?
     pulp_job = self.uninstall_package(packages)
     job = save_job(pulp_job, :package_remove, :packages, packages)
   end
 
   def update_packages packages=nil
     # if no packages are provided, a full system update will be performed (e.g ''yum update' equivalent)
+    raise Errors::SystemGroupEmptyException if self.systems.empty?
     pulp_job = self.update_package(packages)
     job = save_job(pulp_job, :package_update, :packages, packages)
   end
 
   def install_package_groups groups
+    raise Errors::SystemGroupEmptyException if self.systems.empty?
     pulp_job = self.install_package_group(groups)
     job = save_job(pulp_job, :package_group_install, :groups, groups)
   end
 
   def uninstall_package_groups groups
+    raise Errors::SystemGroupEmptyException if self.systems.empty?
     pulp_job = self.uninstall_package_group(groups)
     job = save_job(pulp_job, :package_group_remove, :groups, groups)
   end
 
   def install_errata errata_ids
+    raise Errors::SystemGroupEmptyException if self.systems.empty?
     pulp_job = self.install_consumer_errata(errata_ids)
     job = save_job(pulp_job, :errata_install, :errata_ids, errata_ids)
   end

--- a/src/spec/models/system_group_spec.rb
+++ b/src/spec/models/system_group_spec.rb
@@ -251,5 +251,30 @@ describe SystemGroup do
 
   end
 
+  context "actions" do
+    it "should raise exception on package install, if no systems in group" do
+      lambda{ @group.install_packages("pkg1")}.should raise_exception(Errors::SystemGroupEmptyException)
+    end
+
+    it "should raise exception on package update, if no systems in group" do
+      lambda{ @group.update_packages("pkg1")}.should raise_exception(Errors::SystemGroupEmptyException)
+    end
+
+    it "should raise exception on package remove, if no systems in group" do
+      lambda{ @group.uninstall_packages("pkg1")}.should raise_exception(Errors::SystemGroupEmptyException)
+    end
+
+    it "should raise exception on package group install, if no systems in group" do
+      lambda{ @group.install_package_groups("grp1")}.should raise_exception(Errors::SystemGroupEmptyException)
+    end
+
+    it "should raise exception on package group remove, if no systems in group" do
+      lambda{ @group.uninstall_package_groups("grp1")}.should raise_exception(Errors::SystemGroupEmptyException)
+    end
+
+    it "should raise exception on errata install, if no systems in group" do
+      lambda{ @group.install_errata("errata1")}.should raise_exception(Errors::SystemGroupEmptyException)
+    end
+  end
 
 end


### PR DESCRIPTION
This commit contains changes so that if the user invokes an action
(e.g. pkg install) on a system group that has no members, they will
receive an error message.

From the UI, this might look like:
  "Install of Packages 'xterm' scheduled for System Group 'group2'
  failed. Reason: System group is empty."

From the CLI, this might look like:
  katello> system_group packages --org myorg --name grp1 --install xterm
  System group is empty.
