### PR TITLE
skip RHSM test when registred against hosted

### DIFF
--- a/scripts/system-test/cli_tests/katello_agent.sh
+++ b/scripts/system-test/cli_tests/katello_agent.sh
@@ -23,53 +23,55 @@ baseurl=http://tstrachota.fedorapeople.org/dummy_repos/zoo/
 gpgcheck=0
 EOF
 
-  test_own_cmd_success "rhsm registration with org" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
-    --org="$TEST_ORG" --environment "$TEST_ENV" --name="$HOST" --force
+  if grep 'hostname = subscription.rhn.redhat.com' /etc/rhsm/rhsm.conf; then
+    skip_test_success "rhsm registration" "Could not test against hosted"
+  else
+    test_own_cmd_success "rhsm registration with org" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
+      --org="$TEST_ORG" --environment "$TEST_ENV" --name="$HOST" --force
+    # retrieve the system's uuid for later use
+    identity=$($SUDO subscription-manager identity | grep -o -E "^Current identity is:.*")
+    SYSTEM_UUID=${identity:21}
+ 
+    echo "removing package "$INSTALL_PACKAGE" from the system"
+    $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
+    test_success "remote system package install" system packages --install "$INSTALL_PACKAGE" --name "$HOST" --org "$TEST_ORG"
+    test_own_cmd_success "package installed" rpm -q "$INSTALL_PACKAGE" &> /dev/null
+    test_success "remote system package update" system packages --update "$INSTALL_PACKAGE" --name "$HOST" --org "$TEST_ORG"
+    test_success "remote system package remove" system packages  --remove "$INSTALL_PACKAGE" --name "$HOST" --org "$TEST_ORG"
+    test_own_cmd_failure "package unistalled" rpm -q "$INSTALL_PACKAGE" &> /dev/null
 
-  # retrieve the system's uuid for later use
-  identity=$($SUDO subscription-manager identity | grep -o -E "^Current identity is:.*")
-  SYSTEM_UUID=${identity:21}
+    echo "removing group "$INSTALL_GROUP" from the system"
+    $SUDO yum groupremove -y "$INSTALL_GROUP" &> /dev/null
+    test_success "remote system package group install" system packages --install_group "$INSTALL_GROUP" --name "$HOST" --org "$TEST_ORG"
+    test_own_cmd_success "package group installed"  rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
+    test_success "remote system package group remove" system packages  --remove_group "$INSTALL_GROUP" --name "$HOST" --org "$TEST_ORG"
+    test_own_cmd_failure "package group uninstalled" rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
 
-  echo "removing package "$INSTALL_PACKAGE" from the system"
-  $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
-  test_success "remote system package install" system packages --install "$INSTALL_PACKAGE" --name "$HOST" --org "$TEST_ORG"
-  test_own_cmd_success "package installed" rpm -q "$INSTALL_PACKAGE" &> /dev/null
-  test_success "remote system package update" system packages --update "$INSTALL_PACKAGE" --name "$HOST" --org "$TEST_ORG"
-  test_success "remote system package remove" system packages  --remove "$INSTALL_PACKAGE" --name "$HOST" --org "$TEST_ORG"
-  test_own_cmd_failure "package unistalled" rpm -q "$INSTALL_PACKAGE" &> /dev/null
+    # perform some tests on a system group
+    test_success "system group create" system_group create --name "$SYSTEM_GROUP_NAME" --description "group description" --org "$TEST_ORG"
+    test_success "add system to system group" system_group add_systems --system_uuids "$SYSTEM_UUID" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
 
-  echo "removing group "$INSTALL_GROUP" from the system"
-  $SUDO yum groupremove -y "$INSTALL_GROUP" &> /dev/null
-  test_success "remote system package group install" system packages --install_group "$INSTALL_GROUP" --name "$HOST" --org "$TEST_ORG"
-  test_own_cmd_success "package group installed"  rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
-  test_success "remote system package group remove" system packages  --remove_group "$INSTALL_GROUP" --name "$HOST" --org "$TEST_ORG"
-  test_own_cmd_failure "package group uninstalled" rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
+    echo "removing package "$INSTALL_PACKAGE" from the system"
+    $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
+    test_success "remote system group package install" system_group packages --install "$INSTALL_PACKAGE" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    test_own_cmd_success "package installed" rpm -q "$INSTALL_PACKAGE" &> /dev/null
+    test_success "remote system group package update" system_group packages --update "$INSTALL_PACKAGE" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    test_success "remote system group package remove" system_group packages  --remove "$INSTALL_PACKAGE" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    test_own_cmd_failure "package unistalled" rpm -q "$INSTALL_PACKAGE" &> /dev/null
 
-  # perform some tests on a system group
-  test_success "system group create" system_group create --name "$SYSTEM_GROUP_NAME" --description "group description" --org "$TEST_ORG"
-  test_success "add system to system group" system_group add_systems --system_uuids "$SYSTEM_UUID" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    echo "removing group "$INSTALL_GROUP" from the system"
+    $SUDO yum groupremove -y "$INSTALL_GROUP" &> /dev/null
+    test_success "remote system group package group install" system_group packages --install_group "$INSTALL_GROUP" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    test_own_cmd_success "package group installed"  rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
+    test_success "remote system group package group update" system_group packages --update_group "$INSTALL_GROUP" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    test_success "remote system group package group remove" system_group packages  --remove_group "$INSTALL_GROUP" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    test_own_cmd_failure "package group uninstalled" rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
 
-  echo "removing package "$INSTALL_PACKAGE" from the system"
-  $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
-  test_success "remote system group package install" system_group packages --install "$INSTALL_PACKAGE" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-  test_own_cmd_success "package installed" rpm -q "$INSTALL_PACKAGE" &> /dev/null
-  test_success "remote system group package update" system_group packages --update "$INSTALL_PACKAGE" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-  test_success "remote system group package remove" system_group packages  --remove "$INSTALL_PACKAGE" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-  test_own_cmd_failure "package unistalled" rpm -q "$INSTALL_PACKAGE" &> /dev/null
+    test_success "remove system from system group" system_group remove_systems --system_uuids "$SYSTEM_UUID" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
+    test_success "system group delete" system_group delete --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
 
-  echo "removing group "$INSTALL_GROUP" from the system"
-  $SUDO yum groupremove -y "$INSTALL_GROUP" &> /dev/null
-  test_success "remote system group package group install" system_group packages --install_group "$INSTALL_GROUP" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-  test_own_cmd_success "package group installed"  rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
-  test_success "remote system group package group update" system_group packages --update_group "$INSTALL_GROUP" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-  test_success "remote system group package group remove" system_group packages  --remove_group "$INSTALL_GROUP" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-  test_own_cmd_failure "package group uninstalled" rpm -q "$INSTALL_GROUP_PACKAGE" &> /dev/null
-
-  test_success "remove system from system group" system_group remove_systems --system_uuids "$SYSTEM_UUID" --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-  test_success "system group delete" system_group delete --name "$SYSTEM_GROUP_NAME" --org "$TEST_ORG"
-
-  test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
-
+    test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
+  fi
   rm /etc/yum.repos.d/zoo.repo
 else
   skip_test_success "katello-agent" "katello-agent not installed"

--- a/scripts/system-test/cli_tests/provider_import.sh
+++ b/scripts/system-test/cli_tests/provider_import.sh
@@ -54,23 +54,26 @@ sm_present() {
 
 # testing registration from rhsm
 if sm_present; then
-  test_own_cmd_success "rhsm registration with org" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
-    --org="$MANIFEST_ORG" --name="$HOST" --force
-  test_own_cmd_success "rhsm subscribe to pool" $SUDO subscription-manager subscribe --pool "$POOLID"
-  $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
-  test_own_cmd_success "install package from subscribed product" $SUDO yum install -y "$INSTALL_PACKAGE" --nogpgcheck --releasever "$RELEASEVER" --disablerepo \* --enablerepo "$MANIFEST_REPO_LABEL" &> /dev/null
-  $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
-  test_own_cmd_success "rhsm set releasever" $SUDO subscription-manager release --set "$RELEASEVER"
-  test_own_cmd_success "install package from subscribed product after set releasever" $SUDO yum install -y "$INSTALL_PACKAGE" --nogpgcheck &> /dev/null
-  $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
-  test_own_cmd_success "rhsm unsubscribe all" $SUDO subscription-manager unsubscribe --all
-  test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
+  if grep 'hostname = subscription.rhn.redhat.com' /etc/rhsm/rhsm.conf; then
+    skip_test_success "rhsm registration" "Could not test against hosted"
+  else
+    test_own_cmd_success "rhsm registration with org" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
+      --org="$MANIFEST_ORG" --name="$HOST" --force
+    test_own_cmd_success "rhsm subscribe to pool" $SUDO subscription-manager subscribe --pool "$POOLID"
+    $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
+    test_own_cmd_success "install package from subscribed product" $SUDO yum install -y "$INSTALL_PACKAGE" --nogpgcheck --releasever "$RELEASEVER" --disablerepo \* --enablerepo "$MANIFEST_REPO_LABEL" &> /dev/null
+    $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
+    test_own_cmd_success "rhsm set releasever" $SUDO subscription-manager release --set "$RELEASEVER"
+    test_own_cmd_success "install package from subscribed product after set releasever" $SUDO yum install -y "$INSTALL_PACKAGE" --nogpgcheck &> /dev/null
+    $SUDO yum remove -y "$INSTALL_PACKAGE" &> /dev/null
+    test_own_cmd_success "rhsm unsubscribe all" $SUDO subscription-manager unsubscribe --all
+    test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
 
-  test_own_cmd_success "rhsm list available SLAs" $SUDO subscription-manager service-level --list --org="$MANIFEST_ORG"  --username="$USER" --password="$PASSWORD"
-  test_own_cmd_exit_code 1 "rhsm registration with SLA" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
-    --org="$MANIFEST_ORG" --name="$HOST" --servicelevel="$SLA" --autosubscribe --force
-  test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
-
+    test_own_cmd_success "rhsm list available SLAs" $SUDO subscription-manager service-level --list --org="$MANIFEST_ORG"  --username="$USER" --password="$PASSWORD"
+    test_own_cmd_exit_code 1 "rhsm registration with SLA" $SUDO subscription-manager register --username="$USER" --password="$PASSWORD" \
+      --org="$MANIFEST_ORG" --name="$HOST" --servicelevel="$SLA" --autosubscribe --force
+    test_own_cmd_success "rhsm unregister" $SUDO subscription-manager unregister
+  fi
 else
   skip_test_success "rhsm registration" "subscription-manager command not found"
 fi


### PR DESCRIPTION
addressing:

```
rhsm registration with org              [ FAILED ]
subscription-manager register --username=admin --password=admin --org=org_Y9VdNJY0p8AI --environment env Y9VdNJY0p8AI --name=FILTERED_HOSTNAME_Y9VdNJY0p8AI --force
ERROR: Server does not support environments.
WARNING

This system has already been registered with RHN using RHN Classic technology.

The tool you are using is attempting to re-register using RHN Certificate-Based technology. Red Hat recommends (except in a few cases) that customers only register with RHN once.

To learn more about RHN registration and technologies please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563
removing package cheetah from the system
...
...
rhsm registration with org              [ FAILED ]
subscription-manager register --username=admin --password=admin --org=org_manifest_Y9VdNJY0p8AI --name=FILTERED_HOSTNAME_Y9VdNJY0p8AI --force
Invalid username or password. To create a login, please visit https://www.redhat.com/wapps/ugc/register.html
WARNING

This system has already been registered with RHN using RHN Classic technology.

The tool you are using is attempting to re-register using RHN Certificate-Based technology. Red Hat recommends (except in a few cases) that customers only register with RHN once.

To learn more about RHN registration and technologies please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563
rhsm subscribe to pool                  [ FAILED ]
subscription-manager subscribe --pool 8aa2b6a63996ee0a013996f412c70023
This system is not yet registered. Try 'subscription-manager register --help' for more information.
rhsm set releasever                     [ FAILED ]
subscription-manager release --set 6.2
This system is not yet registered. Try 'subscription-manager register --help' for more information.
rhsm unsubscribe all                    [ OK ]
rhsm unregister                         [ FAILED ]
subscription-manager unregister
This system is currently not registered.
rhsm list available SLAs                [ FAILED ]
subscription-manager service-level --list --org=org_manifest_Y9VdNJY0p8AI --username=admin --password=admin
Invalid username or password. To create a login, please visit https://www.redhat.com/wapps/ugc/register.html
rhsm registration with SLA              [ FAILED ]
subscription-manager register --username=admin --password=admin --org=org_manifest_Y9VdNJY0p8AI --name=FILTERED_HOSTNAME_Y9VdNJY0p8AI --servicelevel=SELF-SUPPORT --autosubscribe --force
Invalid username or password. To create a login, please visit https://www.redhat.com/wapps/ugc/register.html
WARNING

This system has already been registered with RHN using RHN Classic technology.

The tool you are using is attempting to re-register using RHN Certificate-Based technology. Red Hat recommends (except in a few cases) that customers only register with RHN once.

To learn more about RHN registration and technologies please consult this Knowledge Base Article: https://access.redhat.com/kb/docs/DOC-45563
rhsm unregister                         [ FAILED ]
subscription-manager unregister
This system is currently not registered.
```
