### PR TITLE
Truncate Notice text to max 1024 characters.

### DIFF
--- a/src/app/models/notice.rb
+++ b/src/app/models/notice.rb
@@ -38,6 +38,7 @@ class Notice < ActiveRecord::Base
   validates_length_of :request_type, :maximum => 255
 
   before_validation :set_default_notice_level
+  before_validation :trim_text
   before_save :add_to_all_users
 
   scope :readable, lambda { |user| joins(:users).where('users.id' => user) }
@@ -71,5 +72,9 @@ class Notice < ActiveRecord::Base
 
   def set_default_notice_level
     self.level ||= TYPES.first
+  end
+
+  def trim_text
+    self.text = "#{self.text[0, 1020]} ..." if self.text.size > 1024
   end
 end


### PR DESCRIPTION
When some exception with long message (eg PGError value too long) was raised, Notice was not created and it was impossible to find out in Katello UI what happened.
