### PR TITLE
841121 - Long description while creating system group returns PG error

### DIFF
--- a/src/app/models/system_group.rb
+++ b/src/app/models/system_group.rb
@@ -55,6 +55,7 @@ class SystemGroup < ActiveRecord::Base
   validates_presence_of :organization_id, :message => N_("Organization cannot be blank.")
   validates_uniqueness_of :name, :scope => :organization_id, :message => N_("must be unique within one organization")
   validates_uniqueness_of :pulp_id, :message=> N_("must be unique.")
+  validates :description, :length => { :maximum => 255 }
 
   UNLIMITED_SYSTEMS = -1
   validates_numericality_of :max_systems, :only_integer => true, :greater_than_or_equal_to => -1, :message => N_("must be a positive integer value.")


### PR DESCRIPTION
Added length validation to system group description
