### PR TITLE
845041 - UI - Exact Errata search in content search does not return result

### DIFF
--- a/src/app/models/glue/pulp/errata.rb
+++ b/src/app/models/glue/pulp/errata.rb
@@ -90,10 +90,11 @@ class Glue::Pulp::Errata
           :repoids      => { :type => 'string', :index =>:not_analyzed},
           :id_sort      => { :type => 'string', :index => :not_analyzed},
           :id_title     => { :type => 'string', :analyzer =>:title_analyzer},
-          :id           => { :type => 'string', :analyzer =>:kt_name_analyzer},
+          :id           => { :type => 'string', :analyzer =>:snowball},
           :product_ids  => { :type => 'integer', :analyzer =>:kt_name_analyzer},
           :severity     => { :type => 'string', :analyzer =>:kt_name_analyzer},
           :type         => { :type => 'string', :analyzer =>:kt_name_analyzer},
+          :title        => { :type => 'string', :analyzer => :title_analyzer},
         }
       }
     }

--- a/src/app/views/content_search/_browser_box.html.haml
+++ b/src/app/views/content_search/_browser_box.html.haml
@@ -98,7 +98,7 @@
                   %li
                     =_('Searching for an exact errata:')
                     .example
-                      RHSA-2010:0858
+                      id:"RHSA-2010:0858"
                   %li
                     =_('Searching by type (bugfix, security, enhancement allowed):')
                     .example


### PR DESCRIPTION
Passing errata_ids (here named package_ids_in, renamed by me in another PR) to #spanned_product_content method as array means that in #multi_repo_content_search it is used as term not as search query and thus searching for exact match. I also removed analyzer on errata id because I think it is not needed (but maybe I'm wrong?).
