### PR TITLE
841121 -  Long description returns PG error

### DIFF
--- a/src/app/models/role.rb
+++ b/src/app/models/role.rb
@@ -46,7 +46,7 @@ class Role < ActiveRecord::Base
   # scope to facilitate retrieving roles that are 'non-self' roles... group() so that unique roles are returned
   scope :non_self, joins("left outer join users on users.own_role_id = roles.id").where('users.own_role_id'=>nil).order('roles.name')
   validates :name, :uniqueness => true, :katello_name_format => true, :presence => true
-  validates :description, :katello_description_format => true
+  validates :description, :length => { :maximum => 250 }
   validates_with LockValidator, :on => :update
 
   #validates_associated :permissions

--- a/src/app/models/sync_plan.rb
+++ b/src/app/models/sync_plan.rb
@@ -42,6 +42,7 @@ class SyncPlan < ActiveRecord::Base
   validates_inclusion_of :interval,
     :in => TYPES,
     :allow_blank => false
+  validates :description, :katello_description_format => true
 
   scope :readable, lambda { |org| ::Provider.any_readable?(org)? where(:organization_id => org.id ) : where("0 = 1") }
 

--- a/src/app/models/system_group.rb
+++ b/src/app/models/system_group.rb
@@ -55,7 +55,7 @@ class SystemGroup < ActiveRecord::Base
   validates_presence_of :organization_id, :message => N_("Organization cannot be blank.")
   validates_uniqueness_of :name, :scope => :organization_id, :message => N_("must be unique within one organization")
   validates_uniqueness_of :pulp_id, :message=> N_("must be unique.")
-  validates :description, :length => { :maximum => 255 }
+  validates :description, :katello_description_format => true
 
   UNLIMITED_SYSTEMS = -1
   validates_numericality_of :max_systems, :only_integer => true, :greater_than_or_equal_to => -1, :message => N_("must be a positive integer value.")

--- a/src/app/models/system_template.rb
+++ b/src/app/models/system_template.rb
@@ -35,7 +35,7 @@ class SystemTemplate < ActiveRecord::Base
   validates_uniqueness_of :name, :scope => :environment_id
   validates_length_of :name, :maximum => 255
   validates_with ParentTemplateValidator
-  validates_length_of :description, :maximum => 255
+  validates :description, :katello_description_format => true
   validates_length_of :parameters_json, :maximum => 255
 
   belongs_to :parent, :class_name => "SystemTemplate"


### PR DESCRIPTION
Added validation to sync_plan model and modified in role model to be consistent with DB constraint. Use KatelloDescriptionFormatValidator where possible.

I checked:

activation_key - ok
changeset - ok
kt_environment - ok
organization - ok
permission - ok
provider - ok
role - there was limit in migration to 250 chars so i modified validation
sync_plan - added validation
system_group - ok
system_template - ok
system - ok
