### PR TITLE
840735 - headpin create environment returned error :There was an error r...

### DIFF
--- a/src/app/views/systems/_list_systems.html.haml
+++ b/src/app/views/systems/_list_systems.html.haml
@@ -1,2 +1,1 @@
-%div#system_list
-  = render :partial=>"systems/list_system", :collection=>collection, :as=>:item, :locals=>{:accessor=>accessor, :columns=>columns, :name=>name}
+= render :partial=>"systems/list_system", :collection=>collection, :as=>:item, :locals=>{:accessor=>accessor, :columns=>columns, :name=>name}


### PR DESCRIPTION
...etrieving that row:Not Found

also fixing "Error: row not found" when creating a system by environments as noted in comment#4.

the div is long longer needed because the system_edit javascript does
not reference any element with an id of 'system_list'.

this was removed because the 2pane wasn't designed to have a div
within its section element which causes some searching and javascript
to break.
