### PR TITLE
switching our schema config names to match production and relaxing reset

### DIFF
--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -26,9 +26,9 @@ development:
 <%=db%>
   <%else%>
   adapter: postgresql
-  username: katello
-  password: katello
-  database: katello
+  username: katellouser
+  password: katelloschema
+  database: katelloschema
   host: localhost
   encoding: UTF8
   <%end%>

--- a/src/script/katello-reset-dbs
+++ b/src/script/katello-reset-dbs
@@ -2,12 +2,11 @@
 
 SRV="sudo /sbin/service"
 
+KATELLO_PREFIX="/katello"
+
 if [ -f /etc/sysconfig/katello ]; then
   # load configuration values
   . /etc/sysconfig/katello
-else
-  echo "Katello does not seem to be installed on this machine" 1>&2
-  exit 1
 fi
 
 # default configuration values (should be the same as in our sysv init script)


### PR DESCRIPTION
removing required check at top of script/katello-reset-dbs to check for
installed configuration file.  This doesn't exist for people who don't have the katello RPM installed.

Also changed database.yml dev env to match up with the production schema names so the dev setup can run cleanly
