### PR TITLE
855184 - Using --add_package gives undefined method `empty?' for nil:NilClass error

### DIFF
--- a/src/app/models/changeset.rb
+++ b/src/app/models/changeset.rb
@@ -254,12 +254,12 @@ class Changeset < ActiveRecord::Base
                                              package_data[:release], package_data[:epoch])
     end
 
-    if packs.empty? || !package_data
+    if packs.blank? || !package_data
        packs = Katello::PackageUtils::find_latest_packages(
                   product.find_packages_by_name(env_to_verify_on_add_content, name_or_nvre))
     end
 
-    packs.first.with_indifferent_access
+    packs.first.try(:with_indifferent_access)
   end
 
   def env_to_verify_on_add_content


### PR DESCRIPTION
Ensure that no exception raises when package is not found.
