### PR TITLE
854278 - After adding certain objects to katello one will see a

### DIFF
--- a/src/app/controllers/users_controller.rb
+++ b/src/app/controllers/users_controller.rb
@@ -256,7 +256,7 @@ class UsersController < ApplicationController
     if  @user.update_attributes(params[:user])
       notify.success _("User updated successfully.")
 
-      if not search_validate(User, user.id, params[:search])
+      if not search_validate(User, @user.id, params[:search])
         notify.message _("'%s' no longer matches the current search criteria.") % @user["name"]
       end
 


### PR DESCRIPTION
warning, '' did not meet the current search criteria and is not being
shown

when you updated the roles and/or environments of a user and saved them,
you would get a notice " '' no longer matches the current search
criteria. " the next time that katello would poll for notices (so
sometimes it would be delayed).
