### PR TITLE
Bug 754738 - katello-jobs not returning proper service status

### DIFF
--- a/src/deploy/common/katello-jobs.init
+++ b/src/deploy/common/katello-jobs.init
@@ -48,6 +48,8 @@ print_lower() {
 
 status_of_one() {
     PID_FILE="$1"
+    local RC
+    local RETVAL 
     if [ -f "$PID_FILE" ]; then
         # set $pid
         __pids_var_run NOT_USED $PID_FILE
@@ -71,6 +73,9 @@ status_of_one() {
 }
 
 kstatus() {
+    local RETVAL
+    local SECONDVAL
+    local RC
     if [ 0$KATELLO_JOB_WORKERS -eq 1 ]; then
        echo -n "delayed_job is "
        status_of_one $KATELLO_PID_DIR/delayed_job.pid


### PR DESCRIPTION
Total rewrite of katello-jobs service

Now utilizing function from /etc/rc.d/init.d/functions
and handling each process independently.
