### PR TITLE
fix dependecies on Fedora17+

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -64,7 +64,11 @@ gem "apipie-rails"
 group :test, :development do
   # To use debugger
   gem 'redcarpet'
-  gem 'ruby-debug'
+  if RUBY_VERSION >= "1.9.1"
+    gem 'ruby-debug19'
+  else
+    gem 'ruby-debug'
+  end
   gem 'ZenTest', '>= 4.4.0'
   gem 'rspec-rails', '>= 2.0.0'
   gem 'autotest-rails', '>= 4.1.0'


### PR DESCRIPTION
ruby-debug does not work with ruby 1.9, because upstream wanted to rewrite it from scrach.
Which never happened. ruby-debug has been forked to ruby-debug19 in mean time
