### PR TITLE
854697 - manifest import - if first import fails, rollback (unimport it)

### DIFF
--- a/src/lib/resources/candlepin.rb
+++ b/src/lib/resources/candlepin.rb
@@ -266,6 +266,10 @@ module Resources
           self.post(path, {:import => File.new(path_to_file, 'rb')}, self.default_headers.except('content-type'))
         end
 
+        def destroy_imports organization_name
+          self.delete(join_path(path(organization_name), 'imports'), self.default_headers)
+        end
+
         def imports organization_name
           imports_json = self.get(join_path(path(organization_name), 'imports'), self.default_headers)
           JSON.parse(imports_json).collect {|s| s.with_indifferent_access}

--- a/src/lib/task.rb
+++ b/src/lib/task.rb
@@ -11,13 +11,14 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 class Task
-  attr_reader :name, :status, :priority, :action, :timestamp
+  attr_reader :name, :status, :priority, :action, :action_rollback, :timestamp
 
   def initialize opts
     @name      = opts[:name]
     @status    = opts[:status]
     @priority  = opts[:priority] || 0
     @action    = opts[:action]
+    @action_rollback = opts[:action_rollback]
     update_ts
   end
 


### PR DESCRIPTION
This commit contains changes such that if a user attempts to import
a manifest and the import fails, the orchestration will rollback
(i.e. unimport) the manifest.

This change is to address a scenario like the following:
- user sets the CDN to an invalid value
- user imports a manifest
- the import of the manifest in to candlepin succeeds; however,
  the creation of the repos using candlepin/cdn fails (since
  the cdn url is bad)

With this change, the user can fix the cdn url and attempt a
reimport.

A couple of issues to be aware of:
1. The manifest upload history will report the failed upload as
   successful; however, an error notice will be generated.  The
   issue here is that we should not be displaying upload history
   based only on the success of the candlepin upload.  A separate
   bugzilla has been created to address this.
1. This rollback only applies if there have not been any previous
   successful imports.  The reason being rolling back will completely
   remove any information stored in candlepin from that manifest
   and any incrementals previously imported.  In addition, subscriptions
   will be removed.  Support for proper rollbacks are something that
   can be explored in the future.
