### PR TITLE
Fix for removing user's default org.

### DIFF
--- a/src/app/controllers/users_controller.rb
+++ b/src/app/controllers/users_controller.rb
@@ -309,6 +309,7 @@ class UsersController < ApplicationController
       notify.success _("Default Organization: '%s' saved.") % default_org.name
     else
       current_user.default_org = nil
+      current_user.save!
       notify.success _("Default Organization no longer selected.")
     end
     render :text => :ok and return


### PR DESCRIPTION
Due to Partha's suggestion to remove self.save from the model, I neglected to add the save to the org removal.  This is a fix for that.
