### PR TITLE
837000 - [RFE] when updating sync plan by CLI, it resets the interval.

### DIFF
--- a/cli/src/katello/client/core/sync_plan.py
+++ b/cli/src/katello/client/core/sync_plan.py
@@ -151,9 +151,8 @@ class Update(SyncPlanAction):
         opt_parser_add_org(parser, required=1)
         parser.add_option("--description", dest="description", help=_("plan description"))
         parser.add_option('--interval', dest='interval',
-            help=_("interval of recurring synchronizations (choices: [%s], default: none)") %
-                ', '.join(self.interval_choices),
-            default='none', choices=self.interval_choices)
+            help=_("interval of recurring synchronizations (choices: [%s])") %
+                ', '.join(self.interval_choices), choices=self.interval_choices)
         parser.add_option("--date", dest="date", help=_("date of first synchronization (format: YYYY-MM-DD)"))
         parser.add_option("--time", dest="time", help=_("time of first synchronization (format: HH:MM:SS)"))
 


### PR DESCRIPTION
Interval default value was set to 'none' in CLI. This is ok for create action but for update there should be no default.
