### PR TITLE
856220 - adding time to puppet log

### DIFF
--- a/katello-configure/bin/katello-configure
+++ b/katello-configure/bin/katello-configure
@@ -511,7 +511,8 @@ begin
 		processing_logfile = nil
 		t = nil
 		while line = f.gets do
-      puppet_logfile.syswrite(line.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, ''))
+      time = Time.now.strftime("%y%m%d-%H:%M:%S ")
+      puppet_logfile.syswrite(time + line.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, ''))
       puts "Got " + line if ENV['KATELLO_CONFIGURE_DEBUG']
       if nobars
         if line =~ /debug:/

--- a/katello-configure/modules/katello/manifests/config.pp
+++ b/katello-configure/modules/katello/manifests/config.pp
@@ -174,8 +174,8 @@ class katello::config {
     creates => "/var/lib/katello/db_seed_done",
     before  => Class["katello::service"],
     require => $katello::params::deployment ? {
-                'katello' => [ Exec["katello_migrate_db"], File["${katello::params::log_base}"] ],
-                'headpin' => [ Exec["katello_migrate_db"], File["${katello::params::log_base}"] ],
+                'katello' => [ Exec["katello_migrate_db"], Class["candlepin::service"], Class["pulp::service"], File["${katello::params::log_base}"] ],
+                'headpin' => [ Exec["katello_migrate_db"], Class["candlepin::service"], Class["thumbslug::service"], File["${katello::params::log_base}"] ],
                 default => [],
     },
   }

--- a/src/script/service-wait
+++ b/src/script/service-wait
@@ -56,7 +56,8 @@ after_start() {
   case "$SERVICE" in
     tomcat6|tomcat7)
       # RHBZ 789288 - wait until data port is avaiable
-      /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- --no-check-certificate $TOMCAT_TEST_URL
+      /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- --no-check-certificate $TOMCAT_TEST_URL >/dev/null
+      sleep $ADDITIONAL_SLEEP
       ;;
     mongod)
       # RHBZ 824405 - wait until service is avaiable
@@ -71,6 +72,7 @@ after_start() {
       # and create lock and pid files if they does not exist
       [ -f "/var/lock/subsys/postgresql" ] || touch "/var/lock/subsys/postgresql"
       [ -f "/var/run/postmaster.${POSTGRES_PORT}.pid" ] || head -n 1 "$POSTGRES_DATA/postmaster.pid" > "/var/run/postmaster.${POSTGRES_PORT}.pid"
+      sleep $ADDITIONAL_SLEEP
       ;;
   esac
 }


### PR DESCRIPTION
So I am not able to reproduce when installing from my own RPM package, I need to merge this into master and install from repo. Then the bug appears. I pushed 2nd commit that:

1) Adds time and date to puppet logs (I need to see WHEN this happens and what is the delay between tomcat restart and migrate)

2) Adding additional sleep for postgres and tomcat (mongodb already have 5 second sleep)

3) Adding extra dependency for the migrate task (its already transitient, but just to be sure in the future).

Please merge by 12:00 UTC to have it in the next nightly build.
