### PR TITLE
Hide 'new changeset' button when it should not be used

### DIFF
--- a/src/app/helpers/promotions_helper.rb
+++ b/src/app/helpers/promotions_helper.rb
@@ -72,5 +72,13 @@ module PromotionsHelper
     escape_javascript(filters.to_json)
   end
 
+  def show_new_button?(manage_promotion, manage_deletion)
+    if @environment.library?
+      manage_promotion && @next_environment
+    else
+      manage_deletion || (manage_promotion && @next_environment)
+    end
+  end
+
 end
 

--- a/src/app/views/promotions/show.html.haml
+++ b/src/app/views/promotions/show.html.haml
@@ -207,7 +207,7 @@
     = render :partial=>"common/tupane"
   
     #content_tree.left.sliding_tree
-      - if manage_promotion_changesets or manage_deletion_changesets or @environment.organization.environments_manageable?
+      - if show_new_button?(manage_promotion_changesets, manage_deletion_changesets)
         - next_env = @next_environment.nil? ? "" : "&next_env_id=" + @next_environment.id.to_s
         %a.fr{:href => "#", :id => "new", :class => "block", "data-ajax_url" => "#{url_for(:controller=>'changesets', :action=> 'new')}?env_id=#{@environment.id}"+"#{next_env}"}
           #{_('+ New Changeset')}


### PR DESCRIPTION
If either promotion or deletion changeset cannot be created,
user won't see the 'New Changeset' button.
