### PR TITLE
853229 - blank sync plan date gives incorrect error

### DIFF
--- a/src/app/controllers/sync_plans_controller.rb
+++ b/src/app/controllers/sync_plans_controller.rb
@@ -92,8 +92,11 @@ class SyncPlansController < ApplicationController
 
   #convert date, time from UI to object
   def convert_date_time(date, time)
+    return nil if date.blank? || time.blank?
     sync_event = date + ' ' + time + ' '  + DateTime.now.zone
     DateTime.strptime(sync_event, "%m/%d/%Y %I:%M %P %:z")
+  rescue ArgumentError
+    raise _("Invalid date or time format")
   end
 
   def destroy


### PR DESCRIPTION
Previously we relied on convert_date_time to throw an exception to catch.  If an exception occurred we would leave date blank and let the model validation throw a validation error. 

With this commit:  18d2fbe61fef6f6024437964bd4fbc681dbe0e57   that was removed, so the exception convert_date_time threw simply went to the browser as a notification.  This would also mean that invalid formats would show up with a warning that they couldn't be 'blank'.   

So this commit has 2 parts, simply have convert_date_time  return nil if either date or time is blank, so the model validation will get caught.  If the conversion to a date object throws an exception however, we want to catch it and throw a more human readable exception.  Ideally this would occur within the model and be a validaiton error, but that doesn't seem to be easy to do, since the model doesn't even have a time field, and the date field is something different completely.
