### PR TITLE
Getting rid of postgres index warnings

### DIFF
--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -31,6 +31,7 @@ development:
   database: katello
   host: localhost
   encoding: UTF8
+  min_messages: WARNING
   <%end%>
 
 # Warning: The database defined as "test" will be erased and
@@ -47,6 +48,7 @@ test:
   database: katello_test
   host: localhost
   encoding: UTF8
+  min_messages: WARNING
   <%end%>
 
 production:
@@ -60,4 +62,5 @@ production:
   database: katello_production
   host: localhost
   encoding: UTF8
+  min_messages: WARNING
   <%end%>


### PR DESCRIPTION
Getting rid of "NOTICE: CREATE TABLE / PRIMARY KEY will create implicit index" warnings that get output to the console every time you migrate the database using postgres.
