### PR TITLE
855406 - pass correctly environment variables which ruby needs

### DIFF
--- a/src/deploy/common/katello-jobs.init
+++ b/src/deploy/common/katello-jobs.init
@@ -140,7 +140,7 @@ start() {
         # delete Gemfile.lock (it will be regenerated)
         rm -f $KATELLO_DATA_DIR/Gemfile.lock
         # start jobs
-        runuser -m -s /bin/bash - katello -c "bundle exec script/delayed_job $KATELLO_JOB_PARAMS -m -n $KATELLO_JOB_WORKERS start &>>/var/log/katello/jobs-startup.log"
+        runuser -s /bin/bash - katello -c "RAILS_ENV='$RAILS_ENV' KATELLO_LOGGING='$KATELLO_LOGGING' KATELLO_LOGGING_SQL='$KATELLO_LOGGING_SQL' bundle exec script/delayed_job $KATELLO_JOB_PARAMS -m -n $KATELLO_JOB_WORKERS start &>>/var/log/katello/jobs-startup.log"
         RETVAL=$?
         if [ $RETVAL = 0 ]; then
             echo_success
@@ -163,7 +163,7 @@ stop() {
         pushd ${KATELLO_HOME} >/dev/null
         # delete Gemfile.lock (it will be regenerated)
         rm -f $KATELLO_DATA_DIR/Gemfile.lock
-        runuser -m -s /bin/bash - katello -c "bundle exec script/delayed_job stop &>>/var/log/katello/jobs-startup.log"
+        runuser -s /bin/bash - katello -c "RAILS_ENV='$RAILS_ENV' KATELLO_LOGGING='$KATELLO_LOGGING' KATELLO_LOGGING_SQL='$KATELLO_LOGGING_SQL' bundle exec script/delayed_job stop &>>/var/log/katello/jobs-startup.log"
         if [ 0$KATELLO_JOB_WORKERS -eq 1 ]; then
             if [ -f $KATELLO_PID_DIR/delayed_job_monitor.pid ]; then
                 echo -n $"Stopping delayed_job_monitor: "


### PR DESCRIPTION
-m (--preserve-enviroment) preserve only some variable, but not ruby ones, passing them on command line
