### PR TITLE
Fix rpm update from version without converge-ui

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -231,6 +231,8 @@ Documentation files for katello API.
 
 #copy converge-ui
 cp -R /usr/share/converge-ui-devel/* ./vendor/converge-ui
+rm ./public/fonts
+mv ./vendor/converge-ui/fonts ./public/fonts
 
 #configure Bundler
 rm -f Gemfile.lock


### PR DESCRIPTION
There was a change from directory to sym-link for public/fonts which breaks the
yum update form version with directory to version with symlink.
