### PR TITLE
katello-jobs - fix status exit code

### DIFF
--- a/src/deploy/common/katello-jobs.init
+++ b/src/deploy/common/katello-jobs.init
@@ -243,6 +243,7 @@ case "$1" in
         ;;
     status)
         kstatus
+        RETVAL=$?
         ;;
     *)
         echo "Usage: {start|stop|restart|condrestart|condstop|status}"


### PR DESCRIPTION
It was always returning 0 because RETVAL in kstatus was marked local
