### PR TITLE
do not require rubygem-pdf-writer

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -64,7 +64,6 @@ Requires:       rubygem(simple-navigation) >= 3.3.4
 Requires:       rubygem(pg)
 Requires:       rubygem(delayed_job) >= 2.1.4
 Requires:       rubygem(acts_as_reportable) >= 1.1.1
-Requires:       rubygem(pdf-writer) >= 1.1.8
 Requires:       rubygem(ruport) >= 1.6.3
 Requires:       rubygem(daemons) >= 1.1.4
 Requires:       rubygem(uuidtools)
@@ -122,7 +121,6 @@ BuildRequires:       rubygem(simple-navigation) >= 3.3.4
 BuildRequires:       rubygem(pg)
 BuildRequires:       rubygem(delayed_job) >= 2.1.4
 BuildRequires:       rubygem(acts_as_reportable) >= 1.1.1
-BuildRequires:       rubygem(pdf-writer) >= 1.1.8
 BuildRequires:       rubygem(ruport) >= 1.6.3
 BuildRequires:       rubygem(daemons) >= 1.1.4
 BuildRequires:       rubygem(uuidtools)


### PR DESCRIPTION
Katello does not use pdf-writer, we use it via rubygem-ruport.
So do not load it directly and let rubygem-ruport handle the dependecies.
