### PR TITLE
handle exception when katello server is down

### DIFF
--- a/cli/src/katello/client/core/base.py
+++ b/cli/src/katello/client/core/base.py
@@ -388,8 +388,10 @@ class BaseAction(Action):
             try:
                 if "displayMessage" in re.args[1]:
                     msg = re.args[1]["displayMessage"]
-                else:
+                elif "errors" in re.args[1]:
                     msg = ", ".join(re.args[1]["errors"])
+                else:
+                    msg = str(re.args[1])
             except IndexError:
                 msg = re.args[1]
             if re.args[0] == 401:


### PR DESCRIPTION
re.args[1] can be plain string.
addressing:

```
2012-09-17 04:51:16,773 [ERROR][MainThread] error() @ base.py:185 - Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/katello/client/cli/base.py", line 197, in main
    ret_code = super(KatelloCLI, self).main(args, command_name, parent_usage)
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 298, in main
    return subcommand.main(self.args[1:], self.args[0], self._get_usage_line(command_name, parent_usage))
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 393, in main
    msg = ", ".join(re.args[1]["errors"])
TypeError: string indices must be integers
```
