### PR TITLE
Fixed package listing generation in katello-debug (bz#857842)

### DIFF
--- a/src/script/katello-debug
+++ b/src/script/katello-debug
@@ -150,7 +150,7 @@ output = `katello-debug-certificates >> #{File.join(target_dir, "certificates")}
 output = `find /root/ssl-build -ls | sort -k 11 > #{File.join(target_dir, "ssl_build_dir")}`
 
 # Below are custom system calls to get more info
-ouput = `rpm -qa" >> #{File.join(target_dir, "packages")}`
+ouput = `rpm -qa | egrep "katello|candlepin|pulp|thumbslug|qpid" >> #{File.join(target_dir, "packages")}`
 
 
 if (options[:archive])


### PR DESCRIPTION
Seems katello-debug was broken during some recent change. Reverting the change in packages list generation
