### PR TITLE
Katello service wait cmd

### DIFF
--- a/src/script/katello-service
+++ b/src/script/katello-service
@@ -32,11 +32,7 @@ fi
 
 . /etc/init.d/functions
 
-if [ -x "/usr/sbin/service-wait" ]; then
-  SERVICE_CMD="/usr/sbin/service-wait"
-else
-  SERVICE_CMD="/sbin/service"
-fi
+SERVICE_CMD="/usr/sbin/service-wait"
 
 forward_services() {
   ACTION="$1"


### PR DESCRIPTION
Katello-service script does not leverage service-wait script which properly waits for services to start up.

I have removed the waiting code from katello-service and made use of katello-wait script. Waiting script was using lsof which is NOT working in all cases, tomcat6 can report ports 8009 and 8080 as opened while it is still starting up contexts. Therefore better check from katello-wait is used.

Reviewers: One commit reformats mixed tabs and spaces.
