### PR TITLE
do not pretend that we support MLS or Simple selinux

### DIFF
--- a/selinux/katello-selinux/katello-selinux-enable
+++ b/selinux/katello-selinux/katello-selinux-enable
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install SELinux policy modules in one transaction
-for selinuxvariant in targeted simple mls
+for selinuxvariant in targeted
 do
   /usr/sbin/semodule -s ${selinuxvariant} -l >/dev/null 2>&1 && \
   /usr/sbin/semanage -S $selinuxvariant -i - << _EOF

--- a/selinux/katello-selinux/katello-selinux.spec
+++ b/selinux/katello-selinux/katello-selinux.spec
@@ -11,7 +11,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-%define selinux_variants targeted simple mls
+%define selinux_variants targeted
 %define selinux_policyver %(sed -e 's,.*selinux-policy-\\([^/]*\\)/.*,\\1,' /usr/share/selinux/devel/policyhelp 2> /dev/null)
 %define POLICYCOREUTILSVER 1.33.12-1
 


### PR DESCRIPTION
We do not write policy neither for Simple nor MLS, so not pretend that
we can support it.

Addressing rpm error:

```
Installing : katello-selinux-1.1.1-1.git.602.39553a7.el6.noarch 
     188/194Non-fatal POSTIN scriptlet failure in rpm package katello-selinux-1.1.1-1.git.602.39553a7.el6.noarch
warning: %post(katello-selinux-1.1.1-1.git.602.39553a7.el6.noarch) scriptlet failed, exit status 1
```

Which is cause by:

```
+ for selinuxvariant in targeted simple mls
+ /usr/sbin/semodule -s simple -l
/usr/sbin/semodule: SELinux policy is not managed or store cannot be accessed.
+ for selinuxvariant in targeted simple mls
+ /usr/sbin/semodule -s mls -l
/usr/sbin/semodule: SELinux policy is not managed or store cannot be accessed.
```
