### PR TITLE
do not fail if Gemfile.lock does not exist

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -445,7 +445,7 @@ test -f $TOKEN || (echo $(</dev/urandom tr -dc A-Za-z0-9 | head -c128) > $TOKEN 
     && chmod 600 $TOKEN && chown katello:katello $TOKEN)
 
 %posttrans common
-rm -f %{datadir}/Gemfile.lock 2>/dev/null
+rm -f %{datadir}/Gemfile.lock 2>/dev/null || :
 /sbin/service %{name} condrestart >/dev/null 2>&1 || :
 
 %files


### PR DESCRIPTION
addressing:

```
  Installing : katello-selinux-1.1.1-1.git.602.39553a7.el6.noarch       188/194Non-fatal POSTIN scriptlet failure in rpm package katello-selinux-1.1.1-1.git.602.39553a7.el6.noarch

warning: %post(katello-selinux-1.1.1-1.git.602.39553a7.el6.noarch) scriptlet failed, exit status 1
```
