### PR TITLE
Fixed organization rspec test

### DIFF
--- a/src/spec/controllers/organizations_controller_spec.rb
+++ b/src/spec/controllers/organizations_controller_spec.rb
@@ -105,7 +105,7 @@ describe OrganizationsController do
       end
 
       it 'should generate a success notice' do
-        controller.should notify(:success, :success)
+        controller.should notify(:success)
         post 'create', OrgControllerTest::ORGANIZATION
         response.should be_success
       end      


### PR DESCRIPTION
The organization rspec creation should only trigger one success notification since the test data has
an environment. The second notification is to let the user know to set up a new environment. That
was no longer being displayed since the environment is getting properly created.
