### PR TITLE
object labels - by default, assign label by 'labelizing' the object name

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@
 
 require 'util/threadsession'
 require 'util/search'
+require 'util/model_util'
 require 'cgi'
 require 'base64'
 

--- a/src/app/controllers/environments_controller.rb
+++ b/src/app/controllers/environments_controller.rb
@@ -15,7 +15,7 @@ class EnvironmentsController < ApplicationController
   require 'rubygems'
   require 'active_support/json'
 
-  before_filter :find_organization, :only => [:show, :edit, :update, :destroy, :index, :new, :create, :system_templates, :products]
+  before_filter :find_organization, :only => [:show, :edit, :update, :destroy, :index, :new, :create, :default_label, :system_templates, :products]
   before_filter :authorize
   before_filter :find_environment, :only => [:show, :edit, :update, :destroy, :system_templates, :products]
 
@@ -31,6 +31,7 @@ class EnvironmentsController < ApplicationController
       :new => manage_rule,
       :edit => view_rule,
       :create => manage_rule,
+      :default_label => manage_rule,
       :update => manage_rule,
       :destroy => manage_rule,
       :system_templates => view_akey_rule,
@@ -79,6 +80,16 @@ class EnvironmentsController < ApplicationController
     notify.success _("Environment '%s' was created.") % @environment.name
     #this render just means return a 200 success
     render :nothing => true
+  end
+
+  # 'default_label' is an action that is used to  allow the UI to retrieve
+  # a default generated label based upon the name provided.
+  def default_label
+    if params[:name]
+      render :text => Katello::ModelUtils::labelize(params[:name])
+    else
+      render :nothing => true
+    end
   end
 
   # PUT /environments/1

--- a/src/app/controllers/organizations_controller.rb
+++ b/src/app/controllers/organizations_controller.rb
@@ -41,6 +41,7 @@ class OrganizationsController < ApplicationController
       :auto_complete_search => index_test,
       :new => create_test,
       :create => create_test,
+      :default_label => create_test,
       :edit => read_test,
       :update => edit_test,
       :destroy => delete_test,
@@ -98,6 +99,16 @@ class OrganizationsController < ApplicationController
   ensure
     if @organization && @organization.persisted? && @new_env && @new_env.new_record?
       @organization.destroy
+    end
+  end
+
+  # 'default_label' is an action that is used to  allow the UI to retrieve
+  # a default generated label based upon the name provided.
+  def default_label
+    if params[:name]
+      render :text => Katello::ModelUtils::labelize(params[:name])
+    else
+      render :nothing => true
     end
   end
 

--- a/src/app/controllers/products_controller.rb
+++ b/src/app/controllers/products_controller.rb
@@ -14,7 +14,7 @@ class ProductsController < ApplicationController
   respond_to :html, :js
 
   before_filter :find_product, :only => [:edit, :update, :destroy]
-  before_filter :find_provider, :only => [:new, :create, :edit, :update, :destroy]
+  before_filter :find_provider, :only => [:new, :create, :default_label, :edit, :update, :destroy]
   before_filter :authorize
 
   def rules
@@ -25,6 +25,7 @@ class ProductsController < ApplicationController
     {
       :new => edit_test,
       :create => edit_test,
+      :default_label => edit_test,
       :edit =>read_test,
       :update => edit_test,
       :destroy => edit_test,
@@ -51,6 +52,16 @@ class ProductsController < ApplicationController
 
     notify.success _("Product '%s' created.") % product_params[:name]
     render :nothing => true
+  end
+
+  # 'default_label' is an action that is used to  allow the UI to retrieve
+  # a default generated label based upon the name provided.
+  def default_label
+    if params[:name]
+      render :text => Katello::ModelUtils::labelize(params[:name])
+    else
+      render :nothing => true
+    end
   end
 
   def update

--- a/src/app/controllers/repositories_controller.rb
+++ b/src/app/controllers/repositories_controller.rb
@@ -16,8 +16,8 @@ class RepositoriesController < ApplicationController
 
   respond_to :html, :js
 
-  before_filter :find_provider, :only => [:new, :create, :edit, :destroy, :update_gpg_key]
-  before_filter :find_product, :only => [:new, :create, :edit, :destroy, :update_gpg_key]
+  before_filter :find_provider, :only => [:new, :create, :default_label, :edit, :destroy, :update_gpg_key]
+  before_filter :find_product, :only => [:new, :create, :default_label, :edit, :destroy, :update_gpg_key]
   before_filter :authorize
   before_filter :find_repository, :only => [:edit, :destroy, :enable_repo, :update_gpg_key]
 
@@ -29,6 +29,7 @@ class RepositoriesController < ApplicationController
     {
       :new => edit_test,
       :create => edit_test,
+      :default_label => edit_test,
       :edit => read_test,
       :update_gpg_key => edit_test,
       :destroy => edit_test,
@@ -68,6 +69,16 @@ class RepositoriesController < ApplicationController
     notify.error e.message
     execute_after_filters
     render :nothing => true, :status => :bad_request
+  end
+
+  # 'default_label' is an action that is used to  allow the UI to retrieve
+  # a default generated label based upon the name provided.
+  def default_label
+    if params[:name]
+      render :text => Katello::ModelUtils::labelize(params[:name])
+    else
+      render :nothing => true
+    end
   end
 
   def update_gpg_key

--- a/src/app/views/environments/_new.html.haml
+++ b/src/app/views/environments/_new.html.haml
@@ -11,11 +11,11 @@
     &nbsp;
   = kt_form_for KTEnvironment.new, :url => organization_environments_path(@organization.label), :remote=>true, :html => {:id=>"new_subpanel"} do |form|
 
-    = form.text_field :name, :label => _("Name")
-    = form.text_field :label, :label => _("Label")
+    = form.text_field :name, :label => _("Name"), :class => :name_input
+    = form.text_field :label, :label => _("Label"), :class => :label_input, 'data-url' => default_label_organization_environments_path(@organization.label)
 
     = form.text_area :description, :size => "40x5", :label => _("Description")
 
     = form.select :prior, options_for_select(@env_labels, @selected), :label => _("Prior Environment")
 
-    = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'subpanel_create'
+    = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'subpanel_create create_button'

--- a/src/app/views/organizations/_new.html.haml
+++ b/src/app/views/organizations/_new.html.haml
@@ -8,8 +8,8 @@
   .grid_8#new_organization123
     = kt_form_for Organization.new do |form|
 
-      = form.text_field :name, :label => _("Name")
-      = form.text_field :label, :label => _("Label")
+      = form.text_field :name, :label => _("Name"), :class => :name_input
+      = form.text_field :label, :label => _("Label"), :class => :label_input, 'data-url' => default_label_organizations_path()
       = form.text_area :description, :label => _("Description"), :size => "40x5"
 
       %fieldset
@@ -17,10 +17,10 @@
           %label #{_("Initial Application Life Cycle Management Environment")}:
 
       = form.field :envname, :label => _("Name") do
-        = text_field_tag 'environment[name]', nil, :tabindex => form.tabindex, :size => 30
+        = text_field_tag 'environment[name]', nil, :tabindex => form.tabindex, :size => 30, :class => :name_input
 
       = form.field :envlabel, :label => _("Label") do
-        = text_field_tag 'environment[name]', nil, :tabindex => form.tabindex, :size => 30
+        = text_field_tag 'environment[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input
 
 
       = form.field :envdescription, :label => _("Description") do
@@ -30,4 +30,4 @@
         .grid_7.la
           %label= _("Note: This will be set as your initial default environment.")
 
-      = form.submit _("Save")
+      = form.submit _("Save"), :class => :create_button

--- a/src/app/views/products/_new.html.haml
+++ b/src/app/views/products/_new.html.haml
@@ -6,8 +6,8 @@
 = content_for :subcontent do
   = kt_form_for [@provider, Product.new], :remote => true, :html => {:id => "new_subpanel"} do |form|
 
-    = form.text_field :name, :label => _("Name")
-    = form.text_field :label, :label => _("Label")
+    = form.text_field :name, :label => _("Name"), :class => :name_input
+    = form.text_field :label, :label => _("Label"), :class => :label_input, 'data-url' => default_label_provider_products_path(@provider.id)
     = form.text_area :description, :label => _("Description"), :size => "40x5"
 
     = form.field :gpg_key, :label => _("GPG Key") do
@@ -16,7 +16,7 @@
       - else
         = _("None defined for this Organization.")
 
-    = form.submit _("Create"), :class => 'subpanel_create', :disable_with => _("Creating...")
+    = form.submit _("Create"), :class => 'subpanel_create create_button', :disable_with => _("Creating...")
 
     -# Content to be implemented and used at a later date
       %fieldset.clearfix

--- a/src/app/views/repositories/_new.html.haml
+++ b/src/app/views/repositories/_new.html.haml
@@ -16,13 +16,13 @@
       .grid_2.ra
         = label :repo, :name, _("Name")
       .grid_5.la
-        = text_field :repo, :name, :id=>"repo_name_field", :tabindex => auto_tab_index
+        = text_field :repo, :name, :class=>:name_input, :tabindex => auto_tab_index
 
     %fieldset.clearfix
       .grid_2.ra
         = label :repo, :label, _("Label")
       .grid_5.la
-        = text_field :repo, :label, :id=>"repo_label_field", :tabindex => auto_tab_index
+        = text_field :repo, :label, :class=>:label_input, :tabindex => auto_tab_index, 'data-url' => default_label_provider_product_repositories_path(@provider.id, @product.id)
 
     %fieldset.clearfix
       .grid_2.ra
@@ -38,4 +38,4 @@
         - else
           #{_("None defined for this Organization.")}
     .grid_5.prefix_2
-      = submit_tag _("Create"), :class => 'fr subpanel_create', :tabindex => auto_tab_index, :disable_with => _("Creating...")
+      = submit_tag _("Create"), :class => 'fr subpanel_create create_button', :tabindex => auto_tab_index, :disable_with => _("Creating...")

--- a/src/config/assets.yml
+++ b/src/config/assets.yml
@@ -32,6 +32,7 @@ javascripts:
     - public/javascripts/converge-ui/vendor/jquery/plugins/jquery.ba-resize.js
     - public/javascripts/search.js
     - public/javascripts/panel.js
+    - public/javascripts/katello_object.js
     #form
     - public/javascripts/converge-ui/vendor/jquery/plugins/jquery.form.js
     #notices:

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -276,7 +276,10 @@ Src::Application.routes.draw do
   resources :providers do
     get 'auto_complete_search', :on => :collection
     resources :products do
+      get :default_label, :on => :collection
+
       resources :repositories, :only => [:new, :create, :edit, :destroy] do
+        get :default_label, :on => :collection
         member do
           put :update_gpg_key, :as => :update_repo_gpg_key
         end
@@ -331,6 +334,7 @@ Src::Application.routes.draw do
     collection do
       get :auto_complete_search
       get :items
+      get :default_label
     end
     member do
       get :environments_partial
@@ -338,6 +342,7 @@ Src::Application.routes.draw do
       get :download_debug_certificate
     end
     resources :environments do
+      get :default_label, :on => :collection
       member do
         get :system_templates
         get :products

--- a/src/public/javascripts/katello_object.js
+++ b/src/public/javascripts/katello_object.js
@@ -1,0 +1,81 @@
+/**
+ Copyright 2011 Red Hat, Inc.
+
+ This software is licensed to you under the GNU General Public
+ License as published by the Free Software Foundation; either version
+ 2 of the License (GPLv2) or (at your option) any later version.
+ There is NO WARRANTY for this software, express or implied,
+ including the implied warranties of MERCHANTABILITY,
+ NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ have received a copy of GPLv2 along with this software; if not, see
+ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+KT.object = KT.object || {};
+
+// The KT Object label will handle the interaction where a user enters a
+// name and upon completion, we want to retrieve a 'default' label from
+// the server generated off of that name.
+KT.object.label = (function(){
+    var label_input,
+        create_button,
+        initialize = function(){
+            label_input = $(".label_input");
+            if (label_input.length === 0){
+                return;
+            }
+            create_button = $(".create_button");
+
+            disable_inputs(undefined);
+
+            $('.name_input').bind('focusout', function(){
+                var name_input = $(this);
+                if (name_input.val().length > 0) {
+                    // user entered a name so go fetch the label from the server
+                    disable_inputs(name_input);
+                    $.ajax({
+                        type: "GET",
+                        url: label_input.data("url"),
+                        data: {name:name_input.val()},
+                        cache: false,
+                        success: function(data) {
+                            if (data.length > 0) {
+                                // locate the label input and set it to the value received
+                                name_input.closest('fieldset').next('fieldset').find('input.label_input').val(data);
+                                enable_inputs(name_input);
+                            }
+                        },
+                        error: function() {
+                        }
+                    });
+                }
+            });
+            $('.name_input').bind('click', function() {
+                disable_inputs($(this));
+            })
+        },
+    disable_inputs = function(current_name_input) {
+        if (current_name_input === undefined) {
+            // disable all label inputs
+            label_input.attr("disabled", "disabled");
+        } else {
+            // disable the label input associated with the current name
+            current_name_input.closest('fieldset').next('fieldset').find('input.label_input').attr("disabled", "disabled");
+        }
+        create_button.attr("disabled", "disabled");
+    },
+    enable_inputs = function(current_name_input) {
+        if (current_name_input === undefined) {
+            // enable all label inputs
+            label_input.removeAttr("disabled");
+        } else {
+            // enable the label input associated with the current name
+            current_name_input.closest('fieldset').next('fieldset').find('input.label_input').removeAttr("disabled");
+        }
+        create_button.removeAttr("disabled");
+    };
+
+    return {
+        initialize: initialize
+    }
+})();

--- a/src/public/javascripts/organization.js
+++ b/src/public/javascripts/organization.js
@@ -18,12 +18,11 @@ $(document).ready(function() {
     var env_scroll = KT.env_select_scroll({});
     KT.panel.set_expand_cb(function() {
         env_scroll.bind(undefined);
+        KT.object.label.initialize();
     });
-
 
    $('.environment_link').live('click', function() {
         $(this).siblings().show();
-
    });
 
   $('#debug_cert').live('click',function(){

--- a/src/public/javascripts/provider.js
+++ b/src/public/javascripts/provider.js
@@ -15,6 +15,10 @@ KT.panel.list.registerPage('providers', { create : 'new_provider' });
 
 $(document).ready(function() {
 
+    KT.panel.set_expand_cb(function() {
+        KT.object.label.initialize();
+    });
+
   $("#redhatSubscriptionTable").treeTable({
     expandable: true,
     initialState: "collapsed",


### PR DESCRIPTION
This is an initial commit to facilitate assigning the label when
a user creates a new object (org/env/product/repo) in the UI.  The
default assignment will be by running the model_utils::labelize
on the object name.  This will change in the future to use
punycode (or alternative); however, the UI behavior will remain
regardless of algorithm use to derive the label.

The following is the general UI behavior:
1. user clicks the appropriate link to open a new object form (e.g. org)
2. the label input and save button are disabled
3. user clicks on 'name', enters a value and leaves the input box
4. browser initiates an ajax request to server to request a default
   value for the label
5. once received, browser sets the label, enables it and enables
   the save button

If desired, the user may edit the name.  Doing so, will disable
the label input, save button and repeat 3-5.

If the user doesn't like the default label, they may change it,
so long as it follows the 'validation' requirements.
