### PR TITLE
Prevent resubmission on interstitial screen

### DIFF
--- a/src/app/views/user_sessions/_interstitial.js.haml
+++ b/src/app/views/user_sessions/_interstitial.js.haml
@@ -1,2 +1,3 @@
 != "CUI.Login.Actions.interstitial_switcher_animation('#{escape_javascript("#{num_orgs}")}', '#{escape_javascript("#{redir_path}")}');"
 != "$('#switcherButton').click();"
+!= "$('#login_form input:submit').attr('disabled', true);"


### PR DESCRIPTION
On the interstitial screen where users can select their organization, pressing
enter would cause the login form to resubmit sending a request to
dashboard/index.js which would in turn trigger a template missing exception.
BZ #841998
