### PR TITLE
859407 - puppet timeout set to 0 for some steps

### DIFF
--- a/katello-configure/modules/candlepin/manifests/config.pp
+++ b/katello-configure/modules/candlepin/manifests/config.pp
@@ -46,6 +46,7 @@ class candlepin::config {
       path    => "/sbin:/bin:/usr/bin",
       before  => Exec["cpdb"],
       notify  => Postgres::Dropdb["$candlepin::params::db_name"],
+      timeout => 0
     }
     postgres::dropdb {$candlepin::params::db_name:
       logfile => "${katello::params::configure_log_base}/drop-postgresql-candlepin-database.log",
@@ -67,7 +68,8 @@ class candlepin::config {
       File["/etc/candlepin/candlepin.conf"]
     ],
     creates => "/var/lib/katello/cpdb_done",
-    before  => Class["apache2::service"]
+    before  => Class["apache2::service"],
+    timeout => 0
   }
 
 }

--- a/katello-configure/modules/candlepin/manifests/service.pp
+++ b/katello-configure/modules/candlepin/manifests/service.pp
@@ -22,6 +22,7 @@ class candlepin::service {
     command => "/usr/bin/wget --timeout=30 --tries=5 --retry-connrefused -qO- http://localhost:8080/candlepin/admin/init >${katello::params::configure_log_base}/cpinit.log 2>&1 && touch /var/lib/katello/cpinit_done",
     require => [ Service["tomcat6"], File["${katello::params::configure_log_base}"] ],
     creates => "/var/lib/katello/cpinit_done",
-    before  => Class["apache2::service"]
+    before  => Class["apache2::service"],
+    timeout => 0
   }
 }

--- a/katello-configure/modules/elasticsearch/manifests/config.pp
+++ b/katello-configure/modules/elasticsearch/manifests/config.pp
@@ -21,6 +21,7 @@ class elasticsearch::config {
       command => "rm -rf /var/lib/elasticsearch/*",
       path    => "/sbin:/bin:/usr/bin",
       notify  => Service["elasticsearch"],
+      timeout => 0
     }
   }
 }

--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -74,8 +74,9 @@ class foreman::config {
     cwd         => $foreman::app_root,
     environment => "RAILS_ENV=${foreman::environment}",
     command     => "/usr/bin/env rake db:migrate --trace --verbose > ${foreman::configure_log_base}/foreman-db-migrate.log 2>&1 && touch /var/lib/katello/foreman_db_migrate_done",
-    creates => "/var/lib/katello/foreman_db_migrate_done",
-    require => [ Postgres::Createdb[$foreman::db_name],
+    creates     => "/var/lib/katello/foreman_db_migrate_done",
+    timeout     => 0,
+    require     => [ Postgres::Createdb[$foreman::db_name],
                  File["${foreman::config_dir}/settings.yaml"],
                  File["${foreman::config_dir}/database.yml"]];
   }

--- a/katello-configure/modules/katello/manifests/config.pp
+++ b/katello-configure/modules/katello/manifests/config.pp
@@ -126,6 +126,7 @@ class katello::config {
       path    => "/sbin:/bin:/usr/bin",
       before  => Exec["katello_migrate_db"],
       notify  => Postgres::Dropdb["$katello::params::db_name"],
+      timeout => 0
     }
     postgres::dropdb {$katello::params::db_name:
       logfile => "${katello::params::configure_log_base}/drop-postgresql-katello-database.log",
@@ -163,7 +164,8 @@ class katello::config {
     command     => "/usr/bin/env rake db:migrate --trace --verbose > ${katello::params::migrate_log} 2>&1 && touch /var/lib/katello/db_migrate_done",
     creates => "/var/lib/katello/db_migrate_done",
     before  => Class["katello::service"],
-    require => [ Exec["katello_bundler_check"] ]
+    require => [ Exec["katello_bundler_check"] ],
+    timeout => 0
   }
 
   exec {"katello_seed_db":
@@ -172,6 +174,7 @@ class katello::config {
     environment => ["RAILS_ENV=${katello::params::environment}", "KATELLO_LOGGING=debug"],
     command     => "/usr/bin/env rake seed_with_logging --trace --verbose > ${katello::params::seed_log} 2>&1 && touch /var/lib/katello/db_seed_done",
     creates => "/var/lib/katello/db_seed_done",
+    timeout => 0,
     before  => Class["katello::service"],
     require => $katello::params::deployment ? {
                 'katello' => [ Exec["katello_migrate_db"], Class["candlepin::service"], Class["pulp::service"], File["${katello::params::log_base}"] ],

--- a/katello-configure/modules/mongodb/manifests/config.pp
+++ b/katello-configure/modules/mongodb/manifests/config.pp
@@ -21,6 +21,7 @@ class mongodb::config {
     require => File["/var/lib/mongodb/journal"],
     # after mongo has started it renames prealloc.0 to j._0
     creates => "/var/lib/mongodb/journal/j._0",
-    before  => Class["mongodb::service"]
+    before  => Class["mongodb::service"],
+    timeout => 0
   }
 }

--- a/katello-configure/modules/postgres/manifests/service.pp
+++ b/katello-configure/modules/postgres/manifests/service.pp
@@ -14,6 +14,7 @@ class postgres::service {
     require => [Class["postgres::config"]],
   }
 
+  # TODO - get rid of this - waiting was implemented in service-wait now
   # wait 30 seconds for postgresql daemon to accept connections and execute SQL commands or timeout when not running
   exec { "wait-for-postgresql":
     environment => "PGCONNECT_TIMEOUT=5",

--- a/katello-configure/modules/postgres/manifests/sqlexec.pp
+++ b/katello-configure/modules/postgres/manifests/sqlexec.pp
@@ -6,7 +6,7 @@ define sqlexec($username, $passfile, $database, $sql, $sqlcheck = "NONE", $logfi
       default => "PGPASSFILE=${passfile}"
     },
     path        => $path,
-    timeout     => 600,
+    timeout     => 0,
     unless => $sqlcheck? {
         "NONE" => undef,
         default => "psql -U $username $database -c $sqlcheck",

--- a/katello-configure/modules/pulp/manifests/config.pp
+++ b/katello-configure/modules/pulp/manifests/config.pp
@@ -29,10 +29,11 @@ class pulp::config {
 
   if $pulp::params::reset_cache == 'YES' {
     exec {"reset_pulp_cache":
-      command     => "rm -rf /var/lib/pulp/packages/*",
-      path        => "/sbin:/bin:/usr/bin",
-      before      => Exec["migrate_pulp_db"],
-      require     => [
+      command => "rm -rf /var/lib/pulp/packages/*",
+      path    => "/sbin:/bin:/usr/bin",
+      before  => Exec["migrate_pulp_db"],
+      timeout => 0,
+      require => [
         File["/var/lib/pulp/packages"],
         ],
     }
@@ -43,6 +44,7 @@ class pulp::config {
       command     => "rm -f /var/lib/pulp/init.flag; service httpd stop; rm -f /var/lib/mongodb/pulp_database*; rm -rf /var/lib/pulp/{distributions,published,repos}/*; test 1 -eq 1",
       path        => "/sbin:/bin:/usr/bin",
       before      => Exec["migrate_pulp_db"],
+      timeout     => 0,
     }
   }
 
@@ -52,6 +54,7 @@ class pulp::config {
     path        => "/bin:/usr/bin",
     before      => [ Class["pulp::service"], Exec["reload-apache2"], Class["apache2::service"] ],
     notify      => Exec["reload-apache2"],
+    timeout     => 0,
     require     => [
       File["${katello::params::configure_log_base}"],
       Class["mongodb::service"],


### PR DESCRIPTION
http://projects.puppetlabs.com/issues/11686

Default timeout for all exec commands in puppet is 300 secs.

We must add timeout => 0 for all lenghy command. That is mongo-journal-prealloc and maybe wait-for-tomcat. Would be good to do review of all our modules for exec steps.

https://bugzilla.redhat.com/show_bug.cgi?id=859407
