### PR TITLE
Fixed bug where gpg key was not getting set

### DIFF
--- a/src/app/models/glue/pulp/repos.rb
+++ b/src/app/models/glue/pulp/repos.rb
@@ -64,6 +64,7 @@ module Glue::Pulp::Repos
     })
     new_content.create
     add_content new_content
+    repo.environmental_instances.each { |e| e.environment.update_cp_content }
     new_content.content
   end
 


### PR DESCRIPTION
Fixed bug where GPG key was not getting sent to systems if it was added after
the product/repo was created. BZ #824581
