### PR TITLE
BZ 821345: product name now appears instead of a '#'

### DIFF
--- a/src/app/models/promotion_changeset.rb
+++ b/src/app/models/promotion_changeset.rb
@@ -32,7 +32,7 @@ class PromotionChangeset < Changeset
     repos_to_be_promoted.each do |repo|
       if not self.environment.products.to_a.include? repo.product and not products_to_be_promoted.include? repo.product
         raise _("Please add '%s' product to the changeset '%s' if you wish to promote repository '%s' with it.") %
-                  [repo.product, self.name, repo.name]
+                  [repo.product.name, self.name, repo.name]
       end
     end
 


### PR DESCRIPTION
During changeset promotion, if the destination environment doesn't have the product that contains the content the user is promoting, the error message prompts the user to add the product too. This fixes the issue when a '#' was appearing insted of the product name.
