### PR TITLE
Adding rails-dev-boost gem to speed up dev env

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -107,6 +107,7 @@ group :development do
   # profiler
   gem 'newrelic_rpm'
   gem 'logical-insight'
+  gem 'rails-dev-boost', :git => 'git://github.com/thedarkone/rails-dev-boost.git', :require => 'rails_development_boost'
 end
 
 group :test do


### PR DESCRIPTION
Adding this gem seems to cut page load times by about 30-50% in the
development environment.
