### PR TITLE
858011, 854697 - object-labels - needed to use org label on del_owners (...

### DIFF
--- a/src/app/models/glue/provider.rb
+++ b/src/app/models/glue/provider.rb
@@ -176,7 +176,7 @@ module Glue::Provider
       imports = self.owner_imports
       if imports.length == 1
         Rails.logger.debug "Deleting import for provider: #{name}"
-        Resources::Candlepin::Owner.destroy_imports self.organization.cp_key
+        Resources::Candlepin::Owner.destroy_imports self.organization.label
       else
         Rails.logger.debug "Unable to delete import for provider: #{name}. Reason: a successful import was previously completed."
       end


### PR DESCRIPTION
...vs cp_key)

This is a minor change that is needed to rename cp_key to label.
Without this change, 854697 will fail.  It is a change needed
to support the overall efforts of 858011; however, due to timing of
the commits coming in to master the change was missed.
