### PR TITLE
Updating delete activation key error

### DIFF
--- a/src/app/controllers/activation_keys_controller.rb
+++ b/src/app/controllers/activation_keys_controller.rb
@@ -251,6 +251,13 @@ class ActivationKeysController < ApplicationController
   end
 
   def destroy
+    if @activation_key.system_activation_keys.length > 0
+      notify.error _("Cannot delete this activation key. Assure no systems are
+                     dependent on this key and try again.")
+      render :nothing => true
+      return
+    end
+
     if @activation_key.destroy
       notify.success _("Activation key '#{@activation_key[:name]}' was deleted.")
       #render and do the removal in one swoop!


### PR DESCRIPTION
Sending a user friendly error before the activation key delete exception gets
thrown when deleting a key that's associated with systems BZ 858802
