### PR TITLE
858802 - Allowing associated keys to be deleted

### DIFF
--- a/src/app/models/activation_key.rb
+++ b/src/app/models/activation_key.rb
@@ -32,7 +32,7 @@ class ActivationKey < ActiveRecord::Base
   has_many :key_system_groups, :dependent => :destroy
   has_many :system_groups, :through => :key_system_groups
 
-  has_many :system_activation_keys, :dependent => :restrict
+  has_many :system_activation_keys, :dependent => :destroy
   has_many :systems, :through => :system_activation_keys
 
   scope :readable, lambda {|org| ActivationKey.readable?(org) ? where(:organization_id=>org.id) : where("0 = 1")}


### PR DESCRIPTION
Allowing activation keys to be deleted even if they are associated with
systems. Also deleting the system activation key associated model.
