### PR TITLE
Revert "workaround for bz 854263"

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -152,9 +152,6 @@ Requires:       candlepin-selinux
 # the following backend engine deps are required by <katello-configure>
 Requires:       mongodb mongodb-server
 Requires:       qpid-cpp-server qpid-cpp-client qpid-cpp-client-ssl qpid-cpp-server-ssl
-%if 0%{?fedora}
-Requires:       /etc/rc.d/init.d/qpidd
-%endif
 Requires:       foreman foreman-postgresql
 # </katello-configure>
 


### PR DESCRIPTION
BZ 854263 is resolved, so we do not need this anymore.
This reverts commit 3a7e3625623087afd076f93db0ff054bd0e84b4f.
