### PR TITLE
release-version - display message when no available release version choi...

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -283,17 +283,17 @@ class SystemsController < ApplicationController
     begin
       releases = @system.available_releases
     rescue => e
-      # Don't pepper user with notices if there is an error fetching release
-      # versions, but do log them
+      releases_error = e.to_str
       Rails.logger.error e.to_str
-      releases ||= []
     end
+    releases ||= []
+    releases_error ||= nil
 
-    render :partial => "edit", :layout => "tupane_layout",
-           :locals => { :system       => @system, :editable => @system.editable?,
-                        :releases     => releases, :name => controller_display_name,
-                        :environments =>
-                            environment_paths(library_path_element, environment_path_element("systems_readable?")) }
+    # Stuff into var for use in spec tests
+    @locals_hash = { :system => @system, :editable => @system.editable?,
+                    :releases => releases, :releases_error => releases_error, :name => controller_display_name,
+                    :environments => environment_paths(library_path_element, environment_path_element("systems_readable?")) }
+    render :partial => "edit", :layout => "tupane_layout", :locals => @locals_hash
   end
 
   def update

--- a/src/app/stylesheets/sections/systems.scss
+++ b/src/app/stylesheets/sections/systems.scss
@@ -26,6 +26,14 @@
     }
   }
 
+  .edit_select_system_releasever_message {
+    &.error_message {
+      textarea {
+        background: $validation_error_color;
+      }
+    }
+  }
+
   #facts {
     table {
       td {

--- a/src/app/views/systems/_edit.html.haml
+++ b/src/app/views/systems/_edit.html.haml
@@ -64,8 +64,19 @@
       %fieldset
         .grid_2.ra.fieldset
           = label :releaseVer, :releaseVer, _("Release Version")
-        .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever" if editable), 'data-url' => system_path(system.id), 'data-options' => system_releasevers_edit(system, releases)}
-          = system.release
+        - if !releases_error.nil?
+          .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever_message error_message" if editable), 'data-url'=>system_path(system.id), 'data-message'=>releases_error}
+            = system.release == "" ? _("System Default") : system.release
+        - elsif releases == []
+          - if AppConfig.katello?
+            - none_message = ("No alternate release version choices are available. These choices are based upon the repositories that have been enabled and promoted to this system's environment.")
+          - else
+            - none_message = _("No alternate release version choices are available. These choices are based upon the Red Hat manifest imported and the content available in the CDN.")
+          .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever_message" if editable), 'data-url'=>system_path(system.id), 'data-message'=>none_message}
+            = system.release == "" ? _("System Default") : system.release
+        - else
+          .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever" if editable), 'data-url' => system_path(system.id), 'data-options' => system_releasevers_edit(system, releases)}
+            = system.release
       %fieldset
         .grid_2.ra.fieldset
           = label :arch, :arch, _("Arch")

--- a/src/public/javascripts/system_edit.js
+++ b/src/public/javascripts/system_edit.js
@@ -44,6 +44,25 @@ $(document).ready(function() {
         $(this).editable($(this).attr('data-url'), $.extend(common_settings, settings));
     });
 
+    $('.edit_select_system_releasever_message').each(function(){
+        var element = $(this),
+            settings = {
+                type            :  'textarea',
+                name            :  element.attr('name'),
+                data            :  element.data('message'),
+                rows            :  8,
+                cols            :  36,
+                submit          :  false,
+                onsuccess       :  function(result, status, xhr){
+                    notices.checkNotices();
+                },
+                onerror         :  function(result, status, xhr){
+                    notices.checkNotices();
+                }
+            };
+        $(this).editable($(this).attr('data-url'), $.extend(common_settings, settings));
+    });
+
     path_select = KT.path_select('environment_path_selector', 'edit_select_system_environment', KT.available_environments,
         {select_mode:'single', submit_button_text: i18n.save, cancel_button_text: i18n.cancel, activate_on_click: true});
 

--- a/src/spec/controllers/systems_controller_spec.rb
+++ b/src/spec/controllers/systems_controller_spec.rb
@@ -333,7 +333,7 @@ describe SystemsController do
     describe 'bulk deleting a system' do
       before (:each) do
         @system = System.create!(:name=>"bar", :environment => @environment, :cp_type=>"system", :facts=>{"Test" => ""})
-        System.stub(:find).and_return [@system]
+        System.stub(:find).and_return @system
       end
       it "should delete the system" do
         @system.should_receive(:destroy)
@@ -765,6 +765,36 @@ describe SystemsController do
 
     end
 
+    describe "get/set system details" do
+      before (:each) do
+        @system = System.create!(:name=>"bar", :environment => @environment, :cp_type=>"system", :facts => { "test" => "test" }, :serviceLevel => nil)
+        System.stub(:find).and_return(@system)
+      end
+
+      it "should get release version choices" do
+        @system.stub(:available_releases).and_return(["5Server", "6Server"])
+        get :edit, :id => @system.id
+        response.should render_template(:edit)
+        assigns[:locals_hash][:releases].should == ["5Server", "6Server"]
+        assigns[:locals_hash][:releases_error].should == nil
+      end
+
+      it "should get empty release version choices" do
+        @system.stub(:available_releases).and_return([])
+        get :edit, :id => @system.id
+        response.should render_template(:edit)
+        assigns[:locals_hash][:releases].should == []
+        assigns[:locals_hash][:releases_error].should == nil
+      end
+
+      it "should get release version error" do
+        @system.stub(:available_releases).and_raise("some error")
+        get :edit, :id => @system.id
+        response.should render_template(:edit)
+        assigns[:locals_hash][:releases].should == []
+        assigns[:locals_hash][:releases_error].should == "some error"
+      end
+    end
   end
 
 end


### PR DESCRIPTION
...ces or an error occurred fetching them

release-version - spec test

When no choices are available, or there is an error retrieving them, a message is displayed to the user when they go to change from the current release version value.
