### PR TITLE
fix for BZ 860702: both: systems belonging to system groups and not are being shown now on 'Systems' screen

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -698,9 +698,7 @@ class SystemsController < ApplicationController
   # to filter readable systems that can be
   # passed to search
   def readable_filters
-    filters = {:environment_id=>KTEnvironment.systems_readable(current_organization).collect{|item| item.id}}
-    filters[:system_group_ids] = SystemGroup.systems_readable(current_organization).collect{|item| item.id} if AppConfig.katello?
-    filters
+    {:environment_id=>KTEnvironment.systems_readable(current_organization).collect{|item| item.id}}
   end
 
   def search_filter


### PR DESCRIPTION
This fixes an issue when only systems belonging to system groups would show up on 'Systems' screen if one or more system groups have been defined.
