### PR TITLE
858360 - Making katello-upgrade START services after upgrade is complete

### DIFF
--- a/katello-configure/bin/katello-upgrade
+++ b/katello-configure/bin/katello-upgrade
@@ -260,6 +260,7 @@ class UpgradeProcess
 
     if @step_count == 0
       print_nothing_to_do
+      ensure_services_are_on
       exit_with :success
     end
 
@@ -271,6 +272,7 @@ class UpgradeProcess
     if finished_step_count < @step_count
       exit_with :general_error
     else
+      ensure_services_are_on
       exit_with :success
     end
   end
@@ -292,10 +294,21 @@ class UpgradeProcess
       else
         puts "This script can be run in auto-stop mode with the -a / --auto-stop option to"
         puts "disable services automatically."
-        puts "You may always use `service katello-service stop` to stop all the services"
+        puts "You may always use `katello-service stop` to stop all the services"
         puts ""
         exit_service_stop
       end
+    end
+  end
+
+  def ensure_services_are_on
+    if @options[:auto_stop]
+      start_services
+    else
+      puts "Now that Katello has been upgraded, please run `katello-service start"
+      puts "to re-enable all of your services"
+      puts "In the future, you can run this script with the -a / --auto-stop option to"
+      puts "automatically stop & start your services"
     end
   end
 
@@ -312,8 +325,26 @@ class UpgradeProcess
     end
   end
 
+  def start_services
+    puts "We will now start all katello services."
+    if confirm("PROCEED?")
+      if ! system('/usr/bin/katello-service', 'start')
+        puts "There was an issue starting your services. Please resolve this manually"
+        puts "and try again"
+        exit_with :general_error
+      end
+    else
+      exit_service_start
+    end
+  end
+
   def exit_service_stop
     puts "Exiting. Please stop your services and try again"
+    exit_with :general_error
+  end
+
+  def exit_service_stop
+    puts "Exiting. Your Katello installation is upgraded, but please manually start your services"
     exit_with :general_error
   end
 

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -543,6 +543,8 @@ rm -f %{datadir}/Gemfile.lock 2>/dev/null
 %files all
 
 %files headpin
+%attr(600, katello, katello)
+%{_bindir}/katello-*
 %{homedir}/app/controllers
 %{homedir}/app/helpers
 %{homedir}/app/mailers


### PR DESCRIPTION
Note: this also adds katello-service script to HEADPIN mode which was missing before
