### PR TITLE
859415 - object labels - modify ui to assign a default label, if not spe...

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -118,6 +118,17 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Generate a label using the name provided, returning the label and a string with text that may be
+  # sent to the user (e.g. via a notice).
+  def generate_label object_name, object_type
+    # user didn't provide a label, so generate one using the name
+    label = Katello::ModelUtils::labelize(object_name)
+    label_assigned_text = _("A label was not provided during %s creation; therefore, a label of '%s' was " +
+                            "automatically assigned. If you would like a different label, please delete the " +
+                            "%s and recreate it with the desired label.") % [object_type, label, object_type]
+    return label, label_assigned_text
+  end
+
   def flash_to_headers
     return if @_response.nil? or @_response.response_code == 302
     return if flash.blank?

--- a/src/app/controllers/environments_controller.rb
+++ b/src/app/controllers/environments_controller.rb
@@ -75,9 +75,15 @@ class EnvironmentsController < ApplicationController
               :prior => params[:kt_environment][:prior],
               :label => params[:kt_environment][:label],
               :organization_id => @organization.id}
+
+    env_params[:label], label_assigned = generate_label(env_params[:name], _('environment')) if env_params[:label].blank?
+
     @environment = KTEnvironment.new env_params
     @environment.save!
+
     notify.success _("Environment '%s' was created.") % @environment.name
+    notify.message label_assigned unless label_assigned.blank?
+
     #this render just means return a 200 success
     render :nothing => true
   end

--- a/src/app/controllers/products_controller.rb
+++ b/src/app/controllers/products_controller.rb
@@ -47,10 +47,14 @@ class ProductsController < ApplicationController
 
   def create
     product_params = params[:product]
+    product_params[:label], label_assigned = generate_label(product_params[:name], _('product')) if product_params[:label].blank?
+
     gpg = GpgKey.readable(current_organization).find(product_params[:gpg_key]) if product_params[:gpg_key] and product_params[:gpg_key] != ""
     @provider.add_custom_product(product_params[:label], product_params[:name], product_params[:description], product_params[:url], gpg)
 
     notify.success _("Product '%s' created.") % product_params[:name]
+    notify.message label_assigned unless label_assigned.blank?
+
     render :nothing => true
   end
 

--- a/src/app/controllers/repositories_controller.rb
+++ b/src/app/controllers/repositories_controller.rb
@@ -56,6 +56,8 @@ class RepositoriesController < ApplicationController
 
   def create
     repo_params = params[:repo]
+    repo_params[:label], label_assigned = generate_label(repo_params[:name], _('repository')) if repo_params[:label].blank?
+
     raise URI::InvalidURIError.new _('Invalid Url') if !kurl_valid?(repo_params[:feed])
     gpg = GpgKey.readable(current_organization).find(repo_params[:gpg_key]) if repo_params[:gpg_key] and repo_params[:gpg_key] != ""
     # Bundle these into one call, perhaps move to Provider
@@ -64,6 +66,8 @@ class RepositoriesController < ApplicationController
     @product.save!
 
     notify.success _("Repository '%s' created.") % repo_params[:name]
+    notify.message label_assigned unless label_assigned.blank?
+
     render :nothing => true
   rescue Errors::ConflictException, URI::InvalidURIError => e
     notify.error e.message

--- a/src/app/views/organizations/_edit.html.haml
+++ b/src/app/views/organizations/_edit.html.haml
@@ -15,49 +15,49 @@
   = render_menu(1..2, organization_navigation)
 
 = content_for :content do
-  %input#panel_element_id{:name => @organization.id, :type => "hidden", :value => @organization.label, "data-ajax_url"=>edit_organization_path(@organization.label)}
+  #organization_edit
+    %input#panel_element_id{:name => @organization.id, :type => "hidden", :value => @organization.label, "data-ajax_url"=>edit_organization_path(@organization.label)}
 
-  %fieldset
-    .grid_2.ra
-      %label #{_("Label")}:
-    .grid_4.la.multiline #{@organization.label}
+    %fieldset
+      .grid_2.ra
+        %label #{_("Label")}:
+      .grid_4.la.multiline #{@organization.label}
 
-  %fieldset.clearfix
-    .grid_2.ra
-      %label #{_("Description")}:
-    .grid_4.la{:style => "word-wrap: break-word;", 'name' => 'organization[description]', :class=> editable_class(editable), 'data-url'=>edit_organization_path(@organization.label)} #{@organization[:description]}
+    %fieldset.clearfix
+      .grid_2.ra
+        %label #{_("Description")}:
+      .grid_4.la{:style => "word-wrap: break-word;", 'name' => 'organization[description]', :class=> editable_class(editable), 'data-url'=>edit_organization_path(@organization.label)} #{@organization[:description]}
 
-  .grid_7
-    %h5 #{_("Environment Promotion Paths")}:
-
-  - unless @organization.environments.empty?
-    %ul#promotion_paths
-    - @organization.promotion_paths.each do |path|
-      .clear
-        &nbsp;
-      .jbreadcrumb.grid_9
-        %ul
-          %li
-            =link_to _('Library'), "#", :class => "crumb-nohover"
-          - for env in path
-            %li
-              %a.subpanel_element{"data-url"=>edit_organization_environment_path(@organization.label, env.id)}
-                %div
-                  #{env.name}
-
-  - else
     .grid_7
-      #{_("No environments are available in this organization. Please add some environments to be able register systems to this organization.")}:
+      %h5 #{_("Environment Promotion Paths")}:
 
-  .clear
-    &nbsp;
+    - unless @organization.environments.empty?
+      %ul#promotion_paths
+      - @organization.promotion_paths.each do |path|
+        .clear
+          &nbsp;
+        .jbreadcrumb.grid_9
+          %ul
+            %li
+              =link_to _('Library'), "#", :class => "crumb-nohover"
+            - for env in path
+              %li
+                %a.subpanel_element{"data-url"=>edit_organization_environment_path(@organization.label, env.id)}
+                  %div
+                    #{env.name}
 
-  - if editable
-    .button.subpanel_element{"data-url"=>new_organization_environment_path(@organization.label)}
-      = _("Add New Environment")
-  - if editable
-    = render :partial=>"download_debug_certificate"
+    - else
+      .grid_7
+        #{_("No environments are available in this organization. Please add some environments to be able register systems to this organization.")}:
 
+    .clear
+      &nbsp;
+
+    - if editable
+      .button.subpanel_element{"data-url"=>new_organization_environment_path(@organization.label)}
+        = _("Add New Environment")
+    - if editable
+      = render :partial=>"download_debug_certificate"
 
 = content_for :footer do
   = render :partial => "organizations/footer"

--- a/src/app/views/products/_edit.html.haml
+++ b/src/app/views/products/_edit.html.haml
@@ -10,7 +10,7 @@
 = content_for :subcontent do
   %h3
     = _("Edit Product")
-  
+
   %fieldset
     .grid_2.ra
       %label #{_("Name")}:
@@ -25,7 +25,7 @@
     .grid_2.ra
       %label #{_("Description")}:
     .grid_5.la.multiline{'name' => 'product[description]', :class=>("editable edit_textarea" if editable), 'data-url' => provider_product_path(@provider.id)}<> #{@product.description}
-  
+
   %fieldset
     .grid_2.ra
       %label #{_("GPG Key")}:

--- a/src/public/javascripts/katello_object.js
+++ b/src/public/javascripts/katello_object.js
@@ -17,24 +17,28 @@ KT.object = KT.object || {};
 // name and upon completion, we want to retrieve a 'default' label from
 // the server generated off of that name.
 KT.object.label = (function(){
-    var create_button,
-        initial_name_value,
+    var initial_name_value,
+        retrieve_label = true,
 
         initialize = function(){
+            initial_name_value = "";
+            retrieve_label = true;
+
             if ($(".label_input").length === 0){
                 return;
             }
-            create_button = $(".create_button");
 
             disable_inputs(undefined);
 
-            $('.name_input').bind('focusout', function(){
+            $('.create_button').mousedown(function() {retrieve_label = false;});
+
+            $('.name_input').focusout(function(event){
                 var name_input = $(this),
                     name = name_input.val(),
                     label = $(this).closest('fieldset').next('fieldset'),
                     label_input = label.find('input.label_input');
 
-                if ((name.length > 0) && (name !== initial_name_value)) {
+                if ((retrieve_label === true) && (name.length > 0) && (name !== initial_name_value)) {
                     // user changed the name so go fetch the label from the server
                     show_label(label, false);
 
@@ -82,7 +86,6 @@ KT.object.label = (function(){
             // disable the label input associated with the current name
             current_name_input.closest('fieldset').next('fieldset').find('input.label_input').attr("disabled", "disabled");
         }
-        create_button.attr("disabled", "disabled");
     },
     enable_inputs = function(current_name_input) {
         if (current_name_input === undefined) {
@@ -92,7 +95,6 @@ KT.object.label = (function(){
             // enable the label input associated with the current name
             current_name_input.closest('fieldset').next('fieldset').find('input.label_input').removeAttr("disabled");
         }
-        create_button.removeAttr("disabled");
     };
 
     return {

--- a/src/public/javascripts/organization.js
+++ b/src/public/javascripts/organization.js
@@ -19,6 +19,9 @@ $(document).ready(function() {
     KT.panel.set_expand_cb(function() {
         env_scroll.bind(undefined);
         KT.object.label.initialize();
+        if ($('#organization_edit').length > 0) {
+            notices.checkNotices();
+        }
     });
 
    $('.environment_link').live('click', function() {

--- a/src/public/javascripts/provider.js
+++ b/src/public/javascripts/provider.js
@@ -17,6 +17,9 @@ $(document).ready(function() {
 
     KT.panel.set_expand_cb(function() {
         KT.object.label.initialize();
+        if ($('#providers').length > 0) {
+            notices.checkNotices();
+        }
     });
 
   $("#redhatSubscriptionTable").treeTable({


### PR DESCRIPTION
...cified

This commit contains changes to allow the user to submit a new object
(org/env/prod/repo) without specifying the label.  If the user chooses
to do so, the object will be created with a default label and a 'sticky'
message-type notice will be created to inform the user of the label chosen
for them.

Sample message:
   A label was not provided during repository creation; therefore,
   a label of 'repo_2' was automatically assigned. If you would like
   a different label, please delete the repository and recreate it with
   the desired label.
