### PR TITLE
convert string to unicode

### DIFF
--- a/cli/src/katello/client/utils/printer.py
+++ b/cli/src/katello/client/utils/printer.py
@@ -501,4 +501,4 @@ def get_term_width():
 
 def unicode_len(text):
     """ return byte lenght of unicode character """
-    return sum(1+(unicodedata.east_asian_width(c) in "WF") for c in text)
+    return sum(1+(unicodedata.east_asian_width(c) in "WF") for c in u_str(text))


### PR DESCRIPTION
addressing:

```
  File "/usr/lib/python2.7/site-packages/katello/client/cli/base.py", line 197, in main
    ret_code = super(KatelloCLI, self).main(args, command_name, parent_usage)
  File "/usr/lib/python2.7/site-packages/katello/client/core/base.py", line 298, in main
    return subcommand.main(self.args[1:], self.args[0], self._get_usage_line(command_name, parent_usage))
  File "/usr/lib/python2.7/site-packages/katello/client/core/base.py", line 298, in main
    return subcommand.main(self.args[1:], self.args[0], self._get_usage_line(command_name, parent_usage))
  File "/usr/lib/python2.7/site-packages/katello/client/core/base.py", line 376, in main
    return self.run()
  File "/usr/lib/python2.7/site-packages/katello/client/core/organization.py", line 231, in run
    self.printer.print_items(updated_pool_info)
  File "/usr/lib/python2.7/site-packages/katello/client/utils/printer.py", line 384, in print_items
    self.__printer_strategy.print_items(self.get_header(), self.__filtered_columns(), items)
  File "/usr/lib/python2.7/site-packages/katello/client/utils/printer.py", line 207, in print_items
    column_widths = self._calc_column_widths(items, columns)
  File "/usr/lib/python2.7/site-packages/katello/client/utils/printer.py", line 302, in _calc_column_widths
    widths[column['attr_name']] = self._column_width(items, column)
  File "/usr/lib/python2.7/site-packages/katello/client/utils/printer.py", line 283, in _column_width
    width = unicode_len(column['name'])+1
  File "/usr/lib/python2.7/site-packages/katello/client/utils/printer.py", line 504, in unicode_len
    return sum(1+(unicodedata.east_asian_width(c) in "WF") for c in text)
  File "/usr/lib/python2.7/site-packages/katello/client/utils/printer.py", line 504, in <genexpr>
    return sum(1+(unicodedata.east_asian_width(c) in "WF") for c in text)
TypeError: must be unicode, not str
```
