### PR TITLE
demote repo before promotion

### DIFF
--- a/scripts/system-test/cli_tests/_base_cleanup.sh
+++ b/scripts/system-test/cli_tests/_base_cleanup.sh
@@ -3,7 +3,12 @@
 header "Basic environment cleanup"
 
 #clear
+test_failure "repo delete" repo delete --product="$FEWUPS_PRODUCT" --org="$TEST_ORG" --name="$FEWUPS_REPO"
+test_success "changeset create" changeset create --name=delete_repo --deletion --org="$TEST_ORG" --environment="$TEST_ENV"
+test_success "changeset update" changeset update --name=delete_repo --org="$TEST_ORG" --environment="$TEST_ENV" --add_product="$FEWUPS_PRODUCT"
+test_success "changeset promote" changeset promote --name=delete_repo --org="$TEST_ORG" --environment="$TEST_ENV"
 test_success "repo delete" repo delete --product="$FEWUPS_PRODUCT" --org="$TEST_ORG" --name="$FEWUPS_REPO"
+
 test_success "product delete" product delete --org="$TEST_ORG" --name="$FEWUPS_PRODUCT"
 test_success "filter delete" filter delete --org="$TEST_ORG" --name="$FILTER1"
 test_success "provider delete" provider delete --name="$YUM_PROVIDER" --org="$TEST_ORG"


### PR DESCRIPTION
addressing CLIsystem test:

```
----------------------------------------------
Test suite Basic environment cleanup
----------------------------------------------
repo delete                             [ FAILED ]
repo delete --product=fewups_product_UIGyrS13PjB5 --org=org_UIGyrS13PjB5 --name=repo_UIGyrS13PjB5
Repository cannot be deleted since it has already been promoted. Using a changeset, please delete the repository from existing environments before deleting it.
```
