### PR TITLE
fix test according to recent change in printer.py

### DIFF
--- a/scripts/system-test/cli_tests/provider_import.sh
+++ b/scripts/system-test/cli_tests/provider_import.sh
@@ -40,7 +40,7 @@ test_success "changeset create" changeset create --org="$MANIFEST_ORG" --environ
 test_success "changeset add product" changeset update  --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$CS1_NAME" --add_product="$MANIFEST_EPROD"
 check_delayed_jobs_running
 test_success "changeset promote" changeset promote --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --name="$CS1_NAME"
-POOLID=$($CMD org subscriptions --name "$MANIFEST_ORG" -g -d ";" | grep "$MANIFEST_PROD_CP" | awk -F ' *; *' '{print $4}') # grab a pool for CP
+POOLID=$($CMD org subscriptions --name "$MANIFEST_ORG" -g -d ";" --noheading | grep "$MANIFEST_PROD_CP" | awk -F ';' '{print $3}') # grab a pool for CP
 
 test_success "system register with SLA" system register --name="$HOST" --org="$MANIFEST_ORG" --environment="$MANIFEST_ENV" --servicelevel="$SLA"
 test_success "system update SLA" system update --name="$HOST" --org="$MANIFEST_ORG" --servicelevel="$SLA"

--- a/scripts/system-test/helpers
+++ b/scripts/system-test/helpers
@@ -19,7 +19,7 @@ function get_pulp_repo_id() {
 }
 
 function get_repo_name() {
-    echo `$CMD repo list --org="$TEST_ORG" -g -d "##" | grep "$FEWUPS_REPO" | awk -F ' *## *' '{print $3}'`
+    echo `$CMD repo list --org="$TEST_ORG" -g -d "##" | grep "$FEWUPS_REPO" | awk -F '##' '{print $2}'`
 }
 
 function valid_id() {


### PR DESCRIPTION
recently the leading delimiter is not printed
and the value is not surraunded by space

addressing:

```
system subscribe                        [ FAILED ]
system subscribe --org=org_lkY2GA9MplC9 --name=admin_system_lkY2GA9MplC9 --pool=Id                : 8a90c4e63a06eb82013a08054e4a01a0
Subscription pool Id                : 8a90c4e63a06eb82013a08054e4a01a0 does not exist.
```
