### PR TITLE
803702 - switch back to searching in the API by name and not label

### DIFF
--- a/src/app/controllers/api/api_controller.rb
+++ b/src/app/controllers/api/api_controller.rb
@@ -93,7 +93,7 @@ class Api::ApiController < ActionController::Base
 
   def find_optional_organization
     if params[:organization_id]
-      @organization = Organization.first(:conditions => {:label => params[:organization_id].to_s.tr(' ', '_')})
+      @organization = Organization.first(:conditions => {:name => params[:organization_id]})
       raise HttpErrors::NotFound, _("Couldn't find organization '#{params[:organization_id]}'") if @organization.nil?
       @organization
     end

--- a/src/app/controllers/api/organizations_controller.rb
+++ b/src/app/controllers/api/organizations_controller.rb
@@ -82,7 +82,7 @@ class Api::OrganizationsController < Api::ApiController
   private
 
   def find_organization
-    @organization = Organization.first(:conditions => {:label => params[:id].tr(' ', '_')})
+    @organization = Organization.first(:conditions => {:name => params[:id]})
     raise HttpErrors::NotFound, _("Couldn't find organization '#{params[:id]}'") if @organization.nil?
     @organization
   end

--- a/src/spec/controllers/api/organizations_controller_spec.rb
+++ b/src/spec/controllers/api/organizations_controller_spec.rb
@@ -98,7 +98,7 @@ describe Api::OrganizationsController do
       req
     end 
   end
-  
+
   describe "show a organization" do
 
     let(:action) {:show }
@@ -108,14 +108,14 @@ describe Api::OrganizationsController do
     it_should_behave_like "protected action"
 
     it 'should call katello organization find api' do
-      Organization.should_receive(:first).once.with(:conditions => {:label => "spec"})
+      Organization.should_receive(:first).once.with(:conditions => {:name => "spec"})
       req
     end
   end
 
   describe "show a organization" do
     it 'should call katello organization find api and account for spaces in search name' do
-      Organization.should_receive(:first).once.with(:conditions => {:label => "show_org_with_spaces"})
+      Organization.should_receive(:first).once.with(:conditions => {:name => "show org with spaces"})
       get 'show', :id => "show org with spaces"
     end
   end
@@ -129,7 +129,7 @@ describe Api::OrganizationsController do
     it_should_behave_like "protected action"
 
    it 'should call organization destroy method' do
-      Organization.should_receive(:first).once.with(:conditions => {:label => "spec"}).and_return(@org)
+      Organization.should_receive(:first).once.with(:conditions => {:name => "spec"}).and_return(@org)
       OrganizationDestroyer.should_receive(:destroy).with(@org).once
       req
     end
@@ -137,7 +137,7 @@ describe Api::OrganizationsController do
 
   describe "delete a organization" do
     it 'should call organization destroy method while accounting for spaces in search name' do
-      Organization.should_receive(:first).once.with(:conditions => {:label => "delete_org_with_spaces"}).and_return(@org)
+      Organization.should_receive(:first).once.with(:conditions => {:name => "delete org with spaces"}).and_return(@org)
       OrganizationDestroyer.should_receive(:destroy).with(@org).once
       delete 'destroy', :id => "delete org with spaces"
     end
@@ -152,7 +152,7 @@ describe Api::OrganizationsController do
     it_should_behave_like "protected action"
 
     it 'should call org update_attributes' do
-      Organization.should_receive(:first).once.with(:conditions => {:label => "spec"}).and_return(@org)
+      Organization.should_receive(:first).once.with(:conditions => {:name => "spec"}).and_return(@org)
       @org.should_receive(:update_attributes!).once
       put 'update', :id => "spec", :organization=>{:description=>"bah"}
     end
@@ -160,7 +160,7 @@ describe Api::OrganizationsController do
 
   describe "update a organization" do
     it 'should call org update_attributes while accounting for spaces in the search name' do
-      Organization.should_receive(:first).once.with(:conditions => {:label => "update_org_with_spaces"}).and_return(@org)
+      Organization.should_receive(:first).once.with(:conditions => {:name => "update org with spaces"}).and_return(@org)
       @org.should_receive(:update_attributes!).once
       put 'update', :id => "update org with spaces", :organization=>{:description=>"bah"}
     end


### PR DESCRIPTION
This change goes back to looking up the org based on the name instead of
relying on the label which breaks old API and CLI calls.
