### PR TITLE
860709 - pulp-migrate was not executed during upgrade

### DIFF
--- a/katello-configure/upgrade-scripts/default/0002_update_pulp.sh
+++ b/katello-configure/upgrade-scripts/default/0002_update_pulp.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-#name: Update Pulp
+#name: Update Pulp MongoDB database
 #apply: katello
 #description:
 #Actions that need to be taken to upgrade Pulp subsystem
 
-# TODO
+/usr/sbin/service-wait mongod start
+/bin/sleep 10s
+/usr/bin/pulp-migrate
 
 exit 0


### PR DESCRIPTION
Pulp was NOT working after CFSE upgrade at all. Before migration we need to start mongodb, I use service-wait for that and I have added additional 10 second sleep just to be sure everything is ready.
