### PR TITLE
Fixed broken label rspec tests

### DIFF
--- a/src/spec/controllers/api/activation_keys_controller_spec.rb
+++ b/src/spec/controllers/api/activation_keys_controller_spec.rb
@@ -81,7 +81,7 @@ describe Api::ActivationKeysController do
     it_should_behave_like "protected action"
 
     it "should retrieve organization" do
-      Organization.should_receive(:first).once.with(hash_including(:conditions => {:label => '1234'})).and_return(@organization)
+      Organization.should_receive(:first).once.with(hash_including(:conditions => {:name => '1234'})).and_return(@organization)
       get :index, :organization_id => '1234'
     end
 
@@ -316,7 +316,7 @@ describe Api::ActivationKeysController do
 
     it "should throw a 404 is passed in a bad system group id" do
       ids = [90210]
-      post :add_system_groups, :id => @activation_key.id, :organization_id => @organization.id, :activation_key => { :system_group_ids => ids }
+      post :add_system_groups, :id => @activation_key.id, :organization_id => @organization.id.to_s, :activation_key => { :system_group_ids => ids }
       response.status.should == 404
     end
 

--- a/src/spec/controllers/api/products_controller_spec.rb
+++ b/src/spec/controllers/api/products_controller_spec.rb
@@ -160,7 +160,7 @@ describe Api::ProductsController, :katello => true do
     end
 
     it "should find organization" do
-      Organization.should_receive(:first).once.with({:conditions => {:label => @organization.label}}).and_return(@organization)
+      Organization.should_receive(:first).once.with({:conditions => {:name => @organization.name}}).and_return(@organization)
       get 'index', :organization_id => @organization.label
     end
 
@@ -188,7 +188,7 @@ describe Api::ProductsController, :katello => true do
     end
 
     it "should find organization" do
-      Organization.should_receive(:first).once.with({:conditions => {:label => @organization.label}}).and_return(@organization)
+      Organization.should_receive(:first).once.with({:conditions => {:name => @organization.name}}).and_return(@organization)
       get 'index', :organization_id => @organization.label
     end
 


### PR DESCRIPTION
Label was changed back to name in the api as the cli still uses name for
several of its call. The rspec tests were not reverted back to using name so I
fixed that.
