### PR TITLE
ignore fuzzy and obsolete translations

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -95,5 +95,5 @@ module Src
   end
 end
 
-FastGettext.add_text_domain 'app', :path => 'locale', :type => :po
+FastGettext.add_text_domain 'app', :path => 'locale', :type => :po, :ignore_fuzzy => true, :ignore_obsolete => true
 FastGettext.default_text_domain = 'app'


### PR DESCRIPTION
addressing:

```
Warning: fuzzy message was ignored.
         msgid 'package group update timed out'
```
