### PR TITLE
Defensively checking installed product names;

### DIFF
--- a/src/app/models/system.rb
+++ b/src/app/models/system.rb
@@ -263,7 +263,7 @@ class System < ActiveRecord::Base
      :name_sort=>name.downcase, :name_autocomplete=>self.name,
      :system_group=>self.system_groups.collect{|g| g.name},
      :system_group_ids=>self.system_group_ids,
-     :installed_products=>self.installedProducts.collect{|p| p[:productName]}
+     :installed_products=>self.collect_installed_product_names
     }
   end
 
@@ -291,6 +291,10 @@ class System < ActiveRecord::Base
     def fill_defaults
       self.description = _("Initial Registration Params") unless self.description
       self.location = _("None") unless self.location
+    end
+
+    def collect_installed_product_names
+      self.installed_products ? self.installed_products.map{ |p| p[:productName] } : []
     end
 
 end


### PR DESCRIPTION
system.installedProducts can return nil instead of []
