### PR TITLE
858960 - encode the help message before writing

### DIFF
--- a/cli/src/katello/client/i18n_optparse.py
+++ b/cli/src/katello/client/i18n_optparse.py
@@ -73,7 +73,7 @@ class OptionParser(_OptionParser):
         if out_file is None:
             out_file = sys.stdout
         self.displayed_help = True
-        out_file.write(self.format_help())
+        out_file.write(self.format_help().encode('utf-8'))
 
 
     def exit(self, status=0, msg=None):


### PR DESCRIPTION
Otherwse `LANG=ko katello --help` fails with:

```
error: 'ascii' codec can't encode characters in position 80-83:
ordinal not in range(128)
```
