### PR TITLE
do not mask original error by raise in exception

### DIFF
--- a/cli/src/katello/client/core/product.py
+++ b/cli/src/katello/client/core/product.py
@@ -280,9 +280,9 @@ class Promote(SingleProductAction):
                 print _("Product [ %s ] promotion failed: %s" % (prodName, format_task_errors(task.errors())) )
                 returnCode = os.EX_DATAERR
 
-        except Exception as e:
+        except Exception:
             #exception message is printed from action's main method
-            raise e
+            raise
 
         return returnCode
 

--- a/cli/src/katello/client/core/provider.py
+++ b/cli/src/katello/client/core/provider.py
@@ -15,6 +15,7 @@
 #
 
 import os
+import sys
 
 from katello.client.api.provider import ProviderAPI
 from katello.client.cli.base import opt_parser_add_org
@@ -297,7 +298,7 @@ class ImportManifest(SingleProviderAction):
                 re.args[1]["displayMessage"] == "Import is older than existing data":
                 re.args[1]["displayMessage"] = "Import is older then existing data," +\
                     " please try with --force option to import manifest."
-            raise re
+            raise re, None, sys.exc_info()[2]
         f.close()
         print response
         return os.EX_OK

--- a/cli/src/katello/client/core/system.py
+++ b/cli/src/katello/client/core/system.py
@@ -485,7 +485,7 @@ class Unregister(SystemAction):
             if e[0] == 404:
                 return os.EX_DATAERR
             else:
-                raise e
+                raise
 
         self.api.unregister(system['uuid'])
         print _("Successfully unregistered System [ %s ]") % name

--- a/cli/src/katello/client/core/utils.py
+++ b/cli/src/katello/client/core/utils.py
@@ -117,7 +117,7 @@ def parse_tokens(tokenstring):
             tokens.append(tok)
         return tokens
     except Exception, e:
-        raise KatelloError("Unable to parse options", e)
+        raise KatelloError("Unable to parse options", e), None, sys.exc_info()[2]
 
 
 def get_abs_path(path):

--- a/cli/src/katello/client/server.py
+++ b/cli/src/katello/client/server.py
@@ -20,6 +20,7 @@ import httplib
 import os
 import urllib
 import mimetypes
+import sys
 
 try:
     import json
@@ -194,11 +195,11 @@ class KatelloServer(object):
             self.auth_method.set_headers(self.headers)
         except GSSError, e:
             #TODO
-            raise Exception("Missing credentials and unable to authenticate using Kerberos", e)
+            raise Exception("Missing credentials and unable to authenticate using Kerberos", e), None, sys.exc_info()[2]
             #raise KatelloError("Missing credentials and unable to authenticate using Kerberos", e)
         except Exception, e:
             #TODO
-            raise Exception("Invalid credentials or unable to authenticate", e)
+            raise Exception("Invalid credentials or unable to authenticate", e), None, sys.exc_info()[2]
             #raise KatelloError("Invalid credentials or unable to authenticate", e)
 
     # protected request utilities ---------------------------------------------


### PR DESCRIPTION
From Jason email:
In a nutshell, NEVER NEVER NEVER DO THIS:

try:
    .... # some work
except:
    ... # possibly something else that doesn't include logging the traceback
    raise MyOwnExceptionClass('new message here')

We've pointed this out before, and I'm pointing it out again. THIS MASKS
THE ORIGINAL ERROR! When trying to debug these, I usually feel like
strangling someone.

We should either (1) log the current exception and traceback if we're
actually handling the error (e.g. at the top level of the web services
or in the pulp client), (2) re-raise the original error (e.g. useful for
doing some local cleanup), or (3) concatenate the existing traceback to
our new exception (e.g. when differentiating the error condition from an
underlying standard library or third party exception).

Let me demonstrate the last two.

Re-raising the original error (2):

try:
    .... # some work
except:
    .... # local clean up, logging, etc.
    raise

The last empty 'raise' statement will conveniently re-raise the caught
exception.

Concatenating the existing traceback (3):

import sys

try:
    ... # some work
except:
    ... # optional clean up, etc.
    raise PulpException('more meaningful error message'), None, sys.exc_info()[2]

The ', None, sys.exc_info()[2]' portion at the end of the new 'raise'
statement will concatenate the exiting traceback to the traceback
generated by the raise. This allows us to see the original point where
something went wrong instead of hiding it beneath the new PulpException.

Note: it can be any exception, PulpException is just used as an example.
