### PR TITLE
858960 - always set the utf-8 writer for stdout and stderr

### DIFF
--- a/cli/src/katello/client/utils/encoding.py
+++ b/cli/src/katello/client/utils/encoding.py
@@ -34,10 +34,8 @@ def fix_io_encoding():
     This can happen when the command is executed in a subshell.
     We use utf-8 as all our server-side data are utf-8 encoded.
     """
-    if sys.stdout.encoding == None:
-        sys.stdout = encode_stream(sys.stdout)
-    if sys.stderr.encoding == None:
-        sys.stderr = encode_stream(sys.stderr)
+    sys.stdout = encode_stream(sys.stdout)
+    sys.stderr = encode_stream(sys.stderr)
 
 
 def u_str(value):


### PR DESCRIPTION
Otherwise the unicode output is failing when LC_CTYPE is set.
