### PR TITLE
835586 - force the encoding in the header to be UTF8 so Pulp can decode

### DIFF
--- a/src/lib/resources/pulp.rb
+++ b/src/lib/resources/pulp.rb
@@ -53,7 +53,7 @@ module Resources
       def self.default_headers
         {'accept' => 'application/json',
          'accept-language' => I18n.locale,
-         'content-type' => 'application/json'}.merge(::User.pulp_oauth_header)
+         'content-type' => 'application/json; charset=utf-8'}.merge(::User.pulp_oauth_header)
       end
 
       # some old Pulp API need text/plain content type


### PR DESCRIPTION
Without this pulp treats UTF8 encoded strings as standard strings and
will fail to parse some of our headers, namely the pulp-user header.
