### PR TITLE
Notices

### DIFF
--- a/src/public/javascripts/notices.js
+++ b/src/public/javascripts/notices.js
@@ -11,20 +11,6 @@
  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 */
 
-var noticeArray = [];
-
-function storeNotice(event, noticeObj) {
-    var maxAge = 60000;
-    var curTime = (new Date()).valueOf();
-    // Discard notices older than maxAge
-    for (idx=noticeArray.length-1; idx>=0; --idx) {
-        if (curTime - noticeArray[idx].time > maxAge) {
-            noticeArray.splice(idx, 1);
-        }
-    }
-    noticeArray.push(noticeObj);
-}
-
 var notices = (function() {
     return {
         setup_notices: function(pollingTimeOut) {
@@ -32,7 +18,8 @@ var notices = (function() {
             pollingTimeOut = 45000;
           }
           
-          $("body").bind("notice", storeNotice);
+          notices.noticeArray = [];
+          $("body").bind("notice", notices.storeNotice);
 
           notices.checkTimeout = pollingTimeOut;
           //start continual checking for new notifications
@@ -93,6 +80,18 @@ var notices = (function() {
             if( noticesParsed['notices'] && noticesParsed['notices'].length !== 0 ){
                 $.jnotify(generate_list(noticesParsed['notices']), options);
             }
+        },
+        storeNotice: function(event, noticeObj) {
+            var maxAge = 600000,
+                curTime = (new Date()).valueOf(),
+                idx = notices.noticeArray.length - 1;
+            // Discard notices older than maxAge
+            for (; idx>=0; idx-=1) {
+                if (curTime - notices.noticeArray[idx].time > maxAge) {
+                    notices.noticeArray.splice(idx, 1);
+                }
+            }
+            notices.noticeArray.push(noticeObj);
         },
         addNotices: function(data) {
             if (!data || data.new_notices.length === 0) {


### PR DESCRIPTION
Added notice capture for use in automation testing framework.  Notices are stored in an array only until page reload.  This is expected to have a negligible effect on performance, since only a relatively small number of notices should accumulate between page loads.

The alternative of injecting js and using triggers was explored, but would require an unreasonable amount of effort to accomplish due to the need to inject js from within the testing framework on every page load.  This would affect hundreds of call sites and would be difficult to extend.  Additionally, it is probably not possible due to the synchronous nature of page loads in Selenium.  It is too late to inject the js event handler after control is returned from Selenium.

Thus, storing notices in an array was deemed to be an effective and simple solution with no noticeable effect on performance.
