### PR TITLE
863461 - Headpin Cli automation : Failure to list the org updated

### DIFF
--- a/cli/src/katello/client/utils/printer.py
+++ b/cli/src/katello/client/utils/printer.py
@@ -31,7 +31,7 @@ class PrinterStrategy(object):
 
     def __init__(self):
         super(PrinterStrategy, self).__init__()
-        self.out = codecs.getwriter('utf-8')(sys.stdout)
+        self.out = sys.stdout
 
     def print_item(self, heading, columns, item):
         """


### PR DESCRIPTION
with special chars other than ascii chars

this started happening due to strings being double encoded.

cli/src/katello/client/utils/encoding.py blanket-encoded sys.stdout.

then cli/src/katello/client/utils/printer.py encoded all its output that
it was sending to sys.stdout.

string -> encoded -> encoded -> boom

related: https://github.com/Katello/katello/commit/d650484f2c66df5ef8a11179a17094091fdfca65
