### PR TITLE
removing unused import in cli utils printer.py

### DIFF
--- a/cli/src/katello/client/utils/printer.py
+++ b/cli/src/katello/client/utils/printer.py
@@ -13,7 +13,6 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
-import codecs
 import fcntl
 import termios
 import struct


### PR DESCRIPTION
breaks pylint in the build
