### PR TITLE
845198 - fixed getlocale

### DIFF
--- a/cli/src/katello/client/cli/base.py
+++ b/cli/src/katello/client/cli/base.py
@@ -143,7 +143,7 @@ class KatelloCLI(Command):
         port = self.opts.port
         scheme = self.opts.scheme
         path = self.opts.path
-    
+
         self._server = server.KatelloServer(host, int(port), scheme, path, self.__server_locale())
         server.set_active_server(self._server)
 
@@ -154,7 +154,7 @@ class KatelloCLI(Command):
         Eg. en_US -> en-us
         """
         import locale
-        loc = locale.getlocale(locale.LC_ALL)[0] or locale.getdefaultlocale()[0]
+        loc = locale.getlocale()[0] or locale.getdefaultlocale()[0]
         if loc is not None:
             return loc.lower().replace('_', '-')
         else:

--- a/cli/src/katello/client/i18n.py
+++ b/cli/src/katello/client/i18n.py
@@ -30,7 +30,7 @@ def force_encoding(encoding):
     """
     Force locale to use specific encoding and bind output streams to use it.
     """
-    current_locale = locale.getlocale(locale.LC_ALL)[0] or locale.getdefaultlocale()[0]
+    current_locale = locale.getlocale()[0] or locale.getdefaultlocale()[0]
     if current_locale:
         locale.setlocale(locale.LC_ALL, str(current_locale)+'.'+str(encoding))
     else:


### PR DESCRIPTION
locale.getlocale was used with wrong parameter. LC_ALL is not allowed.
See: http://docs.python.org/library/locale.html#locale.getlocale
