### PR TITLE
859442 - systems - update query for adding system groups to system

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -577,8 +577,8 @@ class SystemsController < ApplicationController
   def system_groups
     # retrieve the available groups that aren't currently assigned to the system and that haven't reached their max
     @system_groups = SystemGroup.where(:organization_id=>current_organization).
-        joins(:system_system_groups).
         select("system_groups.id, system_groups.name").
+        joins("LEFT OUTER JOIN system_system_groups ON system_system_groups.system_group_id = system_groups.id").
         group("system_groups.id, system_groups.name, system_groups.max_systems having count(system_system_groups.system_id) < system_groups.max_systems or system_groups.max_systems = -1").
         order(:name) - @system.system_groups
 


### PR DESCRIPTION
A minor change to the query for the Systems -> System Groups pane
for listing the groups that may be assigned to a system.  The previous
query was incorrect performing an inner join which resulted in
no groups to be associated (when a given group had no systems).
