### PR TITLE
864362-autocomplete - rescue bad searches in auto-complete fields

### DIFF
--- a/src/app/controllers/products_controller.rb
+++ b/src/app/controllers/products_controller.rb
@@ -102,7 +102,7 @@ class ProductsController < ApplicationController
     end
     render :json=>products.collect{|s| {:label=>s.name, :value=>s.name, :id=>s.id}}
   rescue Tire::Search::SearchRequestFailed => e
-     render :json=>Support.array_with_total
+    render :json=>Support.array_with_total
   end
 
   protected

--- a/src/app/controllers/system_groups_controller.rb
+++ b/src/app/controllers/system_groups_controller.rb
@@ -218,6 +218,8 @@ class SystemGroupsController < ApplicationController
       filter :terms, {:id=>SystemGroup.editable(org).collect{|g| g.id}}
     end
     render :json=>groups.map{|s| {:label=>s.name, :value=>s.name, :id=>s.id}}
+  rescue Tire::Search::SearchRequestFailed => e
+    render :json=>Support.array_with_total
   end
 
   def controller_display_name

--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -188,6 +188,8 @@ class SystemsController < ApplicationController
       label = _("%s (Registered: %s)") % [s.name, convert_time(format_time(Time.parse(s.created_at)))]
       {:label=>label, :value=>s.name, :id=>s.id}
     }
+  rescue Tire::Search::SearchRequestFailed => e
+    render :json=>Support.array_with_total
   end
 
 


### PR DESCRIPTION
Entering bad search terms will throw an error that, when uncaught, shows up in UI. Rescues added in auto_complete methods lacking rescue.
