### PR TITLE
864565 - Removing duplicate repos from gpgkey show

### DIFF
--- a/src/app/controllers/gpg_keys_controller.rb
+++ b/src/app/controllers/gpg_keys_controller.rb
@@ -76,7 +76,7 @@ class GpgKeysController < ApplicationController
     products = @gpg_key.products
 
     repos_hash = {}
-    @gpg_key.repositories.each do |repo|
+    @gpg_key.repositories.uniq_by(&:label).each do |repo|
       repos_hash[repo.environment_product.product.name] ||= []
       repos_hash[repo.environment_product.product.name] << repo
     end


### PR DESCRIPTION
Multiple repo entries were wrongly showing up for a product on the GPG key 
page.
