### PR TITLE
864654 - katello-headpin-all correction

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -206,7 +206,7 @@ A subscription management only version of Katello.
 Summary:        A meta-package to pull in all components for katello-headpin
 Requires:       katello-headpin
 Requires:       katello-configure
-Requires:       katello-cli-headpin
+Requires:       katello-cli
 Requires:       postgresql-server
 Requires:       postgresql
 Requires:       candlepin-tomcat6


### PR DESCRIPTION
rpm was installing katello-headpin-cli which is obsolete in favor
of katello-cli
