### PR TITLE
fixing - uninitialized constant Candlepin

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -466,6 +466,7 @@ rm -f %{datadir}/Gemfile.lock 2>/dev/null
 %{homedir}/app/helpers
 %{homedir}/app/mailers
 %{homedir}/app/models/*.rb
+%{homedir}/app/models/candlepin
 %{homedir}/app/stylesheets
 %{homedir}/app/views
 %{homedir}/autotest


### PR DESCRIPTION
We have forgot to add new ruby file in the katello.spec file, this was causing LOTS of CLI errors. This patch fixes it.

It took a while to find out what the heck is going on here..
