### PR TITLE
RAM entitlements

### DIFF
--- a/cli/src/katello/client/core/system.py
+++ b/cli/src/katello/client/core/system.py
@@ -139,6 +139,8 @@ class Info(SystemAction):
             self.printer.add_column('release', _('OS release'))
         self.printer.add_column('activation_keys', multiline=True, show_with=printer.VerboseStrategy)
         self.printer.add_column('host', show_with=printer.VerboseStrategy)
+        self.printer.add_column('sockets')
+        self.printer.add_column('ram', _("RAM (MB)"))
         self.printer.add_column('serviceLevel', _('Service Level'))
         self.printer.add_column('guests', show_with=printer.VerboseStrategy)
         if "template" in system:

--- a/src/app/models/glue/candlepin/consumer.rb
+++ b/src/app/models/glue/candlepin/consumer.rb
@@ -286,6 +286,10 @@ module Glue::Candlepin::Consumer
       "#{distribution_name} #{distribution_version}"
     end
 
+    def memory
+      facts["dmi.memory.size"]
+    end
+
     def entitlements_valid?
       "true" == facts["system.entitlements_valid"]
     end

--- a/src/app/models/glue/candlepin/pool.rb
+++ b/src/app/models/glue/candlepin/pool.rb
@@ -21,7 +21,7 @@ module Glue::Candlepin::Pool
       lazy_accessor :pool_derived, :product_name, :consumed, :quantity, :support_level, :support_type,
         :start_date, :end_date, :attrs, :owner, :product_id, :account_number, :contract_number,
         :source_pool_id, :host_id, :virt_only, :virt_limit, :multi_entitlement, :stacking_id,
-        :arch, :sockets, :description, :product_family, :variant, :provided_products,
+        :arch, :sockets, :ram, :description, :product_family, :variant, :provided_products,
         :initializer => lambda {|s|
           json = Resources::Candlepin::Pool.find(cp_id)
           # symbol "attributes" is reserved by Rails and cannot be used
@@ -92,6 +92,7 @@ module Glue::Candlepin::Pool
       @arch = ""
       @support_level = ""
       @sockets = 0
+      @ram = 0
       @description = ""
       @product_family = ""
       @variant = ""
@@ -109,6 +110,8 @@ module Glue::Candlepin::Pool
             @support_level = attr['value']
           when 'sockets'
             @sockets = attr['value'].to_i
+          when 'ram'
+            @ram = attr['value'].to_i
           when 'description'
             @description = attr['value']
           when 'product_family'

--- a/src/app/models/pool.rb
+++ b/src/app/models/pool.rb
@@ -69,6 +69,7 @@ class Pool < ActiveRecord::Base
           :begin        => {:type=>'date'},
           :end          => {:type=>'date'},
           :sockets      => {:type=>'long'},
+          :ram          => {:type=>'long'},
           :sla          => {:type=>'string'},
           :support_level=> {:type=>'string', :index=>:not_analyzed},
           :org          => {:type=>'string', :index=>:not_analyzed},

--- a/src/app/models/system.rb
+++ b/src/app/models/system.rb
@@ -29,8 +29,18 @@ class System < ActiveRecord::Base
   after_rollback :rollback_on_create, :on => :create
 
   index_options :extended_json=>:extended_index_attrs,
-                :json=>{:only=> [:name, :description, :id, :uuid, :created_at, :lastCheckin, :environment_id]},
-                :display_attrs=>[:name, :description, :id, :uuid, :created_at, :lastCheckin, :system_group, :installed_products, "custom_info.KEYNAME"]
+                :json=>{:only=> [:name, :description, :id, :uuid, :created_at, :lastCheckin, :environment_id, :memory, :sockets]},
+                :display_attrs => [:name,
+                                   :description,
+                                   :id,
+                                   :uuid,
+                                   :created_at,
+                                   :lastCheckin,
+                                   :system_group,
+                                   :installed_products,
+                                   "custom_info.KEYNAME",
+                                   :ram,
+                                   :sockets]
 
   dynamic_templates = [
       {
@@ -60,6 +70,8 @@ class System < ActiveRecord::Base
     indexes :lastCheckin, :type=>'date'
     indexes :name_autocomplete, :type=>'string', :analyzer=>'autcomplete_name_analyzer'
     indexes :installed_products, :type=>'string', :analyzer=>:kt_name_analyzer
+    indexes :ram, :type => 'integer'
+    indexes :sockets, :type => 'integer'
     indexes :facts, :path=>"just_name" do
     end
     indexes :custom_info, :path => "just_name" do
@@ -290,6 +302,8 @@ class System < ActiveRecord::Base
      :system_group=>self.system_groups.collect{|g| g.name},
      :system_group_ids=>self.system_group_ids,
      :installed_products=>collect_installed_product_names,
+     :ram => self.memory,
+     :sockets => self.sockets,
      :custom_info=>collect_custom_info
     }
   end

--- a/src/app/views/subscriptions/_edit.html.haml
+++ b/src/app/views/subscriptions/_edit.html.haml
@@ -62,9 +62,10 @@
           = @subscription.virt_only ? _("Virtual Only") : _("Physical or Virtual")
       %fieldset
         .grid_2.ra.fieldset
-          =label :sockets, :sockets, _("Sockets")
+          =label :limits, :limits, _("Limits")
         .grid_8.la
-          = @subscription.sockets
+          = _("Sockets: %s") % @subscription.sockets
+          = _(", RAM: %s") % @subscription.ram if @subscription.ram != 0
       %fieldset
         .grid_2.ra.fieldset
           =label :multientitlement, :multientitlement, _("Multi-entitlement")

--- a/src/app/views/systems/_edit.html.haml
+++ b/src/app/views/systems/_edit.html.haml
@@ -83,6 +83,14 @@
         .grid_5.la #{System.architectures[system.arch]}
       %fieldset
         .grid_2.ra.fieldset
+          = label :ram, :ram, _("RAM (MB)")
+        .grid_5.la #{system.memory_megabytes}
+      %fieldset
+        .grid_2.ra.fieldset
+          = label :sockets, :sockets, _("Sockets")
+        .grid_5.la #{system.sockets}
+      %fieldset
+        .grid_2.ra.fieldset
           = label :location, :location, _("Location")
         .grid_5.la#system_location{'name' => 'system[location]', :class=>("editable edit_textfield" if editable), 'data-url'=>system_path(system.id)} #{system[:location]}
       %fieldset

--- a/src/app/views/systems/_subs.html.haml
+++ b/src/app/views/systems/_subs.html.haml
@@ -66,7 +66,7 @@
             %th
             %th #{_("Subscription")}
             %th #{_("SLA")}
-            %th #{_("Sockets")}
+            %th #{_("Limits")}
             %th #{_("Quantity")}
             %th #{_("Start")}
             %th #{_("End")}
@@ -82,7 +82,7 @@
               %th
               %th #{_("Subscription")}
               %th #{_("SLA")}
-              %th #{_("Sockets")}
+              %th #{_("Limits")}
               %th #{_("Quantity")}
               %th #{_("Start")}
               %th #{_("End")}
@@ -102,7 +102,9 @@
                   %td{:style => "padding-top:9px;"}
                   %td{:style => "padding-top:9px;"}
                   %td{:style => "padding-top:9px;"} #{sub.support_level}
-                  %td{:style => "padding-top:9px;"} #{sub.sockets}
+                  %td{:style => "padding-top:9px;"}
+                    = _("Sockets: %s") % sub.sockets
+                    = _(", RAM: %s") % sub.ram if sub.ram != 0
                   - if sub.multi_entitlement
                     %td
                       = text_field_tag "spinner[#{sub.cp_id}]", nil, :min => 0, :max => (sub.quantity-sub.consumed), :step=>1, :value=>0, :class=>"ui-spinner"


### PR DESCRIPTION
- easier to view memory & socket limits for machines in UI & CLI
- support for limits of various types in the ui
- socket & RAM suppot in elasticsearch
- RAM support in candlepin is still WIP; this provides very basic UI
  support but more work will likely need to be done around pool selection
