### PR TITLE
Do not skip our repo

### DIFF
--- a/repos/katello-candlepin.repo
+++ b/repos/katello-candlepin.repo
@@ -9,7 +9,6 @@ name=An open source entitlement management system.
 baseurl=http://fedorapeople.org/groups/katello/releases/yum/katello-candlepin/@SUBDIR@/$releasever/$basearch/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=1
-skip_if_unavailable=1
 gpgcheck=0
 
 [katello-candlepin-source]
@@ -17,5 +16,4 @@ name=Katello Candlepin source
 baseurl=http://fedorapeople.org/groups/katello/releases/source/katello-candlepin/@SUBDIR@/$releasever/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=0
-skip_if_unavailable=1
 gpgcheck=0

--- a/repos/katello-foreman.repo
+++ b/repos/katello-foreman.repo
@@ -7,7 +7,6 @@ name=Foreman Community Releases
 baseurl=http://fedorapeople.org/groups/katello/releases/yum/katello-foreman/@SUBDIR@/$releasever/$basearch/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=1
-skip_if_unavailable=1
 gpgcheck=0
 
 [katello-foreman-source]
@@ -15,6 +14,5 @@ name=Katello Foreman source
 baseurl=http://fedorapeople.org/groups/katello/releases/source/katello-foreman/@SUBDIR@/$releasever/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=0
-skip_if_unavailable=1
 gpgcheck=0
 

--- a/repos/katello-pulp.repo
+++ b/repos/katello-pulp.repo
@@ -7,7 +7,6 @@ name=Pulp Community Releases
 baseurl=http://fedorapeople.org/groups/katello/releases/yum/katello-pulp/@SUBDIR@/$releasever/$basearch/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=1
-skip_if_unavailable=1
 gpgcheck=0
 
 [katello-pulp-source]
@@ -15,6 +14,5 @@ name=Katello Pulp source
 baseurl=http://fedorapeople.org/groups/katello/releases/source/katello-pulp/@SUBDIR@/$releasever/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=0
-skip_if_unavailable=1
 gpgcheck=0
 

--- a/repos/katello.repo
+++ b/repos/katello.repo
@@ -5,7 +5,6 @@ name=Katello Stable
 baseurl=http://fedorapeople.org/groups/katello/releases/yum/nightly/@SUBDIR@/$releasever/$basearch/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=1
-skip_if_unavailable=1
 gpgcheck=0
 
 [katello-source]
@@ -13,6 +12,5 @@ name=Katello Stable Source
 baseurl=http://fedorapeople.org/groups/katello/releases/source/nightly/@SUBDIR@/$releasever/
 gpgkey=http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg
 enabled=0
-skip_if_unavailable=1
 gpgcheck=0
 


### PR DESCRIPTION
In deep history our repos were unstable and this had sense.
But our repositories are now rock stable and this does not have really sense.
Therefore I suggest to remove it.
