### PR TITLE
866323 - do not print binary files to log

### DIFF
--- a/cli/src/katello/client/server.py
+++ b/cli/src/katello/client/server.py
@@ -17,6 +17,7 @@ import base64
 import kerberos
 from kerberos import GSSError
 import httplib
+import logging
 import os
 import urllib
 import mimetypes
@@ -286,8 +287,12 @@ class KatelloServer(object):
             else:
                 pass
 
-        if response_body:
-            self._log.debug("processing response %s\n%s" % (response.status, u_str(response_body)))
+        if response_body and self._log.isEnabledFor(logging.DEBUG):
+            content_type = response.getheader('content-type')
+            if content_type and (content_type.startswith('text/') or content_type.startswith('application/json')):
+                self._log.debug("processing response %s\n%s" % (response.status, u_str(response_body)))
+            else:
+                self._log.debug("processing response %s of %s" % (response.status, content_type))
         else:
             self._log.debug("processing empty response %s" % (response.status))
 


### PR DESCRIPTION
if file is binary (e.g pdf file) then do not try to convert it to unicode
and print it to log file
additionally execute this part of code only if logging level is set to DEBUG.
