### PR TITLE
do not call pulp service script, call qpidd and mongodb directly

### DIFF
--- a/katello-configure/bin/katello-upgrade
+++ b/katello-configure/bin/katello-upgrade
@@ -19,7 +19,7 @@ ERROR_CODES = {
   :unknown => 127,
 }
 
-BACKEND_SERVICES = ['katello', 'katello-jobs', 'tomcat6', 'pulp-server', 'thumbslug', 'httpd', 'elasticsearch']
+BACKEND_SERVICES = ['katello', 'katello-jobs', 'tomcat6', 'qpidd', 'mongod', 'thumbslug', 'httpd', 'elasticsearch']
 STDOUT_NAME = "stdout"
 
 # Terminate script with error code from ERROR_CODES hash

--- a/katello-configure/upgrade-scripts/default/0004_migrate_katello_db.sh
+++ b/katello-configure/upgrade-scripts/default/0004_migrate_katello_db.sh
@@ -11,7 +11,7 @@ KATELLO_HOME=${KATELLO_HOME:-/usr/share/katello}
 KATELLO_ENV=${KATELLO_ENV:-production}
 KATELLO_PREFIX=${KATELLO_PREFIX:-/katello}
 
-SERVICES = ["tomcat6",  "elasticsearch", "pulp-server"]
+SERVICES = ["tomcat6",  "elasticsearch", "qpidd", "mongod"]
 if [ "$KATELLO_PREFIX" = "/headpin" -o "$KATELLO_PREFIX" = "/sam" ]; then
     SERVICES = ["tomcat6",  "elasticsearch"]
 fi

--- a/scripts/katello_remove.sh
+++ b/scripts/katello_remove.sh
@@ -1,4 +1,4 @@
-service mongod stop; service pulp-server stop; service tomcat6 stop; service katello stop; service katello-jobs stop; service elasticsearch stop
+katello-service stop
 kill -9 `ps -aef | grep katello | grep -v $(basename $0) | grep -v grep | awk '{print $2}'`
 kill -9 `ps -aef | grep delayed_job | grep -v grep | awk '{print $2}'`
 

--- a/scripts/test/katello-stack
+++ b/scripts/test/katello-stack
@@ -26,8 +26,8 @@
 #  ../scripts/test/katello-cli-simple-test.sh
 #
 
-SERVICES_START=(mongod pulp-server postgresql tomcat6)
-SERVICES_STOP=(tomcat6 pulp-server mongod postgresql)
+SERVICES_START=(mongod qpidd httpd postgresql tomcat6)
+SERVICES_STOP=(tomcat6 qpidd httpd mongod postgresql)
 YUM_PARAMS="--disableplugin=subscription-manager,pulp-profile-update,katello"
 
 print_usage()

--- a/src/script/katello-reset-dbs
+++ b/src/script/katello-reset-dbs
@@ -107,7 +107,9 @@ fi
 
 if [ $DEPLOYMENT = "katello" ] ; then
     echo "Stopping Pulp instance"
-    stop_if_running pulp-server
+    stop_if_running mongod
+    stop_if_running qpidd
+    stop_if_running httpd
 fi
 
 echo "Stopping Candlepin instance"
@@ -136,7 +138,9 @@ sudo cp /etc/tomcat6/server.xml.original /etc/tomcat6/server.xml
 
 if [ $DEPLOYMENT = "katello" ] ; then
     echo "Starting Pulp instance"
-    $SRV pulp-server start
+    $SRV qpidd start
+    $SRV mongod start
+    $SRV httpd start
 fi
 
 echo "Starting Candlepin instance"

--- a/src/script/katello-service
+++ b/src/script/katello-service
@@ -25,7 +25,7 @@ if [ -x /etc/init.d/tomcat6 -o -x /lib/systemd/system/tomcat6.service ]; then
 fi
 
 
-SERVICES="$TOMCAT httpd pulp-server thumbslug elasticsearch katello katello-jobs"
+SERVICES="$TOMCAT httpd mongod qpidd thumbslug elasticsearch katello katello-jobs"
 if [ -f /etc/katello/service-list ] ; then
   . /etc/katello/service-list
 fi


### PR DESCRIPTION
pulp-server is not service, it is just wrapper around several other
services and httpd is one of them, which is handled by katello-service and sysV as well,
which cause some failures during startup and shutdown.

addressing:
 katello-service  stop
Shutting down Katello services...
Stopping katello:
Stopping elasticsearch: [  OK  ]
Stopping httpd: [  OK  ]
Stopping Qpid AMQP daemon: [  OK  ]
Stopping mongod: [  OK  ]
Stopping httpd: [FAILED]
Stopping tomcat6: [  OK  ]
Done.
