### PR TITLE
clean out the client cert RPMS

### DIFF
--- a/scripts/katello_remove.sh
+++ b/scripts/katello_remove.sh
@@ -12,3 +12,6 @@ rm -rf /var/log/katello/ /var/log/tomcat6/ /var/log/pulp/ /var/log/candlepin/ /v
 
 # pulp cert stuff 
 rm -rf /etc/pki/pulp/ /etc/pki/content/* /etc/pki/katello /root/ssl-build
+
+# client cert rpms
+rm -rf /var/www/html/pub/candlepin-cert*.rpm


### PR DESCRIPTION
If you don't delete these the next time you install Katello the old ones
will still remain causing new clients to not be able to register
