### PR TITLE
860952 - update Pool::find to not treat response as an array

### DIFF
--- a/src/lib/resources/candlepin.rb
+++ b/src/lib/resources/candlepin.rb
@@ -381,7 +381,7 @@ module Resources
       class << self
         def find pool_id
           pool_json = self.get(path(pool_id), self.default_headers).body
-          Util::Data::array_with_indifferent_access JSON.parse(pool_json)
+          JSON.parse(pool_json).with_indifferent_access
         end
 
         def get_for_owner owner_key


### PR DESCRIPTION
This is a small change to revert a regression from an earlier commit.
The earlier commit introduced Util::Data::array_with_indifferent_access
to handle candlepin responses that contained multiple elements.  Pool::find
was updated with this change; however, in that api we are only requesting
a single pool; therefore, the following error would be generated:

```
undefined method `with_indifferent_access' for
["attributes", []]:Array (NoMethodError)
```
