### PR TITLE
adding parallel_tests gem so our unit tests can use multiple CPUs

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -88,6 +88,9 @@ group :test, :development do
 
   #needed to generate routes in javascript
   gem "js-routes", :require => 'js_routes'
+
+  #parallel_tests to make our specs go faster
+  gem "parallel_tests"
 end
 
 group :profiling do

--- a/src/config/database.yml
+++ b/src/config/database.yml
@@ -44,7 +44,7 @@ test:
   adapter: postgresql
   username: katello
   password: katello
-  database: katello_test
+  database: katello_test<%= ENV['TEST_ENV_NUMBER'] %>
   host: localhost
   encoding: UTF8
   <%end%>


### PR DESCRIPTION
This runs tests in parallel which brings the total runtime down from
10-15 minutes on an average workstation to around 4.
