### PR TITLE
skip symlinks during gettext check

### DIFF
--- a/src/script/check-gettext.rb
+++ b/src/script/check-gettext.rb
@@ -46,6 +46,7 @@ dir << '/' unless dir.end_with?('/')
 
 Dir.glob(File.join(dir, "**", "*")).each do |file|
   next if File.directory?(file)
+  next if File.symlink?(file)
   next if file.include?("/vendor/converge-ui/") # we skip converge-ui for now
   next if file.end_with?("script/check-gettext.rb") # we don't check this very file
   relative_file = file.sub(/^#{Regexp.escape(dir)}/, "")


### PR DESCRIPTION
addressing:
- script/check-gettext.rb -m -i
  script/check-gettext.rb:52:in `read': No such file or directory - /tmp/tito-build/rpmbuild-katello-45b3e05e046a8c582ada0c391c110d4b71837274yvB9Ui/BUILD/katello-git-40.45b3e05/public/fonts (Errno::ENOENT)
      from script/check-gettext.rb:52:in`block in <main>'
      from script/check-gettext.rb:47:in `each'
      from script/check-gettext.rb:47:in`<main>'
  error: Bad exit status from /var/tmp/rpm-tmp.daH6k3 (%build)

fonts is symlink to ../vendor/converge-ui/fonts/
