### PR TITLE
866995: Fix the status API so that it is exposed correctly for rhsm.

### DIFF
--- a/src/app/controllers/api/ping_controller.rb
+++ b/src/app/controllers/api/ping_controller.rb
@@ -13,6 +13,7 @@
 class Api::PingController < Api::ApiController
 
   skip_before_filter :authorize # ok - anyone authenticated can ask for status
+  skip_before_filter :require_user
 
   api :GET, "/ping", "Shows status of system and it's subcomponents"
   def index
@@ -21,7 +22,11 @@ class Api::PingController < Api::ApiController
 
   api :GET, "/status", "Shows version information"
   def status
-    render :json => {:version => "katello/#{AppConfig.katello_version}", :result => true}
+    render :json => {:release => AppConfig.app_name,
+        :version => AppConfig.katello_version,
+        :standalone => true,
+        :timeUTC => Time.now().getutc(),
+        :result => true}
   end
 
   api :GET, "/version", "Shows name and version information"

--- a/src/app/controllers/api/root_controller.rb
+++ b/src/app/controllers/api/root_controller.rb
@@ -22,6 +22,7 @@ class Api::RootController < Api::ApiController
 
     # provide some fake paths that does not exist (but rhsm is checking it's existance)
     api_root_routes << { :href => '/api/packages/', :rel => 'packages' }
+    api_root_routes << { :href => '/api/status/', :rel => 'status' }
 
     # katello only APIs
     katello_only = ["/api/templates/",

--- a/src/spec/controllers/api/ping_controller_spec.rb
+++ b/src/spec/controllers/api/ping_controller_spec.rb
@@ -1,0 +1,56 @@
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'spec_helper'
+
+describe Api::PingController do
+  include LoginHelperMethods
+
+  before (:each) do
+    login_user
+    @request.env["HTTP_ACCEPT"] = "application/json"
+  end
+
+  def resource_list
+    get :resource_list
+  end
+
+  def json(response)
+    JSON.parse(response.body)
+  end
+
+  context "in headpin mode" do
+    before (:each) do
+      AppConfig.stub!(:app_name).and_return("Headpin")
+      AppConfig.stub!(:katello_version).and_return("12")
+    end
+    it "staus should reflect the correct information" do
+      get :status
+      json(response).should include "release" => "Headpin"
+      json(response).should include "version" => "12"
+    end
+  end
+
+  context "in katello mode" do
+
+    before (:each) do
+      AppConfig.stub!(:app_name).and_return("Katello")
+      AppConfig.stub!(:katello_version).and_return("12")
+    end
+    it "staus should reflect the correct information" do
+      get :status
+      json(response).should include "release" => "Katello"
+      json(response).should include "version" => "12"
+    end
+  end
+
+end


### PR DESCRIPTION
The issues included:
1) status link was not exposed in /api reposonse body
2) the require_user filter was not skipped, which required that he user be logged in
3) the contents of the body had version only, and not release.
