### PR TITLE
switching to parallel_tests for our jenkins job and removing yard run

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -19,4 +19,4 @@ fi
 cd src
 sudo bundle install
 rake db:migrate:reset --trace 
-rake yard hudson:spec SPEC_OPTS="-p" --trace
+rake hudson:spec SPEC_OPTS="-p" --trace

--- a/src/lib/tasks/hudson.rake
+++ b/src/lib/tasks/hudson.rake
@@ -3,7 +3,7 @@
 begin
   require 'ci/reporter/rake/rspec'
   namespace :hudson do
-    task :spec => ["rake:configuration", "hudson:setup:rspec", 'rake:spec']
+    task :spec => ["rake:configuration", "hudson:setup:rspec", 'parallel:spec']
 
     namespace :setup do
       task :pre_ci do


### PR DESCRIPTION
The yard run just took extra time but didn't do anything for our unit
tests
