### PR TITLE
862997 - On content search page, during repository comparison, clicking

### DIFF
--- a/src/app/controllers/content_search_controller.rb
+++ b/src/app/controllers/content_search_controller.rb
@@ -196,7 +196,9 @@ class ContentSearchController < ApplicationController
 
     cols = {}
     sort_repos(@repos).each{|r| cols[r.id] = {:id=>r.id, :content => repo_compare_name_display(r)}}
-    rows += [metadata_row(packages.total, offset.to_i + rows.length, {:repos=>params[:repos]}, 'compare')] if packages.total > current_user.page_size
+    if !packages.empty?
+      rows += [metadata_row(packages.total, offset.to_i + rows.length, {:repos=>params[:repos]}, 'compare')] if packages.total > current_user.page_size
+    end
     render :json => {:rows=>rows, :cols=>cols, :name=>_("Repository Comparison")}
   end
 

--- a/src/public/javascripts/content_search.js
+++ b/src/public/javascripts/content_search.js
@@ -79,7 +79,9 @@ KT.content_search = function(paths_in){
         errata:   {method:"POST", url:KT.routes.errata_items_content_search_index_path(), include_search:true},
         packages: {method:"POST", url:KT.routes.packages_items_content_search_index_path(), include_search:true},
         repo_packages:{method:"GET", url:KT.routes.repo_packages_content_search_index_path(), include_search:false},
-        repo_errata: {method:"GET", url:KT.routes.repo_errata_content_search_index_path(), include_search:false}
+        repo_errata: {method:"GET", url:KT.routes.repo_errata_content_search_index_path(), include_search:false},
+        compare_packages: {method:"GET", url:KT.routes.repo_compare_packages_content_search_index_path(), include_search:false},
+        compare_errata: {method:"GET", url:KT.routes.repo_compare_errata_content_search_index_path(), include_search:false}
     };
 
 


### PR DESCRIPTION
the show more button will now properly load more data for packages and
errata.

https://bugzilla.redhat.com/show_bug.cgi?id=862997
