### PR TITLE
gettext - fix malformed gettext stings in CLI code

### DIFF
--- a/cli/src/katello/client/core/gpg_key.py
+++ b/cli/src/katello/client/core/gpg_key.py
@@ -126,8 +126,8 @@ class Create(GpgKeyAction):
                                help=_("GPG key name (required)"))
         opt_parser_add_org(parser, required=1)
         parser.add_option('--file', dest='file',
-                               help=_("file with public GPG key, if not\
-                                 specified, standard input will be used"))
+                               help=_("file with public GPG key, if not "\
+                                 "specified, standard input will be used"))
 
     def check_options(self, validator):
         validator.require(('name', 'org'))

--- a/cli/src/katello/client/core/product.py
+++ b/cli/src/katello/client/core/product.py
@@ -318,7 +318,7 @@ class Create(ProductAction):
         parser.add_option("--assumeyes", action="store_true", dest="assumeyes",
             help=_("assume yes; automatically create candidate repositories for discovered urls (optional)"))
         parser.add_option("--gpgkey", dest="gpgkey",
-            help=_("assign a gpg key; this key will be used for every new repository unless gpgkey or nogpgkey" + \
+            help=_("assign a gpg key; this key will be used for every new repository unless gpgkey or nogpgkey"\
                 " is specified for the repo"))
 
 

--- a/cli/src/katello/client/core/system_group.py
+++ b/cli/src/katello/client/core/system_group.py
@@ -409,7 +409,7 @@ class Packages(SystemGroupAction):
         parser.add_option('--remove', dest='remove', type="list",
             help=_("packages to be removed remotely from the systems, package names are separated with comma"))
         parser.add_option('--update', dest='update', type="list",
-            help=_("packages to be updated on the systems, use --all to update all packages, " + \
+            help=_("packages to be updated on the systems, use --all to update all packages, "\
                 "package names are separated with comma"))
         parser.add_option('--install_groups', dest='install_groups', type="list",
             help=_("package groups to be installed remotely on the systems, group names are separated with comma"))


### PR DESCRIPTION
Something like this is not handled correctly by gettext

```
_("This is some" + \
  "very long string)
```

Only "This is some" gets into keys.pot file.

However, this variant works:

```
_("This is some"\
  "very long string)
```
