### PR TITLE
fixing busted cli tests

### DIFF
--- a/cli/test/katello/tests/core/organization/organization_data.py
+++ b/cli/test/katello/tests/core/organization/organization_data.py
@@ -7,7 +7,8 @@ ORGS = [
     "updated_at": "2011-08-23T08:10:52Z",
     "id": 1,
     "label": "ACME_Corporation",
-    "description": "ACME Corporation Organization"
+    "description": "ACME Corporation Organization",
+    "system_info_keys" : ["asset_tag"]
   }
 ]
 


### PR DESCRIPTION
# 

ERROR: test_finds_org
## (katello.tests.core.organization.organization_info_test.OrgInfoTest)

Traceback (most recent call last):
  File
"/home/hudson/workspace/katello-cli-unittests/katello/cli/test/katello/tests/core/organization/organization_info_test.py",
line 45, in test_finds_org
    self.run_action()
  File
"/home/hudson/workspace/katello-cli-unittests/katello/cli/test/katello/tests/core/action_test_utils.py",
line 111, in run_action
    self.action.run()
  File "../src/katello/client/core/organization.py", line 106, in run
    org['system_info_keys'] = "[ %s ]" % ",
".join(org['system_info_keys'])
KeyError: 'system_info_keys'
# 

ERROR: test_returns_ok
## (katello.tests.core.organization.organization_info_test.OrgInfoTest)

Traceback (most recent call last):
  File
"/home/hudson/workspace/katello-cli-unittests/katello/cli/test/katello/tests/core/organization/organization_info_test.py",
line 49, in test_returns_ok
    self.run_action(os.EX_OK)
  File
"/home/hudson/workspace/katello-cli-unittests/katello/cli/test/katello/tests/core/action_test_utils.py",
line 108, in run_action
    self.assert_exits_with(expected_return_code)
  File
"/home/hudson/workspace/katello-cli-unittests/katello/cli/test/katello/tests/core/action_test_utils.py",
line 118, in assert_exits_with
    ret_val = self.action.run()
  File "../src/katello/client/core/organization.py", line 106, in run
    org['system_info_keys'] = "[ %s ]" % ",
".join(org['system_info_keys'])
KeyError: 'system_info_keys'

---
