### PR TITLE
865811 - use the concurrency level calculation suggested in BZ

### DIFF
--- a/katello-configure/modules/pulp/templates/etc/pulp/pulp.conf.erb
+++ b/katello-configure/modules/pulp/templates/etc/pulp/pulp.conf.erb
@@ -148,7 +148,7 @@ sync_timeout = 10:7200
 # how many concurent threads run in parallel
 # default is NumCpu-1
 <% if processorcount.to_i <= 1 %>
-concurrency_threshold = 1
+concurrency_threshold = 2
 <% else %>
-concurrency_threshold = <%= processorcount.to_i-1 %>
+concurrency_threshold = <%= processorcount.to_i + 1 %>
 <% end %>


### PR DESCRIPTION
Using too small number (1) causes dead lock when syncing repos, not syncing
anything at all. At least 2 processes need to be allowed.
