### PR TITLE
Gemfile for 1.8 and 1.9 Ruby

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -8,14 +8,14 @@ end
 # and use this version if possible. Also check Fedora version (usually higher).
 source 'http://rubygems.org'
 
-gem 'rails', '>= 3.0.10'
+gem 'rails', '~> 3.0.10'
 gem 'thin', '>= 1.2.8'
 gem 'tire', '>= 0.3.0', '< 0.4'
 gem 'json'
 gem 'rest-client', :require => 'rest_client'
-gem 'jammit'
+gem 'jammit', '>= 0.6.5'
 gem 'pg'
-gem 'rails_warden'
+gem 'rails_warden', '>= 0.5.2'
 gem 'net-ldap'
 gem 'oauth'
 gem 'ldap_fluff'


### PR DESCRIPTION
Guys,

I have tested Dmitri's new Gemfile that works with both Ruby 1.8 and 
Ruby 1.9 against rubygems.org. Works great, except one minor issue.

To test it, you can use your own system Ruby or rvm/rbenv. For example:

rbenv local 1.9.3-p194
rm Gemfile.lock
bundle install 
bundle exec spec ...

It is necessary to delete the Gemfile.lock because we are switching over
to rubygems.org and also due to changes in the Gemfile itself.

I have tested it also with 1.8.7-p370 - both work great. When testing 
this with rbenv/rvm please make sure you:
- have latest version of rubygems
- have latest version of bundler
- environment variables are set properly
- Gemfile.lock is deleted before running bundle install for the first 
  time (with the particular Ruby version)

For some reasons, I have to specify exact version of Rails (= 3.0.11)
otherwise my Bundler got stuck calculating dependencies for hours and 
hours. There are rare cases when Bundler is unable to calculate 
dependencies. I am not yet sure if this is an issue with my setup only.
Please try it and if your bundler gets stuck, change rails gem version 
from >= to =.

For RPM deployment, we cannot specify exact version there because it is
different in RHEL and Fedoras. I am not sure if this is an issue with my
setup only, but I saw several reposts on the internet:

http://stackoverflow.com/questions/8677090/bundle-update-spikes-cpu-and-does-nothing

FYI Ruby 1.8: Finished in 15 minutes 39.36 seconds

Ruby 1.9: Finished in 10 minutes 17.8 seconds

On my i5 core laptop (no parallel testing), that is a 30 % boost.

DO NOT MERGE, this pull request is for evaluation purposes, but I don't
say it does not get merged :-)
