### PR TITLE
868916 - katello-upgrade bash array fix

### DIFF
--- a/katello-configure/upgrade-scripts/default/0004_migrate_katello_db.sh
+++ b/katello-configure/upgrade-scripts/default/0004_migrate_katello_db.sh
@@ -11,21 +11,22 @@ KATELLO_HOME=${KATELLO_HOME:-/usr/share/katello}
 KATELLO_ENV=${KATELLO_ENV:-production}
 KATELLO_PREFIX=${KATELLO_PREFIX:-/katello}
 
-SERVICES = ["tomcat6",  "elasticsearch", "qpidd", "mongod"]
 if [ "$KATELLO_PREFIX" = "/headpin" -o "$KATELLO_PREFIX" = "/sam" ]; then
-    SERVICES = ["tomcat6",  "elasticsearch"]
+    SERVICES=("tomcat6" "elasticsearch")
+else
+    SERVICES=("tomcat6" "elasticsearch" "qpidd" "mongod")
 fi
-for SERVICE in $SERVICES; do 
+
+for SERVICE in ${SERVICES[@]}; do 
     service $SERVICE start
 done
-
 
 pushd $KATELLO_HOME >/dev/null
 RAILS_RELATIVE_URL_ROOT=$KATELLO_PREFIX RAILS_ENV=$KATELLO_ENV rake db:migrate --trace 2>&1
 ret_code=$?
 popd >/dev/null
 
-for SERVICE in $SERVICES; do
+for SERVICE in ${SERVICES[@]}; do 
     service $SERVICE stop
 done
 


### PR DESCRIPTION
Adressing:

```
 bash -x /usr/share/katello/install/upgrade-scripts/default/0004_migrate_katello_db.sh
+ '[' -f /etc/sysconfig/katello ']'
+ . /etc/sysconfig/katello
++ KATELLO_PREFIX=/katello
++ KATELLO_JOB_WORKERS=1
+ KATELLO_HOME=/usr/share/katello
+ KATELLO_ENV=production
+ KATELLO_PREFIX=/katello
+ SERVICES = '[tomcat6,' elasticsearch, qpidd, 'mongod]'
/usr/share/katello/install/upgrade-scripts/default/0004_migrate_katello_db.sh: line 14: SERVICES: command not found
```

I wonder if this was ever working in bash:

```
SERVICES = '[tomcat6,' elasticsearch, qpidd, 'mongod]'
```

my bash does not accept even this:

```
SERVICES = '[tomcat6,' elasticsearch, qpidd, 'mongod]'
```

changed to standard array initialization.
