### PR TITLE
865472 - system groups - fix auto-complete on add of systems to groups

### DIFF
--- a/src/public/javascripts/system_groups.js
+++ b/src/public/javascripts/system_groups.js
@@ -323,7 +323,7 @@ KT.system_groups = (function(){
             $.get(KT.routes.auto_complete_systems_path(), {term:string}, function(data){
                 var found = false;
                 $.each(data, function(index, element){
-                    if (element.label === string){
+                    if (element.label.split(' ')[0] === string){
                         found = element.id;
 
                         return false;


### PR DESCRIPTION
This is a minor change to allow a user to do the following:
- go to System Groups -> [group X ] -> Systems
- paste a system name in the input box
- either hit enter or click 'Add'

There was a recent change to the autocomplete response to include
the system's registration timestamp.  That change caused the system
to not be added when the above was performed.
