### PR TITLE
861513 - Fixes issue with failed sync's not generating proper notifications.

### DIFF
--- a/src/app/models/glue/pulp/repo.rb
+++ b/src/app/models/glue/pulp/repo.rb
@@ -416,7 +416,7 @@ module Glue::Pulp::Repo
       return
     end
 
-    task = PulpTaskStatus.using_pulp_task(pulp_tasks.first)
+    task = PulpSyncStatus.pulp_task(pulp_tasks.first)
     task.user ||= User.current
     task.organization ||= self.environment.organization
     task.save!

--- a/src/app/models/repository.rb
+++ b/src/app/models/repository.rb
@@ -164,15 +164,15 @@ class Repository < ActiveRecord::Base
       end
     elsif task.state == 'error'
       details = if task.progress.error_details.present?
-                  task.progress.error_details
+                  task.progress.error_details.map { |error| error[:error].to_s }
                 else
-                  task.result[:errors].flatten
-                end
+                  task.result[:errors].flatten.map(&:chomp)
+                end.join("\n")
 
-      Rails.logger.error("*** Sync error: " +  details.to_json)
+      Rails.logger.error("*** Sync error: " +  details)
       if user && notify
         Notify.error _("There were errors syncing repository '%s'. See notices page for more details.") % self.name,
-                     :details => details.map(&:chomp).join("\n"), :user => user, :organization => self.organization
+                     :details => details, :user => user, :organization => self.organization
       end
     end
   end


### PR DESCRIPTION
Syncs that contained errors from pulp were getting labeled as
having errors on the sync management page but generating success
notifications and thus not displaying the error details.  This was
caused by the state of the sync task not being set properly which in
turn revealed that the details of an errored sync were being formatted
such that an error was being thrown and the details not generated for
user consumption.
