### PR TITLE
remove fuzzy warnings

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -96,5 +96,6 @@ module Src
   end
 end
 
-FastGettext.add_text_domain 'app', :path => 'locale', :type => :po, :ignore_fuzzy => true, :ignore_obsolete => true
+FastGettext.add_text_domain 'app', :path => 'locale', :type => :po,
+                            :ignore_fuzzy => true, :report_warning => false, :ignore_obsolete => true
 FastGettext.default_text_domain = 'app'


### PR DESCRIPTION
works with rpm-gem and up-to-date version of FastGettext
