### PR TITLE
changing user under foreman-config is run

### DIFF
--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -85,7 +85,9 @@ class foreman::config {
                               -k oauth_consumer_key -v '${foreman::oauth_consumer_key}'\
                               -k oauth_consumer_secret -v '${foreman::oauth_consumer_secret}'\
                               -k oauth_map_users -v '${foreman::oauth_map_users}'",
+   user    => "foreman",
    timeout => 0,
+   require => User[$foreman::user],
   }
 
 }


### PR DESCRIPTION
Fixes the nightly installation, db seed fails because foreman is not running, because production.log was created with wrong permissions.

I also created a patch in Foreman to avoid this when running as root.
