### PR TITLE
835321 - Fixing the user name validation

### DIFF
--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ActiveRecord::Base
   has_many :search_histories, :dependent => :destroy
   serialize :preferences, HashWithIndifferentAccess
 
-  validates :username, :uniqueness => true, :presence => true, :username => true, :length => { :maximum => 255 }
+  validates :username, :uniqueness => true, :presence => true, :username => true
   validates :email, :presence => true, :if => :not_ldap_mode?
   validates :default_locale, :inclusion => {:in => AppConfig.available_locales, :allow_nil => true, :message => _("must be one of %s") % AppConfig.available_locales.join(', ')}
 

--- a/src/spec/models/user_spec.rb
+++ b/src/spec/models/user_spec.rb
@@ -22,12 +22,36 @@ describe User do
   PASSWORD = "password1234"
   EMAIL = "testuser@somewhere.com"
 
+  INVALID_USERNAME = (0...260).map{ ('a'..'z').to_a[rand(26)] }.join
+
   let(:to_create_simple) do
     {
       :username => USERNAME,
       :password => PASSWORD,
       :email => EMAIL
     }
+  end
+
+  let(:to_create_invalid_user) do
+    {
+      :username => INVALID_USERNAME,
+      :password => PASSWORD,
+      :email => EMAIL
+    }
+  end
+
+  describe "User shouldn't" do 
+    before(:each) do
+      disable_user_orchestration
+      AppConfig.warden = 'database'
+    end
+
+    it "be able to create" do
+      user = User.new(to_create_invalid_user)
+      user.should_not be_valid
+      user.errors[:username].should include("cannot contain more than 64 characters")
+    end
+
   end
 
   describe "Users in LDAP should" do


### PR DESCRIPTION
Now instead of two validation errors:
- Username is too long (maximum is 255 characters)
- Username cannot contain more than 64 characters

there will be only one:  
- Username cannot contain more than 64 characters

because there is no point to have the default validation of username with maximum length 255 characters.
