### PR TITLE
precreating log file for foreman with correct perms

### DIFF
--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -85,6 +85,7 @@ class foreman::config {
     creates     => "/var/lib/katello/foreman_db_migrate_done",
     timeout     => 0,
     require     => [ Postgres::Createdb[$foreman::db_name],
+                 File["${foreman::log_base}/production.log"],
                  File["${foreman::config_dir}/settings.yaml"],
                  File["${foreman::config_dir}/database.yml"]];
   } ~>


### PR DESCRIPTION
It looks like we need to create the file before we run our puppet code.
