### PR TITLE
Revert "headpin-system-groups - fence pulp hooks in system model"

### DIFF
--- a/src/app/models/system.rb
+++ b/src/app/models/system.rb
@@ -318,15 +318,11 @@ class System < ActiveRecord::Base
 
   private
     def add_pulp_consumer_group record
-      if AppConfig.use_pulp
-        record.add_consumers([self.uuid])
-      end
+      record.add_consumers([self.uuid])
     end
 
     def remove_pulp_consumer_group record
-      if AppConfig.use_pulp
-        record.del_consumers([self.uuid])
-      end
+      record.del_consumers([self.uuid])
     end
 
     def save_task_status pulp_task, task_type, parameters_type, parameters


### PR DESCRIPTION
This reverts commit 916e9d3801283ae29697d0c190721b29a17a4090.

Removing system groups from headpin mode
