### PR TITLE
869938 - avoiding cronjob root mail folder flooding

### DIFF
--- a/src/script/katello-refresh-cdn
+++ b/src/script/katello-refresh-cdn
@@ -6,6 +6,6 @@
 RAILS_DIR=/usr/share/katello
 pushd $RAILS_DIR &> /dev/null
 
-rake katello:refresh_cdn RAILS_ENV=production
+rake katello:refresh_cdn RAILS_ENV=production >/dev/null
 
 popd &> /dev/null


### PR DESCRIPTION
Preventing everyday mail in the root mailbox with content of:

   (in /usr/share/katello)

As simple as that.
