### PR TITLE
866995 - additional fix for ping controller

### DIFF
--- a/src/app/controllers/api/ping_controller.rb
+++ b/src/app/controllers/api/ping_controller.rb
@@ -13,14 +13,16 @@
 class Api::PingController < Api::ApiController
 
   skip_before_filter :authorize # ok - anyone authenticated can ask for status
-  skip_before_filter :require_user
+  skip_before_filter :require_user, :only => [:status]
 
   api :GET, "/ping", "Shows status of system and it's subcomponents"
+  description "This service is only available for authenticated users"
   def index
     render :json => Ping.ping().to_json and return
   end
 
   api :GET, "/status", "Shows version information"
+  description "This service is also available for unauthenticated users"
   def status
     render :json => {:release => AppConfig.app_name,
         :version => AppConfig.katello_version,
@@ -30,6 +32,7 @@ class Api::PingController < Api::ApiController
   end
 
   api :GET, "/version", "Shows name and version information"
+  description "This service is only available for authenticated users"
   def version
     render :json => {:name => AppConfig.app_name, :version => AppConfig.katello_version}
   end


### PR DESCRIPTION
Skipping authentication for ping controller introduced regression when pulp was failing on pulp_auth ping test. This fixes that.
