### PR TITLE
moving .bundle/config out of RPM to configure

### DIFF
--- a/katello-configure/modules/katello/manifests/config.pp
+++ b/katello-configure/modules/katello/manifests/config.pp
@@ -76,7 +76,13 @@ class katello::config {
       content => template("katello/etc/ldap_fluff.yml.erb"),
       owner   => $katello::params::user,
       group   => $katello::params::group,
-      mode    => "600",
+      mode    => "600";
+
+    "/usr/share/katello/.bundle/config":
+      content => template("katello/bundle_config.erb"),
+      owner   => "root",
+      group   => "root",
+      mode    => "644";
   }
 
   exec {"httpd-restart":
@@ -106,6 +112,7 @@ class katello::config {
                   File["${katello::params::log_base}/production.log"], 
                   File["${katello::params::log_base}/production_sql.log"], 
                   File["${katello::params::config_dir}/katello.yml"],
+                  File["/usr/share/katello/.bundle/config"],
                   Postgres::Createdb[$katello::params::db_name]
                 ],
                 'headpin' => [
@@ -113,6 +120,7 @@ class katello::config {
                   Class["thumbslug::service"],
                   File["${katello::params::log_base}"],
                   File["${katello::params::config_dir}/katello.yml"],
+                  File["/usr/share/katello/.bundle/config"],
                   Postgres::Createdb[$katello::params::db_name]
                 ],
                 default => [],

--- a/katello-configure/modules/katello/templates/bundle_config.erb
+++ b/katello-configure/modules/katello/templates/bundle_config.erb
@@ -1,0 +1,6 @@
+--- 
+<% if scope.lookupvar("katello::params::deployment") == 'katello' %>
+BUNDLE_WITHOUT: development:test
+<% else %>
+BUNDLE_WITHOUT: development:test:foreman
+<% end %>

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -20,6 +20,10 @@ gem 'net-ldap'
 gem 'oauth'
 gem 'ldap_fluff'
 
+group :foreman do
+  gem 'foreman_api', '>= 0.0.7'
+end
+
 gem 'delayed_job', '~> 2.1.4'
 gem 'daemons', '>= 1.1.4'
 gem 'uuidtools'

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -6,11 +6,18 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "active_resource/railtie"
 require "rails/test_unit/railtie"
+require "lib/util/boot_util"
 
 # If you have a Gemfile, require the gems listed there, including any gems
 # you've limited to :test, :development, or :production.
 require 'apipie-rails' # FIXME will be removed after https://github.com/Pajk/apipie-rails/pull/62
-Bundler.require(:default, Rails.env) if defined?(Bundler)
+
+if defined?(Bundler)
+  Bundler.require(:default, Rails.env)
+  
+  # require backend engines only if in katello/cfse mode
+  Bundler.require(:foreman) if Katello::BootUtil.katello?
+end
 
 module Src
   class Application < Rails::Application    

--- a/src/config/initializers/app_config.rb
+++ b/src/config/initializers/app_config.rb
@@ -2,6 +2,7 @@
 # are not available in all initializers starting with 'a' letter.
 require 'ostruct'
 require 'yaml'
+require "lib/util/boot_util"
 
 module ApplicationConfiguration
 
@@ -22,7 +23,7 @@ module ApplicationConfiguration
       @hash.deep_merge!(config[Rails.env] || {})
 
       # Based upon root url, switch between headpin and katello modes
-      if ENV['RAILS_RELATIVE_URL_ROOT'] == '/headpin' || ENV['RAILS_RELATIVE_URL_ROOT'] == '/sam'
+      if Katello::BootUtil.headpin?
         @hash["app_name"] = 'Headpin'
         @hash["katello?"] = false
       else

--- a/src/deploy/bundle-config
+++ b/src/deploy/bundle-config
@@ -1,2 +1,0 @@
---- 
-BUNDLE_WITHOUT: development:test

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -374,7 +374,6 @@ mkdir -p %{buildroot}/%{_mandir}/man8
 
 #copy the application to the target directory
 mkdir .bundle
-mv ./deploy/bundle-config .bundle/config
 cp -R .bundle Gemfile Rakefile app autotest ca config config.ru db integration_spec lib locale public script spec vendor %{buildroot}%{homedir}
 
 #copy configs and other var files (will be all overwriten with symlinks)
@@ -506,7 +505,7 @@ rm -f %{datadir}/Gemfile.lock 2>/dev/null
 %{homedir}/spec
 %{homedir}/tmp
 %{homedir}/vendor
-%{homedir}/.bundle
+%dir %{homedir}/.bundle
 %{homedir}/config.ru
 %{homedir}/Gemfile
 %ghost %attr(0644,katello,katello) %{_sharedstatedir}/%{name}/Gemfile.lock

--- a/src/lib/util/boot_util.rb
+++ b/src/lib/util/boot_util.rb
@@ -1,0 +1,24 @@
+#
+# Copyright 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+# utility functions available during Rails boot time
+module Katello
+  module BootUtil
+    def self.headpin?
+      ENV['RAILS_RELATIVE_URL_ROOT'] == '/headpin' || ENV['RAILS_RELATIVE_URL_ROOT'] == '/sam'
+    end
+
+    def self.katello?
+      not headpin?
+    end
+  end
+end


### PR DESCRIPTION
Resolving

```
uninitialized constant Resources::Foreman::ForemanApi
/usr/share/katello/lib/resources/foreman.rb:26
```

We have introduced our new gem dependency foreman_api which is needed for Katello, but not for Headpin (runtime). Therefore I am creating new Gemfile group called :foreman which is used only when running in Katello mode. This way we can add more groups (candlepin, pulp) when we need to.

Technically I removed our .bundle/config file from the RPM distribution and added it to katello-configure, it deploys it according to the deployment - with or without foreman group, depends on if you are deploying katello mode or headpin mode.

Brno - please ACK it before 1 PM, I want to get nightly running today again.
