### PR TITLE
870456 - existing orgs do not get default value for system_info_keys

### DIFF
--- a/src/db/migrate/20120924211134_add_system_info_key_to_organizations.rb
+++ b/src/db/migrate/20120924211134_add_system_info_key_to_organizations.rb
@@ -1,6 +1,15 @@
 class AddSystemInfoKeyToOrganizations < ActiveRecord::Migration
+
+  class Organization < ActiveRecord::Base
+  end
+
   def self.up
     add_column :organizations, :system_info_keys, :text
+    Organization.reset_column_information
+    Organization.where(:system_info_keys => nil).each do |o|
+      o.system_info_keys = Array.new()
+      o.save!
+    end
   end
 
   def self.down


### PR DESCRIPTION
in database

if you hit an error similar to this:
    NoMethodError: You have a nil object when you didn't expect it!
    You might have expected an instance of Array.
    The error occurred while evaluating nil.each
    /home/tomckay/code/katello/src/app/models/system.rb:230:in
    `init_default_custom_info_keys'
it means you had at least one org that existed prior to default system
info keys.

run 'rake db:migrate:redo VERSION=20120924211134' to undo the
system_info_keys migration and correct apply the new column to all
pre-existing organizations.

If any of your organizations had any information in the system_info_keys
column, unfortunately it will be removed.
