### PR TITLE
813291 - [RFE] Username cannot contain characters other than alpha

### DIFF
--- a/src/app/models/role.rb
+++ b/src/app/models/role.rb
@@ -45,7 +45,7 @@ class Role < ActiveRecord::Base
 
   # scope to facilitate retrieving roles that are 'non-self' roles... group() so that unique roles are returned
   scope :non_self, joins("left outer join users on users.own_role_id = roles.id").where('users.own_role_id'=>nil).order('roles.name')
-  validates :name, :uniqueness => true, :katello_name_format => true, :presence => true
+  validates :name, :uniqueness => true, :no_trailing_space => true, :length => { :maximum => 128, :minimum => 2 }, :presence => true
   validates :description, :length => { :maximum => 250 }
   validates_with LockValidator, :on => :update
 


### PR DESCRIPTION
numerals,'_', '-', can not resume after failure

Can now have email address as username only in headpin mode.
katello mode blows up if you don't keep restrictions on characters.
