### PR TITLE
wrapping headpin only gems to the if statement

### DIFF
--- a/katello-configure/modules/katello/manifests/config.pp
+++ b/katello-configure/modules/katello/manifests/config.pp
@@ -77,12 +77,6 @@ class katello::config {
       owner   => $katello::params::user,
       group   => $katello::params::group,
       mode    => "600";
-
-    "/usr/share/katello/.bundle/config":
-      content => template("katello/bundle_config.erb"),
-      owner   => "root",
-      group   => "root",
-      mode    => "644";
   }
 
   exec {"httpd-restart":
@@ -112,7 +106,6 @@ class katello::config {
                   File["${katello::params::log_base}/production.log"], 
                   File["${katello::params::log_base}/production_sql.log"], 
                   File["${katello::params::config_dir}/katello.yml"],
-                  File["/usr/share/katello/.bundle/config"],
                   Postgres::Createdb[$katello::params::db_name]
                 ],
                 'headpin' => [
@@ -120,7 +113,6 @@ class katello::config {
                   Class["thumbslug::service"],
                   File["${katello::params::log_base}"],
                   File["${katello::params::config_dir}/katello.yml"],
-                  File["/usr/share/katello/.bundle/config"],
                   Postgres::Createdb[$katello::params::db_name]
                 ],
                 default => [],

--- a/katello-configure/modules/katello/templates/bundle_config.erb
+++ b/katello-configure/modules/katello/templates/bundle_config.erb
@@ -1,6 +1,0 @@
---- 
-<% if scope.lookupvar("katello::params::deployment") == 'katello' %>
-BUNDLE_WITHOUT: development:test
-<% else %>
-BUNDLE_WITHOUT: development:test:foreman
-<% end %>

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -4,6 +4,8 @@ if ENV['BUNDLER_ENABLE_RPM_PREFERRING'] == 'true'
   require File.join(File.dirname(__FILE__), 'lib', 'bundler_patch_rpm-gems_preferred')
 end
 
+require './lib/util/boot_util'
+
 # When adding new version requirement check out EPEL6 repository first
 # and use this version if possible. Also check Fedora version (usually higher).
 source 'http://rubygems.org'
@@ -20,8 +22,12 @@ gem 'net-ldap'
 gem 'oauth'
 gem 'ldap_fluff'
 
-group :foreman do
-  gem 'foreman_api', '>= 0.0.7'
+# those groups are only available in the katello mode, otherwise bundler would require
+# them to resolve dependencies (even when groups would be excluded from the list)
+if Katello::BootUtil.katello?
+  group :foreman do
+    gem 'foreman_api', '>= 0.0.7'
+  end
 end
 
 gem 'delayed_job', '~> 2.1.4'


### PR DESCRIPTION
My patch from yesterday broke headpin. This fixes it, I am not adding .bundle/config file anymore because I have found we no longer need it in the RPM installation since test and development groups are cut in the build phase.

According to Petr's findings, bundler must have all the gems to resolve dependencies, even those which are defined in excluded groups. Therefore the only way to get over it (since the foreman merge we now have a gem that is not distributed for headpin) is:

a) Exclude it with our environment variable we have set (current solution, a bit "hacky")

b) distribute two Gemfiles in two conflicting RPM packages (we need to create them in the build phase - also a big hacky)

c) get rid of bundler on the production - this is what aeolus team is currently doing and I think it is the best approach for us (https://github.com/aeolus-incubator/bundler_ext) - I guess the good plan is to ask aeolus team to make a package for us in Fedora and EPEL and start using it. or we can copy*paste the code, its just one file (cca 30 lines). after this patch, no more issues with bundler as it will be turned off and katello will be using only system rubygems.
