### PR TITLE
foreman menu

### DIFF
--- a/src/app/helpers/menu.rb
+++ b/src/app/helpers/menu.rb
@@ -23,12 +23,19 @@ module Menu
       helper_method :render_main_menu
       helper_method :render_main_sub_menu
       helper_method :render_admin_menu
+      helper_method :render_provision_menu
     end
   end
   def render_menu(level, items = nil, prune = true)
     items ||= menu_main
     prune_menu(items) if prune
     render_navigation(:items=>items, :expand_all=>true, :level => level)
+  end
+
+  def render_provision_menu
+    items ||= provision_items
+    prune_menu(items)
+    render_navigation(:items=>items, :expand_all=>true, :renderer => ProvisionMenuRenderer)
   end
 
   def render_main_menu()

--- a/src/app/models/organization.rb
+++ b/src/app/models/organization.rb
@@ -153,6 +153,14 @@ class Organization < ActiveRecord::Base
     User.allowed_to?([:gpg], :organizations, nil, self)
   end
 
+  def provisioning_readable?
+    User.allowed_to?([:read_provisioning, :manage_provisioning], :organizations, nil, self)
+  end
+
+  def provisioning_manageable?
+    User.allowed_to?([:manage_provisioning], :organizations, nil, self)
+  end
+
   def self.list_verbs global = false
     if AppConfig.katello?
       org_verbs = {
@@ -163,7 +171,9 @@ class Organization < ActiveRecord::Base
         :update_systems => _("Modify Systems"),
         :delete_systems => _("Delete Systems"),
         :sync => _("Sync Products"),
-        :gpg => _("Administer GPG Keys")
+        :gpg => _("Administer GPG Keys"),
+        :manage_provisioning => _("Administer Provisioning Data"),
+        :read_provisioning => _("Read Provisioning Data")
      }
     else
       org_verbs = {
@@ -184,7 +194,7 @@ class Organization < ActiveRecord::Base
   end
 
   def self.read_verbs
-    [:read, :read_systems]
+    [:read, :read_systems, :read_provisioning]
   end
 
 

--- a/src/app/navigation_renderers/provision_menu_renderer.rb
+++ b/src/app/navigation_renderers/provision_menu_renderer.rb
@@ -1,0 +1,45 @@
+# provision menu renderer
+class ProvisionMenuRenderer < SimpleNavigation::Renderer::Base
+  def render(item_container)
+    list_content = item_container.items.inject([]) do |list, item|
+      li_options = item.html_options.reject {|k, v| k == :link}
+      li_content = tag_for(item, options[:subnav])
+      if include_sub_navigation?(item)
+        li_content << item.sub_navigation.render(self.options.merge({:subnav => true}))
+      end
+      list << content_tag(:li, li_content, li_options)
+    end.join
+
+    if skip_if_empty? && item_container.empty?
+      ''
+    else
+      content_tag(:ul, list_content, {:id => item_container.dom_id, :class => item_container.dom_class})
+    end
+  end
+
+  protected
+
+  # determine and return link or static content depending on
+  # item/renderer conditions.
+  def tag_for(item, subnav = false)
+    if !subnav
+      content = content_tag(:i, '') + content_tag(:div, '', :class=>:arrow_icon_menu)
+      content_tag :a, content, link_options_for(item)
+    elsif item.url.blank?
+      content_tag('span', item.name, link_options_for(item).except(:method))
+    else
+      link_to(item.name, item.url, link_options_for(item))
+    end
+  end
+
+  # Extracts the options relevant for the generated link
+  def link_options_for(item)
+    special_options = {:method => item.method, :class => item.selected_class}.reject {|k, v| v.nil? }
+    link_options = item.html_options[:link]
+    return special_options unless link_options
+    opts = special_options.merge(link_options)
+    opts[:class] = [link_options[:class], item.selected_class].flatten.compact.join(' ')
+    opts.delete(:class) if opts[:class].nil? || opts[:class] == ''
+    opts
+  end
+end

--- a/src/app/stylesheets/katello.scss
+++ b/src/app/stylesheets/katello.scss
@@ -9,6 +9,7 @@
 @import "look";
 @import "menu";
 
+@import "widgets/provision_menu";
 @import "widgets/org_switcher";
 @import "widgets/search";
 @import "widgets/multiselect";

--- a/src/app/stylesheets/widgets/_provision_menu.scss
+++ b/src/app/stylesheets/widgets/_provision_menu.scss
@@ -1,0 +1,66 @@
+#provisionContainer {
+  height: 100%;
+  margin-right: 5px;
+  margin-top: 2px;
+  float: left;
+
+  #provisionButton {
+    cursor: pointer;
+    width: 100%;
+    height: 100%;
+    text-align: left;
+    color: $font_color;
+    float: left;
+    margin: 2px 2px 0 8px;
+    text-decoration: none;
+
+    .arrow_icon_menu {
+      height: 11px;
+      width: 13px;
+      background: $arrow_icon;
+      float: right;
+      margin: 4px 12px 0 0;
+    }
+
+    &.active {
+      @include border-bottom-lr-radius(0);
+      .arrow_icon_menu {
+          background: $arrow_icon;
+          background-position: 0 -13px;
+      }
+    }
+  }
+
+  #provisionBox {
+    position: absolute;
+    top: 27px;
+    display: none;
+    z-index: 2000;
+    width: 170px;
+    border: 0 none;
+    @include box-shadow(0px 5px 10px rgba(0, 0, 0, 0.4));
+    margin-top: 8px;
+    background-color: $switcher-top_color;
+    @include border-radius(2px);
+
+   a {
+      cursor: pointer;
+      font-family: $screenfont;
+      text-transform: none;
+      text-decoration: none;
+      font-weight: normal;
+      color: $taboff_color;
+      display: block;
+      padding: 6px 12px;
+
+      &.selected {
+        color: $tabon_color;
+        font-weight: bold;
+        border-bottom: 3px solid $kselected_color;
+        padding-bottom: 3px;
+      }
+
+      &:hover { color: lighten($kselected_color,10%); }
+    }
+  }
+}

--- a/src/app/views/common/_header.haml
+++ b/src/app/views/common/_header.haml
@@ -11,6 +11,10 @@
   - if not current_user.nil?
     = render_menu(1)
 
+= content_for(:custom_tabs) do
+  - if (not current_user.nil?) && AppConfig.katello? && AppConfig.use_foreman
+    = render_provision_menu
+
 = content_for(:widgets) do
   = hidden_field_tag 'get_notices_url', nil, 'data-url' => notices_get_new_path
   = link_to _("Log Out"), logout_path, :method=>"POST", :class => "header-widget"

--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -26,7 +26,7 @@ module Src
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{Rails.root}/lib)
+    config.autoload_paths += %W(#{Rails.root}/lib #{Rails.root}/app/navigation_renderers)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/src/lib/navigation/main.rb
+++ b/src/lib/navigation/main.rb
@@ -13,6 +13,7 @@ require 'navigation/content_management'
 require 'navigation/administration'
 require 'navigation/organization'
 require 'navigation/dashboard'
+require 'navigation/provision'
 require 'navigation/systems'
 require 'navigation/main'
 
@@ -24,6 +25,7 @@ module Navigation
     base.send :include, OrganizationMenu
     base.send :include, DashboardMenu
     base.send :include, SystemMenu
+    base.send :include, ProvisionMenu
   end
 
   module MainMenu
@@ -35,6 +37,12 @@ module Navigation
   module AdministrationMenu
     def admin_main
       [ menu_administration ]
+    end
+  end
+
+  module ProvisionMenu
+    def provision_items
+      [ menu_provision ]
     end
   end
 end

--- a/src/lib/navigation/provision.rb
+++ b/src/lib/navigation/provision.rb
@@ -1,0 +1,117 @@
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+module Navigation
+  module ProvisionMenu
+
+    def menu_provision
+      {
+        :key => :provision,
+        :name => _("Provisioning"),
+        :url => false,
+        :options => {
+          :class=>'provision top_level', "data-menu"=>"provision",
+          :container_id=>'provisionContainer',
+          :link => {:id=>'provisionButton'}},
+        :items=> [
+          menu_architectures, menu_domains, menu_hwmodels,
+          menu_installation_media, menu_operating_systems,
+          menu_partition_tables, menu_provisioning_templates,
+          menu_subnets
+        ],
+        :if => lambda{current_organization && current_organization.provisioning_readable?}
+      }
+    end
+
+    def menu_architectures
+      {
+        :key => :architectures,
+        :name => _("Architectures"),
+        #TODO: change to the real path when the controller is ready
+        :url => dashboard_index_path,
+        :if => lambda{current_organization},
+        :options => {:class=>'provision second_level', "data-menu"=>"provision",
+          :container_id=>'provisionBox'},
+        :class => "abc"
+      }
+    end
+
+    def menu_domains
+      {:key => :domains,
+       :name => _("Domains"),
+       #TODO: change to the real path when the controller is ready
+       :url => dashboard_index_path,
+       :if => lambda{current_organization},
+       :options => {:class=>'provision second_level', "data-menu"=>"provision"}
+      }
+    end
+
+    def menu_hwmodels
+      {:key => :hwmodels,
+        :name => _("Hardware Models"),
+        #TODO: change to the real path when the controller is ready
+        :url => dashboard_index_path,
+        :if => lambda {current_organization},
+        :options => {:class=>'provision second_level', "data-menu"=>"provision"}
+       }
+    end
+
+    def menu_installation_media
+      {:key => :installation_media,
+       :name => _("Installation Media"),
+       #TODO: change to the real path when the controller is ready
+       :url => dashboard_index_path,
+       :if => lambda{current_organization},
+       :options => {:class=>'provision second_level', "data-menu"=>"provision"}
+      }
+    end
+
+    def menu_operating_systems
+      {:key => :operating_systems,
+       :name => _("Operating Systems"),
+       :url => dashboard_index_path,
+       #TODO: change to the real path when the controller is ready
+       :if => lambda{current_organization},
+       :options => {:class=>'provision second_level', "data-menu"=>"provision"}
+      }
+    end
+
+    def menu_partition_tables
+      {:key => :partition_tables,
+       :name => _("Partition Tables"),
+       :url => dashboard_index_path,
+       #TODO: change to the real path when the controller is ready
+       :if => lambda{current_organization},
+       :options => {:class=>'provision second_level', "data-menu"=>"provision"}
+      }
+    end
+
+    def menu_provisioning_templates
+      {:key => :provisioning_templates,
+       :name => _("Provisioning Templates"),
+       :url => dashboard_index_path,
+       #TODO: change to the real path when the controller is ready
+       :if => lambda{current_organization},
+       :options => {:class=>'provision second_level', "data-menu"=>"provision"}
+      }
+    end
+
+    def menu_subnets
+      {:key => :subnets,
+       :name => _("Subnets"),
+       #TODO: change to the real path when the controller is ready
+       :url => dashboard_index_path,
+       :if => lambda{current_organization},
+       :options => {:class=>'provision second_level', "data-menu"=>"provision"}
+      }
+    end
+  end
+end

--- a/src/public/javascripts/katello.js
+++ b/src/public/javascripts/katello.js
@@ -270,6 +270,21 @@ KT.common = (function() {
             }
           });
         },
+        provisionMenuSetup : function() {
+            var button = $('#provisionButton');
+            var container = $('#provisionContainer');
+            var box = $('#provisionBox');
+
+            container.hover(function() {
+                box.fadeIn('fast');
+                button.addClass('active');
+                container.addClass('active');
+            }, function(){
+                button.removeClass('active');
+                container.removeClass('active');
+                box.fadeOut('fast');
+            });
+        },
         orgSwitcherSetup : function() {
             //org switcher
             var button = $('#switcherButton');
@@ -546,6 +561,8 @@ $(document).ready(function (){
 
     KT.common.orgSwitcherSetup();
     KT.common.orgFilterSetup();
+
+    KT.common.provisionMenuSetup();
 
 });
 


### PR DESCRIPTION
Foreman menu Pajk created and demoed quite some time ago. It is intended to hold links to provisioning-related controllers. 

Notes:
- At the moment the menu items have fake links. We will add the real ones later.
- It is rendered into 'custom_tabs' section of a header template. This section was newly added to converge-ui and we have to wait until it's merged.
