### PR TITLE
750660 - System packages list doesn't allow you to search for a package installed on the system

### DIFF
--- a/src/app/controllers/system_packages_controller.rb
+++ b/src/app/controllers/system_packages_controller.rb
@@ -126,17 +126,16 @@ class SystemPackagesController < ApplicationController
                        :message=>_("Hypervisors do not have packages")}
       return
     end
-
+    
     offset = current_user.page_size
     packages = @system.simple_packages.sort {|a,b| a.nvrea.downcase <=> b.nvrea.downcase}
     total_packages = packages.length
-    if packages.length > 0
+    if total_packages > 0
       if params.has_key? :pkg_order
         if params[:pkg_order].downcase == "desc"
           packages.reverse!
         end
       end
-      packages = packages[0...offset]
     else
       packages = []
     end
@@ -154,38 +153,16 @@ class SystemPackagesController < ApplicationController
   end
 
   def more_packages
-    #grab the current user setting for page size
-    size = current_user.page_size
-    #what packages are available?
     packages = @system.simple_packages.sort {|a,b| a.nvrea.downcase <=> b.nvrea.downcase}
 
-    if packages.length > 0
-      #check for the params offset (start of array chunk)
-      if params.has_key? :offset
-        offset = params[:offset].to_i
-      else
-        offset = current_user.page_size
+    if params.has_key? :pkg_order
+      if params[:pkg_order].downcase == "desc"
+        packages.reverse!
       end
-      if params.has_key? :pkg_order
-        if params[:pkg_order].downcase == "desc"
-          #reverse if order is desc
-          packages.reverse!
-        end
-      end
-      if params.has_key? :reverse
-        packages = packages[0...params[:reverse].to_i]
-      else
-        packages = packages[offset...offset+size]
-      end
-      packages ||= [] # fence for case when offset extended beyond range, etc.
-    else
-      packages = []
     end
 
-    packages = packages ? packages : []
-
     render :partial=>"package_items", :locals=>{:packages => packages, :package_tasks => nil,
-                                                :group_tasks => nil, :offset=> offset, 
+                                                :group_tasks => nil, :offset=> 0, 
                                                 :editable => @system.editable?}
   end
 

--- a/src/app/stylesheets/sections/systems.scss
+++ b/src/app/stylesheets/sections/systems.scss
@@ -8,6 +8,11 @@
   table {
     margin-bottom: 4px;
     width: 100%;
+    td {
+      &.package_select {
+          width: 29px;
+      }
+    }
   }
   .tall {
     @extend .block;

--- a/src/app/views/system_packages/_package_items.html.haml
+++ b/src/app/views/system_packages/_package_items.html.haml
@@ -31,9 +31,9 @@
             = image_tag("embed/icons/spinner.gif")
             = get_status_string(t.task_type)
 
--packages.each do |p|
+-packages.each_with_index do |p,index|
 
-  %tr{:class => row_shading + ' package'}
+  %tr{:class => 'package', :style => "#{index < offset ? ' ' : 'display:none;' }" }
     - if editable
       %td.package_select
         = check_box_tag "package[#{p.name}]", "0", false, {:tabindex => auto_tab_index}
@@ -41,5 +41,3 @@
     %td.package_name
       #{p.nvrea}
     %td.package_action_status
-    -#%td
-      -#TODO: installed date

--- a/src/app/views/system_packages/_packages.html.haml
+++ b/src/app/views/system_packages/_packages.html.haml
@@ -41,7 +41,7 @@
       "x_of_y_packages" : function(x,y){ return '#{escape_javascript(_("(Loaded %X of %Y Total)"))}'.replace("%X", x).replace("%Y", y); }
       });
 
-= javascript :filtertable, :system_packages
+= javascript :packages_filtertable, :system_packages
 
 = render :partial => "systems/system_tupane_header_nav"
 
@@ -90,7 +90,7 @@
       &nbsp;
 
     .grid_8
-      = render :partial => "common/filter_table", :locals => {:filter_placeholder => _('Filter on loaded packages...')}
+      = render :partial => "common/filter_table", :locals => {:filter_placeholder => _('Filter on all packages...')}
       = form_tag system_system_packages_path(@system.id), :id => "packages_form", :method => "post", :remote => true do
         %table.filter_table.packages.ajaxScroll{'data-system_id' => @system.id, 'data-total_packages' => total_packages}
           %thead
@@ -101,8 +101,11 @@
             -#%th
               -##{_("Date Added")}
           %tbody
-            = render :partial => 'package_items', :locals => {:editable => editable, :package_tasks => package_tasks,
-                                                              :group_tasks => group_tasks, :packages => packages}
+            = render :partial => 'package_items', :locals => {:editable => editable,
+                                                              :package_tasks => package_tasks,
+                                                              :group_tasks => group_tasks, 
+                                                              :packages => packages,
+                                                              :offset => offset}
 
       #list-spinner
         = image_tag("embed/icons/spinner.gif", :class=>"ajax_scroll")

--- a/src/config/assets.yml
+++ b/src/config/assets.yml
@@ -179,6 +179,9 @@ javascripts:
   filtertable:
     - public/javascripts/converge-ui/vendor/jquery/plugins/jquery.uitablefilter.js
     - public/javascripts/filtertable.js
+  packages_filtertable:  
+    - public/javascripts/converge-ui/vendor/jquery/plugins/jquery.uitablefilter.js
+    - public/javascripts/packages_filtertable.js
   scroll_pane:
     - public/javascripts/scroll_pane.js
   tabs:

--- a/src/public/javascripts/packages_filtertable.js
+++ b/src/public/javascripts/packages_filtertable.js
@@ -1,0 +1,63 @@
+/**
+ Copyright 2011 Red Hat, Inc.
+
+ This software is licensed to you under the GNU General Public
+ License as published by the Free Software Foundation; either version
+ 2 of the License (GPLv2) or (at your option) any later version.
+ There is NO WARRANTY for this software, express or implied,
+ including the implied warranties of MERCHANTABILITY,
+ NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ have received a copy of GPLv2 along with this software; if not, see
+ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+*/
+
+KT.packages_filtertable = (function() {
+    var initialize = function() {
+        var theTable = $('table.filter_table.packages');
+        var filter = $('#filter');
+        var load_more = $('a#more');
+        var load_summary = $('span#loaded_summary');
+        var count = theTable.attr('data-packageCount', 25);
+
+        theTable.find('tbody tr:visible:odd').addClass('alt');
+
+        filter.live('change, keyup', function(){
+            if ( !this.value ){
+                count = theTable.attr('data-packageCount');
+                theTable.find('tbody tr').hide();
+                theTable.find('tbody tr:lt('+count+')').show();
+                coloring();
+                footer("visible");
+            } else {                  
+                $.uiTableFilter(theTable, this.value);
+                coloring();
+                footer("hidden");
+            }
+
+            function coloring(){
+                theTable.find('tbody tr').removeClass('alt');
+                theTable.find('tbody tr:visible:odd').addClass('alt');
+            }
+            function footer(method){
+                load_more.css('visibility',method);
+                load_summary.css('visibility',method);
+            }
+        });
+
+        //override the submit so it doesn't try to push a form
+        $('#filter_form').submit(function () {
+            filter.keyup();
+            return false;
+        }).focus(); //Give focus to input field
+        $('.filter_button').click(function(){filter.change()});
+    };
+    return {
+        initialize: initialize
+    }
+}(jQuery));
+
+$(document).ready(function() {
+    // initialize the filter table
+    KT.packages_filtertable.initialize();
+    //packages_filtertable.initialize();
+});

--- a/src/public/javascripts/system_packages.js
+++ b/src/public/javascripts/system_packages.js
@@ -132,49 +132,19 @@ KT.system_packages = function() {
         return action_type;
     },
     morePackages = function() {
-        var list = $('.packages');
-        var spinner = $('#list-spinner');
-        var dataScrollURL = more_button.attr("data-scroll_url");
+        var list = $('table.packages');
+        var currentCount = list.attr('data-packageCount');
+        var newCount = Number(currentCount) + Number(25);
 
-        var offset = parseInt(more_button.attr("data-offset"), 10);
-        dataScrollURL = dataScrollURL + "?offset=" + offset + "&pkg_order="+ sort_button.attr("data-sort") +"&";
-        //console.log(dataScrollURL + ", page_size: " + offset);
-        spinner.fadeIn();
-        $.ajax({
-            type: "GET",
-            url: dataScrollURL,
-            cache: false,
-            success: function(data) {
-                retrievingNewContent = false;
-                spinner.fadeOut();
+        list.find('tbody tr').hide();
+        list.find('tbody tr:lt('+newCount+')').show();
+        list.find('tbody tr:visible').removeClass('alt');
+        list.find('tbody tr:visible:odd').addClass('alt');
 
-                // using the response received, update the tabindexes for the packages and buttons
-                var pkgs_response = $(data);
-                pkgs_response.find('input[type="checkbox"]').each( function(){
-                    $(this).attr('tabindex', ++packages_tabindex);
-                });
-                list.append(pkgs_response);
-                more_button.attr('tabindex', ++packages_tabindex);
-                update_all_button.attr('tabindex', ++packages_tabindex);
-                update_button.attr('tabindex', ++packages_tabindex);
-                remove_button.attr('tabindex', ++packages_tabindex);
+        list.attr('data-packageCount', newCount);
 
-                registerCheckboxEvents();
-                $('#filter').keyup();
-                $('.scroll-pane').jScrollPane().data('jsp').reinitialise();
-                updateLoadedSummary();
-                if (data.length == 0) {
-                    more_button.empty().remove();
-                }else{
-                    offset = offset + parseInt(more_button.attr("data-page_size"), 10);
-                    more_button.attr("data-offset", offset);
-                }
-            },
-            error: function() {
-                spinner.fadeOut();
-                retrievingNewContent = false;
-            }
-        });
+        updateLoadedSummary();
+        registerCheckboxEvents();
     },
     sortOrder = function() {
         var packageSortOrder = sort_button.attr("data-sort");
@@ -208,7 +178,6 @@ KT.system_packages = function() {
                 registerCheckboxEvents();
                 $('#filter').keyup();
                 $('.scroll-pane').jScrollPane().data('jsp').reinitialise();
-                updateLoadedSummary();
                 if (data.length == 0) {
                     more_button.empty().remove();
                 }else{
@@ -444,7 +413,6 @@ KT.system_packages = function() {
                 event.preventDefault();
             }
         });
-
         more_button.bind('click', morePackages);
         more_button.bind('keypress', function(event) {
             if( event.which === 13) {
@@ -727,7 +695,7 @@ KT.system_packages = function() {
         });
     },
     updateLoadedSummary = function() {
-        var total_loaded = $('tr.package').length,
+        var total_loaded = $('tr.package:visible').length,
             message = i18n.x_of_y_packages(total_loaded, total_packages);
         loaded_summary.html(message);
 


### PR DESCRIPTION
Fixing problem with searching just over loaded packages.
Now the search is being done over all packages of the system.
For searching there is used only one table which content is
dynamicaly switching between loaded packages and searched packages.
For this reason the method more_packages in system_packages.js had
to be overwritten,so it doesn't have to use ajax anymore.
The filtering logic for packages is being placed in packages_filtertable.js
