### PR TITLE
adding OpenJDK check into katello-configure

### DIFF
--- a/katello-configure/bin/katello-configure
+++ b/katello-configure/bin/katello-configure
@@ -26,6 +26,7 @@ ERROR_CODES = {
   :error_executing_puppet => 6,
   :hostname_error => 7,
   :not_root => 8,
+  :java_error => 9,
   :unknown => 127,
 }
 
@@ -434,8 +435,14 @@ end
 # we MUST change the current directory to /root because Puppet expects that
 Dir.chdir '/root'
 
-# perform check-up
+# <BEFORE CONFIGURATION CHECKS>
 check_hostname
+
+if not `java -version 2>&1`.include? 'OpenJDK'
+	$stderr.puts "Command 'java -version' does not return OpenJDK, only OpenJDK is supported."
+  exit_with :java_error
+end
+# </BEFORE CONFIGURATION CHECKS>
 
 # Puppet tries to determine FQDN from /etc/resolv.conf and we do NOT want this behavior
 # (see https://bugzilla.redhat.com/show_bug.cgi?id=760265)


### PR DESCRIPTION
Candlepin cpdb only works with OpenJDK java, otherwise katello-configure errors with:

```
Command output: Error: Could not find or load main class liquibase.integration.commandline.Main
```

This adds check before starting configuration.
