### PR TITLE
fixing a regression in headpin due to ascii username restrictions in

### DIFF
--- a/src/app/models/username_validator.rb
+++ b/src/app/models/username_validator.rb
@@ -13,7 +13,9 @@
 class UsernameValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if value
-      record.errors[attribute] << _("cannot contain characters other than ASCII values") unless value.ascii_only?
+      if AppConfig.katello?
+        record.errors[attribute] << _("cannot contain characters other than ASCII values") unless value.ascii_only?
+      end
       KatelloNameFormatValidator.validate_length(record, attribute, value, 64, 3)
     end
   end

--- a/src/spec/models/user_spec.rb
+++ b/src/spec/models/user_spec.rb
@@ -41,7 +41,7 @@ describe User do
     }
   end
 
-  describe "User shouldn't" do 
+  describe "User shouldn't" do
     before(:each) do
       disable_user_orchestration
       AppConfig.warden = 'database'
@@ -128,7 +128,7 @@ describe User do
       u.should_not be_nil
     end
 
-    it "have ASCII username" do
+    it "have ASCII username", :katello => true do
       non_ascii = {
         :username => 'Cuiabá_user1',
         :password => PASSWORD,


### PR DESCRIPTION
katello.

fenced the ascii restrictions to katello only. This will allow
usernames to contain email-address characters as well at international
characters.
