### PR TITLE
katello-configure - always chomp generated password

### DIFF
--- a/katello-configure/lib/puppet/parser/functions/katello_create_read_password.rb
+++ b/katello-configure/lib/puppet/parser/functions/katello_create_read_password.rb
@@ -10,7 +10,7 @@ module Puppet::Parser::Functions
       puts "Generating new random seed in #{filename}"
       randomhash = `openssl rand -base64 24`
       File.open(filename, 'w', 0600) {|f| f.write(randomhash) }
-      randomhash
+      randomhash.chomp
     end
   end
 end


### PR DESCRIPTION
We use this value as command arguments an the new line makes troubles when configure foreman oauth. Also it was not consistent with the case when the password was already generated.
