### PR TITLE
puppet race condition in foreman

### DIFF
--- a/katello-configure/modules/foreman/manifests/service.pp
+++ b/katello-configure/modules/foreman/manifests/service.pp
@@ -1,7 +1,12 @@
 class foreman::service {
   service {'foreman':
-    ensure    => 'running',
-    enable    => true,
-    hasstatus => true,
+    ensure     => running,
+    enable     => true,
+    hasstatus  => true,
+    hasrestart => true,
+    start      => '/usr/sbin/service-wait foreman start',
+    stop       => '/usr/sbin/service-wait foreman stop',
+    restart    => '/usr/sbin/service-wait foreman restart',
+    status     => '/usr/sbin/service-wait foreman status',
   }
 }

--- a/src/deploy/common/service-wait.sysconfig
+++ b/src/deploy/common/service-wait.sysconfig
@@ -20,3 +20,6 @@
 
 # postgres data directory
 #POSTGRES_DATA=/var/lib/pgsql/data
+
+# foreman test url
+#FOREMAN_TEST_URL=http://localhost:5500/foreman/api

--- a/src/script/service-wait
+++ b/src/script/service-wait
@@ -44,6 +44,7 @@ ELASTICSEARCH_TEST_URL=${ELASTICSEARCH_TEST_URL:-http://localhost:$ELASTICSEARCH
 MONGO_PORT=${MONGO_PORT:-27017}
 POSTGRES_PORT=${POSTGRES_PORT:-5432}
 POSTGRES_DATA=${POSTGRES_DATA:-/var/lib/pgsql/data}
+FOREMAN_TEST_URL=${FOREMAN_TEST_URL:-http://localhost:5500/foreman/api}
 
 # for some services we add few extra seconds after start
 ADDITIONAL_SLEEP=5
@@ -63,6 +64,10 @@ after_start() {
       ;;
     elasticsearch)
       /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- --no-check-certificate $ELASTICSEARCH_TEST_URL >/dev/null
+      sleep $ADDITIONAL_SLEEP
+      ;;
+    foreman)
+      /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- --no-check-certificate $FOREMAN_TEST_URL >/dev/null
       sleep $ADDITIONAL_SLEEP
       ;;
     mongod)


### PR DESCRIPTION
We are not waiting until foreman is really up, there is a race condition in the installer:

```
rake aborted!
404 Resource Not Found
/usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/abstract_response.rb:48:in `return!'
/usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:220:in `process_result'
/usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:169:in `transmit'
/usr/lib/ruby/1.8/net/http.rb:543:in `start'
/usr/lib/ruby/gems/1.8/gems/rest-client-1.6.1/lib/restclient/request.rb:166:in `transmit'
...
/usr/share/katello/lib/resources/abstract_model.rb:225:in `all'
/usr/share/katello/db/seeds.rb:44
```

And I also _hope_ it will help with that strange foreman-admin-user not found. Let's see. I will initiate nightly build once this is merged.
