### PR TITLE
adding missing require for foreman service

### DIFF
--- a/katello-configure/modules/katello/manifests/config.pp
+++ b/katello-configure/modules/katello/manifests/config.pp
@@ -102,6 +102,7 @@ class katello::config {
                 'katello' => [
                   Class["candlepin::service"], 
                   Class["pulp::service"], 
+                  Class["foreman::service"], 
                   File["${katello::params::log_base}"], 
                   File["${katello::params::log_base}/production.log"], 
                   File["${katello::params::log_base}/production_sql.log"], 
@@ -176,7 +177,7 @@ class katello::config {
     timeout => 0,
     before  => Class["katello::service"],
     require => $katello::params::deployment ? {
-                'katello' => [ Exec["katello_migrate_db"], Class["candlepin::service"], Class["pulp::service"], File["${katello::params::log_base}"] ],
+                'katello' => [ Exec["katello_migrate_db"], Class["candlepin::service"], Class["pulp::service"], Class["foreman::service"], File["${katello::params::log_base}"] ],
                 'headpin' => [ Exec["katello_migrate_db"], Class["candlepin::service"], Class["thumbslug::service"], File["${katello::params::log_base}"] ],
                 default => [],
     },


### PR DESCRIPTION
I cannot believe we (he :-) forgot to add require statement to the katello seed script to actually START foreman instance before proceeding :-)

This fixes it. MERGE ASAP
