### PR TITLE
Add an installation script for ISO delivery.

### DIFF
--- a/scripts/iso/README
+++ b/scripts/iso/README
@@ -1,0 +1,12 @@
+KATELLO ISO DELIVERY
+====================
+This ISO contains the packages for the katello project. Users will need
+to follow a two step process for the installation.
+
+Step 1 is to run install_packages from this ISO. It will create a
+temporary yum repo file on your machine, and will install the packages
+for you. This script will also handle updates to an already installed
+machine.
+
+Step 2 is to run katello_configure as documented in the installation
+guide. This will configure the machine so that it is ready to run.

--- a/scripts/iso/install_packages
+++ b/scripts/iso/install_packages
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+#
+# Install the katello packages from an ISO. This assumes that the
+# script exists in a directory which is a valid repo. It should have
+# a Packages and repository subdirectorties
+#
+# After this command is run, the user will need to run the
+# the katello-configure script in order to set up the installation.
+#
+# Copyright (c) 2012 Red Hat, Inc.
+#
+#
+import os
+import subprocess
+import sys
+
+
+# Runs a command, and exits if the command is not successful.
+# The output is returned.
+def run_command(cmd):
+    try:
+        stdout = subprocess.check_output(cmd)
+    except (OSError, subprocess.CalledProcessError), e:
+        sys.stderr.write("Error while executing command: '%s'\n" % (" ".join(cmd)))
+        sys.exit(-1)
+
+    return stdout
+
+# Ensure we are root
+if os.getuid() != 0:
+    sys.stderr.write('Error: this command requires root access to execute\n')
+    sys.exit(8)
+
+# Figure out where we are running
+INSTALL_FILE = os.path.abspath(__file__)
+PWD = os.path.dirname(INSTALL_FILE)
+REPO_FILE = "/etc/yum.repos.d/katello-local.repo"
+PACAKGES_DIR = os.path.join(PWD, "Packags")
+ISO_PACKAGE_DIR = os.path.join(PWD, "Packages")
+ISO_REPODATA_DIR = os.path.join(PWD, "repodata")
+INDENT = "   - "
+
+
+print "This script will install the katello packages on the current machine."
+print INDENT + "Ensuring we are in an expected directory."
+# Try to make sure we are in a sane directory
+if (not os.path.exists(ISO_PACKAGE_DIR)):
+    sys.stderr.write('Error: There is no Packages Directory\n')
+    sys.exit(-1)
+
+if (not os.path.exists(ISO_REPODATA_DIR)):
+    sys.stderr.write('Error: There is no repodata Directory\n')
+    sys.exit(-1)
+
+# Create a yum repository pointing to the current directory
+print INDENT + "Creating a Repository File"
+repo_file = open(REPO_FILE, 'w')
+repo_file.write("""#
+# Repository for the locally mounted katello repo
+#
+[katello-local]
+name=katello-local
+baseurl=file://%s
+enabled=1
+gpgcheck=1""" % (PWD))
+repo_file.close()
+
+# Determine if we need to do install or update
+
+upgrade = False
+
+print INDENT + "Checking to see if Katello is already installed."
+if (run_command(["rpm", "-qa", "katello-common"])):
+    upgrade = True
+
+if upgrade:
+    print INDENT + "Katello is already installed, running 'yum upgrade'."
+    output = run_command(["yum", "upgrade"])
+
+else:
+    # Determine if we need to install katello-all or Katello-headpin-all
+    katello_all = False
+    for f in os.listdir(ISO_PACKAGE_DIR):
+        if f.startswith('katello-all'):
+            katello_all = True
+    if (katello_all):
+        print INDENT + "katello-all is not yet installed, installing it."
+        run_command(["yum", "install", "-y", "katello-all"])
+    else:
+        print INDENT + "katello-headpin-all is not yet installed, installing it."
+        run_command(["yum", "install", "-y", "katello-headpin-all"])
+
+# Remove the repository file
+print INDENT + "Removing the repository file."
+os.remove(REPO_FILE)
+print
+
+
+# fini
+if (upgrade):
+    print "Upgrade is complete. Please backup your data and run katello-configure."
+else:
+    print "Install is complete. Please run katello-configure."
+
+


### PR DESCRIPTION
This script will only do the package installs. It requires that katelo-configure is run at a later time.
