### PR TITLE
enabling foreman authentication by default

### DIFF
--- a/katello-configure/modules/foreman/manifests/params.pp
+++ b/katello-configure/modules/foreman/manifests/params.pp
@@ -3,8 +3,8 @@ class foreman::params {
   $install     = false
   # should foreman manage host provisioning as well
   $unattended   = true
-  # Enable users authentication (default user:admin pw:changeme)
-  $authentication = false
+  # Enable users authentication
+  $authentication = true
   # force SSL (note: requires passenger)
   $ssl         = false
 
@@ -22,7 +22,7 @@ class foreman::params {
   $db_name = "foreman"
   $db_pass = "foreman"
 
-  $thin_ip            = "0.0.0.0"
+  $thin_ip            = "127.0.0.1"
   $thin_start_port    = "5500"
   $thin_log           = "/var/log/foreman/thin-log.log"
   $thin_process_count = 2


### PR DESCRIPTION
This enables authentication in foreman, it is perhaps the reason why installer STILL fails (now with 404 error).
