### PR TITLE
871086 - Changes to respond with template validation errors as bad reque...

### DIFF
--- a/src/app/controllers/api/templates_controller.rb
+++ b/src/app/controllers/api/templates_controller.rb
@@ -24,8 +24,9 @@ class Api::TemplatesController < Api::ApiController
 
   before_filter :find_environment, :only => [:create, :import, :index]
   before_filter :find_template, :only => [:show, :update, :destroy, :promote, :export, :validate]
-
   before_filter :authorize
+
+  rescue_from Errors::TemplateValidationException, :with => proc { |e| render_exception(400, e) }
 
   def rules
     read_test = lambda{ SystemTemplate.readable?(@template.environment.organization) }


### PR DESCRIPTION
...sts instead of internal server errors.

Adds rescue for template validation exceptions into API controller to have invalid template execeptions returned as 400 bad requests instead of 500 server errors.  This is inspired by the bug mentioned above which causes the CLI to present to the user a generic 500 error and masking the real validation error when trying to export an invalid template.
