### PR TITLE
include rubygems 1.8

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -96,6 +96,7 @@
        <packagereq type="default">rubygem-tzinfo</packagereq>
        <packagereq type="default">rubygem-warden</packagereq>
        <packagereq type="default">rubygem-yui-compressor</packagereq>
+       <packagereq type="default">rubygems</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
in RHEL is rubygems 1.3, which cause problem to rubygem-ZenTest
https://github.com/seattlerb/zentest/issues/5#issuecomment-1644733
