### PR TITLE
872493 - Katello-configure --reset-data incorrectly sets mongod up

### DIFF
--- a/katello-configure/modules/pulp/manifests/config.pp
+++ b/katello-configure/modules/pulp/manifests/config.pp
@@ -41,7 +41,7 @@ class pulp::config {
 
   if $pulp::params::reset_data == 'YES' {
     exec {"reset_pulp_db":
-      command     => "rm -f /var/lib/pulp/init.flag; service httpd stop; rm -f /var/lib/mongodb/pulp_database*; rm -rf /var/lib/pulp/{distributions,published,repos}/*; test 1 -eq 1",
+      command     => "rm -f /var/lib/pulp/init.flag; service-wait httpd stop; service-wait mongod stop; rm -f /var/lib/mongodb/pulp_database*; service-wait mongod start; rm -rf /var/lib/pulp/{distributions,published,repos}/*; true",
       path        => "/sbin:/bin:/usr/bin",
       before      => Exec["migrate_pulp_db"],
       timeout     => 0,


### PR DESCRIPTION
katello-configure -b --reset-data=YES does not work well with mongod
