### PR TITLE
864936 - small but important chg to fix manifest imports

### DIFF
--- a/src/app/models/glue/candlepin/product.rb
+++ b/src/app/models/glue/candlepin/product.rb
@@ -44,7 +44,7 @@ module Glue::Candlepin::Product
       productContent_attrs = []
     end
 
-    attrs = attrs.merge('name' => validate_name(attrs['name']))
+    attrs = attrs.merge('name' => validate_name(attrs['name']), 'label' => Katello::ModelUtils::labelize(attrs['name']))
 
     product = Product.new(attrs, &block)
     product.orchestration_for = :import_from_cp_ar_setup
@@ -60,7 +60,7 @@ module Glue::Candlepin::Product
   end
 
   def self.import_marketing_from_cp(attrs, engineering_product_ids, &block)
-    attrs = attrs.merge('name' => validate_name(attrs['name']))
+    attrs = attrs.merge('name' => validate_name(attrs['name']), 'label' => Katello::ModelUtils::labelize(attrs['name']))
 
     product = MarketingProduct.new(attrs, &block)
     product.orchestration_for = :import_from_cp_ar_setup

--- a/src/app/models/product.rb
+++ b/src/app/models/product.rb
@@ -70,7 +70,7 @@ class Product < ActiveRecord::Base
 
   scope :engineering, where(:type => "Product")
 
-  before_save :assign_label
+  before_save :assign_unique_label
   after_save :update_related_index
 
   def extended_index_attrs
@@ -201,7 +201,7 @@ class Product < ActiveRecord::Base
     Product.all_editable(self.organization).where(:id => id).count > 0
   end
 
-  def assign_label
+  def assign_unique_label
     self.label = Katello::ModelUtils::labelize(self.name) if self.label.blank?
 
     # if the object label is already being used in this org, append the id to make it unique


### PR DESCRIPTION
Label is required on product; therefore, labelizing on products
created on import.  The before_save on the product will ensure
that the labelized product is unique and reassign it, if necessary.
