### PR TITLE
841317-410 - recovery mechanism for candlepin 410s

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -169,7 +169,6 @@ class SystemsController < ApplicationController
     end
     render_panel_direct(System, @panel_options, search, params[:offset], order,
                         {:default_field => :name, :filter=>filters, :load=>true})
-
   end
 
   def auto_complete

--- a/src/lib/resources/candlepin.rb
+++ b/src/lib/resources/candlepin.rb
@@ -132,6 +132,10 @@ module Resources
 
         def destroy uuid
           self.delete(path(uuid), User.cp_oauth_header).code.to_i
+        # Deleting an already-deleted consumer is alright. This situation can arise in the
+        # 'rake rindex' task to recover from out-of-sync databases.
+        rescue RestClient::Gone
+          return true
         end
 
         def available_pools(uuid, listall=false)


### PR DESCRIPTION
If candlepin gets into a situation where katello's db has a consumer that candlepin has deleted (ie. returning 410s on query), running 'rake reindex' will remove the obsolete record.
