### PR TITLE
847037 - Environment and organization names should be case insensitive

### DIFF
--- a/src/app/controllers/environments_controller.rb
+++ b/src/app/controllers/environments_controller.rb
@@ -74,7 +74,7 @@ class EnvironmentsController < ApplicationController
               :description => params[:kt_environment][:description],
               :prior => params[:kt_environment][:prior],
               :label => params[:kt_environment][:label],
-              :organization_id => @organization.id}
+              :organization_id => @organization.id} 
 
     env_params[:label], label_assigned = generate_label(env_params[:name], _('environment')) if env_params[:label].blank?
 

--- a/src/app/controllers/organizations_controller.rb
+++ b/src/app/controllers/organizations_controller.rb
@@ -208,7 +208,7 @@ class OrganizationsController < ApplicationController
   end
 
   def find_organization_by_id
-    @organization = Organization.find(params[:id])
+    @organization = Organization.find(params[:id])    
   end
 
   def setup_options

--- a/src/app/models/kt_environment.rb
+++ b/src/app/models/kt_environment.rb
@@ -92,7 +92,7 @@ class KTEnvironment < ActiveRecord::Base
 
   scope :completer_scope, lambda { |options| where('organization_id = ?', options[:organization_id])}
 
-  validates_uniqueness_of :name, :scope => :organization_id, :message => N_("must be unique within one organization")
+  validates_uniqueness_of :name, :case_sensitive => false, :scope => :organization_id, :message => N_("must be unique within one organization")
   validates_uniqueness_of :label, :scope => :organization_id, :message => N_("must be unique within one organization")
   validates_presence_of :organization
   validates :name, :presence => true, :katello_name_format => true

--- a/src/app/models/organization.rb
+++ b/src/app/models/organization.rb
@@ -48,7 +48,7 @@ class Organization < ActiveRecord::Base
 
   before_create :create_library
   before_create :create_redhat_provider
-  validates :name, :uniqueness => true, :presence => true, :katello_name_format => true
+  validates :name, :uniqueness => { :case_sensitive => false, :message => N_(" of an organization must be unique.") }, :presence => true, :katello_name_format => true
   validates :label, :uniqueness => true, :presence => true, :katello_label_format => true
   validates :description, :katello_description_format => true
 

--- a/src/spec/models/environment_spec.rb
+++ b/src/spec/models/environment_spec.rb
@@ -178,6 +178,14 @@ describe KTEnvironment do
         @environment2.errors[:name].should_not be_empty
       end
 
+      it "should be invalid to create two envs with the same name but different cases within one organization" do
+        @environment2 = KTEnvironment.new({:name => @env_name.upcase})
+        @organization.environments << @environment2
+
+        @environment2.should_not be_valid
+        @environment2.errors[:prior].should_not be_empty
+      end
+
       it "should be invalid to create an environment without a prior" do
         @environment2 = KTEnvironment.new({:name => @env_name})
         @organization.environments << @environment2

--- a/src/spec/models/organization_spec.rb
+++ b/src/spec/models/organization_spec.rb
@@ -47,6 +47,11 @@ describe Organization do
     it "should complain on duplicate name" do
       lambda{Organization.create!(:name => @organization.name, :label => @organization.name + "foo")}.should raise_error
     end
+
+    it "should complain on duplicate name" do
+      lambda{Organization.create!(:name => @organization.name.upcase, :label => @organization.name.upcase)}.should raise_error
+    end
+
     it "should complain on duplicate label" do
       lambda{Organization.create!(:name => @organization.name + "foo", :label =>@organization.name)}.should raise_error
     end


### PR DESCRIPTION
Fixing the bug with creating the organization/environment with the same
name but different cases i.e. Env and env and ENV are now treated as equals.
The validation for organization is checked agains all organizations names.
The validation for environment is checked agains all environments names in
the scope of current organization.
