### PR TITLE
subsfilter - fixes BZ 859038 where the subscription filtering chooser wo...

### DIFF
--- a/src/app/views/systems/_subs.html.haml
+++ b/src/app/views/systems/_subs.html.haml
@@ -56,7 +56,7 @@
   %h5
     #{_("Available Subscriptions")}
   = form_tag update_preference_user_path(current_user), :id=>"matchsystem_form", :method=>"put", :remote=>false do
-    = select_tag 'subscription_filters', subscription_filters.html_safe, :prompt => _("Filters"), :multiple => true, "data-placeholder" => _("Subscription Filter Options")
+    = select_tag 'subscription_filters', subscription_filters.html_safe, :prompt => _("Filters"), :multiple => true, "data-placeholder" => _("Subscription Filter Options"), :disabled => true
   = form_tag update_subscriptions_system_path, :id=>"subscribe", :method=>"post", :remote=>true do
     = hidden_field_tag "subscribe_action", "subscribe"
     %div.hidden#available_spinner

--- a/src/public/javascripts/systems.js
+++ b/src/public/javascripts/systems.js
@@ -18,6 +18,8 @@ KT.panel.set_expand_cb(function(){
     });
 
     KT.system_groups_pane.register_multiselect();
+
+    setTimeout("$('#subscription_filters').attr('disabled', false).trigger('liszt:updated');", 500);
 });
 
 KT.panel_search_autocomplete = KT.panel_search_autocomplete.concat(["distribution.name:", "distribution.version:", "network.hostname:", "network.ipaddr:"]);


### PR DESCRIPTION
...uld grab focus when the panel opens

The fix is to create the chooser disabled and then after a slight delay enable it in the document.read() call. (Myriad other attempts to correct did not work.)
