### PR TITLE
Fixed the permissions to access the RH Subscriptions page

### DIFF
--- a/src/lib/navigation/content_management.rb
+++ b/src/lib/navigation/content_management.rb
@@ -57,7 +57,7 @@ module Navigation
       {:key => :subscriptions,
        :name =>_("Red Hat Subscriptions"),
        :url => subscriptions_path,
-       :if => lambda{current_organization},
+       :if => lambda{current_organization.redhat_provider.readable?},
        :options => {:class=>'content third_level', "data-menu"=>"subscriptions", "data-dropdown"=>"subscriptions"}
       }
     end


### PR DESCRIPTION
The RH Subscriptions page should show up as a menu item only if the user has permissions to read the rh provider. This small PR  should fix that.
