### PR TITLE
873302 - Environments do not populate when adding a new user without

### DIFF
--- a/src/app/controllers/organizations_controller.rb
+++ b/src/app/controllers/organizations_controller.rb
@@ -29,7 +29,7 @@ class OrganizationsController < ApplicationController
 
     environments_partial_test = lambda do
       if "true" == params[:new]
-        Organization.creatable?
+        User.creatable?
       else
         params[:user_id] &&
             ((current_user.id.to_s ==  params[:user_id].to_s) || current_user.editable?)


### PR DESCRIPTION
full admin

we were checking against the wrong permission in the rules.

According to Rules of Engagement dictated in an earlier commit [1],
A user with create/update permissions on Users should be able to choose
an Organization and an Environment for the new user.

[1] 95624038c590c34897b5aaeb83fc2100b207da6f
https://github.com/Katello/katello/commit/95624038c590c34897b5aaeb83fc2100b207da6f
