### PR TITLE
864936 - products - labelize name on create entry

### DIFF
--- a/src/app/controllers/products_controller.rb
+++ b/src/app/controllers/products_controller.rb
@@ -48,6 +48,8 @@ class ProductsController < ApplicationController
   def create
     product_params = params[:product]
     requested_label = String.new(product_params[:label]) unless product_params[:label].blank?
+    product_params[:label], label_assigned = generate_label(product_params[:name], _('product')) if product_params[:label].blank?
+
 
     gpg = GpgKey.readable(current_organization).find(product_params[:gpg_key]) if product_params[:gpg_key] and product_params[:gpg_key] != ""
     product = @provider.add_custom_product(product_params[:label], product_params[:name],


### PR DESCRIPTION
If user creates a product without providing a label, labelize the
name immediately.  This will allow the label to be validated.
If that label is found not to be unique in the product 'before_save'
the cp_id will be appended; however, the label will still be valid.
