### PR TITLE
874160 - adding ES reindex after we migrate during upgrade

### DIFF
--- a/katello-configure/upgrade-scripts/default/0004_migrate_katello_db.sh
+++ b/katello-configure/upgrade-scripts/default/0004_migrate_katello_db.sh
@@ -23,6 +23,7 @@ done
 
 pushd $KATELLO_HOME >/dev/null
 RAILS_RELATIVE_URL_ROOT=$KATELLO_PREFIX RAILS_ENV=$KATELLO_ENV rake db:migrate --trace 2>&1
+RAILS_RELATIVE_URL_ROOT=$KATELLO_PREFIX RAILS_ENV=$KATELLO_ENV rake reindex --trace 2>&1
 ret_code=$?
 popd >/dev/null
 


### PR DESCRIPTION
Fixes the

```
#<Errors::SecurityViolation: User does not belong to an organization.>
```
