### PR TITLE
874510, 874502

### DIFF
--- a/src/app/stylesheets/katello.scss
+++ b/src/app/stylesheets/katello.scss
@@ -657,7 +657,6 @@ fieldset {
       #new {
           border-bottom: 0 none;
           padding: 8px;
-          position: absolute;
           margin: 0;
           clear: right;
           text-align: center;


### PR DESCRIPTION
- Activation Key Page in 'ja' language headings ovewritten in headpin
- Upload manifests UI in 'ja' language contains headings overwritten on each other

under the japanese language localization, the page title "Activation
Key" and the "+ activation key" button overlapped. The same thing
was happening on the Manifests page. See attached images from the
respective bugs.

This change drops the add-activation-key/import-manifest buttons down
below the title. Effectively it will always drop the "new" button down
below the title provided that the title is too wide.
