### PR TITLE
Added java 1.7 to RHEL6 repo

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -99,6 +99,7 @@
        <packagereq type="default">sigar-java</packagereq>
        <packagereq type="default">sigar</packagereq>
        <packagereq type="default">snappy-java</packagereq>
+       <packagereq type="default">java-1.7.0-openjdk</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
This will add java 7 to our RHEL 6 repo to check if all works well with the new java.
