### PR TITLE
874391-mandel - async job behind deleting manifest

### DIFF
--- a/src/app/controllers/providers_controller.rb
+++ b/src/app/controllers/providers_controller.rb
@@ -16,7 +16,7 @@ class ProvidersController < ApplicationController
 
   before_filter :find_rh_provider, :only => [:redhat_provider]
 
-  before_filter :find_provider, :only => [:products_repos, :show, :edit, :update, :destroy, :import_progress]
+  before_filter :find_provider, :only => [:products_repos, :show, :edit, :update, :destroy, :manifest_progress]
   before_filter :authorize #after find_provider
   before_filter :panel_options, :only => [:index, :items]
   before_filter :search_filter, :only => [:auto_complete_search]
@@ -44,7 +44,7 @@ class ProvidersController < ApplicationController
       :update => edit_test,
       :destroy => delete_test,
       :products_repos => read_test,
-      :import_progress => edit_test,
+      :manifest_progress => edit_test,
 
       :redhat_provider =>read_test,
     }
@@ -63,13 +63,13 @@ class ProvidersController < ApplicationController
                                          :repositories_cloned_in_envrs=>repositories_cloned_in_envrs}
   end
 
-  def import_progress
-    expire_page :action => :import_progress
+  def manifest_progress
+    expire_page :action => :manifest_progress
     # "finished" is checked for in the javascript to see if polling for task progress should be done
-    if @provider.import_task.nil?
+    if @provider.manifest_task.nil?
       to_ret = {'state' => 'finished'}
     else
-      to_ret = @provider.import_task.to_json
+      to_ret = @provider.manifest_task.to_json
     end
 
     # Never cache these results since the user may close and re-open the "new" panel and no status would

--- a/src/app/models/async_orchestration.rb
+++ b/src/app/models/async_orchestration.rb
@@ -19,12 +19,15 @@ module AsyncOrchestration
       raise ArgumentError, "Please pass in organization to which the sync job belongs to" unless options.has_key?(:organization)
       @organization = options.delete(:organization)
 
+      @task_type = options.delete(:task_type)
+
       @options = options
     end
 
     # under 1.9.3 ActiveSupport::BasicObject inherits from ::BasicObject, which is outside of standard library namespace.
     def method_missing(method, *args)
-      t = ::TaskStatus.create!(:uuid => ::UUIDTools::UUID.random_create.to_s, :user_id=>::User.current.id, :organization => @organization, :state => ::TaskStatus::Status::WAITING)
+      t = ::TaskStatus.create!(:uuid => ::UUIDTools::UUID.random_create.to_s, :user_id=>::User.current.id,
+                               :organization => @organization, :state => ::TaskStatus::Status::WAITING, :task_type => @task_type)
       ::Delayed::Job.enqueue({:payload_object => ::AsyncOperation.new(t.id, ::User.current.username, @target, method.to_sym, args)}.merge(@options))
       t
     end

--- a/src/app/models/provider.rb
+++ b/src/app/models/provider.rb
@@ -240,7 +240,7 @@ class Provider < ActiveRecord::Base
     Repository.joins(:environment_product => :product).where("products.provider_id" => self.id)
   end
 
-  def import_task
+  def manifest_task
     return task_status
   end
 

--- a/src/app/views/subscriptions/_new.html.haml
+++ b/src/app/views/subscriptions/_new.html.haml
@@ -31,49 +31,64 @@
           .grid_6.la.fl
             = subscriptions_manifest_link_helper({'webAppPrefix'=>@details[:webAppPrefix], 'upstreamId'=>@details['upstreamUuid']}, @details['upstreamUuid'])
         - if @provider.editable? && !AppConfig.katello?
-          = form_for @provider, :html => {:method => :post, :id => :delete_manifest}, :remote => true, :url => delete_manifest_subscriptions_path do |f|
-            %fieldset
-              .grid_3.ra.fieldset
-                &nbsp;
-              .grid_6.la#delete_button
-                = f.submit _("Delete Manifest"), :id => :delete_form_button, :confirm => _("Deleting a manifest " + |
-                      "will permanently remove all current subscriptions. All systems consuming these subscriptions " + |
-                      "have them removed. Do you wish to proceed with removing this manifest?") |
+          - if !@provider.manifest_task || @provider.manifest_task.finished?
+            = form_for @provider, :html => {:method => :post, :id => :delete_manifest}, :remote => true, :url => delete_manifest_subscriptions_path do |f|
+              %fieldset
+                .grid_3.ra.fieldset
+                  &nbsp;
+                .grid_6.la#delete_button
+                  = f.submit _("Delete Manifest"), :id => :delete_form_button, :confirm => _("Deleting a manifest " + |
+                        "will permanently remove all current subscriptions. All systems consuming these subscriptions " + |
+                        "have them removed. Do you wish to proceed with removing this manifest?") |
+          - elsif @provider.manifest_task && !@provider.manifest_task.finished? && @provider.manifest_task.task_type == "delete manifest"
+            .grid_10
+              %fieldset
+                .grid_3.ra.fieldset
+                  &nbsp;
+                .grid_6.la
+                  .fl
+                    %div.manifest_progress{:provider_id=>@provider.id}
+                      = image_tag("embed/icons/spinner.gif", {:class=>"fl"})
+                      .fl.manifest_progress_message
+                        = _("Delete in progress (%s)") % @provider.manifest_task.state
     .clear
     - if @provider.editable?
-      .grid_10
-        %h5 #{_("Upload New Manifest")}
-      - if @provider.import_task && !@provider.import_task.finished?
-        .grid_10
-          %fieldset
-            .grid_2.ra.fieldset
-              =label :upload, :upload, _("Manifest File")
-            .grid_8.la
-              .fl
-                %div.import_progress{:provider_id=>@provider.id}
-                  = image_tag("embed/icons/spinner.gif", {:class=>"fl"})
-                  .fl.import_progress_message
-                    = _("Import in progress (%s)") % @provider.import_task.state
-      - else
-        = form_for @provider, :html => {:multipart => true, :method => :post, :id => :upload_manifest}, :remote => true, :url => upload_subscriptions_path do |f|
+      - if @provider.manifest_task && !@provider.manifest_task.finished?
+        - if @provider.manifest_task.task_type == "import manifest"
+          .grid_10
+            %h5 #{_("Upload New Manifest")}
           .grid_10
             %fieldset
-              .grid_3.ra.fieldset
+              .grid_2.ra.fieldset
                 =label :upload, :upload, _("Manifest File")
-              .grid_6.la
-                = f.file_field :contents
-            %fieldset
-              .grid_3.ra.fieldset
-                &nbsp;
-              .grid_6.la#upload_button
-                = f.submit _("Upload"), :id => :upload_form_button
+              .grid_8.la
+                .fl
+                  %div.manifest_progress{:provider_id=>@provider.id}
+                    = image_tag("embed/icons/spinner.gif", {:class=>"fl"})
+                    .fl.manifest_progress_message
+                      = _("Import in progress (%s)") % @provider.manifest_task.state
+      - else
+        .grid_10
+          %h5 #{_("Upload New Manifest")}
+          = form_for @provider, :html => {:multipart => true, :method => :post, :id => :upload_manifest}, :remote => true, :url => upload_subscriptions_path do |f|
+            .grid_10
+              %fieldset
+                .grid_3.ra.fieldset
+                  =label :upload, :upload, _("Manifest File")
+                .grid_6.la
+                  = f.file_field :contents
+              %fieldset
+                .grid_3.ra.fieldset
+                  &nbsp;
+                .grid_6.la#upload_button
+                  = f.submit _("Upload"), :id => :upload_form_button
 
     .grid_10
-      %h5 #{_("Upload History")}
+      %h5 #{_("Manifest History")}
       %table
         %thead
           %th #{_("Message")}
-          %th #{_("Import Time")}
+          %th #{_("Time")}
         - if @statuses
           %tbody
             - @statuses[0..2].each do |status|

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -294,7 +294,7 @@ Src::Application.routes.draw do
     end
     member do
       get :products_repos
-      get :import_progress
+      get :manifest_progress
       get :schedule
     end
   end

--- a/src/public/javascripts/routes.js
+++ b/src/public/javascripts/routes.js
@@ -513,8 +513,8 @@
   return Utils.build_path(1, ["/api/organizations/new"], arguments)
   },
 // import_progress_provider => /providers/:id/import_progress(.:format)
-  import_progress_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/providers/", "/import_progress"], arguments)
+  manifest_progress_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/providers/", "/manifest_progress"], arguments)
   },
 // auto_complete_system_groups => /system_groups/auto_complete(.:format)
   auto_complete_system_groups_path: function(options) {

--- a/src/public/javascripts/subscription.js
+++ b/src/public/javascripts/subscription.js
@@ -13,17 +13,17 @@
 */
 
 KT.subscription = (function() {
-    var import_updater
+    var manifest_updater
 
     // Data that is unchanged from previous will come in as ""
     updateStatus = function(data) {
-        if (data !== "" && $('.import_progress_message')) {
-            $(".import_progress_message").html(i18n.import_in_progress(data["state"]));
+        if (data !== "" && $('.manifest_progress_message')) {
+            $(".manifest_progress_message").html(i18n.import_in_progress(data["state"]));
         }
         if (data !== "" && data["state"] !== "running" && data["state"] !== "waiting") {
             notices.checkNotices();
-            if (import_updater) {
-                import_updater.stop();
+            if (manifest_updater) {
+                manifest_updater.stop();
             }
 
             active = $('#new');
@@ -35,14 +35,14 @@ KT.subscription = (function() {
         var timeout = 6000,
             provider_id;
 
-        if (import_updater !== undefined) {
-            import_updater.stop();
+        if (manifest_updater !== undefined) {
+            manifest_updater.stop();
         }
 
-        // When the import progress element is present, start the polling for success
-        provider_id = $('.import_progress').attr("provider_id");
+        // When the manifest progress element is present, start the polling for success
+        provider_id = $('.manifest_progress').attr("provider_id");
         if (provider_id) {
-            import_updater = $.PeriodicalUpdater(KT.common.rootURL()+'providers/'+provider_id+'/import_progress/', {
+            manifest_updater = $.PeriodicalUpdater(KT.common.rootURL()+'providers/'+provider_id+'/manifest_progress/', {
                 method: 'get',
                 type: 'json',
                 cache: false,


### PR DESCRIPTION
Since manifest deletion is an async task in candlepin, wait for it in katello.
