### PR TITLE
Setting therubyracer version

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -123,7 +123,7 @@ group :jshintrb do
   #
   #needed for syntax checking
   gem 'libv8'
-  gem 'therubyracer'
+  gem 'therubyracer', "~> 0.10.2"
   gem 'jshintrb', '0.1.1'
 end
 


### PR DESCRIPTION
Setting therubyracer version as older versions don't seem to work with the v8 
rpm package on RHEL 6 and Fedora.
