### PR TITLE
make bundler happy

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -46,7 +46,7 @@ gem 'gettext_i18n_rails'
 gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
 
 # Reports
-gem 'ruport', '>=1.7.0', :git => 'https://github.com/ruport/ruport' 
+gem 'ruport', '>=1.7.0' #, :git => 'https://github.com/ruport/ruport' 
 gem 'prawn'
 gem 'acts_as_reportable', '>=1.1.1'
 


### PR DESCRIPTION
addressing:
rake aborted!
https://github.com/ruport/ruport (at master) is not checked out. Please run `bundle install`
/home/jenkins/workspace/katello-unit/src/config/boot.rb:8
/home/jenkins/workspace/katello-unit/src/config/application.rb:1
/home/jenkins/workspace/katello-unit/src/Rakefile:4
(See full trace by running task with --trace)
rake aborted!
https://github.com/ruport/ruport (at master) is not checked out. Please run `bundle install`
/home/jenkins/workspace/katello-unit/src/config/boot.rb:8
/home/jenkins/workspace/katello-unit/src/config/application.rb:1
/home/jenkins/workspace/katello-unit/src/Rakefile:4
(See full trace by running task with --trace)
rake aborted!
https://github.com/ruport/ruport (at master) is not checked out. Please run `bundle install`
/home/jenkins/workspace/katello-unit/src/config/boot.rb:8
/home/jenkins/workspace/katello-unit/src/config/application.rb:1
/home/jenkins/workspace/katello-unit/src/Rakefile:4
(See full trace by running task with --trace)
rake aborted!
https://github.com/ruport/ruport (at master) is not checked out. Please run `bundle install`
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/source.rb:801:in `load_spec_files'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/source.rb:381:in`local_specs'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/source.rb:774:in `specs'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/lazy_specification.rb:53:in`**materialize**'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/spec_set.rb:86:in `materialize'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/spec_set.rb:83:in`map!'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/spec_set.rb:83:in `materialize'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/definition.rb:113:in`specs'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/definition.rb:158:in `specs_for'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/definition.rb:147:in`requested_specs'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/environment.rb:23:in `requested_specs'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler/runtime.rb:11:in`setup'
/usr/lib/ruby/gems/1.8/gems/bundler-1.2.1/lib/bundler.rb:116:in `setup'
/home/jenkins/workspace/katello-unit/src/config/boot.rb:8
/usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in`gem_original_require'
/usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
/home/jenkins/workspace/katello-unit/src/config/application.rb:1
/usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in`gem_original_require'
/usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
/home/jenkins/workspace/katello-unit/src/Rakefile:4
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/rake_module.rb:25:in`load'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/rake_module.rb:25:in `load_rakefile'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/application.rb:580:in`raw_load_rakefile'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/application.rb:86:in `load_rakefile'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/application.rb:157:in`standard_exception_handling'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/application.rb:85:in `load_rakefile'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/application.rb:69:in`run'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/application.rb:157:in `standard_exception_handling'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/lib/rake/application.rb:67:in`run'
/usr/lib/ruby/gems/1.8/gems/rake-10.0.0/bin/rake:37
/usr/bin/rake:19:in `load'
/usr/bin/rake:19
Build step 'Execute shell' marked build as failure
