### PR TITLE
Gemfile - Fixes reference to Ruport git.

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -46,7 +46,7 @@ gem 'gettext_i18n_rails'
 gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
 
 # Reports
-gem 'ruport', '>=1.7.0', :git => 'https://github.com/ruport/ruport' 
+gem 'ruport', '>=1.7.0', :git => 'git://github.com/ruport/ruport.git'
 gem 'prawn'
 gem 'acts_as_reportable', '>=1.1.1'
 


### PR DESCRIPTION
This fixes the reference to the Ruport git link to fix bundle installs and being able to run in development mode.
