### PR TITLE
content views - ui - initial CRUD support for name/label/description

### DIFF
--- a/src/app/controllers/content_view_definitions_controller.rb
+++ b/src/app/controllers/content_view_definitions_controller.rb
@@ -1,0 +1,141 @@
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+class ContentViewDefinitionsController < ApplicationController
+
+  before_filter :require_user
+  before_filter :find_content_view_definition, :only => [:show, :edit, :update, :destroy]
+  before_filter :authorize #after find_content_view_definition, since the definition is required for authorization
+  before_filter :panel_options, :only => [:index, :items]
+
+  respond_to :html, :js
+
+  def section_id
+    'contents'
+  end
+
+  def rules
+    read_test = lambda{current_organization && ContentViewDefinition.any_readable?(current_organization)}
+    manage_test = lambda{true}  # TODO: update w/ correct permissions
+    {
+      :index => read_test,
+      :items => read_test,
+      :show => read_test,
+
+      :new => manage_test,
+      :create => manage_test,
+
+      :edit => read_test,
+      :update => manage_test,
+
+      :destroy => manage_test,
+
+      :default_label => manage_test
+    }
+  end
+
+  def param_rules
+    {
+      :create => {:view_definition => [:name, :label, :description]},
+      :update => {:view_definition => [:name, :description]}
+    }
+  end
+
+  def items
+    render_panel_direct(ContentViewDefinition, @panel_options, params[:search], params[:offset], [:name_sort, 'asc'],
+        {:default_field => :name, :filter=>{:organization_id=>[current_organization.id]}})
+  end
+
+  def show
+    render :partial=>"common/list_update", :locals=>{:item=>@view_definition, :accessor=>"id", :columns=>['name']}
+  end
+
+  def new
+    render :partial => "new", :layout => "tupane_layout"
+  end
+
+  def create
+    @view_definition = ContentViewDefinition.create!(params[:content_view_definition]) do |cv|
+      cv.organization = current_organization
+    end
+    notify.success _("Content view definition '%s' was created.") % @view_definition['name']
+
+    if search_validate(ContentViewDefinition, @view_definition.id, params[:search])
+      render :partial=>"common/list_item", :locals=>{:item=>@view_definition, :accessor=>"id", :columns=>['name'], :name=>controller_display_name}
+    else
+      notify.message _("'%s' did not meet the current search criteria and is not being shown.") % @view_definition["name"]
+      render :json => { :no_match => true }
+    end
+  end
+
+  def edit
+    render :partial => "edit", :layout => "tupane_layout", :locals => {:view_definition => @view_definition,
+                                                                       :editable => @view_definition.editable?,
+                                                                       :name => controller_display_name}
+  end
+
+  def update
+    result = params[:view_definition].nil? ? "" : params[:view_definition].values.first
+
+    unless params[:view_definition][:description].nil?
+      result = params[:view_definition][:description] = params[:view_definition][:description].gsub("\n",'')
+    end
+
+    @view_definition.update_attributes!(params[:view_definition])
+
+    notify.success _("Content view definition '%s' was updated.") % @view_definition["name"]
+
+    if not search_validate(ContentViewDefinition, @view_definition.id, params[:search])
+      notify.message _("'%s' no longer matches the current search criteria.") % @view_definition["name"]
+    end
+
+    render :text => escape_html(result)
+  end
+
+  def destroy
+    if @view_definition.destroy
+      notify.success _("Content view definition '%s' was deleted.") % @view_definition[:name]
+      render :partial => "common/list_remove", :locals => {:id=>params[:id], :name=>controller_display_name}
+    end
+  end
+
+  protected
+
+  def find_content_view_definition
+    @view_definition = ContentViewDefinition.find(params[:id])
+  end
+
+  def panel_options
+    @panel_options = { 
+      :title => _('Content View Definitions'),
+      :col => ['name'],
+      :titles => [_('Name')],
+      :create => _('Key'),
+      :create_label => _('+ New View Definition'),
+      :name => controller_display_name,
+      :ajax_load  => true,
+      :ajax_scroll => items_content_view_definitions_path(),
+      :enable_create => ContentViewDefinition.creatable?(current_organization),
+      :search_class => ContentViewDefinition}
+  end
+
+  private
+
+  def controller_display_name
+    return 'content_view_definition'
+  end
+
+  def search_filter
+    @filter = {:organization_id => current_organization}
+  end
+
+end

--- a/src/app/models/content_view_definition.rb
+++ b/src/app/models/content_view_definition.rb
@@ -13,6 +13,7 @@
 require 'util/model_util.rb'
 
 class ContentViewDefinition < ActiveRecord::Base
+  include Glue::ElasticSearch::ContentViewDefinition if AppConfig.use_elasticsearch
   include Katello::LabelFromName
   include Authorization::ContentViewDefinition
 

--- a/src/app/models/glue/elastic_search/content_view_definition.rb
+++ b/src/app/models/glue/elastic_search/content_view_definition.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+module Glue::ElasticSearch::ContentViewDefinition
+  def self.included(base)
+    base.send :include, IndexedModel
+
+    base.class_eval do
+      index_options :extended_json => :extended_index_attrs, :display_attrs => [:name, :description]
+
+      mapping do
+        indexes :name, :type => 'string', :analyzer => :kt_name_analyzer
+        indexes :name_sort, :type => 'string', :index => :not_analyzed
+      end
+    end
+  end
+
+  def extended_index_attrs
+    {:name_sort => name.downcase}
+  end
+
+end

--- a/src/app/views/content_view_definitions/_edit.html.haml
+++ b/src/app/views/content_view_definitions/_edit.html.haml
@@ -1,0 +1,30 @@
+= javascript :edit_helpers
+
+= content_for :title do
+  #{view_definition.name}
+
+= content_for :remove_item do
+  - if editable
+    = link_to _("Remove"), content_view_definition_path(view_definition.id), :confirm => _('Are you sure?'), :method => :delete, :class=>"remove_item", :remote=>true
+
+= content_for :navigation do
+  = render_menu(1..2, content_view_definition_navigation)
+
+= content_for :content do
+  %input#panel_element_id{:name => view_definition.id, :type => "hidden", :value => "#{name}_#{view_definition.id}", "data-ajax_url"=>content_view_definition_path(view_definition.id)}
+
+  .grid_10#view_definition
+    %fieldset
+      .grid_2.ra
+        %label #{_("Name")}:
+      .grid_7.la{'name' => 'view_definition[name]', :class => ("editable edit_panel_element" if editable), 'data-url' => content_view_definition_path(view_definition.id)} #{view_definition[:name]}
+
+    %fieldset
+      .grid_2.ra
+        %label #{_("Label")}:
+      .grid_7.la #{view_definition.label}
+
+    %fieldset
+      .grid_2.ra
+        %label #{_("Description")}:
+      .grid_7.la{:style => "word-wrap: break-word;", 'name' => 'view_definition[description]', :class => ("editable edit_textarea" if editable), 'data-url' => content_view_definition_path(view_definition.id)}<> #{view_definition[:description]}

--- a/src/app/views/content_view_definitions/_new.html.haml
+++ b/src/app/views/content_view_definitions/_new.html.haml
@@ -1,0 +1,17 @@
+= content_for :title do
+  #{_("New View Definition")}
+
+= content_for :content do
+  .clear
+    &nbsp;
+  = kt_form_for ContentViewDefinition.new do |form|
+
+    = form.text_field :name, :label => _("Name"), :class => :name_input
+
+    = form.field :label, :label => _("Label") do
+      = text_field_tag 'content_view_definition[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_content_view_definitions_path
+      = image_tag "embed/icons/spinner.gif", :class => 'label_spinner hidden'
+
+    = form.text_area :description, :size => "40x5", :label => _("Description")
+
+    = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'create_button'

--- a/src/app/views/content_view_definitions/index.html.haml
+++ b/src/app/views/content_view_definitions/index.html.haml
@@ -1,0 +1,10 @@
+.grid_16#main
+  = two_panel(@view_definitions, @panel_options)
+
+= javascript :content_view_definition
+
+= javascript do
+  :plain
+    localize({
+    });
+

--- a/src/config/assets.yml
+++ b/src/config/assets.yml
@@ -65,6 +65,8 @@ javascripts:
     - public/javascripts/converge-ui/vendor/jquery/plugins/jquery.treeTable.js
     - public/javascripts/content.js
     - public/javascripts/converge-ui/vendor/jquery/plugins/jquery.periodicalupdater.js
+  content_view_definition:
+    - public/javascripts/content_view_definition.js
   dashboard:
     - public/javascripts/converge-ui/vendor/jquery/plugins/flot-0.7/jquery.flot.js
     - public/javascripts/converge-ui/vendor/jquery/plugins/flot-0.7/jquery.flot.pie.js

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -54,6 +54,13 @@ Src::Application.routes.draw do
       end
   end
 
+  resources :content_view_definitions do
+    collection do
+      get :default_label
+      get :items
+    end
+  end
+
   resources :activation_keys do
     collection do
       get :auto_complete_search

--- a/src/lib/navigation/content_management.rb
+++ b/src/lib/navigation/content_management.rb
@@ -13,6 +13,7 @@ module Navigation
   module ContentMenu
     def self.included(base)
       base.class_eval do
+        helper_method :content_view_definition_navigation
         helper_method :custom_provider_navigation
         helper_method :activation_keys_navigation
         helper_method :promotion_packages_navigation
@@ -23,6 +24,17 @@ module Navigation
         helper_method :subscriptions_navigation
         helper_method :new_subscription_navigation
       end
+    end
+
+    def content_view_definition_navigation
+      [
+        { :key => :edit_view_definition,
+          :name =>_("Details"),
+          :url => (@view_definition.nil? || @view_definition.new_record?) ? "" : edit_content_view_definition_path(@view_definition.id),
+          :if => lambda{!@view_definition.nil? && @view_definition.readable? && !@view_definition.new_record?},
+          :options => {:class=>"panel_link"}
+        }
+      ]
     end
 
     def custom_provider_navigation
@@ -88,8 +100,10 @@ module Navigation
         :url => :sub_level,
         :options => {:class=>'content top_level', "data-menu"=>"content"},
         :if => lambda{current_organization},
-        :items=> AppConfig.katello? ? [ menu_subscriptions, menu_providers, menu_sync_management, menu_content_search, menu_system_templates, menu_changeset_management] :
-            [ menu_subscriptions, menu_system_templates]
+        :items=> AppConfig.katello? ?
+            [menu_subscriptions, menu_providers, menu_sync_management, menu_content_search,
+             menu_content_view_definitions, menu_system_templates, menu_changeset_management] :
+            [menu_subscriptions, menu_system_templates]
       }
     end
 
@@ -101,7 +115,6 @@ module Navigation
        :options => {:class=>'content second_level menu_parent', "data-menu"=>"content", "data-dropdown"=>"repositories"},
        :items => [menu_custom_providers, menu_redhat_providers, menu_filters, menu_gpg]
       }
-
     end
 
     def menu_redhat_providers
@@ -140,6 +153,14 @@ module Navigation
       }
     end
 
+    def menu_content_view_definitions
+      {:key => :content_view_definitions,
+       :name => _("Content View Definitions"),
+       :if => lambda{AppConfig.katello? && ContentViewDefinition.any_readable?(current_organization)},
+       :options => {:class=>'content second_level', "data-menu"=>"content"},
+       :url =>content_view_definitions_path,
+      }
+    end
 
     def menu_sync_status
       {:key => :sync_status,
@@ -148,7 +169,6 @@ module Navigation
         :options => {:class=>"third_level", "data-dropdown"=>"sync"}
       }
     end
-
 
     def menu_sync_plan
       {:key => :sync_plans,

--- a/src/public/javascripts/content_view_definition.js
+++ b/src/public/javascripts/content_view_definition.js
@@ -1,0 +1,18 @@
+/**
+ Copyright 2011 Red Hat, Inc.
+
+ This software is licensed to you under the GNU General Public
+ License as published by the Free Software Foundation; either version
+ 2 of the License (GPLv2) or (at your option) any later version.
+ There is NO WARRANTY for this software, express or implied,
+ including the implied warranties of MERCHANTABILITY,
+ NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ have received a copy of GPLv2 along with this software; if not, see
+ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+*/
+
+KT.panel.list.registerPage('content_view_definitions', { create : 'new_content_view_definition' });
+
+KT.panel.set_expand_cb(function() {
+    KT.object.label.initialize();
+});

--- a/src/public/javascripts/routes.js
+++ b/src/public/javascripts/routes.js
@@ -84,121 +84,637 @@
   };
 
   window.KT.routes = {
-// repositories_api_environment_product => /api/environments/:environment_id/products/:id/repositories(.:format)
-  repositories_api_environment_product_path: function(_environment_id, _id, options) {
-  return Utils.build_path(3, ["/api/environments/", "/products/", "/repositories"], arguments)
+// gpg_keys => /gpg_keys(.:format)
+  gpg_keys_path: function(options) {
+  return Utils.build_path(1, ["/gpg_keys"], arguments)
   },
-// content_api_gpg_key => /api/gpg_keys/:id/content(.:format)
-  content_api_gpg_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/gpg_keys/", "/content"], arguments)
+// system_event => /systems/:system_id/events/:id(.:format)
+  system_event_path: function(_system_id, _id, options) {
+  return Utils.build_path(3, ["/systems/", "/events/"], arguments)
+  },
+// copy_system_group => /system_groups/:id/copy(.:format)
+  copy_system_group_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/copy"], arguments)
+  },
+// edit_api_activation_key => /api/activation_keys/:id/edit(.:format)
+  edit_api_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/activation_keys/", "/edit"], arguments)
+  },
+// status_system_system_packages => /systems/:system_id/system_packages/status(.:format)
+  status_system_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/system_packages/status"], arguments)
+  },
+// consumers_subscription => /subscriptions/:id/consumers(.:format)
+  consumers_subscription_path: function(_id, options) {
+  return Utils.build_path(2, ["/subscriptions/", "/consumers"], arguments)
+  },
+// products_organization_environment => /organizations/:organization_id/environments/:id/products(.:format)
+  products_organization_environment_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/organizations/", "/environments/", "/products"], arguments)
+  },
+// auto_complete_library_packages => /packages/auto_complete_library(.:format)
+  auto_complete_library_packages_path: function(options) {
+  return Utils.build_path(1, ["/packages/auto_complete_library"], arguments)
+  },
+// new_content_view_definition => /content_view_definitions/new(.:format)
+  new_content_view_definition_path: function(options) {
+  return Utils.build_path(1, ["/content_view_definitions/new"], arguments)
+  },
+// edit_system => /systems/:id/edit(.:format)
+  edit_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/edit"], arguments)
+  },
+// new_system_template => /system_templates/new(.:format)
+  new_system_template_path: function(options) {
+  return Utils.build_path(1, ["/system_templates/new"], arguments)
+  },
+// sync_management_manage => /sync_management/manage(.:format)
+  sync_management_manage_path: function(options) {
+  return Utils.build_path(1, ["/sync_management/manage"], arguments)
+  },
+// system_groups_system => /systems/:id/system_groups(.:format)
+  system_groups_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/system_groups"], arguments)
+  },
+// edit_api_role => /api/roles/:id/edit(.:format)
+  edit_api_role_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/roles/", "/edit"], arguments)
+  },
+// environments_systems => /systems/environments(.:format)
+  environments_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/environments"], arguments)
+  },
+// bulk_content_remove_systems => /systems/bulk_content_remove(.:format)
+  bulk_content_remove_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/bulk_content_remove"], arguments)
+  },
+// organization_environment => /organizations/:organization_id/environments/:id(.:format)
+  organization_environment_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/organizations/", "/environments/"], arguments)
+  },
+// auto_complete_search_sync_plans => /sync_plans/auto_complete_search(.:format)
+  auto_complete_search_sync_plans_path: function(options) {
+  return Utils.build_path(1, ["/sync_plans/auto_complete_search"], arguments)
+  },
+// activation_key => /activation_keys/:id(.:format)
+  activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/"], arguments)
+  },
+// owners => /owners(.:format)
+  owners_path: function(options) {
+  return Utils.build_path(1, ["/owners"], arguments)
+  },
+// items_activation_keys => /activation_keys/items(.:format)
+  items_activation_keys_path: function(options) {
+  return Utils.build_path(1, ["/activation_keys/items"], arguments)
+  },
+// default_label_provider_products => /providers/:provider_id/products/default_label(.:format)
+  default_label_provider_products_path: function(_provider_id, options) {
+  return Utils.build_path(2, ["/providers/", "/products/default_label"], arguments)
+  },
+// promotion => /promotions/:id(.:format)
+  promotion_path: function(_id, options) {
+  return Utils.build_path(2, ["/promotions/"], arguments)
+  },
+// remove_packages_filter => /filters/:id/remove_packages(.:format)
+  remove_packages_filter_path: function(_id, options) {
+  return Utils.build_path(2, ["/filters/", "/remove_packages"], arguments)
+  },
+// password_resets => /password_resets(.:format)
+  password_resets_path: function(options) {
+  return Utils.build_path(1, ["/password_resets"], arguments)
+  },
+// report_api_organization_systems => /api/organizations/:organization_id/systems/report(.:format)
+  report_api_organization_systems_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/api/organizations/", "/systems/report"], arguments)
+  },
+// provider_product_repository => /providers/:provider_id/products/:product_id/repositories/:id(.:format)
+  provider_product_repository_path: function(_provider_id, _product_id, _id, options) {
+  return Utils.build_path(4, ["/providers/", "/products/", "/repositories/"], arguments)
+  },
+// set_org_user_session => /user_session/set_org(.:format)
+  set_org_user_session_path: function(options) {
+  return Utils.build_path(1, ["/user_session/set_org"], arguments)
+  },
+// system_group_errata => /system_groups/:system_group_id/errata(.:format)
+  system_group_errata_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/errata"], arguments)
+  },
+// product_create_api_provider => /api/providers/:id/product_create(.:format)
+  product_create_api_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/providers/", "/product_create"], arguments)
+  },
+// redhat_provider_providers => /providers/redhat_provider(.:format)
+  redhat_provider_providers_path: function(options) {
+  return Utils.build_path(1, ["/providers/redhat_provider"], arguments)
+  },
+// destroy_systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/destroy_systems(.:format)
+  destroy_systems_api_organization_system_group_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/destroy_systems"], arguments)
+  },
+// import_api_templates => /api/templates/import(.:format)
+  import_api_templates_path: function(options) {
+  return Utils.build_path(1, ["/api/templates/import"], arguments)
+  },
+// systems => /systems(.:format)
+  systems_path: function(options) {
+  return Utils.build_path(1, ["/systems"], arguments)
+  },
+// edit_sync_plan => /sync_plans/:id/edit(.:format)
+  edit_sync_plan_path: function(_id, options) {
+  return Utils.build_path(2, ["/sync_plans/", "/edit"], arguments)
+  },
+// edit_api_template_product => /api/templates/:template_id/products/:id/edit(.:format)
+  edit_api_template_product_path: function(_template_id, _id, options) {
+  return Utils.build_path(3, ["/api/templates/", "/products/", "/edit"], arguments)
+  },
+// new_api_organization => /api/organizations/new(.:format)
+  new_api_organization_path: function(options) {
+  return Utils.build_path(1, ["/api/organizations/new"], arguments)
+  },
+// edit_system_group => /system_groups/:id/edit(.:format)
+  edit_system_group_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/edit"], arguments)
+  },
+// auto_complete_search_changesets => /changesets/auto_complete_search(.:format)
+  auto_complete_search_changesets_path: function(options) {
+  return Utils.build_path(1, ["/changesets/auto_complete_search"], arguments)
+  },
+// apply_api_changeset => /api/changesets/:id/apply(.:format)
+  apply_api_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/apply"], arguments)
+  },
+// errata_items_content_search_index => /content_search/errata_items(.:format)
+  errata_items_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/errata_items"], arguments)
+  },
+// edit_user_session => /user_session/edit(.:format)
+  edit_user_session_path: function(options) {
+  return Utils.build_path(1, ["/user_session/edit"], arguments)
+  },
+// edit_api_template_package_group => /api/templates/:template_id/package_groups/:id/edit(.:format)
+  edit_api_template_package_group_path: function(_template_id, _id, options) {
+  return Utils.build_path(3, ["/api/templates/", "/package_groups/", "/edit"], arguments)
+  },
+// new_owner => /owners/new(.:format)
+  new_owner_path: function(options) {
+  return Utils.build_path(1, ["/owners/new"], arguments)
+  },
+// remove_system_groups_activation_key => /activation_keys/:id/remove_system_groups(.:format)
+  remove_system_groups_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/remove_system_groups"], arguments)
+  },
+// content_search_index => /content_search(.:format)
+  content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search"], arguments)
+  },
+// products => /products(.:format)
+  products_path: function(options) {
+  return Utils.build_path(1, ["/products"], arguments)
+  },
+// new_api_changeset_erratum => /api/changesets/:changeset_id/errata/new(.:format)
+  new_api_changeset_erratum_path: function(_changeset_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/errata/new"], arguments)
+  },
+// create_role_ldap_groups => /roles/:role_id/ldap_groups(.:format)
+  create_role_ldap_groups_path: function(_role_id, options) {
+  return Utils.build_path(2, ["/roles/", "/ldap_groups"], arguments)
   },
 // edit_api_template_repository => /api/templates/:template_id/repositories/:id/edit(.:format)
   edit_api_template_repository_path: function(_template_id, _id, options) {
   return Utils.build_path(3, ["/api/templates/", "/repositories/", "/edit"], arguments)
   },
-// clear_helptips_user => /users/:id/clear_helptips(.:format)
-  clear_helptips_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/", "/clear_helptips"], arguments)
+// filelist_repository_distribution => /repositories/:repository_id/distributions/:id/filelist(.:format)
+  filelist_repository_distribution_path: function(_repository_id, _id, options) {
+  return Utils.build_path(3, ["/repositories/", "/distributions/", "/filelist"], arguments)
   },
-// items_gpg_keys => /gpg_keys/items(.:format)
-  items_gpg_keys_path: function(options) {
-  return Utils.build_path(1, ["/gpg_keys/items"], arguments)
-  },
-// new_system => /systems/new(.:format)
-  new_system_path: function(options) {
-  return Utils.build_path(1, ["/systems/new"], arguments)
-  },
-// provider => /providers/:id(.:format)
-  provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/providers/"], arguments)
+// promotions_dashboard_index => /dashboard/promotions(.:format)
+  promotions_dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard/promotions"], arguments)
   },
 // sync_plan_api_organization_product => /api/organizations/:organization_id/products/:id/sync_plan(.:format)
   sync_plan_api_organization_product_path: function(_organization_id, _id, options) {
   return Utils.build_path(3, ["/api/organizations/", "/products/", "/sync_plan"], arguments)
   },
-// edit_repository => /repositories/:id/edit(.:format)
-  edit_repository_path: function(_id, options) {
-  return Utils.build_path(2, ["/repositories/", "/edit"], arguments)
+// subscription => /subscriptions/:id(.:format)
+  subscription_path: function(_id, options) {
+  return Utils.build_path(2, ["/subscriptions/"], arguments)
   },
-// allowed_orgs_user_session => /user_session/allowed_orgs(.:format)
-  allowed_orgs_user_session_path: function(options) {
-  return Utils.build_path(1, ["/user_session/allowed_orgs"], arguments)
+// new_api_changeset_template => /api/changesets/:changeset_id/templates/new(.:format)
+  new_api_changeset_template_path: function(_changeset_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/templates/new"], arguments)
   },
-// systems_dashboard_index => /dashboard/systems(.:format)
-  systems_dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard/systems"], arguments)
+// more_events_system_events => /systems/:system_id/events/more_events(.:format)
+  more_events_system_events_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/events/more_events"], arguments)
   },
 // history_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/history(.:format)
   history_api_organization_system_group_path: function(_organization_id, _id, options) {
   return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/history"], arguments)
   },
-// auto_complete_products => /products/auto_complete(.:format)
-  auto_complete_products_path: function(options) {
-  return Utils.build_path(1, ["/products/auto_complete"], arguments)
+// auto_complete_search_gpg_keys => /gpg_keys/auto_complete_search(.:format)
+  auto_complete_search_gpg_keys_path: function(options) {
+  return Utils.build_path(1, ["/gpg_keys/auto_complete_search"], arguments)
   },
-// items_system_events => /systems/:system_id/events/items(.:format)
-  items_system_events_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/events/items"], arguments)
+// items_users => /users/items(.:format)
+  items_users_path: function(options) {
+  return Utils.build_path(1, ["/users/items"], arguments)
   },
-// errata_content_search_index => /content_search/errata(.:format)
-  errata_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/errata"], arguments)
+// download_debug_certificate_organization => /organizations/:id/download_debug_certificate(.:format)
+  download_debug_certificate_organization_path: function(_id, options) {
+  return Utils.build_path(2, ["/organizations/", "/download_debug_certificate"], arguments)
   },
-// edit_organization_environment => /organizations/:organization_id/environments/:id/edit(.:format)
-  edit_organization_environment_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/organizations/", "/environments/", "/edit"], arguments)
+// default_label_content_view_definitions => /content_view_definitions/default_label(.:format)
+  default_label_content_view_definitions_path: function(options) {
+  return Utils.build_path(1, ["/content_view_definitions/default_label"], arguments)
   },
-// repo_packages_content_search_index => /content_search/repo_packages(.:format)
-  repo_packages_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/repo_packages"], arguments)
+// packages_api_system => /api/systems/:id/packages(.:format)
+  packages_api_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/packages"], arguments)
   },
-// system_groups_api_system => /api/systems/:id/system_groups(.:format)
-  system_groups_api_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/system_groups"], arguments)
+// validate_system_template => /system_templates/:id/validate(.:format)
+  validate_system_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_templates/", "/validate"], arguments)
   },
-// subscription => /subscriptions/:id(.:format)
-  subscription_path: function(_id, options) {
-  return Utils.build_path(2, ["/subscriptions/"], arguments)
+// system_group_event => /system_groups/:system_group_id/events/:id(.:format)
+  system_group_event_path: function(_system_group_id, _id, options) {
+  return Utils.build_path(3, ["/system_groups/", "/events/"], arguments)
   },
-// edit_content_search => /content_search/:id/edit(.:format)
-  edit_content_search_path: function(_id, options) {
-  return Utils.build_path(2, ["/content_search/", "/edit"], arguments)
+// update_preference_user => /users/:id/update_preference(.:format)
+  update_preference_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/update_preference"], arguments)
   },
-// changeset => /changesets/:id(.:format)
-  changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/changesets/"], arguments)
+// enable_api_repository => /api/repositories/:id/enable(.:format)
+  enable_api_repository_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/repositories/", "/enable"], arguments)
   },
-// new_environment => /environments/new(.:format)
-  new_environment_path: function(options) {
-  return Utils.build_path(1, ["/environments/new"], arguments)
+// edit_repository => /repositories/:id/edit(.:format)
+  edit_repository_path: function(_id, options) {
+  return Utils.build_path(2, ["/repositories/", "/edit"], arguments)
+  },
+// owner => /owners/:id(.:format)
+  owner_path: function(_id, options) {
+  return Utils.build_path(2, ["/owners/"], arguments)
+  },
+// changesets => /changesets(.:format)
+  changesets_path: function(options) {
+  return Utils.build_path(1, ["/changesets"], arguments)
+  },
+// repositories_api_environment_product => /api/environments/:environment_id/products/:id/repositories(.:format)
+  repositories_api_environment_product_path: function(_environment_id, _id, options) {
+  return Utils.build_path(3, ["/api/environments/", "/products/", "/repositories"], arguments)
   },
 // roles => /roles(.:format)
   roles_path: function(options) {
   return Utils.build_path(1, ["/roles"], arguments)
   },
-// filter => /filters/:id(.:format)
-  filter_path: function(_id, options) {
-  return Utils.build_path(2, ["/filters/"], arguments)
+// content_view_definition => /content_view_definitions/:id(.:format)
+  content_view_definition_path: function(_id, options) {
+  return Utils.build_path(2, ["/content_view_definitions/"], arguments)
   },
-// remove_system_system_packages => /systems/:system_id/system_packages/remove(.:format)
-  remove_system_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/system_packages/remove"], arguments)
+// content_api_gpg_key => /api/gpg_keys/:id/content(.:format)
+  content_api_gpg_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/gpg_keys/", "/content"], arguments)
+  },
+// add_system_system_packages => /systems/:system_id/system_packages/add(.:format)
+  add_system_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/system_packages/add"], arguments)
+  },
+// systems_system_group => /system_groups/:id/systems(.:format)
+  systems_system_group_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/systems"], arguments)
+  },
+// users => /users(.:format)
+  users_path: function(options) {
+  return Utils.build_path(1, ["/users"], arguments)
   },
 // notices_auto_complete_search => /notices/auto_complete_search(.:format)
   notices_auto_complete_search_path: function(options) {
   return Utils.build_path(1, ["/notices/auto_complete_search"], arguments)
   },
-// install_system_errata => /systems/:system_id/errata/install(.:format)
-  install_system_errata_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/errata/install"], arguments)
+// apply_api_organization_system_info_keys => /api/organizations/:organization_id/system_info_keys/apply(.:format)
+  apply_api_organization_system_info_keys_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/api/organizations/", "/system_info_keys/apply"], arguments)
+  },
+// items_system_errata => /systems/:system_id/errata/items(.:format)
+  items_system_errata_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/errata/items"], arguments)
   },
 // items_subscriptions => /subscriptions/items(.:format)
   items_subscriptions_path: function(options) {
   return Utils.build_path(1, ["/subscriptions/items"], arguments)
   },
-// edit_organization => /organizations/:id/edit(.:format)
-  edit_organization_path: function(_id, options) {
-  return Utils.build_path(2, ["/organizations/", "/edit"], arguments)
+// auto_complete_nvrea_library_packages => /packages/auto_complete_nvrea_library(.:format)
+  auto_complete_nvrea_library_packages_path: function(options) {
+  return Utils.build_path(1, ["/packages/auto_complete_nvrea_library"], arguments)
+  },
+// edit_content_view_definition => /content_view_definitions/:id/edit(.:format)
+  edit_content_view_definition_path: function(_id, options) {
+  return Utils.build_path(2, ["/content_view_definitions/", "/edit"], arguments)
+  },
+// subscriptions_system => /systems/:id/subscriptions(.:format)
+  subscriptions_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/subscriptions"], arguments)
+  },
+// edit_system_template => /system_templates/:id/edit(.:format)
+  edit_system_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_templates/", "/edit"], arguments)
+  },
+// status_system_group_packages => /system_groups/:system_group_id/packages/status(.:format)
+  status_system_group_packages_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/packages/status"], arguments)
+  },
+// add_system_groups_system => /systems/:id/add_system_groups(.:format)
+  add_system_groups_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/add_system_groups"], arguments)
+  },
+// bulk_destroy_systems => /systems/bulk_destroy(.:format)
+  bulk_destroy_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/bulk_destroy"], arguments)
+  },
+// role_create_permission => /roles/:role_id/create_permission(.:format)
+  role_create_permission_path: function(_role_id, options) {
+  return Utils.build_path(2, ["/roles/", "/create_permission"], arguments)
+  },
+// bulk_errata_install_systems => /systems/bulk_errata_install(.:format)
+  bulk_errata_install_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/bulk_errata_install"], arguments)
+  },
+// product_comps_system_templates => /system_templates/product_comps(.:format)
+  product_comps_system_templates_path: function(options) {
+  return Utils.build_path(1, ["/system_templates/product_comps"], arguments)
+  },
+// items_sync_plans => /sync_plans/items(.:format)
+  items_sync_plans_path: function(options) {
+  return Utils.build_path(1, ["/sync_plans/items"], arguments)
+  },
+// sync_plans => /sync_plans(.:format)
+  sync_plans_path: function(options) {
+  return Utils.build_path(1, ["/sync_plans"], arguments)
+  },
+// changeset => /changesets/:id(.:format)
+  changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/changesets/"], arguments)
+  },
+// auto_complete_search_filters => /filters/auto_complete_search(.:format)
+  auto_complete_search_filters_path: function(options) {
+  return Utils.build_path(1, ["/filters/auto_complete_search"], arguments)
+  },
+// sync_schedules_apply => /sync_schedules/apply(.:format)
+  sync_schedules_apply_path: function(options) {
+  return Utils.build_path(1, ["/sync_schedules/apply"], arguments)
+  },
+// subscriptions_activation_keys => /activation_keys/subscriptions(.:format)
+  subscriptions_activation_keys_path: function(options) {
+  return Utils.build_path(1, ["/activation_keys/subscriptions"], arguments)
+  },
+// default_label_provider_product_repositories => /providers/:provider_id/products/:product_id/repositories/default_label(.:format)
+  default_label_provider_product_repositories_path: function(_provider_id, _product_id, options) {
+  return Utils.build_path(3, ["/providers/", "/products/", "/repositories/default_label"], arguments)
+  },
+// tasks_api_organization_systems => /api/organizations/:organization_id/systems/tasks(.:format)
+  tasks_api_organization_systems_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/api/organizations/", "/systems/tasks"], arguments)
+  },
+// products_filter => /filters/:id/products(.:format)
+  products_filter_path: function(_id, options) {
+  return Utils.build_path(2, ["/filters/", "/products"], arguments)
+  },
+// sync_management_product_status => /sync_management/product_status(.:format)
+  sync_management_product_status_path: function(options) {
+  return Utils.build_path(1, ["/sync_management/product_status"], arguments)
+  },
+// import_owner => /owners/:id/import(.:format)
+  import_owner_path: function(_id, options) {
+  return Utils.build_path(2, ["/owners/", "/import"], arguments)
+  },
+// provider_products => /providers/:provider_id/products(.:format)
+  provider_products_path: function(_provider_id, options) {
+  return Utils.build_path(2, ["/providers/", "/products"], arguments)
+  },
+// products_api_provider => /api/providers/:id/products(.:format)
+  products_api_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/providers/", "/products"], arguments)
+  },
+// products_repos_provider => /providers/:id/products_repos(.:format)
+  products_repos_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/providers/", "/products_repos"], arguments)
+  },
+// repositories_api_organization_environment => /api/organizations/:organization_id/environments/:id/repositories(.:format)
+  repositories_api_organization_environment_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/environments/", "/repositories"], arguments)
+  },
+// export_api_template => /api/templates/:id/export(.:format)
+  export_api_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/export"], arguments)
+  },
+// operations => /operations(.:format)
+  operations_path: function(options) {
+  return Utils.build_path(1, ["/operations"], arguments)
+  },
+// name_changeset => /changesets/:id/name(.:format)
+  name_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/changesets/", "/name"], arguments)
+  },
+// edit_api_organization => /api/organizations/:id/edit(.:format)
+  edit_api_organization_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/organizations/", "/edit"], arguments)
+  },
+// system_group => /system_groups/:id(.:format)
+  system_group_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_groups/"], arguments)
+  },
+// destroy_favorite_search_index => /search/favorite/:id(.:format)
+  destroy_favorite_search_index_path: function(_id, options) {
+  return Utils.build_path(2, ["/search/favorite/"], arguments)
+  },
+// repositories => /repositories(.:format)
+  repositories_path: function(options) {
+  return Utils.build_path(1, ["/repositories"], arguments)
+  },
+// provider => /providers/:id(.:format)
+  provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/providers/"], arguments)
+  },
+// list_changesets => /changesets/list(.:format)
+  list_changesets_path: function(options) {
+  return Utils.build_path(1, ["/changesets/list"], arguments)
+  },
+// system => /systems/:id(.:format)
+  system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/"], arguments)
+  },
+// new_api_template_parameter => /api/templates/:template_id/parameters/new(.:format)
+  new_api_template_parameter_path: function(_template_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/parameters/new"], arguments)
+  },
+// organizations => /organizations(.:format)
+  organizations_path: function(options) {
+  return Utils.build_path(1, ["/organizations"], arguments)
+  },
+// dependencies_api_changeset => /api/changesets/:id/dependencies(.:format)
+  dependencies_api_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/dependencies"], arguments)
+  },
+// repos_content_search_index => /content_search/repos(.:format)
+  repos_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/repos"], arguments)
+  },
+// edit_owner => /owners/:id/edit(.:format)
+  edit_owner_path: function(_id, options) {
+  return Utils.build_path(2, ["/owners/", "/edit"], arguments)
+  },
+// sync_plan => /sync_plans/:id(.:format)
+  sync_plan_path: function(_id, options) {
+  return Utils.build_path(2, ["/sync_plans/"], arguments)
+  },
+// package => /packages/:id(.:format)
+  package_path: function(_id, options) {
+  return Utils.build_path(2, ["/packages/"], arguments)
+  },
+// new_system => /systems/new(.:format)
+  new_system_path: function(options) {
+  return Utils.build_path(1, ["/systems/new"], arguments)
+  },
+// new_content_search => /content_search/new(.:format)
+  new_content_search_path: function(options) {
+  return Utils.build_path(1, ["/content_search/new"], arguments)
+  },
+// promotion_details_system_template => /system_templates/:id/promotion_details(.:format)
+  promotion_details_system_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_templates/", "/promotion_details"], arguments)
+  },
+// new_api_template_distribution => /api/templates/:template_id/distributions/new(.:format)
+  new_api_template_distribution_path: function(_template_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/distributions/new"], arguments)
+  },
+// edit_api_changeset_erratum => /api/changesets/:changeset_id/errata/:id/edit(.:format)
+  edit_api_changeset_erratum_path: function(_changeset_id, _id, options) {
+  return Utils.build_path(3, ["/api/changesets/", "/errata/", "/edit"], arguments)
+  },
+// repository_distribution => /repositories/:repository_id/distributions/:id(.:format)
+  repository_distribution_path: function(_repository_id, _id, options) {
+  return Utils.build_path(3, ["/repositories/", "/distributions/"], arguments)
+  },
+// products_promotion => /promotions/:id/products(.:format)
+  products_promotion_path: function(_id, options) {
+  return Utils.build_path(2, ["/promotions/", "/products"], arguments)
+  },
+// systems_dashboard_index => /dashboard/systems(.:format)
+  systems_dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard/systems"], arguments)
+  },
+// organization => /organizations/:id(.:format)
+  organization_path: function(_id, options) {
+  return Utils.build_path(2, ["/organizations/"], arguments)
+  },
+// edit_api_changeset_template => /api/changesets/:changeset_id/templates/:id/edit(.:format)
+  edit_api_changeset_template_path: function(_changeset_id, _id, options) {
+  return Utils.build_path(3, ["/api/changesets/", "/templates/", "/edit"], arguments)
+  },
+// auto_complete_search_organizations => /organizations/auto_complete_search(.:format)
+  auto_complete_search_organizations_path: function(options) {
+  return Utils.build_path(1, ["/organizations/auto_complete_search"], arguments)
+  },
+// items_system_events => /systems/:system_id/events/items(.:format)
+  items_system_events_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/events/items"], arguments)
+  },
+// new_api_repository_package => /api/repositories/:repository_id/packages/new(.:format)
+  new_api_repository_package_path: function(_repository_id, options) {
+  return Utils.build_path(2, ["/api/repositories/", "/packages/new"], arguments)
+  },
+// default_label_organization_environments => /organizations/:organization_id/environments/default_label(.:format)
+  default_label_organization_environments_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/organizations/", "/environments/default_label"], arguments)
+  },
+// items_gpg_keys => /gpg_keys/items(.:format)
+  items_gpg_keys_path: function(options) {
+  return Utils.build_path(1, ["/gpg_keys/items"], arguments)
+  },
+// show_user_session => /user_session(.:format)
+  show_user_session_path: function(options) {
+  return Utils.build_path(1, ["/user_session"], arguments)
+  },
+// enable_helptip_users => /users/enable_helptip(.:format)
+  enable_helptip_users_path: function(options) {
+  return Utils.build_path(1, ["/users/enable_helptip"], arguments)
+  },
+// jammit => /assets/:package.:extension(.:format)
+  jammit_path: function(_package, _extension, options) {
+  return Utils.build_path(3, ["/assets/", "."], arguments)
+  },
+// auto_complete_library_repositories => /repositories/auto_complete_library(.:format)
+  auto_complete_library_repositories_path: function(options) {
+  return Utils.build_path(1, ["/repositories/auto_complete_library"], arguments)
+  },
+// items_content_view_definitions => /content_view_definitions/items(.:format)
+  items_content_view_definitions_path: function(options) {
+  return Utils.build_path(1, ["/content_view_definitions/items"], arguments)
+  },
+// errata_api_system => /api/systems/:id/errata(.:format)
+  errata_api_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/errata"], arguments)
+  },
+// update_content_system_template => /system_templates/:id/update_content(.:format)
+  update_content_system_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_templates/", "/update_content"], arguments)
+  },
+// add_system_group_packages => /system_groups/:system_group_id/packages/add(.:format)
+  add_system_group_packages_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/packages/add"], arguments)
+  },
+// setup_default_org_user => /users/:id/setup_default_org(.:format)
+  setup_default_org_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/setup_default_org"], arguments)
+  },
+// sync_complete_api_repositories => /api/repositories/sync_complete(.:format)
+  sync_complete_api_repositories_path: function(options) {
+  return Utils.build_path(1, ["/api/repositories/sync_complete"], arguments)
+  },
+// verbs_and_scopes => /roles/:organization_id/resource_type/verbs_and_scopes(.:format)
+  verbs_and_scopes_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/roles/", "/resource_type/verbs_and_scopes"], arguments)
+  },
+// discovery_api_organization_repositories => /api/organizations/:organization_id/repositories/discovery(.:format)
+  discovery_api_organization_repositories_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/api/organizations/", "/repositories/discovery"], arguments)
+  },
+// add_systems_system_group => /system_groups/:id/add_systems(.:format)
+  add_systems_system_group_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/add_systems"], arguments)
+  },
+// root => /(.:format)
+  root_path: function(options) {
+  return Utils.build_path(1, ["/"], arguments)
+  },
+// remove_system_system_packages => /systems/:system_id/system_packages/remove(.:format)
+  remove_system_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/system_packages/remove"], arguments)
+  },
+// auto_complete_search_system_templates => /system_templates/auto_complete_search(.:format)
+  auto_complete_search_system_templates_path: function(options) {
+  return Utils.build_path(1, ["/system_templates/auto_complete_search"], arguments)
+  },
+// upload_subscriptions => /subscriptions/upload(.:format)
+  upload_subscriptions_path: function(options) {
+  return Utils.build_path(1, ["/subscriptions/upload"], arguments)
+  },
+// install_system_errata => /systems/:system_id/errata/install(.:format)
+  install_system_errata_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/errata/install"], arguments)
+  },
+// new_api_user => /api/users/new(.:format)
+  new_api_user_path: function(options) {
+  return Utils.build_path(1, ["/api/users/new"], arguments)
+  },
+// activation_keys => /activation_keys(.:format)
+  activation_keys_path: function(options) {
+  return Utils.build_path(1, ["/activation_keys"], arguments)
+  },
+// new_user => /users/new(.:format)
+  new_user_path: function(options) {
+  return Utils.build_path(1, ["/users/new"], arguments)
   },
 // validate_name_library_packages => /packages/validate_name_library(.:format)
   validate_name_library_packages_path: function(options) {
@@ -208,1457 +724,1017 @@
   update_subscriptions_system_path: function(_id, options) {
   return Utils.build_path(2, ["/systems/", "/update_subscriptions"], arguments)
   },
-// auto_complete_search_providers => /providers/auto_complete_search(.:format)
-  auto_complete_search_providers_path: function(options) {
-  return Utils.build_path(1, ["/providers/auto_complete_search"], arguments)
-  },
-// status_system_group_events => /system_groups/:system_group_id/events/status(.:format)
-  status_system_group_events_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/events/status"], arguments)
-  },
-// object_changeset => /changesets/:id/object(.:format)
-  object_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/changesets/", "/object"], arguments)
-  },
-// jammit => /assets/:package.:extension(.:format)
-  jammit_path: function(_package, _extension, options) {
-  return Utils.build_path(3, ["/assets/", "."], arguments)
-  },
-// providers => /providers(.:format)
-  providers_path: function(options) {
-  return Utils.build_path(1, ["/providers"], arguments)
-  },
-// subscriptions_activation_keys => /activation_keys/subscriptions(.:format)
-  subscriptions_activation_keys_path: function(options) {
-  return Utils.build_path(1, ["/activation_keys/subscriptions"], arguments)
-  },
-// remove_system_groups_system => /systems/:id/remove_system_groups(.:format)
-  remove_system_groups_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/remove_system_groups"], arguments)
-  },
-// provider_products => /providers/:provider_id/products(.:format)
-  provider_products_path: function(_provider_id, options) {
-  return Utils.build_path(2, ["/providers/", "/products"], arguments)
-  },
-// remove_system_group_packages => /system_groups/:system_group_id/packages/remove(.:format)
-  remove_system_group_packages_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/packages/remove"], arguments)
-  },
-// add_packages_filter => /filters/:id/add_packages(.:format)
-  add_packages_filter_path: function(_id, options) {
-  return Utils.build_path(2, ["/filters/", "/add_packages"], arguments)
-  },
-// bulk_add_system_group_systems => /systems/bulk_add_system_group(.:format)
-  bulk_add_system_group_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/bulk_add_system_group"], arguments)
-  },
-// products_repos_provider => /providers/:id/products_repos(.:format)
-  products_repos_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/providers/", "/products_repos"], arguments)
-  },
-// show_user_session => /user_session(.:format)
-  show_user_session_path: function(options) {
-  return Utils.build_path(1, ["/user_session"], arguments)
-  },
-// dependencies_api_changeset => /api/changesets/:id/dependencies(.:format)
-  dependencies_api_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/dependencies"], arguments)
-  },
-// destroy_role_ldap_group => /roles/:role_id/ldap_groups/:id(.:format)
-  destroy_role_ldap_group_path: function(_role_id, _id, options) {
-  return Utils.build_path(3, ["/roles/", "/ldap_groups/"], arguments)
-  },
-// edit_api_activation_key => /api/activation_keys/:id/edit(.:format)
-  edit_api_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/activation_keys/", "/edit"], arguments)
-  },
-// edit_api_organization_sync_plan => /api/organizations/:organization_id/sync_plans/:id/edit(.:format)
-  edit_api_organization_sync_plan_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/sync_plans/", "/edit"], arguments)
-  },
-// system_events => /systems/:system_id/events(.:format)
-  system_events_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/events"], arguments)
-  },
-// remove_systems_system_group => /system_groups/:id/remove_systems(.:format)
-  remove_systems_system_group_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/remove_systems"], arguments)
-  },
-// edit_api_changeset_erratum => /api/changesets/:changeset_id/errata/:id/edit(.:format)
-  edit_api_changeset_erratum_path: function(_changeset_id, _id, options) {
-  return Utils.build_path(3, ["/api/changesets/", "/errata/", "/edit"], arguments)
-  },
-// sync_schedules_index => /sync_schedules/index(.:format)
-  sync_schedules_index_path: function(options) {
-  return Utils.build_path(1, ["/sync_schedules/index"], arguments)
-  },
-// sync_management_product_status => /sync_management/product_status(.:format)
-  sync_management_product_status_path: function(options) {
-  return Utils.build_path(1, ["/sync_management/product_status"], arguments)
-  },
-// environments_partial_organization => /organizations/:id/environments_partial(.:format)
-  environments_partial_organization_path: function(_id, options) {
-  return Utils.build_path(2, ["/organizations/", "/environments_partial"], arguments)
-  },
-// products_api_provider => /api/providers/:id/products(.:format)
-  products_api_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/providers/", "/products"], arguments)
-  },
-// install_system_group_errata => /system_groups/:system_group_id/errata/install(.:format)
-  install_system_group_errata_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/errata/install"], arguments)
-  },
-// edit_api_changeset_template => /api/changesets/:changeset_id/templates/:id/edit(.:format)
-  edit_api_changeset_template_path: function(_changeset_id, _id, options) {
-  return Utils.build_path(3, ["/api/changesets/", "/templates/", "/edit"], arguments)
-  },
-// environments => /environments(.:format)
-  environments_path: function(options) {
-  return Utils.build_path(1, ["/environments"], arguments)
-  },
-// export_api_template => /api/templates/:id/export(.:format)
-  export_api_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/export"], arguments)
-  },
-// repositories_api_organization_environment => /api/organizations/:organization_id/environments/:id/repositories(.:format)
-  repositories_api_organization_environment_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/environments/", "/repositories"], arguments)
-  },
-// new_api_repository_package => /api/repositories/:repository_id/packages/new(.:format)
-  new_api_repository_package_path: function(_repository_id, options) {
-  return Utils.build_path(2, ["/api/repositories/", "/packages/new"], arguments)
-  },
-// edit_role => /roles/:id/edit(.:format)
-  edit_role_path: function(_id, options) {
-  return Utils.build_path(2, ["/roles/", "/edit"], arguments)
-  },
-// repository_distribution => /repositories/:repository_id/distributions/:id(.:format)
-  repository_distribution_path: function(_repository_id, _id, options) {
-  return Utils.build_path(3, ["/repositories/", "/distributions/"], arguments)
-  },
-// system_groups => /system_groups(.:format)
-  system_groups_path: function(options) {
-  return Utils.build_path(1, ["/system_groups"], arguments)
-  },
-// edit_api_consumer => /api/consumers/:id/edit(.:format)
-  edit_api_consumer_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/consumers/", "/edit"], arguments)
-  },
-// new_api_template_parameter => /api/templates/:template_id/parameters/new(.:format)
-  new_api_template_parameter_path: function(_template_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/parameters/new"], arguments)
-  },
-// packages_erratum => /errata/:id/packages(.:format)
-  packages_erratum_path: function(_id, options) {
-  return Utils.build_path(2, ["/errata/", "/packages"], arguments)
-  },
-// owner => /owners/:id(.:format)
-  owner_path: function(_id, options) {
-  return Utils.build_path(2, ["/owners/"], arguments)
-  },
-// sync_complete_api_repositories => /api/repositories/sync_complete(.:format)
-  sync_complete_api_repositories_path: function(options) {
-  return Utils.build_path(1, ["/api/repositories/sync_complete"], arguments)
-  },
-// new_api_template_distribution => /api/templates/:template_id/distributions/new(.:format)
-  new_api_template_distribution_path: function(_template_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/distributions/new"], arguments)
-  },
-// products_organization_environment => /organizations/:organization_id/environments/:id/products(.:format)
-  products_organization_environment_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/organizations/", "/environments/", "/products"], arguments)
-  },
-// download_system_template => /system_templates/:id/download(.:format)
-  download_system_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_templates/", "/download"], arguments)
-  },
-// update_roles_user => /users/:id/update_roles(.:format)
-  update_roles_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/", "/update_roles"], arguments)
-  },
-// products_repos_gpg_key => /gpg_keys/:id/products_repos(.:format)
-  products_repos_gpg_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/gpg_keys/", "/products_repos"], arguments)
-  },
-// auto_complete_library_repositories => /repositories/auto_complete_library(.:format)
-  auto_complete_library_repositories_path: function(options) {
-  return Utils.build_path(1, ["/repositories/auto_complete_library"], arguments)
-  },
-// repository => /repositories/:id(.:format)
-  repository_path: function(_id, options) {
-  return Utils.build_path(2, ["/repositories/"], arguments)
-  },
-// system_groups_dashboard_index => /dashboard/system_groups(.:format)
-  system_groups_dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard/system_groups"], arguments)
-  },
-// products_content_search_index => /content_search/products(.:format)
-  products_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/products"], arguments)
-  },
-// packages_api_system => /api/systems/:id/packages(.:format)
-  packages_api_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/packages"], arguments)
-  },
-// organization_environment => /organizations/:organization_id/environments/:id(.:format)
-  organization_environment_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/organizations/", "/environments/"], arguments)
-  },
-// sync_management => /sync_management/:id(.:format)
-  sync_management_path: function(_id, options) {
-  return Utils.build_path(2, ["/sync_management/"], arguments)
-  },
-// repo_errata_content_search_index => /content_search/repo_errata(.:format)
-  repo_errata_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/repo_errata"], arguments)
-  },
-// new_system_template => /system_templates/new(.:format)
-  new_system_template_path: function(options) {
-  return Utils.build_path(1, ["/system_templates/new"], arguments)
-  },
-// gpg_key => /gpg_keys/:id(.:format)
-  gpg_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/gpg_keys/"], arguments)
-  },
-// set_org_user_session => /user_session/set_org(.:format)
-  set_org_user_session_path: function(options) {
-  return Utils.build_path(1, ["/user_session/set_org"], arguments)
-  },
-// system_system_packages => /systems/:system_id/system_packages(.:format)
-  system_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/system_packages"], arguments)
-  },
-// changelog_package => /packages/:id/changelog(.:format)
-  changelog_package_path: function(_id, options) {
-  return Utils.build_path(2, ["/packages/", "/changelog"], arguments)
-  },
-// status_system_errata => /systems/:system_id/errata/status(.:format)
-  status_system_errata_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/errata/status"], arguments)
-  },
-// gpg_keys => /gpg_keys(.:format)
-  gpg_keys_path: function(options) {
-  return Utils.build_path(1, ["/gpg_keys"], arguments)
-  },
-// upload_subscriptions => /subscriptions/upload(.:format)
-  upload_subscriptions_path: function(options) {
-  return Utils.build_path(1, ["/subscriptions/upload"], arguments)
-  },
-// delete_manifest_subscriptions => /subscriptions/delete_manifest(.:format)
-  delete_manifest_subscriptions_path: function(options) {
-  return Utils.build_path(1, ["/subscriptions/delete_manifest"], arguments)
-  },
-// auto_complete_search_changesets => /changesets/auto_complete_search(.:format)
-  auto_complete_search_changesets_path: function(options) {
-  return Utils.build_path(1, ["/changesets/auto_complete_search"], arguments)
-  },
-// products_system => /systems/:id/products(.:format)
-  products_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/products"], arguments)
-  },
-// update_repo_gpg_key_provider_product_repository => /providers/:provider_id/products/:product_id/repositories/:id/update_gpg_key(.:format)
-  update_repo_gpg_key_provider_product_repository_path: function(_provider_id, _product_id, _id, options) {
-  return Utils.build_path(4, ["/providers/", "/products/", "/repositories/", "/update_gpg_key"], arguments)
-  },
-// system_template => /system_templates/:id(.:format)
-  system_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_templates/"], arguments)
-  },
-// more_items_system_group_events => /system_groups/:system_group_id/events/more_items(.:format)
-  more_items_system_group_events_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/events/more_items"], arguments)
-  },
-// enable_repo => /repositories/:id/enable_repo(.:format)
-  enable_repo_path: function(_id, options) {
-  return Utils.build_path(2, ["/repositories/", "/enable_repo"], arguments)
-  },
-// applied_subscriptions_activation_key => /activation_keys/:id/applied_subscriptions(.:format)
-  applied_subscriptions_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/applied_subscriptions"], arguments)
-  },
-// auto_complete_systems => /systems/auto_complete(.:format)
-  auto_complete_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/auto_complete"], arguments)
-  },
-// discovery_api_organization_repositories => /api/organizations/:organization_id/repositories/discovery(.:format)
-  discovery_api_organization_repositories_path: function(_organization_id, options) {
-  return Utils.build_path(2, ["/api/organizations/", "/repositories/discovery"], arguments)
-  },
-// new_provider_product => /providers/:provider_id/products/new(.:format)
-  new_provider_product_path: function(_provider_id, options) {
-  return Utils.build_path(2, ["/providers/", "/products/new"], arguments)
-  },
-// system => /systems/:id(.:format)
-  system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/"], arguments)
-  },
-// edit_user_session => /user_session/edit(.:format)
-  edit_user_session_path: function(options) {
-  return Utils.build_path(1, ["/user_session/edit"], arguments)
-  },
-// remove_packages_filter => /filters/:id/remove_packages(.:format)
-  remove_packages_filter_path: function(_id, options) {
-  return Utils.build_path(2, ["/filters/", "/remove_packages"], arguments)
-  },
-// notices_get_new => /notices/get_new(.:format)
-  notices_get_new_path: function(options) {
-  return Utils.build_path(1, ["/notices/get_new"], arguments)
-  },
-// bulk_remove_system_group_systems => /systems/bulk_remove_system_group(.:format)
-  bulk_remove_system_group_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/bulk_remove_system_group"], arguments)
-  },
-// new_api_organization => /api/organizations/new(.:format)
-  new_api_organization_path: function(options) {
-  return Utils.build_path(1, ["/api/organizations/new"], arguments)
-  },
-// import_progress_provider => /providers/:id/import_progress(.:format)
-  import_progress_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/providers/", "/import_progress"], arguments)
-  },
-// auto_complete_system_groups => /system_groups/auto_complete(.:format)
-  auto_complete_system_groups_path: function(options) {
-  return Utils.build_path(1, ["/system_groups/auto_complete"], arguments)
-  },
-// create_role_ldap_groups => /roles/:role_id/ldap_groups(.:format)
-  create_role_ldap_groups_path: function(_role_id, options) {
-  return Utils.build_path(2, ["/roles/", "/ldap_groups"], arguments)
-  },
-// new_api_organization_environment => /api/organizations/:organization_id/environments/new(.:format)
-  new_api_organization_environment_path: function(_organization_id, options) {
-  return Utils.build_path(2, ["/api/organizations/", "/environments/new"], arguments)
-  },
-// new_api_changeset_package => /api/changesets/:changeset_id/packages/new(.:format)
-  new_api_changeset_package_path: function(_changeset_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/packages/new"], arguments)
-  },
-// destroy_systems_system_group => /system_groups/:id/destroy_systems(.:format)
-  destroy_systems_system_group_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/destroy_systems"], arguments)
-  },
-// new_api_user_role => /api/users/:user_id/roles/new(.:format)
-  new_api_user_role_path: function(_user_id, options) {
-  return Utils.build_path(2, ["/api/users/", "/roles/new"], arguments)
-  },
-// system_templates => /system_templates(.:format)
-  system_templates_path: function(options) {
-  return Utils.build_path(1, ["/system_templates"], arguments)
-  },
-// available_verbs_api_roles => /api/roles/available_verbs(.:format)
-  available_verbs_api_roles_path: function(options) {
-  return Utils.build_path(1, ["/api/roles/available_verbs"], arguments)
-  },
-// new_api_changeset_distribution => /api/changesets/:changeset_id/distributions/new(.:format)
-  new_api_changeset_distribution_path: function(_changeset_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/distributions/new"], arguments)
-  },
-// new_api_organization_system_group_packages => /api/organizations/:organization_id/system_groups/:system_group_id/packages/new(.:format)
-  new_api_organization_system_group_packages_path: function(_organization_id, _system_group_id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/packages/new"], arguments)
-  },
-// events_organization => /organizations/:id/events(.:format)
-  events_organization_path: function(_id, options) {
-  return Utils.build_path(2, ["/organizations/", "/events"], arguments)
-  },
-// status_system_group_errata => /system_groups/:system_group_id/errata/status(.:format)
-  status_system_group_errata_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/errata/status"], arguments)
-  },
-// user_session_logout => /user_session/logout(.:format)
-  user_session_logout_path: function(options) {
-  return Utils.build_path(1, ["/user_session/logout"], arguments)
-  },
-// new_api_role => /api/roles/new(.:format)
-  new_api_role_path: function(options) {
-  return Utils.build_path(1, ["/api/roles/new"], arguments)
-  },
-// validate_api_template => /api/templates/:id/validate(.:format)
-  validate_api_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/validate"], arguments)
-  },
-// edit_api_repository_package => /api/repositories/:repository_id/packages/:id/edit(.:format)
-  edit_api_repository_package_path: function(_repository_id, _id, options) {
-  return Utils.build_path(3, ["/api/repositories/", "/packages/", "/edit"], arguments)
-  },
-// edit_api_template_parameter => /api/templates/:template_id/parameters/:id/edit(.:format)
-  edit_api_template_parameter_path: function(_template_id, _id, options) {
-  return Utils.build_path(3, ["/api/templates/", "/parameters/", "/edit"], arguments)
-  },
-// short_details_erratum => /errata/:id/short_details(.:format)
-  short_details_erratum_path: function(_id, options) {
-  return Utils.build_path(2, ["/errata/", "/short_details"], arguments)
-  },
-// packages_promotion => /promotions/:id/packages(.:format)
-  packages_promotion_path: function(_id, options) {
-  return Utils.build_path(2, ["/promotions/", "/packages"], arguments)
-  },
-// login => /login(.:format)
-  login_path: function(options) {
-  return Utils.build_path(1, ["/login"], arguments)
-  },
-// sync_management_sync_status => /sync_management/sync_status(.:format)
-  sync_management_sync_status_path: function(options) {
-  return Utils.build_path(1, ["/sync_management/sync_status"], arguments)
-  },
-// user_session => /user_session(.:format)
-  user_session_path: function(options) {
-  return Utils.build_path(1, ["/user_session"], arguments)
-  },
-// edit_password_reset => /password_resets/:id/edit(.:format)
-  edit_password_reset_path: function(_id, options) {
-  return Utils.build_path(2, ["/password_resets/", "/edit"], arguments)
-  },
-// edit_api_template_distribution => /api/templates/:template_id/distributions/:id/edit(.:format)
-  edit_api_template_distribution_path: function(_template_id, _id, options) {
-  return Utils.build_path(3, ["/api/templates/", "/distributions/", "/edit"], arguments)
-  },
-// root => /(.:format)
-  root_path: function(options) {
-  return Utils.build_path(1, ["/"], arguments)
-  },
-// auto_complete_search_users => /users/auto_complete_search(.:format)
-  auto_complete_search_users_path: function(options) {
-  return Utils.build_path(1, ["/users/auto_complete_search"], arguments)
-  },
-// pools_api_activation_key => /api/activation_keys/:id/pools(.:format)
-  pools_api_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/activation_keys/", "/pools"], arguments)
-  },
-// validate_system_template => /system_templates/:id/validate(.:format)
-  validate_system_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_templates/", "/validate"], arguments)
-  },
-// new_api_template => /api/templates/new(.:format)
-  new_api_template_path: function(options) {
-  return Utils.build_path(1, ["/api/templates/new"], arguments)
-  },
-// update_locale_user => /users/:id/update_locale(.:format)
-  update_locale_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/", "/update_locale"], arguments)
-  },
-// sync_dashboard_index => /dashboard/sync(.:format)
-  sync_dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard/sync"], arguments)
-  },
-// subscriptions_dashboard_index => /dashboard/subscriptions(.:format)
-  subscriptions_dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard/subscriptions"], arguments)
-  },
-// role_create_permission => /roles/:role_id/create_permission(.:format)
-  role_create_permission_path: function(_role_id, options) {
-  return Utils.build_path(2, ["/roles/", "/create_permission"], arguments)
-  },
-// packages_content_search_index => /content_search/packages(.:format)
-  packages_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/packages"], arguments)
-  },
-// errata_api_system => /api/systems/:id/errata(.:format)
-  errata_api_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/errata"], arguments)
-  },
-// content_search => /content_search/:id(.:format)
-  content_search_path: function(_id, options) {
-  return Utils.build_path(2, ["/content_search/"], arguments)
-  },
-// repo_compare_packages_content_search_index => /content_search/repo_compare_packages(.:format)
-  repo_compare_packages_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/repo_compare_packages"], arguments)
-  },
-// edit_system_template => /system_templates/:id/edit(.:format)
-  edit_system_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_templates/", "/edit"], arguments)
-  },
-// system_templates_promotion => /promotions/:id/system_templates(.:format)
-  system_templates_promotion_path: function(_id, options) {
-  return Utils.build_path(2, ["/promotions/", "/system_templates"], arguments)
-  },
-// user => /users/:id(.:format)
-  user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/"], arguments)
-  },
-// filters => /filters(.:format)
-  filters_path: function(options) {
-  return Utils.build_path(1, ["/filters"], arguments)
-  },
-// packages_system_system_packages => /systems/:system_id/system_packages/packages(.:format)
-  packages_system_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/system_packages/packages"], arguments)
-  },
-// product_comps_system_templates => /system_templates/product_comps(.:format)
-  product_comps_system_templates_path: function(options) {
-  return Utils.build_path(1, ["/system_templates/product_comps"], arguments)
-  },
-// history_subscriptions => /subscriptions/history(.:format)
-  history_subscriptions_path: function(options) {
-  return Utils.build_path(1, ["/subscriptions/history"], arguments)
-  },
-// name_changeset => /changesets/:id/name(.:format)
-  name_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/changesets/", "/name"], arguments)
-  },
-// new_gpg_key => /gpg_keys/new(.:format)
-  new_gpg_key_path: function(options) {
-  return Utils.build_path(1, ["/gpg_keys/new"], arguments)
-  },
-// filelist_package => /packages/:id/filelist(.:format)
-  filelist_package_path: function(_id, options) {
-  return Utils.build_path(2, ["/packages/", "/filelist"], arguments)
-  },
-// system_errata => /systems/:system_id/errata(.:format)
-  system_errata_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/errata"], arguments)
-  },
-// auto_complete_search_filters => /filters/auto_complete_search(.:format)
-  auto_complete_search_filters_path: function(options) {
-  return Utils.build_path(1, ["/filters/auto_complete_search"], arguments)
-  },
-// list_changesets => /changesets/list(.:format)
-  list_changesets_path: function(options) {
-  return Utils.build_path(1, ["/changesets/list"], arguments)
-  },
-// owners => /owners(.:format)
-  owners_path: function(options) {
-  return Utils.build_path(1, ["/owners"], arguments)
-  },
-// more_products_system => /systems/:id/more_products(.:format)
-  more_products_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/more_products"], arguments)
-  },
-// provider_product_repositories => /providers/:provider_id/products/:product_id/repositories(.:format)
-  provider_product_repositories_path: function(_provider_id, _product_id, options) {
-  return Utils.build_path(3, ["/providers/", "/products/", "/repositories"], arguments)
-  },
-// items_system_group_events => /system_groups/:system_group_id/events/items(.:format)
-  items_system_group_events_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/events/items"], arguments)
-  },
-// destroy_favorite_search_index => /search/favorite/:id(.:format)
-  destroy_favorite_search_index_path: function(_id, options) {
-  return Utils.build_path(2, ["/search/favorite/"], arguments)
-  },
-// products_filter => /filters/:id/products(.:format)
-  products_filter_path: function(_id, options) {
-  return Utils.build_path(2, ["/filters/", "/products"], arguments)
-  },
-// items_system_groups => /system_groups/items(.:format)
-  items_system_groups_path: function(options) {
-  return Utils.build_path(1, ["/system_groups/items"], arguments)
-  },
-// changesets => /changesets(.:format)
-  changesets_path: function(options) {
-  return Utils.build_path(1, ["/changesets"], arguments)
-  },
-// available_subscriptions_activation_key => /activation_keys/:id/available_subscriptions(.:format)
-  available_subscriptions_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/available_subscriptions"], arguments)
-  },
-// items_systems => /systems/items(.:format)
-  items_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/items"], arguments)
-  },
-// edit_provider_product => /providers/:provider_id/products/:id/edit(.:format)
-  edit_provider_product_path: function(_provider_id, _id, options) {
-  return Utils.build_path(3, ["/providers/", "/products/", "/edit"], arguments)
-  },
-// bulk_content_install_systems => /systems/bulk_content_install(.:format)
-  bulk_content_install_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/bulk_content_install"], arguments)
-  },
-// edit_api_organization => /api/organizations/:id/edit(.:format)
-  edit_api_organization_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/organizations/", "/edit"], arguments)
-  },
-// schedule_provider => /providers/:id/schedule(.:format)
-  schedule_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/providers/", "/schedule"], arguments)
-  },
-// edit_api_organization_environment => /api/organizations/:organization_id/environments/:id/edit(.:format)
-  edit_api_organization_environment_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/environments/", "/edit"], arguments)
-  },
-// validate_name_system_groups => /system_groups/validate_name(.:format)
-  validate_name_system_groups_path: function(options) {
-  return Utils.build_path(1, ["/system_groups/validate_name"], arguments)
-  },
-// edit_api_changeset_package => /api/changesets/:changeset_id/packages/:id/edit(.:format)
-  edit_api_changeset_package_path: function(_changeset_id, _id, options) {
-  return Utils.build_path(3, ["/api/changesets/", "/packages/", "/edit"], arguments)
-  },
-// edit_api_user_role => /api/users/:user_id/roles/:id/edit(.:format)
-  edit_api_user_role_path: function(_user_id, _id, options) {
-  return Utils.build_path(3, ["/api/users/", "/roles/", "/edit"], arguments)
-  },
-// add_systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/add_systems(.:format)
-  add_systems_api_organization_system_group_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/add_systems"], arguments)
-  },
-// distributions_promotion => /promotions/:id/distributions(.:format)
-  distributions_promotion_path: function(_id, options) {
-  return Utils.build_path(2, ["/promotions/", "/distributions"], arguments)
-  },
-// import_products_api_provider => /api/providers/:id/import_products(.:format)
-  import_products_api_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/providers/", "/import_products"], arguments)
-  },
-// edit_api_changeset_distribution => /api/changesets/:changeset_id/distributions/:id/edit(.:format)
-  edit_api_changeset_distribution_path: function(_changeset_id, _id, options) {
-  return Utils.build_path(3, ["/api/changesets/", "/distributions/", "/edit"], arguments)
-  },
-// edit_api_organization_system_group_packages => /api/organizations/:organization_id/system_groups/:system_group_id/packages/edit(.:format)
-  edit_api_organization_system_group_packages_path: function(_organization_id, _system_group_id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/packages/edit"], arguments)
-  },
-// notices_note_count => /notices/note_count(.:format)
-  notices_note_count_path: function(options) {
-  return Utils.build_path(1, ["/notices/note_count"], arguments)
-  },
-// new_owner => /owners/new(.:format)
-  new_owner_path: function(options) {
-  return Utils.build_path(1, ["/owners/new"], arguments)
-  },
-// download_debug_certificate_organization => /organizations/:id/download_debug_certificate(.:format)
-  download_debug_certificate_organization_path: function(_id, options) {
-  return Utils.build_path(2, ["/organizations/", "/download_debug_certificate"], arguments)
-  },
-// system_groups_activation_key => /activation_keys/:id/system_groups(.:format)
-  system_groups_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/system_groups"], arguments)
-  },
-// new_api_provider => /api/providers/new(.:format)
-  new_api_provider_path: function(options) {
-  return Utils.build_path(1, ["/api/providers/new"], arguments)
-  },
-// edit_api_role => /api/roles/:id/edit(.:format)
-  edit_api_role_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/roles/", "/edit"], arguments)
-  },
-// promotion_details_system_template => /system_templates/:id/promotion_details(.:format)
-  promotion_details_system_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_templates/", "/promotion_details"], arguments)
-  },
-// organization => /organizations/:id(.:format)
-  organization_path: function(_id, options) {
-  return Utils.build_path(2, ["/organizations/"], arguments)
-  },
-// verbs_and_scopes => /roles/:organization_id/resource_type/verbs_and_scopes(.:format)
-  verbs_and_scopes_path: function(_organization_id, options) {
-  return Utils.build_path(2, ["/roles/", "/resource_type/verbs_and_scopes"], arguments)
-  },
-// new_api_template_package => /api/templates/:template_id/packages/new(.:format)
-  new_api_template_package_path: function(_template_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/packages/new"], arguments)
-  },
-// package_groups_api_repository => /api/repositories/:id/package_groups(.:format)
-  package_groups_api_repository_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/repositories/", "/package_groups"], arguments)
-  },
-// edit_environment => /environments/:id/edit(.:format)
-  edit_environment_path: function(_id, options) {
-  return Utils.build_path(2, ["/environments/", "/edit"], arguments)
-  },
-// new_api_template_package_group_category => /api/templates/:template_id/package_group_categories/new(.:format)
-  new_api_template_package_group_category_path: function(_template_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/package_group_categories/new"], arguments)
-  },
-// new_activation_key => /activation_keys/new(.:format)
-  new_activation_key_path: function(options) {
-  return Utils.build_path(1, ["/activation_keys/new"], arguments)
-  },
-// new_provider => /providers/new(.:format)
-  new_provider_path: function(options) {
-  return Utils.build_path(1, ["/providers/new"], arguments)
-  },
-// password_reset => /password_resets/:id(.:format)
-  password_reset_path: function(_id, options) {
-  return Utils.build_path(2, ["/password_resets/"], arguments)
-  },
-// repositories => /repositories(.:format)
-  repositories_path: function(options) {
-  return Utils.build_path(1, ["/repositories"], arguments)
-  },
-// items_users => /users/items(.:format)
-  items_users_path: function(options) {
-  return Utils.build_path(1, ["/users/items"], arguments)
-  },
-// activation_keys => /activation_keys(.:format)
-  activation_keys_path: function(options) {
-  return Utils.build_path(1, ["/activation_keys"], arguments)
-  },
-// update_content_system_template => /system_templates/:id/update_content(.:format)
-  update_content_system_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_templates/", "/update_content"], arguments)
-  },
-// edit_api_template => /api/templates/:id/edit(.:format)
-  edit_api_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/edit"], arguments)
-  },
-// update_preference_user => /users/:id/update_preference(.:format)
-  update_preference_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/", "/update_preference"], arguments)
-  },
-// notices_dashboard_index => /dashboard/notices(.:format)
-  notices_dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard/notices"], arguments)
-  },
-// sync_management_sync => /sync_management/sync(.:format)
-  sync_management_sync_path: function(options) {
-  return Utils.build_path(1, ["/sync_management/sync"], arguments)
-  },
-// organizations => /organizations(.:format)
-  organizations_path: function(options) {
-  return Utils.build_path(1, ["/organizations"], arguments)
-  },
-// dashboard_index => /dashboard(.:format)
-  dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard"], arguments)
-  },
-// new_system_group => /system_groups/new(.:format)
-  new_system_group_path: function(options) {
-  return Utils.build_path(1, ["/system_groups/new"], arguments)
-  },
-// auto_complete_search_system_templates => /system_templates/auto_complete_search(.:format)
-  auto_complete_search_system_templates_path: function(options) {
-  return Utils.build_path(1, ["/system_templates/auto_complete_search"], arguments)
-  },
-// packages_items_content_search_index => /content_search/packages_items(.:format)
-  packages_items_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/packages_items"], arguments)
-  },
-// pools_api_system => /api/systems/:id/pools(.:format)
-  pools_api_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/pools"], arguments)
-  },
-// subscriptions => /subscriptions(.:format)
-  subscriptions_path: function(options) {
-  return Utils.build_path(1, ["/subscriptions"], arguments)
-  },
-// new_user => /users/new(.:format)
-  new_user_path: function(options) {
-  return Utils.build_path(1, ["/users/new"], arguments)
-  },
-// repo_compare_errata_content_search_index => /content_search/repo_compare_errata(.:format)
-  repo_compare_errata_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/repo_compare_errata"], arguments)
-  },
-// edit_subscription => /subscriptions/:id/edit(.:format)
-  edit_subscription_path: function(_id, options) {
-  return Utils.build_path(2, ["/subscriptions/", "/edit"], arguments)
-  },
-// more_packages_system_system_packages => /systems/:system_id/system_packages/more_packages(.:format)
-  more_packages_system_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/system_packages/more_packages"], arguments)
-  },
-// history_items_subscriptions => /subscriptions/history_items(.:format)
-  history_items_subscriptions_path: function(options) {
-  return Utils.build_path(1, ["/subscriptions/history_items"], arguments)
-  },
-// dependencies_changeset => /changesets/:id/dependencies(.:format)
-  dependencies_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/changesets/", "/dependencies"], arguments)
-  },
-// edit_gpg_key => /gpg_keys/:id/edit(.:format)
-  edit_gpg_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/gpg_keys/", "/edit"], arguments)
-  },
-// dependencies_package => /packages/:id/dependencies(.:format)
-  dependencies_package_path: function(_id, options) {
-  return Utils.build_path(2, ["/packages/", "/dependencies"], arguments)
-  },
-// sync_plans => /sync_plans(.:format)
-  sync_plans_path: function(options) {
-  return Utils.build_path(1, ["/sync_plans"], arguments)
-  },
-// system_erratum => /systems/:system_id/errata/:id(.:format)
-  system_erratum_path: function(_system_id, _id, options) {
-  return Utils.build_path(3, ["/systems/", "/errata/"], arguments)
-  },
-// new_provider_product_repository => /providers/:provider_id/products/:product_id/repositories/new(.:format)
-  new_provider_product_repository_path: function(_provider_id, _product_id, options) {
-  return Utils.build_path(3, ["/providers/", "/products/", "/repositories/new"], arguments)
-  },
-// system_group_events => /system_groups/:system_group_id/events(.:format)
-  system_group_events_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/events"], arguments)
-  },
-// auto_complete_products_repos_filters => /filters/auto_complete_products_repos(.:format)
-  auto_complete_products_repos_filters_path: function(options) {
-  return Utils.build_path(1, ["/filters/auto_complete_products_repos"], arguments)
-  },
-// items_changesets => /changesets/items(.:format)
-  items_changesets_path: function(options) {
-  return Utils.build_path(1, ["/changesets/items"], arguments)
-  },
-// facts_system => /systems/:id/facts(.:format)
-  facts_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/facts"], arguments)
-  },
-// update_products_filter => /filters/:id/update_products(.:format)
-  update_products_filter_path: function(_id, options) {
-  return Utils.build_path(2, ["/filters/", "/update_products"], arguments)
-  },
-// import_owner => /owners/:id/import(.:format)
-  import_owner_path: function(_id, options) {
-  return Utils.build_path(2, ["/owners/", "/import"], arguments)
-  },
-// remove_subscriptions_activation_key => /activation_keys/:id/remove_subscriptions(.:format)
-  remove_subscriptions_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/remove_subscriptions"], arguments)
-  },
-// env_items_systems => /systems/env_items(.:format)
-  env_items_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/env_items"], arguments)
-  },
-// provider_product => /providers/:provider_id/products/:id(.:format)
-  provider_product_path: function(_provider_id, _id, options) {
-  return Utils.build_path(3, ["/providers/", "/products/"], arguments)
-  },
-// role_permission_update => /roles/:role_id/permission/:permission_id/update_permission(.:format)
-  role_permission_update_path: function(_role_id, _permission_id, options) {
-  return Utils.build_path(3, ["/roles/", "/permission/", "/update_permission"], arguments)
-  },
-// system_group_errata => /system_groups/:system_group_id/errata(.:format)
-  system_group_errata_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/errata"], arguments)
-  },
-// bulk_content_update_systems => /systems/bulk_content_update(.:format)
-  bulk_content_update_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/bulk_content_update"], arguments)
-  },
-// new_api_changeset_product => /api/changesets/:changeset_id/products/new(.:format)
-  new_api_changeset_product_path: function(_changeset_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/products/new"], arguments)
-  },
-// copy_system_group => /system_groups/:id/copy(.:format)
-  copy_system_group_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/copy"], arguments)
-  },
-// report_api_users => /api/users/report(.:format)
-  report_api_users_path: function(options) {
-  return Utils.build_path(1, ["/api/users/report"], arguments)
-  },
-// new_api_system_packages => /api/systems/:system_id/packages/new(.:format)
-  new_api_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/packages/new"], arguments)
-  },
-// favorite_search_index => /search/favorite(.:format)
-  favorite_search_index_path: function(options) {
-  return Utils.build_path(1, ["/search/favorite"], arguments)
-  },
-// new_sync_plan => /sync_plans/new(.:format)
-  new_sync_plan_path: function(options) {
-  return Utils.build_path(1, ["/sync_plans/new"], arguments)
-  },
-// new_api_changeset_repository => /api/changesets/:changeset_id/repositories/new(.:format)
-  new_api_changeset_repository_path: function(_changeset_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/repositories/new"], arguments)
-  },
-// import_manifest_api_provider => /api/providers/:id/import_manifest(.:format)
-  import_manifest_api_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/providers/", "/import_manifest"], arguments)
-  },
-// copy_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/copy(.:format)
-  copy_api_organization_system_group_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/copy"], arguments)
-  },
-// promotions => /promotions(.:format)
-  promotions_path: function(options) {
-  return Utils.build_path(1, ["/promotions"], arguments)
-  },
-// add_system_groups_activation_key => /activation_keys/:id/add_system_groups(.:format)
-  add_system_groups_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/add_system_groups"], arguments)
-  },
-// edit_api_provider => /api/providers/:id/edit(.:format)
-  edit_api_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/providers/", "/edit"], arguments)
-  },
-// email_logins_password_resets => /password_resets/email_logins(.:format)
-  email_logins_password_resets_path: function(options) {
-  return Utils.build_path(1, ["/password_resets/email_logins"], arguments)
-  },
-// edit_owner => /owners/:id/edit(.:format)
-  edit_owner_path: function(_id, options) {
-  return Utils.build_path(2, ["/owners/", "/edit"], arguments)
-  },
-// system_templates_organization_environment => /organizations/:organization_id/environments/:id/system_templates(.:format)
-  system_templates_organization_environment_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/organizations/", "/environments/", "/system_templates"], arguments)
-  },
-// object_system_template => /system_templates/:id/object(.:format)
-  object_system_template_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_templates/", "/object"], arguments)
-  },
-// search_index => /search(.:format)
-  search_index_path: function(options) {
-  return Utils.build_path(1, ["/search"], arguments)
-  },
-// new_subscription => /subscriptions/new(.:format)
-  new_subscription_path: function(options) {
-  return Utils.build_path(1, ["/subscriptions/new"], arguments)
-  },
-// edit_api_template_package => /api/templates/:template_id/packages/:id/edit(.:format)
-  edit_api_template_package_path: function(_template_id, _id, options) {
-  return Utils.build_path(3, ["/api/templates/", "/packages/", "/edit"], arguments)
-  },
-// package_group_categories_api_repository => /api/repositories/:id/package_group_categories(.:format)
-  package_group_categories_api_repository_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/repositories/", "/package_group_categories"], arguments)
-  },
-// new_changeset => /changesets/new(.:format)
-  new_changeset_path: function(options) {
-  return Utils.build_path(1, ["/changesets/new"], arguments)
-  },
-// edit_api_template_package_group_category => /api/templates/:template_id/package_group_categories/:id/edit(.:format)
-  edit_api_template_package_group_category_path: function(_template_id, _id, options) {
-  return Utils.build_path(3, ["/api/templates/", "/package_group_categories/", "/edit"], arguments)
-  },
-// releases_api_environment => /api/environments/:id/releases(.:format)
-  releases_api_environment_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/environments/", "/releases"], arguments)
-  },
-// products => /products(.:format)
-  products_path: function(options) {
-  return Utils.build_path(1, ["/products"], arguments)
-  },
-// enable_helptip_users => /users/enable_helptip(.:format)
-  enable_helptip_users_path: function(options) {
-  return Utils.build_path(1, ["/users/enable_helptip"], arguments)
-  },
-// edit_activation_key => /activation_keys/:id/edit(.:format)
-  edit_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/edit"], arguments)
-  },
-// edit_provider => /providers/:id/edit(.:format)
-  edit_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/providers/", "/edit"], arguments)
-  },
-// users => /users(.:format)
-  users_path: function(options) {
-  return Utils.build_path(1, ["/users"], arguments)
-  },
-// edit_environment_user => /users/:id/edit_environment(.:format)
-  edit_environment_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/", "/edit_environment"], arguments)
-  },
-// errata_dashboard_index => /dashboard/errata(.:format)
-  errata_dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard/errata"], arguments)
-  },
-// status_system_events => /systems/:system_id/events/status(.:format)
-  status_system_events_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/events/status"], arguments)
-  },
-// organization_environments => /organizations/:organization_id/environments(.:format)
-  organization_environments_path: function(_organization_id, options) {
-  return Utils.build_path(2, ["/organizations/", "/environments"], arguments)
-  },
-// edit_system_group => /system_groups/:id/edit(.:format)
-  edit_system_group_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/edit"], arguments)
-  },
-// items_system_templates => /system_templates/items(.:format)
-  items_system_templates_path: function(options) {
-  return Utils.build_path(1, ["/system_templates/items"], arguments)
-  },
-// errata_items_content_search_index => /content_search/errata_items(.:format)
-  errata_items_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/errata_items"], arguments)
-  },
-// releases_api_system => /api/systems/:id/releases(.:format)
-  releases_api_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/releases"], arguments)
-  },
-// edit_user => /users/:id/edit(.:format)
-  edit_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/", "/edit"], arguments)
-  },
-// content_search_index => /content_search(.:format)
-  content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search"], arguments)
-  },
-// new_user_session => /user_session/new(.:format)
-  new_user_session_path: function(options) {
-  return Utils.build_path(1, ["/user_session/new"], arguments)
-  },
-// sync_management_index => /sync_management/index(.:format)
-  sync_management_index_path: function(options) {
-  return Utils.build_path(1, ["/sync_management/index"], arguments)
+// items_system_group_errata => /system_groups/:system_group_id/errata/items(.:format)
+  items_system_group_errata_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/errata/items"], arguments)
   },
 // new_product => /products/new(.:format)
   new_product_path: function(options) {
   return Utils.build_path(1, ["/products/new"], arguments)
   },
-// rails_info_properties => /rails/info/properties(.:format)
-  rails_info_properties_path: function(options) {
-  return Utils.build_path(1, ["/rails/info/properties"], arguments)
-  },
-// system_event => /systems/:system_id/events/:id(.:format)
-  system_event_path: function(_system_id, _id, options) {
-  return Utils.build_path(3, ["/systems/", "/events/"], arguments)
-  },
-// status_system_system_packages => /systems/:system_id/system_packages/status(.:format)
-  status_system_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/system_packages/status"], arguments)
-  },
-// operations => /operations(.:format)
-  operations_path: function(options) {
-  return Utils.build_path(1, ["/operations"], arguments)
-  },
-// products_subscription => /subscriptions/:id/products(.:format)
-  products_subscription_path: function(_id, options) {
-  return Utils.build_path(2, ["/subscriptions/", "/products"], arguments)
-  },
-// edit_system => /systems/:id/edit(.:format)
-  edit_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/edit"], arguments)
-  },
-// apply_changeset => /changesets/:id/apply(.:format)
-  apply_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/changesets/", "/apply"], arguments)
-  },
-// auto_complete_search_sync_plans => /sync_plans/auto_complete_search(.:format)
-  auto_complete_search_sync_plans_path: function(options) {
-  return Utils.build_path(1, ["/sync_plans/auto_complete_search"], arguments)
-  },
-// auto_complete_library_packages => /packages/auto_complete_library(.:format)
-  auto_complete_library_packages_path: function(options) {
-  return Utils.build_path(1, ["/packages/auto_complete_library"], arguments)
-  },
-// system_groups_system => /systems/:id/system_groups(.:format)
-  system_groups_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/system_groups"], arguments)
-  },
-// edit_provider_product_repository => /providers/:provider_id/products/:product_id/repositories/:id/edit(.:format)
-  edit_provider_product_repository_path: function(_provider_id, _product_id, _id, options) {
-  return Utils.build_path(4, ["/providers/", "/products/", "/repositories/", "/edit"], arguments)
-  },
-// system_group_event => /system_groups/:system_group_id/events/:id(.:format)
-  system_group_event_path: function(_system_group_id, _id, options) {
-  return Utils.build_path(3, ["/system_groups/", "/events/"], arguments)
-  },
-// items_filters => /filters/items(.:format)
-  items_filters_path: function(options) {
-  return Utils.build_path(1, ["/filters/items"], arguments)
-  },
-// product => /products/:id(.:format)
-  product_path: function(_id, options) {
-  return Utils.build_path(2, ["/products/"], arguments)
-  },
-// auto_complete_search_activation_keys => /activation_keys/auto_complete_search(.:format)
-  auto_complete_search_activation_keys_path: function(options) {
-  return Utils.build_path(1, ["/activation_keys/auto_complete_search"], arguments)
-  },
-// environments_systems => /systems/environments(.:format)
-  environments_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/environments"], arguments)
-  },
-// items_providers => /providers/items(.:format)
-  items_providers_path: function(options) {
-  return Utils.build_path(1, ["/providers/items"], arguments)
-  },
-// environment => /environments/:id(.:format)
-  environment_path: function(_id, options) {
-  return Utils.build_path(2, ["/environments/"], arguments)
-  },
-// import_status_owner => /owners/:id/import_status(.:format)
-  import_status_owner_path: function(_id, options) {
-  return Utils.build_path(2, ["/owners/", "/import_status"], arguments)
-  },
-// add_subscriptions_activation_key => /activation_keys/:id/add_subscriptions(.:format)
-  add_subscriptions_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/add_subscriptions"], arguments)
-  },
-// bulk_content_remove_systems => /systems/bulk_content_remove(.:format)
-  bulk_content_remove_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/bulk_content_remove"], arguments)
-  },
-// promote_api_changeset => /api/changesets/:id/promote(.:format)
-  promote_api_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/promote"], arguments)
-  },
-// auto_complete_search_roles => /roles/auto_complete_search(.:format)
-  auto_complete_search_roles_path: function(options) {
-  return Utils.build_path(1, ["/roles/auto_complete_search"], arguments)
-  },
-// edit_api_changeset_product => /api/changesets/:changeset_id/products/:id/edit(.:format)
-  edit_api_changeset_product_path: function(_changeset_id, _id, options) {
-  return Utils.build_path(3, ["/api/changesets/", "/products/", "/edit"], arguments)
-  },
-// systems_system_group => /system_groups/:id/systems(.:format)
-  systems_system_group_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/systems"], arguments)
-  },
-// sync_ldap_roles_api_users => /api/users/sync_ldap_roles(.:format)
-  sync_ldap_roles_api_users_path: function(options) {
-  return Utils.build_path(1, ["/api/users/sync_ldap_roles"], arguments)
-  },
-// products_promotion => /promotions/:id/products(.:format)
-  products_promotion_path: function(_id, options) {
-  return Utils.build_path(2, ["/promotions/", "/products"], arguments)
-  },
-// edit_api_system_packages => /api/systems/:system_id/packages/edit(.:format)
-  edit_api_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/packages/edit"], arguments)
-  },
-// report_api_organization_systems => /api/organizations/:organization_id/systems/report(.:format)
-  report_api_organization_systems_path: function(_organization_id, options) {
-  return Utils.build_path(2, ["/api/organizations/", "/systems/report"], arguments)
-  },
-// role => /roles/:id(.:format)
-  role_path: function(_id, options) {
-  return Utils.build_path(2, ["/roles/"], arguments)
-  },
-// edit_sync_plan => /sync_plans/:id/edit(.:format)
-  edit_sync_plan_path: function(_id, options) {
-  return Utils.build_path(2, ["/sync_plans/", "/edit"], arguments)
-  },
-// new_api_user => /api/users/new(.:format)
-  new_api_user_path: function(options) {
-  return Utils.build_path(1, ["/api/users/new"], arguments)
-  },
-// edit_api_changeset_repository => /api/changesets/:changeset_id/repositories/:id/edit(.:format)
-  edit_api_changeset_repository_path: function(_changeset_id, _id, options) {
-  return Utils.build_path(3, ["/api/changesets/", "/repositories/", "/edit"], arguments)
-  },
-// auto_complete_search_organizations => /organizations/auto_complete_search(.:format)
-  auto_complete_search_organizations_path: function(options) {
-  return Utils.build_path(1, ["/organizations/auto_complete_search"], arguments)
-  },
-// refresh_products_api_provider => /api/providers/:id/refresh_products(.:format)
-  refresh_products_api_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/providers/", "/refresh_products"], arguments)
-  },
-// status_system_group_packages => /system_groups/:system_group_id/packages/status(.:format)
-  status_system_group_packages_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/packages/status"], arguments)
-  },
-// remove_systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/remove_systems(.:format)
-  remove_systems_api_organization_system_group_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/remove_systems"], arguments)
-  },
-// sync_plan => /sync_plans/:id(.:format)
-  sync_plan_path: function(_id, options) {
-  return Utils.build_path(2, ["/sync_plans/"], arguments)
-  },
-// remove_system_groups_activation_key => /activation_keys/:id/remove_system_groups(.:format)
-  remove_system_groups_activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/", "/remove_system_groups"], arguments)
-  },
-// role_permission_destroy => /roles/:role_id/permission/:permission_id/destroy_permission(.:format)
-  role_permission_destroy_path: function(_role_id, _permission_id, options) {
-  return Utils.build_path(3, ["/roles/", "/permission/", "/destroy_permission"], arguments)
-  },
-// search_api_repository_packages => /api/repositories/:repository_id/packages/search(.:format)
-  search_api_repository_packages_path: function(_repository_id, options) {
-  return Utils.build_path(2, ["/api/repositories/", "/packages/search"], arguments)
-  },
-// new_api_template_product => /api/templates/:template_id/products/new(.:format)
-  new_api_template_product_path: function(_template_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/products/new"], arguments)
-  },
-// systems => /systems(.:format)
-  systems_path: function(options) {
-  return Utils.build_path(1, ["/systems"], arguments)
-  },
-// notices => /notices(.:format)
-  notices_path: function(options) {
-  return Utils.build_path(1, ["/notices"], arguments)
-  },
-// history_search_index => /search/history(.:format)
-  history_search_index_path: function(options) {
-  return Utils.build_path(1, ["/search/history"], arguments)
-  },
-// package => /packages/:id(.:format)
-  package_path: function(_id, options) {
-  return Utils.build_path(2, ["/packages/"], arguments)
-  },
-// gpg_key_content_api_repository => /api/repositories/:id/gpg_key_content(.:format)
-  gpg_key_content_api_repository_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/repositories/", "/gpg_key_content"], arguments)
-  },
-// edit_changeset => /changesets/:id/edit(.:format)
-  edit_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/changesets/", "/edit"], arguments)
-  },
-// new_api_template_package_group => /api/templates/:template_id/package_groups/new(.:format)
-  new_api_template_package_group_path: function(_template_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/package_groups/new"], arguments)
-  },
-// logout => /logout(.:format)
-  logout_path: function(options) {
-  return Utils.build_path(1, ["/logout"], arguments)
-  },
-// report_api_environment_systems => /api/environments/:environment_id/systems/report(.:format)
-  report_api_environment_systems_path: function(_environment_id, options) {
-  return Utils.build_path(2, ["/api/environments/", "/systems/report"], arguments)
-  },
-// edit_filter => /filters/:id/edit(.:format)
-  edit_filter_path: function(_id, options) {
-  return Utils.build_path(2, ["/filters/", "/edit"], arguments)
-  },
-// new_api_template_repository => /api/templates/:template_id/repositories/new(.:format)
-  new_api_template_repository_path: function(_template_id, options) {
-  return Utils.build_path(2, ["/api/templates/", "/repositories/new"], arguments)
-  },
-// disable_helptip_users => /users/disable_helptip(.:format)
-  disable_helptip_users_path: function(options) {
-  return Utils.build_path(1, ["/users/disable_helptip"], arguments)
-  },
-// auto_complete_search_gpg_keys => /gpg_keys/auto_complete_search(.:format)
-  auto_complete_search_gpg_keys_path: function(options) {
-  return Utils.build_path(1, ["/gpg_keys/auto_complete_search"], arguments)
-  },
-// new_filter => /filters/new(.:format)
-  new_filter_path: function(options) {
-  return Utils.build_path(1, ["/filters/new"], arguments)
-  },
-// repositories_api_organization_product => /api/organizations/:organization_id/products/:id/repositories(.:format)
-  repositories_api_organization_product_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/products/", "/repositories"], arguments)
-  },
-// update_environment_user => /users/:id/update_environment(.:format)
-  update_environment_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/users/", "/update_environment"], arguments)
-  },
-// new_repository => /repositories/new(.:format)
-  new_repository_path: function(options) {
-  return Utils.build_path(1, ["/repositories/new"], arguments)
-  },
-// activation_key => /activation_keys/:id(.:format)
-  activation_key_path: function(_id, options) {
-  return Utils.build_path(2, ["/activation_keys/"], arguments)
-  },
-// promotions_dashboard_index => /dashboard/promotions(.:format)
-  promotions_dashboard_index_path: function(options) {
-  return Utils.build_path(1, ["/dashboard/promotions"], arguments)
-  },
-// systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/systems(.:format)
-  systems_api_organization_system_group_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/systems"], arguments)
-  },
-// erratum => /errata/:id(.:format)
-  erratum_path: function(_id, options) {
-  return Utils.build_path(2, ["/errata/"], arguments)
-  },
 // errata_promotion => /promotions/:id/errata(.:format)
   errata_promotion_path: function(_id, options) {
   return Utils.build_path(2, ["/promotions/", "/errata"], arguments)
   },
-// more_events_system_events => /systems/:system_id/events/more_events(.:format)
-  more_events_system_events_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/events/more_events"], arguments)
+// remove_system_groups_system => /systems/:id/remove_system_groups(.:format)
+  remove_system_groups_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/remove_system_groups"], arguments)
   },
-// product_packages_system_templates => /system_templates/product_packages(.:format)
-  product_packages_system_templates_path: function(options) {
-  return Utils.build_path(1, ["/system_templates/product_packages"], arguments)
+// notices_get_new => /notices/get_new(.:format)
+  notices_get_new_path: function(options) {
+  return Utils.build_path(1, ["/notices/get_new"], arguments)
   },
-// notices_details => /notices/:id/details(.:format)
-  notices_details_path: function(_id, options) {
-  return Utils.build_path(2, ["/notices/", "/details"], arguments)
+// bulk_add_system_group_systems => /systems/bulk_add_system_group(.:format)
+  bulk_add_system_group_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/bulk_add_system_group"], arguments)
   },
-// new_organization_environment => /organizations/:organization_id/environments/new(.:format)
-  new_organization_environment_path: function(_organization_id, options) {
-  return Utils.build_path(2, ["/organizations/", "/environments/new"], arguments)
+// about => /about(.:format)
+  about_path: function(options) {
+  return Utils.build_path(1, ["/about"], arguments)
   },
-// system_group => /system_groups/:id(.:format)
-  system_group_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_groups/"], arguments)
+// update_repo_gpg_key_provider_product_repository => /providers/:provider_id/products/:product_id/repositories/:id/update_gpg_key(.:format)
+  update_repo_gpg_key_provider_product_repository_path: function(_provider_id, _product_id, _id, options) {
+  return Utils.build_path(4, ["/providers/", "/products/", "/repositories/", "/update_gpg_key"], arguments)
   },
-// repos_content_search_index => /content_search/repos(.:format)
-  repos_content_search_index_path: function(options) {
-  return Utils.build_path(1, ["/content_search/repos"], arguments)
+// auto_complete_products_repos_filters => /filters/auto_complete_products_repos(.:format)
+  auto_complete_products_repos_filters_path: function(options) {
+  return Utils.build_path(1, ["/filters/auto_complete_products_repos"], arguments)
   },
-// enabled_repos_api_system => /api/systems/:id/enabled_repos(.:format)
-  enabled_repos_api_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/systems/", "/enabled_repos"], arguments)
-  },
-// new_content_search => /content_search/new(.:format)
-  new_content_search_path: function(options) {
-  return Utils.build_path(1, ["/content_search/new"], arguments)
-  },
-// edit_product => /products/:id/edit(.:format)
-  edit_product_path: function(_id, options) {
-  return Utils.build_path(2, ["/products/", "/edit"], arguments)
-  },
-// add_system_system_packages => /systems/:system_id/system_packages/add(.:format)
-  add_system_system_packages_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/system_packages/add"], arguments)
-  },
-// items_system_errata => /systems/:system_id/errata/items(.:format)
-  items_system_errata_path: function(_system_id, options) {
-  return Utils.build_path(2, ["/systems/", "/errata/items"], arguments)
-  },
-// consumers_subscription => /subscriptions/:id/consumers(.:format)
-  consumers_subscription_path: function(_id, options) {
-  return Utils.build_path(2, ["/subscriptions/", "/consumers"], arguments)
-  },
-// new_organization => /organizations/new(.:format)
-  new_organization_path: function(options) {
-  return Utils.build_path(1, ["/organizations/new"], arguments)
-  },
-// subscriptions_system => /systems/:id/subscriptions(.:format)
-  subscriptions_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/subscriptions"], arguments)
-  },
-// promotion => /promotions/:id(.:format)
-  promotion_path: function(_id, options) {
-  return Utils.build_path(2, ["/promotions/"], arguments)
-  },
-// status_changeset => /changesets/:id/status(.:format)
-  status_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/changesets/", "/status"], arguments)
-  },
-// items_sync_plans => /sync_plans/items(.:format)
-  items_sync_plans_path: function(options) {
-  return Utils.build_path(1, ["/sync_plans/items"], arguments)
-  },
-// auto_complete_nvrea_library_packages => /packages/auto_complete_nvrea_library(.:format)
-  auto_complete_nvrea_library_packages_path: function(options) {
-  return Utils.build_path(1, ["/packages/auto_complete_nvrea_library"], arguments)
-  },
-// repos_promotion => /promotions/:id/repos(.:format)
-  repos_promotion_path: function(_id, options) {
-  return Utils.build_path(2, ["/promotions/", "/repos"], arguments)
-  },
-// items_activation_keys => /activation_keys/items(.:format)
-  items_activation_keys_path: function(options) {
-  return Utils.build_path(1, ["/activation_keys/items"], arguments)
-  },
-// add_system_groups_system => /systems/:id/add_system_groups(.:format)
-  add_system_groups_system_path: function(_id, options) {
-  return Utils.build_path(2, ["/systems/", "/add_system_groups"], arguments)
+// applied_subscriptions_activation_key => /activation_keys/:id/applied_subscriptions(.:format)
+  applied_subscriptions_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/applied_subscriptions"], arguments)
   },
 // system_groups_api_organization_activation_key => /api/organizations/:organization_id/activation_keys/:id/system_groups(.:format)
   system_groups_api_organization_activation_key_path: function(_organization_id, _id, options) {
   return Utils.build_path(3, ["/api/organizations/", "/activation_keys/", "/system_groups"], arguments)
   },
-// provider_product_repository => /providers/:provider_id/products/:product_id/repositories/:id(.:format)
-  provider_product_repository_path: function(_provider_id, _product_id, _id, options) {
-  return Utils.build_path(4, ["/providers/", "/products/", "/repositories/"], arguments)
+// new_provider_product => /providers/:provider_id/products/new(.:format)
+  new_provider_product_path: function(_provider_id, options) {
+  return Utils.build_path(2, ["/providers/", "/products/new"], arguments)
   },
-// add_system_group_packages => /system_groups/:system_group_id/packages/add(.:format)
-  add_system_group_packages_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/packages/add"], arguments)
+// update_products_filter => /filters/:id/update_products(.:format)
+  update_products_filter_path: function(_id, options) {
+  return Utils.build_path(2, ["/filters/", "/update_products"], arguments)
   },
-// packages_filter => /filters/:id/packages(.:format)
-  packages_filter_path: function(_id, options) {
-  return Utils.build_path(2, ["/filters/", "/packages"], arguments)
+// import_status_owner => /owners/:id/import_status(.:format)
+  import_status_owner_path: function(_id, options) {
+  return Utils.build_path(2, ["/owners/", "/import_status"], arguments)
   },
-// sync_schedules_apply => /sync_schedules/apply(.:format)
-  sync_schedules_apply_path: function(options) {
-  return Utils.build_path(1, ["/sync_schedules/apply"], arguments)
+// import_products_api_provider => /api/providers/:id/import_products(.:format)
+  import_products_api_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/providers/", "/import_products"], arguments)
   },
-// bulk_destroy_systems => /systems/bulk_destroy(.:format)
-  bulk_destroy_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/bulk_destroy"], arguments)
+// import_progress_provider => /providers/:id/import_progress(.:format)
+  import_progress_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/providers/", "/import_progress"], arguments)
   },
-// redhat_provider_providers => /providers/redhat_provider(.:format)
-  redhat_provider_providers_path: function(options) {
-  return Utils.build_path(1, ["/providers/redhat_provider"], arguments)
+// new_api_organization_system_group_packages => /api/organizations/:organization_id/system_groups/:system_group_id/packages/new(.:format)
+  new_api_organization_system_group_packages_path: function(_organization_id, _system_group_id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/packages/new"], arguments)
   },
-// roles_show_permission => /roles/show_permission(.:format)
-  roles_show_permission_path: function(options) {
-  return Utils.build_path(1, ["/roles/show_permission"], arguments)
+// environments => /environments(.:format)
+  environments_path: function(options) {
+  return Utils.build_path(1, ["/environments"], arguments)
   },
-// bulk_errata_install_systems => /systems/bulk_errata_install(.:format)
-  bulk_errata_install_systems_path: function(options) {
-  return Utils.build_path(1, ["/systems/bulk_errata_install"], arguments)
+// validate_api_template => /api/templates/:id/validate(.:format)
+  validate_api_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/validate"], arguments)
   },
-// apply_api_changeset => /api/changesets/:id/apply(.:format)
-  apply_api_changeset_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/apply"], arguments)
-  },
-// product_repos_system_templates => /system_templates/product_repos(.:format)
-  product_repos_system_templates_path: function(options) {
-  return Utils.build_path(1, ["/system_templates/product_repos"], arguments)
-  },
-// items_roles => /roles/items(.:format)
-  items_roles_path: function(options) {
-  return Utils.build_path(1, ["/roles/items"], arguments)
-  },
-// new_api_activation_key => /api/activation_keys/new(.:format)
-  new_api_activation_key_path: function(options) {
-  return Utils.build_path(1, ["/api/activation_keys/new"], arguments)
+// new_api_organization_content_view_definition => /api/organizations/:organization_id/content_view_definitions/new(.:format)
+  new_api_organization_content_view_definition_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/api/organizations/", "/content_view_definitions/new"], arguments)
   },
 // new_api_organization_sync_plan => /api/organizations/:organization_id/sync_plans/new(.:format)
   new_api_organization_sync_plan_path: function(_organization_id, options) {
   return Utils.build_path(2, ["/api/organizations/", "/sync_plans/new"], arguments)
   },
-// add_systems_system_group => /system_groups/:id/add_systems(.:format)
-  add_systems_system_group_path: function(_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/add_systems"], arguments)
+// dependencies_changeset => /changesets/:id/dependencies(.:format)
+  dependencies_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/changesets/", "/dependencies"], arguments)
   },
-// new_api_changeset_erratum => /api/changesets/:changeset_id/errata/new(.:format)
-  new_api_changeset_erratum_path: function(_changeset_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/errata/new"], arguments)
+// sync_schedules_index => /sync_schedules/index(.:format)
+  sync_schedules_index_path: function(options) {
+  return Utils.build_path(1, ["/sync_schedules/index"], arguments)
   },
-// tasks_api_organization_systems => /api/organizations/:organization_id/systems/tasks(.:format)
-  tasks_api_organization_systems_path: function(_organization_id, options) {
-  return Utils.build_path(2, ["/api/organizations/", "/systems/tasks"], arguments)
+// packages_erratum => /errata/:id/packages(.:format)
+  packages_erratum_path: function(_id, options) {
+  return Utils.build_path(2, ["/errata/", "/packages"], arguments)
   },
-// edit_api_user => /api/users/:id/edit(.:format)
-  edit_api_user_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/users/", "/edit"], arguments)
+// user_session => /user_session(.:format)
+  user_session_path: function(options) {
+  return Utils.build_path(1, ["/user_session"], arguments)
   },
-// password_resets => /password_resets(.:format)
-  password_resets_path: function(options) {
-  return Utils.build_path(1, ["/password_resets"], arguments)
+// repos_promotion => /promotions/:id/repos(.:format)
+  repos_promotion_path: function(_id, options) {
+  return Utils.build_path(2, ["/promotions/", "/repos"], arguments)
   },
-// items_organizations => /organizations/items(.:format)
-  items_organizations_path: function(options) {
-  return Utils.build_path(1, ["/organizations/items"], arguments)
+// errata_content_search_index => /content_search/errata(.:format)
+  errata_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/errata"], arguments)
   },
-// product_create_api_provider => /api/providers/:id/product_create(.:format)
-  product_create_api_provider_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/providers/", "/product_create"], arguments)
+// items_changesets => /changesets/items(.:format)
+  items_changesets_path: function(options) {
+  return Utils.build_path(1, ["/changesets/items"], arguments)
   },
-// items_system_group_errata => /system_groups/:system_group_id/errata/items(.:format)
-  items_system_group_errata_path: function(_system_group_id, options) {
-  return Utils.build_path(2, ["/system_groups/", "/errata/items"], arguments)
+// sync_management_sync_status => /sync_management/sync_status(.:format)
+  sync_management_sync_status_path: function(options) {
+  return Utils.build_path(1, ["/sync_management/sync_status"], arguments)
   },
-// destroy_systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/destroy_systems(.:format)
-  destroy_systems_api_organization_system_group_path: function(_organization_id, _id, options) {
-  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/destroy_systems"], arguments)
-  },
-// new_api_changeset_template => /api/changesets/:changeset_id/templates/new(.:format)
-  new_api_changeset_template_path: function(_changeset_id, options) {
-  return Utils.build_path(2, ["/api/changesets/", "/templates/new"], arguments)
+// edit_api_template_parameter => /api/templates/:template_id/parameters/:id/edit(.:format)
+  edit_api_template_parameter_path: function(_template_id, _id, options) {
+  return Utils.build_path(3, ["/api/templates/", "/parameters/", "/edit"], arguments)
   },
 // system_group_packages => /system_groups/:system_group_id/packages(.:format)
   system_group_packages_path: function(_system_group_id, options) {
   return Utils.build_path(2, ["/system_groups/", "/packages"], arguments)
   },
-// import_api_templates => /api/templates/import(.:format)
-  import_api_templates_path: function(options) {
-  return Utils.build_path(1, ["/api/templates/import"], arguments)
+// system_templates => /system_templates(.:format)
+  system_templates_path: function(options) {
+  return Utils.build_path(1, ["/system_templates"], arguments)
   },
-// edit_api_template_product => /api/templates/:template_id/products/:id/edit(.:format)
-  edit_api_template_product_path: function(_template_id, _id, options) {
-  return Utils.build_path(3, ["/api/templates/", "/products/", "/edit"], arguments)
+// repo_packages_content_search_index => /content_search/repo_packages(.:format)
+  repo_packages_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/repo_packages"], arguments)
   },
-// filelist_repository_distribution => /repositories/:repository_id/distributions/:id/filelist(.:format)
-  filelist_repository_distribution_path: function(_repository_id, _id, options) {
-  return Utils.build_path(3, ["/repositories/", "/distributions/", "/filelist"], arguments)
+// new_api_changeset_package => /api/changesets/:changeset_id/packages/new(.:format)
+  new_api_changeset_package_path: function(_changeset_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/packages/new"], arguments)
   },
-// new_role => /roles/new(.:format)
-  new_role_path: function(options) {
-  return Utils.build_path(1, ["/roles/new"], arguments)
+// repository => /repositories/:id(.:format)
+  repository_path: function(_id, options) {
+  return Utils.build_path(2, ["/repositories/"], arguments)
+  },
+// edit_content_search => /content_search/:id/edit(.:format)
+  edit_content_search_path: function(_id, options) {
+  return Utils.build_path(2, ["/content_search/", "/edit"], arguments)
+  },
+// object_system_template => /system_templates/:id/object(.:format)
+  object_system_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_templates/", "/object"], arguments)
+  },
+// role_permission_update => /roles/:role_id/permission/:permission_id/update_permission(.:format)
+  role_permission_update_path: function(_role_id, _permission_id, options) {
+  return Utils.build_path(3, ["/roles/", "/permission/", "/update_permission"], arguments)
+  },
+// edit_api_template_distribution => /api/templates/:template_id/distributions/:id/edit(.:format)
+  edit_api_template_distribution_path: function(_template_id, _id, options) {
+  return Utils.build_path(3, ["/api/templates/", "/distributions/", "/edit"], arguments)
+  },
+// logout => /logout(.:format)
+  logout_path: function(options) {
+  return Utils.build_path(1, ["/logout"], arguments)
+  },
+// new_api_template => /api/templates/new(.:format)
+  new_api_template_path: function(options) {
+  return Utils.build_path(1, ["/api/templates/new"], arguments)
+  },
+// new_api_changeset_distribution => /api/changesets/:changeset_id/distributions/new(.:format)
+  new_api_changeset_distribution_path: function(_changeset_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/distributions/new"], arguments)
+  },
+// providers => /providers(.:format)
+  providers_path: function(options) {
+  return Utils.build_path(1, ["/providers"], arguments)
+  },
+// favorite_search_index => /search/favorite(.:format)
+  favorite_search_index_path: function(options) {
+  return Utils.build_path(1, ["/search/favorite"], arguments)
+  },
+// system_groups_dashboard_index => /dashboard/system_groups(.:format)
+  system_groups_dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard/system_groups"], arguments)
+  },
+// items_organizations => /organizations/items(.:format)
+  items_organizations_path: function(options) {
+  return Utils.build_path(1, ["/organizations/items"], arguments)
+  },
+// edit_api_repository_package => /api/repositories/:repository_id/packages/:id/edit(.:format)
+  edit_api_repository_package_path: function(_repository_id, _id, options) {
+  return Utils.build_path(3, ["/api/repositories/", "/packages/", "/edit"], arguments)
+  },
+// disable_helptip_users => /users/disable_helptip(.:format)
+  disable_helptip_users_path: function(options) {
+  return Utils.build_path(1, ["/users/disable_helptip"], arguments)
+  },
+// system_templates_organization_environment => /organizations/:organization_id/environments/:id/system_templates(.:format)
+  system_templates_organization_environment_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/organizations/", "/environments/", "/system_templates"], arguments)
+  },
+// products_repos_gpg_key => /gpg_keys/:id/products_repos(.:format)
+  products_repos_gpg_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/gpg_keys/", "/products_repos"], arguments)
+  },
+// status_system_group_events => /system_groups/:system_group_id/events/status(.:format)
+  status_system_group_events_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/events/status"], arguments)
+  },
+// edit_environment_user => /users/:id/edit_environment(.:format)
+  edit_environment_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/edit_environment"], arguments)
+  },
+// pools_api_system => /api/systems/:id/pools(.:format)
+  pools_api_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/pools"], arguments)
+  },
+// remove_system_group_packages => /system_groups/:system_group_id/packages/remove(.:format)
+  remove_system_group_packages_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/packages/remove"], arguments)
+  },
+// user => /users/:id(.:format)
+  user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/"], arguments)
+  },
+// search_index => /search(.:format)
+  search_index_path: function(options) {
+  return Utils.build_path(1, ["/search"], arguments)
+  },
+// items_system_groups => /system_groups/items(.:format)
+  items_system_groups_path: function(options) {
+  return Utils.build_path(1, ["/system_groups/items"], arguments)
+  },
+// new_changeset => /changesets/new(.:format)
+  new_changeset_path: function(options) {
+  return Utils.build_path(1, ["/changesets/new"], arguments)
+  },
+// details_promotion => /promotions/:id/details(.:format)
+  details_promotion_path: function(_id, options) {
+  return Utils.build_path(2, ["/promotions/", "/details"], arguments)
+  },
+// pools_api_activation_key => /api/activation_keys/:id/pools(.:format)
+  pools_api_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/activation_keys/", "/pools"], arguments)
+  },
+// items_system_templates => /system_templates/items(.:format)
+  items_system_templates_path: function(options) {
+  return Utils.build_path(1, ["/system_templates/items"], arguments)
+  },
+// remove_systems_system_group => /system_groups/:id/remove_systems(.:format)
+  remove_systems_system_group_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/remove_systems"], arguments)
+  },
+// filter => /filters/:id(.:format)
+  filter_path: function(_id, options) {
+  return Utils.build_path(2, ["/filters/"], arguments)
+  },
+// user_session_logout => /user_session/logout(.:format)
+  user_session_logout_path: function(options) {
+  return Utils.build_path(1, ["/user_session/logout"], arguments)
+  },
+// system_system_packages => /systems/:system_id/system_packages(.:format)
+  system_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/system_packages"], arguments)
+  },
+// report_api_users => /api/users/report(.:format)
+  report_api_users_path: function(options) {
+  return Utils.build_path(1, ["/api/users/report"], arguments)
+  },
+// delete_manifest_subscriptions => /subscriptions/delete_manifest(.:format)
+  delete_manifest_subscriptions_path: function(options) {
+  return Utils.build_path(1, ["/subscriptions/delete_manifest"], arguments)
+  },
+// changelog_package => /packages/:id/changelog(.:format)
+  changelog_package_path: function(_id, options) {
+  return Utils.build_path(2, ["/packages/", "/changelog"], arguments)
+  },
+// content_view_definitions => /content_view_definitions(.:format)
+  content_view_definitions_path: function(options) {
+  return Utils.build_path(1, ["/content_view_definitions"], arguments)
+  },
+// status_system_errata => /systems/:system_id/errata/status(.:format)
+  status_system_errata_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/errata/status"], arguments)
+  },
+// edit_api_user => /api/users/:id/edit(.:format)
+  edit_api_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/users/", "/edit"], arguments)
+  },
+// install_system_group_errata => /system_groups/:system_group_id/errata/install(.:format)
+  install_system_group_errata_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/errata/install"], arguments)
+  },
+// edit_user => /users/:id/edit(.:format)
+  edit_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/edit"], arguments)
+  },
+// products_system => /systems/:id/products(.:format)
+  products_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/products"], arguments)
+  },
+// edit_product => /products/:id/edit(.:format)
+  edit_product_path: function(_id, options) {
+  return Utils.build_path(2, ["/products/", "/edit"], arguments)
+  },
+// auto_complete_systems => /systems/auto_complete(.:format)
+  auto_complete_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/auto_complete"], arguments)
+  },
+// bulk_remove_system_group_systems => /systems/bulk_remove_system_group(.:format)
+  bulk_remove_system_group_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/bulk_remove_system_group"], arguments)
+  },
+// rails_info_properties => /rails/info/properties(.:format)
+  rails_info_properties_path: function(options) {
+  return Utils.build_path(1, ["/rails/info/properties"], arguments)
   },
 // new_api_consumer => /api/consumers/new(.:format)
   new_api_consumer_path: function(options) {
   return Utils.build_path(1, ["/api/consumers/new"], arguments)
   },
-// enable_api_repository => /api/repositories/:id/enable(.:format)
-  enable_api_repository_path: function(_id, options) {
-  return Utils.build_path(2, ["/api/repositories/", "/enable"], arguments)
+// edit_password_reset => /password_resets/:id/edit(.:format)
+  edit_password_reset_path: function(_id, options) {
+  return Utils.build_path(2, ["/password_resets/", "/edit"], arguments)
   },
-// edit_api_template_package_group => /api/templates/:template_id/package_groups/:id/edit(.:format)
-  edit_api_template_package_group_path: function(_template_id, _id, options) {
-  return Utils.build_path(3, ["/api/templates/", "/package_groups/", "/edit"], arguments)
+// organization_environments => /organizations/:organization_id/environments(.:format)
+  organization_environments_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/organizations/", "/environments"], arguments)
   },
-// details_promotion => /promotions/:id/details(.:format)
-  details_promotion_path: function(_id, options) {
-  return Utils.build_path(2, ["/promotions/", "/details"], arguments)
+// promotions => /promotions(.:format)
+  promotions_path: function(options) {
+  return Utils.build_path(1, ["/promotions"], arguments)
+  },
+// available_subscriptions_activation_key => /activation_keys/:id/available_subscriptions(.:format)
+  available_subscriptions_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/available_subscriptions"], arguments)
+  },
+// new_api_system_packages => /api/systems/:system_id/packages/new(.:format)
+  new_api_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/packages/new"], arguments)
+  },
+// provider_product_repositories => /providers/:provider_id/products/:product_id/repositories(.:format)
+  provider_product_repositories_path: function(_provider_id, _product_id, options) {
+  return Utils.build_path(3, ["/providers/", "/products/", "/repositories"], arguments)
+  },
+// items_filters => /filters/items(.:format)
+  items_filters_path: function(options) {
+  return Utils.build_path(1, ["/filters/items"], arguments)
+  },
+// pools_api_organization_activation_key => /api/organizations/:organization_id/activation_keys/:id/pools(.:format)
+  pools_api_organization_activation_key_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/activation_keys/", "/pools"], arguments)
+  },
+// import_manifest_api_provider => /api/providers/:id/import_manifest(.:format)
+  import_manifest_api_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/providers/", "/import_manifest"], arguments)
+  },
+// edit_provider_product => /providers/:provider_id/products/:id/edit(.:format)
+  edit_provider_product_path: function(_provider_id, _id, options) {
+  return Utils.build_path(3, ["/providers/", "/products/", "/edit"], arguments)
+  },
+// new_user_session => /user_session/new(.:format)
+  new_user_session_path: function(options) {
+  return Utils.build_path(1, ["/user_session/new"], arguments)
+  },
+// add_systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/add_systems(.:format)
+  add_systems_api_organization_system_group_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/add_systems"], arguments)
+  },
+// notices_note_count => /notices/note_count(.:format)
+  notices_note_count_path: function(options) {
+  return Utils.build_path(1, ["/notices/note_count"], arguments)
+  },
+// new_api_provider => /api/providers/new(.:format)
+  new_api_provider_path: function(options) {
+  return Utils.build_path(1, ["/api/providers/new"], arguments)
+  },
+// schedule_provider => /providers/:id/schedule(.:format)
+  schedule_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/providers/", "/schedule"], arguments)
+  },
+// edit_api_organization_system_group_packages => /api/organizations/:organization_id/system_groups/:system_group_id/packages/edit(.:format)
+  edit_api_organization_system_group_packages_path: function(_organization_id, _system_group_id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/packages/edit"], arguments)
+  },
+// edit_api_organization_content_view_definition => /api/organizations/:organization_id/content_view_definitions/:id/edit(.:format)
+  edit_api_organization_content_view_definition_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/content_view_definitions/", "/edit"], arguments)
+  },
+// new_api_template_package => /api/templates/:template_id/packages/new(.:format)
+  new_api_template_package_path: function(_template_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/packages/new"], arguments)
+  },
+// short_details_erratum => /errata/:id/short_details(.:format)
+  short_details_erratum_path: function(_id, options) {
+  return Utils.build_path(2, ["/errata/", "/short_details"], arguments)
+  },
+// edit_api_organization_sync_plan => /api/organizations/:organization_id/sync_plans/:id/edit(.:format)
+  edit_api_organization_sync_plan_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/sync_plans/", "/edit"], arguments)
+  },
+// system_template => /system_templates/:id(.:format)
+  system_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_templates/"], arguments)
+  },
+// apply_changeset => /changesets/:id/apply(.:format)
+  apply_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/changesets/", "/apply"], arguments)
+  },
+// content_views_api_content_view_definition => /api/content_view_definitions/:id/content_views(.:format)
+  content_views_api_content_view_definition_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/content_view_definitions/", "/content_views"], arguments)
+  },
+// system_groups_activation_key => /activation_keys/:id/system_groups(.:format)
+  system_groups_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/system_groups"], arguments)
+  },
+// products_content_search_index => /content_search/products(.:format)
+  products_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/products"], arguments)
+  },
+// new_api_template_package_group_category => /api/templates/:template_id/package_group_categories/new(.:format)
+  new_api_template_package_group_category_path: function(_template_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/package_group_categories/new"], arguments)
+  },
+// repo_errata_content_search_index => /content_search/repo_errata(.:format)
+  repo_errata_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/repo_errata"], arguments)
+  },
+// edit_api_changeset_package => /api/changesets/:changeset_id/packages/:id/edit(.:format)
+  edit_api_changeset_package_path: function(_changeset_id, _id, options) {
+  return Utils.build_path(3, ["/api/changesets/", "/packages/", "/edit"], arguments)
+  },
+// auto_complete_search_roles => /roles/auto_complete_search(.:format)
+  auto_complete_search_roles_path: function(options) {
+  return Utils.build_path(1, ["/roles/auto_complete_search"], arguments)
+  },
+// sync_dashboard_index => /dashboard/sync(.:format)
+  sync_dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard/sync"], arguments)
+  },
+// edit_api_template => /api/templates/:id/edit(.:format)
+  edit_api_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/edit"], arguments)
+  },
+// edit_api_changeset_distribution => /api/changesets/:changeset_id/distributions/:id/edit(.:format)
+  edit_api_changeset_distribution_path: function(_changeset_id, _id, options) {
+  return Utils.build_path(3, ["/api/changesets/", "/distributions/", "/edit"], arguments)
+  },
+// notices => /notices(.:format)
+  notices_path: function(options) {
+  return Utils.build_path(1, ["/notices"], arguments)
+  },
+// sync_management_sync => /sync_management/sync(.:format)
+  sync_management_sync_path: function(options) {
+  return Utils.build_path(1, ["/sync_management/sync"], arguments)
+  },
+// enable_repo => /repositories/:id/enable_repo(.:format)
+  enable_repo_path: function(_id, options) {
+  return Utils.build_path(2, ["/repositories/", "/enable_repo"], arguments)
+  },
+// subscriptions_dashboard_index => /dashboard/subscriptions(.:format)
+  subscriptions_dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard/subscriptions"], arguments)
+  },
+// edit_filter => /filters/:id/edit(.:format)
+  edit_filter_path: function(_id, options) {
+  return Utils.build_path(2, ["/filters/", "/edit"], arguments)
+  },
+// default_label_organizations => /organizations/default_label(.:format)
+  default_label_organizations_path: function(options) {
+  return Utils.build_path(1, ["/organizations/default_label"], arguments)
+  },
+// more_items_system_group_events => /system_groups/:system_group_id/events/more_items(.:format)
+  more_items_system_group_events_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/events/more_items"], arguments)
+  },
+// role_permission_destroy => /roles/:role_id/permission/:permission_id/destroy_permission(.:format)
+  role_permission_destroy_path: function(_role_id, _permission_id, options) {
+  return Utils.build_path(3, ["/roles/", "/permission/", "/destroy_permission"], arguments)
+  },
+// clear_helptips_user => /users/:id/clear_helptips(.:format)
+  clear_helptips_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/clear_helptips"], arguments)
+  },
+// new_provider => /providers/new(.:format)
+  new_provider_path: function(options) {
+  return Utils.build_path(1, ["/providers/new"], arguments)
+  },
+// package_groups_api_repository => /api/repositories/:id/package_groups(.:format)
+  package_groups_api_repository_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/repositories/", "/package_groups"], arguments)
+  },
+// update_environment_user => /users/:id/update_environment(.:format)
+  update_environment_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/update_environment"], arguments)
+  },
+// releases_api_system => /api/systems/:id/releases(.:format)
+  releases_api_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/releases"], arguments)
+  },
+// history_search_index => /search/history(.:format)
+  history_search_index_path: function(options) {
+  return Utils.build_path(1, ["/search/history"], arguments)
+  },
+// auto_complete_products => /products/auto_complete(.:format)
+  auto_complete_products_path: function(options) {
+  return Utils.build_path(1, ["/products/auto_complete"], arguments)
+  },
+// auto_complete_system_groups => /system_groups/auto_complete(.:format)
+  auto_complete_system_groups_path: function(options) {
+  return Utils.build_path(1, ["/system_groups/auto_complete"], arguments)
+  },
+// edit_changeset => /changesets/:id/edit(.:format)
+  edit_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/changesets/", "/edit"], arguments)
+  },
+// packages_system_system_packages => /systems/:system_id/system_packages/packages(.:format)
+  packages_system_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/system_packages/packages"], arguments)
+  },
+// product_packages_system_templates => /system_templates/product_packages(.:format)
+  product_packages_system_templates_path: function(options) {
+  return Utils.build_path(1, ["/system_templates/product_packages"], arguments)
+  },
+// destroy_systems_system_group => /system_groups/:id/destroy_systems(.:format)
+  destroy_systems_system_group_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/destroy_systems"], arguments)
+  },
+// edit_subscription => /subscriptions/:id/edit(.:format)
+  edit_subscription_path: function(_id, options) {
+  return Utils.build_path(2, ["/subscriptions/", "/edit"], arguments)
+  },
+// sync_ldap_roles_api_users => /api/users/sync_ldap_roles(.:format)
+  sync_ldap_roles_api_users_path: function(options) {
+  return Utils.build_path(1, ["/api/users/sync_ldap_roles"], arguments)
+  },
+// system_errata => /systems/:system_id/errata(.:format)
+  system_errata_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/errata"], arguments)
+  },
+// history_subscriptions => /subscriptions/history(.:format)
+  history_subscriptions_path: function(options) {
+  return Utils.build_path(1, ["/subscriptions/history"], arguments)
+  },
+// filelist_package => /packages/:id/filelist(.:format)
+  filelist_package_path: function(_id, options) {
+  return Utils.build_path(2, ["/packages/", "/filelist"], arguments)
+  },
+// more_products_system => /systems/:id/more_products(.:format)
+  more_products_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/more_products"], arguments)
+  },
+// status_system_group_errata => /system_groups/:system_group_id/errata/status(.:format)
+  status_system_group_errata_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/errata/status"], arguments)
+  },
+// items_systems => /systems/items(.:format)
+  items_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/items"], arguments)
+  },
+// role => /roles/:id(.:format)
+  role_path: function(_id, options) {
+  return Utils.build_path(2, ["/roles/"], arguments)
+  },
+// bulk_content_install_systems => /systems/bulk_content_install(.:format)
+  bulk_content_install_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/bulk_content_install"], arguments)
+  },
+// edit_api_consumer => /api/consumers/:id/edit(.:format)
+  edit_api_consumer_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/consumers/", "/edit"], arguments)
+  },
+// password_reset => /password_resets/:id(.:format)
+  password_reset_path: function(_id, options) {
+  return Utils.build_path(2, ["/password_resets/"], arguments)
+  },
+// new_organization_environment => /organizations/:organization_id/environments/new(.:format)
+  new_organization_environment_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/organizations/", "/environments/new"], arguments)
+  },
+// new_gpg_key => /gpg_keys/new(.:format)
+  new_gpg_key_path: function(options) {
+  return Utils.build_path(1, ["/gpg_keys/new"], arguments)
+  },
+// remove_subscriptions_activation_key => /activation_keys/:id/remove_subscriptions(.:format)
+  remove_subscriptions_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/remove_subscriptions"], arguments)
+  },
+// edit_api_system_packages => /api/systems/:system_id/packages/edit(.:format)
+  edit_api_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/packages/edit"], arguments)
+  },
+// new_provider_product_repository => /providers/:provider_id/products/:product_id/repositories/new(.:format)
+  new_provider_product_repository_path: function(_provider_id, _product_id, options) {
+  return Utils.build_path(3, ["/providers/", "/products/", "/repositories/new"], arguments)
+  },
+// packages_filter => /filters/:id/packages(.:format)
+  packages_filter_path: function(_id, options) {
+  return Utils.build_path(2, ["/filters/", "/packages"], arguments)
+  },
+// delete_manifest_api_provider => /api/providers/:id/delete_manifest(.:format)
+  delete_manifest_api_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/providers/", "/delete_manifest"], arguments)
+  },
+// provider_product => /providers/:provider_id/products/:id(.:format)
+  provider_product_path: function(_provider_id, _id, options) {
+  return Utils.build_path(3, ["/providers/", "/products/"], arguments)
+  },
+// copy_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/copy(.:format)
+  copy_api_organization_system_group_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/copy"], arguments)
+  },
+// edit_api_provider => /api/providers/:id/edit(.:format)
+  edit_api_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/providers/", "/edit"], arguments)
+  },
+// product_repos_system_templates => /system_templates/product_repos(.:format)
+  product_repos_system_templates_path: function(options) {
+  return Utils.build_path(1, ["/system_templates/product_repos"], arguments)
+  },
+// new_organization => /organizations/new(.:format)
+  new_organization_path: function(options) {
+  return Utils.build_path(1, ["/organizations/new"], arguments)
+  },
+// new_api_organization_environment => /api/organizations/:organization_id/environments/new(.:format)
+  new_api_organization_environment_path: function(_organization_id, options) {
+  return Utils.build_path(2, ["/api/organizations/", "/environments/new"], arguments)
+  },
+// status_changeset => /changesets/:id/status(.:format)
+  status_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/changesets/", "/status"], arguments)
+  },
+// edit_api_template_package => /api/templates/:template_id/packages/:id/edit(.:format)
+  edit_api_template_package_path: function(_template_id, _id, options) {
+  return Utils.build_path(3, ["/api/templates/", "/packages/", "/edit"], arguments)
+  },
+// edit_environment => /environments/:id/edit(.:format)
+  edit_environment_path: function(_id, options) {
+  return Utils.build_path(2, ["/environments/", "/edit"], arguments)
+  },
+// product => /products/:id(.:format)
+  product_path: function(_id, options) {
+  return Utils.build_path(2, ["/products/"], arguments)
+  },
+// systems_activation_key => /activation_keys/:id/systems(.:format)
+  systems_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/systems"], arguments)
+  },
+// packages_content_search_index => /content_search/packages(.:format)
+  packages_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/packages"], arguments)
+  },
+// new_api_changeset_product => /api/changesets/:changeset_id/products/new(.:format)
+  new_api_changeset_product_path: function(_changeset_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/products/new"], arguments)
+  },
+// roles_show_permission => /roles/show_permission(.:format)
+  roles_show_permission_path: function(options) {
+  return Utils.build_path(1, ["/roles/show_permission"], arguments)
+  },
+// edit_api_template_package_group_category => /api/templates/:template_id/package_group_categories/:id/edit(.:format)
+  edit_api_template_package_group_category_path: function(_template_id, _id, options) {
+  return Utils.build_path(3, ["/api/templates/", "/package_group_categories/", "/edit"], arguments)
+  },
+// repo_compare_packages_content_search_index => /content_search/repo_compare_packages(.:format)
+  repo_compare_packages_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/repo_compare_packages"], arguments)
+  },
+// items_roles => /roles/items(.:format)
+  items_roles_path: function(options) {
+  return Utils.build_path(1, ["/roles/items"], arguments)
+  },
+// new_api_changeset_repository => /api/changesets/:changeset_id/repositories/new(.:format)
+  new_api_changeset_repository_path: function(_changeset_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/repositories/new"], arguments)
+  },
+// notices_dashboard_index => /dashboard/notices(.:format)
+  notices_dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard/notices"], arguments)
+  },
+// login => /login(.:format)
+  login_path: function(options) {
+  return Utils.build_path(1, ["/login"], arguments)
+  },
+// dashboard_index => /dashboard(.:format)
+  dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard"], arguments)
+  },
+// environments_partial_organization => /organizations/:id/environments_partial(.:format)
+  environments_partial_organization_path: function(_id, options) {
+  return Utils.build_path(2, ["/organizations/", "/environments_partial"], arguments)
+  },
+// new_activation_key => /activation_keys/new(.:format)
+  new_activation_key_path: function(options) {
+  return Utils.build_path(1, ["/activation_keys/new"], arguments)
+  },
+// items_system_group_events => /system_groups/:system_group_id/events/items(.:format)
+  items_system_group_events_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/events/items"], arguments)
+  },
+// update_roles_user => /users/:id/update_roles(.:format)
+  update_roles_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/update_roles"], arguments)
+  },
+// edit_provider => /providers/:id/edit(.:format)
+  edit_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/providers/", "/edit"], arguments)
+  },
+// package_group_categories_api_repository => /api/repositories/:id/package_group_categories(.:format)
+  package_group_categories_api_repository_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/repositories/", "/package_group_categories"], arguments)
+  },
+// new_role => /roles/new(.:format)
+  new_role_path: function(options) {
+  return Utils.build_path(1, ["/roles/new"], arguments)
+  },
+// content_search => /content_search/:id(.:format)
+  content_search_path: function(_id, options) {
+  return Utils.build_path(2, ["/content_search/"], arguments)
+  },
+// enabled_repos_api_system => /api/systems/:id/enabled_repos(.:format)
+  enabled_repos_api_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/enabled_repos"], arguments)
+  },
+// gpg_key => /gpg_keys/:id(.:format)
+  gpg_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/gpg_keys/"], arguments)
+  },
+// sync_management_index => /sync_management/index(.:format)
+  sync_management_index_path: function(options) {
+  return Utils.build_path(1, ["/sync_management/index"], arguments)
+  },
+// packages_promotion => /promotions/:id/packages(.:format)
+  packages_promotion_path: function(_id, options) {
+  return Utils.build_path(2, ["/promotions/", "/packages"], arguments)
+  },
+// releases_api_environment => /api/environments/:id/releases(.:format)
+  releases_api_environment_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/environments/", "/releases"], arguments)
+  },
+// validate_name_system_groups => /system_groups/validate_name(.:format)
+  validate_name_system_groups_path: function(options) {
+  return Utils.build_path(1, ["/system_groups/validate_name"], arguments)
+  },
+// filters => /filters(.:format)
+  filters_path: function(options) {
+  return Utils.build_path(1, ["/filters"], arguments)
+  },
+// new_api_activation_key => /api/activation_keys/new(.:format)
+  new_api_activation_key_path: function(options) {
+  return Utils.build_path(1, ["/api/activation_keys/new"], arguments)
+  },
+// email_logins_password_resets => /password_resets/email_logins(.:format)
+  email_logins_password_resets_path: function(options) {
+  return Utils.build_path(1, ["/password_resets/email_logins"], arguments)
+  },
+// more_packages_system_system_packages => /systems/:system_id/system_packages/more_packages(.:format)
+  more_packages_system_system_packages_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/system_packages/more_packages"], arguments)
+  },
+// products_subscription => /subscriptions/:id/products(.:format)
+  products_subscription_path: function(_id, options) {
+  return Utils.build_path(2, ["/subscriptions/", "/products"], arguments)
+  },
+// dependencies_package => /packages/:id/dependencies(.:format)
+  dependencies_package_path: function(_id, options) {
+  return Utils.build_path(2, ["/packages/", "/dependencies"], arguments)
+  },
+// sync_management => /sync_management/:id(.:format)
+  sync_management_path: function(_id, options) {
+  return Utils.build_path(2, ["/sync_management/"], arguments)
+  },
+// system_erratum => /systems/:system_id/errata/:id(.:format)
+  system_erratum_path: function(_system_id, _id, options) {
+  return Utils.build_path(3, ["/systems/", "/errata/"], arguments)
+  },
+// history_items_subscriptions => /subscriptions/history_items(.:format)
+  history_items_subscriptions_path: function(options) {
+  return Utils.build_path(1, ["/subscriptions/history_items"], arguments)
+  },
+// available_verbs_api_roles => /api/roles/available_verbs(.:format)
+  available_verbs_api_roles_path: function(options) {
+  return Utils.build_path(1, ["/api/roles/available_verbs"], arguments)
+  },
+// facts_system => /systems/:id/facts(.:format)
+  facts_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/systems/", "/facts"], arguments)
+  },
+// new_api_role => /api/roles/new(.:format)
+  new_api_role_path: function(options) {
+  return Utils.build_path(1, ["/api/roles/new"], arguments)
+  },
+// environment => /environments/:id(.:format)
+  environment_path: function(_id, options) {
+  return Utils.build_path(2, ["/environments/"], arguments)
+  },
+// env_items_systems => /systems/env_items(.:format)
+  env_items_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/env_items"], arguments)
+  },
+// allowed_orgs_user_session => /user_session/allowed_orgs(.:format)
+  allowed_orgs_user_session_path: function(options) {
+  return Utils.build_path(1, ["/user_session/allowed_orgs"], arguments)
+  },
+// bulk_content_update_systems => /systems/bulk_content_update(.:format)
+  bulk_content_update_systems_path: function(options) {
+  return Utils.build_path(1, ["/systems/bulk_content_update"], arguments)
+  },
+// edit_organization_environment => /organizations/:organization_id/environments/:id/edit(.:format)
+  edit_organization_environment_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/organizations/", "/environments/", "/edit"], arguments)
+  },
+// edit_gpg_key => /gpg_keys/:id/edit(.:format)
+  edit_gpg_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/gpg_keys/", "/edit"], arguments)
+  },
+// auto_complete_search_activation_keys => /activation_keys/auto_complete_search(.:format)
+  auto_complete_search_activation_keys_path: function(options) {
+  return Utils.build_path(1, ["/activation_keys/auto_complete_search"], arguments)
+  },
+// auto_complete_search_providers => /providers/auto_complete_search(.:format)
+  auto_complete_search_providers_path: function(options) {
+  return Utils.build_path(1, ["/providers/auto_complete_search"], arguments)
+  },
+// system_templates_promotion => /promotions/:id/system_templates(.:format)
+  system_templates_promotion_path: function(_id, options) {
+  return Utils.build_path(2, ["/promotions/", "/system_templates"], arguments)
+  },
+// add_subscriptions_activation_key => /activation_keys/:id/add_subscriptions(.:format)
+  add_subscriptions_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/add_subscriptions"], arguments)
+  },
+// edit_provider_product_repository => /providers/:provider_id/products/:product_id/repositories/:id/edit(.:format)
+  edit_provider_product_repository_path: function(_provider_id, _product_id, _id, options) {
+  return Utils.build_path(4, ["/providers/", "/products/", "/repositories/", "/edit"], arguments)
+  },
+// add_packages_filter => /filters/:id/add_packages(.:format)
+  add_packages_filter_path: function(_id, options) {
+  return Utils.build_path(2, ["/filters/", "/add_packages"], arguments)
+  },
+// new_environment => /environments/new(.:format)
+  new_environment_path: function(options) {
+  return Utils.build_path(1, ["/environments/new"], arguments)
+  },
+// refresh_products_api_provider => /api/providers/:id/refresh_products(.:format)
+  refresh_products_api_provider_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/providers/", "/refresh_products"], arguments)
+  },
+// items_providers => /providers/items(.:format)
+  items_providers_path: function(options) {
+  return Utils.build_path(1, ["/providers/items"], arguments)
+  },
+// remove_systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/remove_systems(.:format)
+  remove_systems_api_organization_system_group_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/remove_systems"], arguments)
+  },
+// new_subscription => /subscriptions/new(.:format)
+  new_subscription_path: function(options) {
+  return Utils.build_path(1, ["/subscriptions/new"], arguments)
+  },
+// edit_organization => /organizations/:id/edit(.:format)
+  edit_organization_path: function(_id, options) {
+  return Utils.build_path(2, ["/organizations/", "/edit"], arguments)
+  },
+// new_sync_plan => /sync_plans/new(.:format)
+  new_sync_plan_path: function(options) {
+  return Utils.build_path(1, ["/sync_plans/new"], arguments)
+  },
+// new_api_template_product => /api/templates/:template_id/products/new(.:format)
+  new_api_template_product_path: function(_template_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/products/new"], arguments)
+  },
+// edit_api_organization_environment => /api/organizations/:organization_id/environments/:id/edit(.:format)
+  edit_api_organization_environment_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/environments/", "/edit"], arguments)
+  },
+// system_events => /systems/:system_id/events(.:format)
+  system_events_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/events"], arguments)
+  },
+// object_changeset => /changesets/:id/object(.:format)
+  object_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/changesets/", "/object"], arguments)
+  },
+// new_system_group => /system_groups/new(.:format)
+  new_system_group_path: function(options) {
+  return Utils.build_path(1, ["/system_groups/new"], arguments)
+  },
+// promote_api_changeset => /api/changesets/:id/promote(.:format)
+  promote_api_changeset_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/changesets/", "/promote"], arguments)
+  },
+// new_api_template_package_group => /api/templates/:template_id/package_groups/new(.:format)
+  new_api_template_package_group_path: function(_template_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/package_groups/new"], arguments)
+  },
+// add_system_groups_activation_key => /activation_keys/:id/add_system_groups(.:format)
+  add_system_groups_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/add_system_groups"], arguments)
+  },
+// packages_items_content_search_index => /content_search/packages_items(.:format)
+  packages_items_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/packages_items"], arguments)
+  },
+// edit_api_changeset_product => /api/changesets/:changeset_id/products/:id/edit(.:format)
+  edit_api_changeset_product_path: function(_changeset_id, _id, options) {
+  return Utils.build_path(3, ["/api/changesets/", "/products/", "/edit"], arguments)
+  },
+// repo_compare_errata_content_search_index => /content_search/repo_compare_errata(.:format)
+  repo_compare_errata_content_search_index_path: function(options) {
+  return Utils.build_path(1, ["/content_search/repo_compare_errata"], arguments)
+  },
+// publish_api_organization_content_view_definition => /api/organizations/:organization_id/content_view_definitions/:id/publish(.:format)
+  publish_api_organization_content_view_definition_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/content_view_definitions/", "/publish"], arguments)
+  },
+// destroy_role_ldap_group => /roles/:role_id/ldap_groups/:id(.:format)
+  destroy_role_ldap_group_path: function(_role_id, _id, options) {
+  return Utils.build_path(3, ["/roles/", "/ldap_groups/"], arguments)
+  },
+// new_api_template_repository => /api/templates/:template_id/repositories/new(.:format)
+  new_api_template_repository_path: function(_template_id, options) {
+  return Utils.build_path(2, ["/api/templates/", "/repositories/new"], arguments)
+  },
+// edit_api_changeset_repository => /api/changesets/:changeset_id/repositories/:id/edit(.:format)
+  edit_api_changeset_repository_path: function(_changeset_id, _id, options) {
+  return Utils.build_path(3, ["/api/changesets/", "/repositories/", "/edit"], arguments)
+  },
+// errata_dashboard_index => /dashboard/errata(.:format)
+  errata_dashboard_index_path: function(options) {
+  return Utils.build_path(1, ["/dashboard/errata"], arguments)
+  },
+// repositories_api_organization_product => /api/organizations/:organization_id/products/:id/repositories(.:format)
+  repositories_api_organization_product_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/products/", "/repositories"], arguments)
+  },
+// status_system_events => /systems/:system_id/events/status(.:format)
+  status_system_events_path: function(_system_id, options) {
+  return Utils.build_path(2, ["/systems/", "/events/status"], arguments)
+  },
+// systems_api_organization_system_group => /api/organizations/:organization_id/system_groups/:id/systems(.:format)
+  systems_api_organization_system_group_path: function(_organization_id, _id, options) {
+  return Utils.build_path(3, ["/api/organizations/", "/system_groups/", "/systems"], arguments)
+  },
+// system_groups => /system_groups(.:format)
+  system_groups_path: function(options) {
+  return Utils.build_path(1, ["/system_groups"], arguments)
+  },
+// distributions_promotion => /promotions/:id/distributions(.:format)
+  distributions_promotion_path: function(_id, options) {
+  return Utils.build_path(2, ["/promotions/", "/distributions"], arguments)
+  },
+// search_api_repository_packages => /api/repositories/:repository_id/packages/search(.:format)
+  search_api_repository_packages_path: function(_repository_id, options) {
+  return Utils.build_path(2, ["/api/repositories/", "/packages/search"], arguments)
+  },
+// notices_details => /notices/:id/details(.:format)
+  notices_details_path: function(_id, options) {
+  return Utils.build_path(2, ["/notices/", "/details"], arguments)
+  },
+// new_filter => /filters/new(.:format)
+  new_filter_path: function(options) {
+  return Utils.build_path(1, ["/filters/new"], arguments)
+  },
+// auto_complete_search_users => /users/auto_complete_search(.:format)
+  auto_complete_search_users_path: function(options) {
+  return Utils.build_path(1, ["/users/auto_complete_search"], arguments)
+  },
+// events_organization => /organizations/:id/events(.:format)
+  events_organization_path: function(_id, options) {
+  return Utils.build_path(2, ["/organizations/", "/events"], arguments)
+  },
+// edit_activation_key => /activation_keys/:id/edit(.:format)
+  edit_activation_key_path: function(_id, options) {
+  return Utils.build_path(2, ["/activation_keys/", "/edit"], arguments)
+  },
+// erratum => /errata/:id(.:format)
+  erratum_path: function(_id, options) {
+  return Utils.build_path(2, ["/errata/"], arguments)
+  },
+// download_system_template => /system_templates/:id/download(.:format)
+  download_system_template_path: function(_id, options) {
+  return Utils.build_path(2, ["/system_templates/", "/download"], arguments)
+  },
+// system_group_events => /system_groups/:system_group_id/events(.:format)
+  system_group_events_path: function(_system_group_id, options) {
+  return Utils.build_path(2, ["/system_groups/", "/events"], arguments)
+  },
+// update_locale_user => /users/:id/update_locale(.:format)
+  update_locale_user_path: function(_id, options) {
+  return Utils.build_path(2, ["/users/", "/update_locale"], arguments)
+  },
+// gpg_key_content_api_repository => /api/repositories/:id/gpg_key_content(.:format)
+  gpg_key_content_api_repository_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/repositories/", "/gpg_key_content"], arguments)
+  },
+// new_repository => /repositories/new(.:format)
+  new_repository_path: function(options) {
+  return Utils.build_path(1, ["/repositories/new"], arguments)
+  },
+// system_groups_api_system => /api/systems/:id/system_groups(.:format)
+  system_groups_api_system_path: function(_id, options) {
+  return Utils.build_path(2, ["/api/systems/", "/system_groups"], arguments)
+  },
+// edit_role => /roles/:id/edit(.:format)
+  edit_role_path: function(_id, options) {
+  return Utils.build_path(2, ["/roles/", "/edit"], arguments)
+  },
+// subscriptions => /subscriptions(.:format)
+  subscriptions_path: function(options) {
+  return Utils.build_path(1, ["/subscriptions"], arguments)
+  },
+// report_api_environment_systems => /api/environments/:environment_id/systems/report(.:format)
+  report_api_environment_systems_path: function(_environment_id, options) {
+  return Utils.build_path(2, ["/api/environments/", "/systems/report"], arguments)
   }}
 ;
   


### PR DESCRIPTION
This is just an initial commit to get some structure in
to begin building out the UI.
- Provides the following:
  - basic create/review/update/delete of a content view
    that has name/label/description.
  - search based on name or description
  - adding content view to the main Content navigation
  - only single Details navigation for a view
