### PR TITLE
force devboost to be on in development mode.

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -137,7 +137,8 @@ group :development do
   gem 'logical-insight'
 end
 
-group :devboost do
+group :development do
+  # devboost just for dev mode
   gem 'rails-dev-boost', :require => 'rails_development_boost'
 end
 


### PR DESCRIPTION
those of us who use devboost are not seeing any issues with this gem
and it greatly speeds up development. This should be on by default and
not be optional since most people are not enabling it by hand.
