### PR TITLE
Use updated oauth from our repo

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -49,6 +49,7 @@
        <packagereq type="default">rubygem-ldap_fluff</packagereq>
        <packagereq type="default">rubygem-multi_json</packagereq>
        <packagereq type="default">rubygem-net-ldap</packagereq>
+       <packagereq type="default">rubygem-oauth</packagereq>
        <packagereq type="default">rubygem-pdf-writer</packagereq>
        <packagereq type="default">rubygem-prawn</packagereq>
        <packagereq type="default">rubygem-rcov</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-server-fedora17.xml
@@ -45,6 +45,7 @@
        <packagereq type="default">rubygem-hashr</packagereq>
        <packagereq type="default">rubygem-jammit</packagereq>
        <packagereq type="default">rubygem-ldap_fluff</packagereq>
+       <packagereq type="default">rubygem-oauth</packagereq>
        <packagereq type="default">rubygem-pdf-writer</packagereq>
        <packagereq type="default">rubygem-prawn</packagereq>
        <packagereq type="default">rubygem-rcov</packagereq>


### PR DESCRIPTION
New version brings better support for Rails 3 and fixes the problems
with Foreman communication.
