### PR TITLE
katello-upgrade - fix in katello-configure first installation

### DIFF
--- a/katello-configure/modules/katello/manifests/config.pp
+++ b/katello-configure/modules/katello/manifests/config.pp
@@ -183,9 +183,10 @@ class katello::config {
     },
   }
 
-  # during first installation we mark all upgrade scripts as executed
+  # during first installation we mark all 'once'  upgrade scripts as executed
   exec {"update_upgrade_history":
-    command => "ls ${katello::params::katello_upgrade_scripts_dir} > ${katello::params::katello_upgrade_history_file}",
+    cwd     => "${katello::params::katello_upgrade_scripts_dir}",
+    command => "grep -E '#.*run:.*once' * | awk -F: '{print \$1}' > ${katello::params::katello_upgrade_history_file}",
     creates => "${katello::params::katello_upgrade_history_file}",
     path    => "/bin",
     before  => Class["katello::service"],

--- a/katello-configure/modules/katello/manifests/params.pp
+++ b/katello-configure/modules/katello/manifests/params.pp
@@ -50,7 +50,7 @@ class katello::params {
   $seed_log    = "$configure_log_base/db_seed.log"
 
   # katello upgrade settings
-  $katello_upgrade_scripts_dir  = "/usr/share/katello/install/upgrade-scripts/upgrade/"
+  $katello_upgrade_scripts_dir  = "/usr/share/katello/install/upgrade-scripts"
   $katello_upgrade_history_file = "/var/lib/katello/upgrade-history"
 
   # SSL settings


### PR DESCRIPTION
Fixing minor katello-configure error (which was not blocking Katello from to be installed):

```
err: /Stage[main]/Katello::Config/Exec[update_upgrade_history]/returns: change from notrun to 0 failed: ls /usr/share/katello/install/upgrade-scripts/upgrade/ > /var/lib/katello/upgrade-history returned 2 instead of one of [0] at /usr/share/katello/install/puppet/modules/katello/manifests/config.pp:192
```

Edit: Fixed error msg.
