### PR TITLE
Adding client-ca.pem to /etc/thumbslug for thumbslug .27

### DIFF
--- a/katello-configure/modules/thumbslug/manifests/config.pp
+++ b/katello-configure/modules/thumbslug/manifests/config.pp
@@ -10,4 +10,12 @@ class thumbslug::config {
     require => Class["certs::config"],
     notify  => Service["thumbslug"];
   }
+
+  # copy candlepin cert to thumbslug dir
+  # required as of thumbslug-0.27
+  file { "/etc/thumbslug/client-ca.pem":
+    source => "/etc/candlepin/certs/candlepin-ca.crt",
+    require => [Class["certs::config"]],
+    notify => Service["thumbslug"];
+  }
 }


### PR DESCRIPTION
would appreciate comments on file perms

defaults to

 -rw-r--r--. 1 root katello   1675 Nov 15 11:49 client-ca.pem
