### PR TITLE
content views - shorting nav label to use Views

### DIFF
--- a/src/lib/navigation/content_management.rb
+++ b/src/lib/navigation/content_management.rb
@@ -155,7 +155,7 @@ module Navigation
 
     def menu_content_view_definitions
       {:key => :content_view_definitions,
-       :name => _("Content View Definitions"),
+       :name => _("Views"),
        :if => lambda{AppConfig.katello? && ContentViewDefinition.any_readable?(current_organization)},
        :options => {:class=>'content second_level', "data-menu"=>"content"},
        :url =>content_view_definitions_path,


### PR DESCRIPTION
Just a quick PR to ensure that all Content navigations are being rendered...

Found that using "Content View Definitions" causes the navigation
to exceed horizontal limits.  When this happens, Changeset Management
is dropped off of the nav. There is work planned to revamp some
of the navigation, so shortening the name now to ensure that all
navs are displayed and when the revaming is completed, we can expand
it to be the intended name.
