### PR TITLE
875609-hypervisor - allow hypervisors to successfully register and list ...

### DIFF
--- a/cli/src/katello/client/core/system.py
+++ b/cli/src/katello/client/core/system.py
@@ -443,7 +443,7 @@ class RemoveDeletion(SystemAction):
                        help=_("hypervisor uuid (required)"))
 
     def check_options(self, validator):
-        validator.require_option('uuid')
+        validator.require('uuid')
 
     def run(self):
         uuid = self.get_option('uuid')

--- a/src/app/models/glue/candlepin/consumer.rb
+++ b/src/app/models/glue/candlepin/consumer.rb
@@ -102,6 +102,7 @@ module Glue::Candlepin::Consumer
 
     def load_from_cp(consumer_json)
       self.uuid = consumer_json[:uuid]
+      consumer_json[:facts] ||= {'sockets'=>0}
       convert_from_cp_fields(consumer_json).each do |k,v|
         instance_variable_set("@#{k}", v) if respond_to?("#{k}=")
       end


### PR DESCRIPTION
...in katello

Facts no longer come back from candlepin in this call so if none are present, a stub facts is added. Since 'sockets' are required for proper elasticsearch that is added here.
