### PR TITLE
add rubygem(rspec-core) to rhel6 comps as devel deps

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -130,6 +130,7 @@
        <packagereq type="default">rubygem-parallel</packagereq>
        <packagereq type="default">rubygem-parallel_tests</packagereq>
        <packagereq type="default">rubygem-rails-dev-boost</packagereq>
+       <packagereq type="default">rubygem-rspec-core</packagereq>
        <packagereq type="default">rubygem-rspec-expectations</packagereq>
        <packagereq type="default">rubygem-rspec-mocks</packagereq>
        <packagereq type="default">rubygem-rspec-rails</packagereq>


### PR DESCRIPTION
addressing:

```
yum install katello-devel-all
...
--> Finished Dependency Resolution
Error: Package: rubygem-rspec-rails-2.6.1-7.el6.noarch (katello)
           Requires: rubygem(rspec-core) < 2.7
Error: Package: rubygem-rspec-rails-2.6.1-7.el6.noarch (katello)
           Requires: rubygem(rspec-core) >= 2.6.0
 You could try using --skip-broken to work around the problem
```
