### PR TITLE
katello-configure - make sure Foreman is accessible through https only

### DIFF
--- a/katello-configure/modules/foreman/templates/httpd.conf.erb
+++ b/katello-configure/modules/foreman/templates/httpd.conf.erb
@@ -9,6 +9,8 @@ ProxyTimeout 5400
 </Proxy>
 
 <Location /foreman>
+  SSLRequireSSL
+  RequestHeader set X_FORWARDED_PROTO 'https'
   ProxyPass balancer://foremanthinservers
   ProxyPassReverse balancer://foremanthinservers
 </Location>


### PR DESCRIPTION
And forward the https information to thin. Otherwise the mismatch
between oauth request is in risk, especially during katello-configure.
