### PR TITLE
add foreman ping support

### DIFF
--- a/src/app/models/ping.rb
+++ b/src/app/models/ping.rb
@@ -30,7 +30,8 @@ class Ping
           :elasticsearch => {},
           :pulp_auth => {},
           :candlepin_auth => {},
-          :katello_jobs => {}
+          :katello_jobs => {},
+          :foreman_auth => {},
         }}
       else
         result = { :result => 'ok', :status => {
@@ -55,6 +56,7 @@ class Ping
         RestClient.get "#{url}/status"
       end
 
+      # elasticsearch - ping without oauth
       url = AppConfig.elastic_url
       exception_watch(result[:status][:elasticsearch]) do
         RestClient.get "#{url}/_status"
@@ -72,10 +74,15 @@ class Ping
         Resources::Candlepin::CandlepinPing.ping
       end
 
+      # foreman - ping with oauth
+      exception_watch(result[:status][:foreman_auth]) do
+        Resources::Foreman::Home.status
+      end
+
+      # katello jobs - TODO we should not spawn processes
       exception_watch(result[:status][:katello_jobs]) do
         raise _("katello-jobs service not running") if !system("/sbin/service katello-jobs status")
       end
-
 
       # set overall status result code
       result[:status].each_value { |v| result[:result] = 'fail' if v[:result] != 'ok' }


### PR DESCRIPTION
I have been drying this patch until Foreman installation is fixed. Now it's working again, tested.

It adds foreman service under the "katello ping" command.

```
candlepin      ok     131ms    
candlepin_auth ok     20ms     
elasticsearch  ok     14ms     
foreman_auth   ok     55ms     
katello_jobs   ok     628ms    
pulp           ok     390ms    
pulp_auth      ok     107ms
```
