### PR TITLE
Add dependencies for katello-devel-jshintrb

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -78,6 +78,7 @@
        <packagereq type="default">rubygem-autotest-rails</packagereq>
        <packagereq type="default">rubygem-ci_reporter</packagereq>
        <packagereq type="default">rubygem-js-routes</packagereq>
+       <packagereq type="default">rubygem-jshintrb</packagereq>
        <packagereq type="default">rubygem-libv8</packagereq>
        <packagereq type="default">rubygem-logical-insight</packagereq>
        <packagereq type="default">rubygem-macaddr</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-server-fedora17.xml
@@ -71,6 +71,7 @@
        <packagereq type="default">rubygem-autotest-rails</packagereq>
        <packagereq type="default">rubygem-ci_reporter</packagereq>
        <packagereq type="default">rubygem-js-routes</packagereq>
+       <packagereq type="default">rubygem-jshintrb</packagereq>
        <packagereq type="default">rubygem-libv8</packagereq>
        <packagereq type="default">rubygem-logical-insight</packagereq>
        <packagereq type="default">rubygem-macaddr</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -121,6 +121,7 @@
        <packagereq type="default">rubygem-ci_reporter</packagereq>
        <packagereq type="default">rubygem-columnize</packagereq>
        <packagereq type="default">rubygem-js-routes</packagereq>
+       <packagereq type="default">rubygem-jshintrb</packagereq>
        <packagereq type="default">rubygem-logical-insight</packagereq>
        <packagereq type="default">rubygem-libv8</packagereq>
        <packagereq type="default">rubygem-macaddr</packagereq>

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -290,6 +290,7 @@ Requires:        %{name} = %{version}-%{release}
 Requires:        rubygem(newrelic_rpm)
 Requires:        rubygem(logical-insight)
 Requires:        rubygem(libv8)
+Requires:        rubygem(jshintrb)
 
 %description devel-jshintrb
 Rake tasks and dependecies for Katello developers, which enables


### PR DESCRIPTION
Still one remaining - rubyracer, but I will do that tommorow.
Lets just merge this for now to easy Bryan pain :)
