### PR TITLE
bundler_ext - no need to run bundler during configure steps

### DIFF
--- a/katello-configure/bin/katello-configure
+++ b/katello-configure/bin/katello-configure
@@ -374,11 +374,7 @@ if url_root == 'katello' || url_root == 'cfse'
   end
 end
 
-# set relative url root
 ENV['RAILS_RELATIVE_URL_ROOT'] = "/" + url_root
-
-# we do not want to stop during rake steps
-ENV['BUNDLER_EXT_NOSTRICT'] = 1
 
 # handle ca password separately, because we do not want
 # to store it into the katello-configure.conf

--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -9,6 +9,7 @@ class foreman::config {
   # request which can easily result with a lot of old and unrequired in your
   # database eventually slowing it down.
   cron{'clear_session_table':
+    environment => ["RAILS_ENV=${foreman::environment}", "BUNDLER_EXT_NOSTRICT=1"],
     command => "(cd ${foreman::app_root} && rake db:sessions:clear)",
     minute  => '15',
     hour    => '23',
@@ -80,7 +81,7 @@ class foreman::config {
 
   exec {"foreman_migrate_db":
     cwd         => $foreman::app_root,
-    environment => "RAILS_ENV=${foreman::environment}",
+    environment => ["RAILS_ENV=${foreman::environment}", "BUNDLER_EXT_NOSTRICT=1"],
     command     => "/usr/bin/env rake db:migrate --trace --verbose > ${foreman::configure_log_base}/foreman-db-migrate.log 2>&1 && touch /var/lib/katello/foreman_db_migrate_done",
     creates     => "/var/lib/katello/foreman_db_migrate_done",
     require     => [ Postgres::Createdb[$foreman::db_name],

--- a/katello-configure/modules/katello/manifests/config.pp
+++ b/katello-configure/modules/katello/manifests/config.pp
@@ -144,7 +144,7 @@ class katello::config {
   exec {"katello_migrate_db":
     cwd         => $katello::params::katello_dir,
     user        => "root",
-    environment => "RAILS_ENV=${katello::params::environment}",
+    environment => ["RAILS_ENV=${katello::params::environment}", "BUNDLER_EXT_NOSTRICT=1"]
     command     => "/usr/bin/env rake db:migrate --trace --verbose > ${katello::params::migrate_log} 2>&1 && touch /var/lib/katello/db_migrate_done",
     creates => "/var/lib/katello/db_migrate_done",
     before  => Class["katello::service"],
@@ -154,7 +154,7 @@ class katello::config {
   exec {"katello_seed_db":
     cwd         => $katello::params::katello_dir,
     user        => "root",
-    environment => ["RAILS_ENV=${katello::params::environment}", "KATELLO_LOGGING=debug"],
+    environment => ["RAILS_ENV=${katello::params::environment}", "KATELLO_LOGGING=debug", "BUNDLER_EXT_NOSTRICT=1"],
     command     => "/usr/bin/env rake seed_with_logging --trace --verbose > ${katello::params::seed_log} 2>&1 && touch /var/lib/katello/db_seed_done",
     creates => "/var/lib/katello/db_seed_done",
     before  => Class["katello::service"],


### PR DESCRIPTION
We do not want to set BUNDLER_EXT_NOSTRICT globally but only for particular puppet steps. This also fixes:

```
/usr/sbin/katello-configure:381:in `[]=': can't convert Fixnum into String (TypeError)
```

TY
