### PR TITLE
update gems jshintrb and therubyracer

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -92,6 +92,7 @@
        <packagereq type="default">rubygem-rails-dev-boost</packagereq>
        <packagereq type="default">rubygem-ruby-prof</packagereq>
        <packagereq type="default">rubygem-systemu</packagereq>
+       <packagereq type="default">rubygem-therubyracer</packagereq>
        <packagereq type="default">rubygem-uuid</packagereq>
        <packagereq type="default">rubygem-ZenTest</packagereq>
     </packagelist>

--- a/rel-eng/comps/comps-katello-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-server-fedora17.xml
@@ -87,6 +87,7 @@
        <packagereq type="default">rubygem-simplecov</packagereq>
        <packagereq type="default">rubygem-simplecov-html</packagereq>
        <packagereq type="default">rubygem-systemu</packagereq>
+       <packagereq type="default">rubygem-therubyracer</packagereq>
        <packagereq type="default">rubygem-uuid</packagereq>
     </packagelist>
   </group>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -141,6 +141,7 @@
        <packagereq type="default">rubygem-ruby-prof</packagereq>
        <packagereq type="default">rubygem-sqlite3</packagereq>
        <packagereq type="default">rubygem-systemu</packagereq>
+       <packagereq type="default">rubygem-therubyracer</packagereq>
        <packagereq type="default">rubygem-uuid</packagereq>
        <packagereq type="default">rubygem-vcr</packagereq>
        <packagereq type="default">rubygem-webmock</packagereq>

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -113,9 +113,11 @@ group :jshintrb do
   #needed for unit tests
   #
   #needed for syntax checking
-  gem 'libv8'
-  gem 'therubyracer', "~> 0.10.2"
-  gem 'jshintrb', '0.1.1'
+  gem 'therubyracer', ">= 0.11.0"
+    gem 'ref'
+  gem 'jshintrb', '0.2.1'
+    gem 'execjs'
+    gem 'multi_json', '>= 1.3'
 end
 
 group :development do

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -293,7 +293,7 @@ BuildArch:       noarch
 Requires:        %{name} = %{version}-%{release}
 Requires:        rubygem(newrelic_rpm)
 Requires:        rubygem(logical-insight)
-Requires:        rubygem(libv8)
+Requires:        rubygem(therubyracer)
 Requires:        rubygem(jshintrb)
 
 %description devel-jshintrb


### PR DESCRIPTION
- rubygem-libv8 is not needed anymore, because new jshintrb use v8 directly
- new jshintrb require new multi_json, which is added as well.
