### PR TITLE
Ensure that the name and label is unique across all all orgs

### DIFF
--- a/src/app/controllers/api/organizations_controller.rb
+++ b/src/app/controllers/api/organizations_controller.rb
@@ -82,7 +82,10 @@ class Api::OrganizationsController < Api::ApiController
   private
 
   def find_organization
+    # Look first based on name, and then based on label.
+    # The latter is to better support subscrption manager.
     @organization = Organization.first(:conditions => {:name => params[:id]})
+    @organization = Organization.first(:conditions => {:label => params[:id]}) if @organization.nil?
     raise HttpErrors::NotFound, _("Couldn't find organization '%s'") % params[:id] if @organization.nil?
     @organization
   end


### PR DESCRIPTION
So the thing is not to let users to create AND update orgs with name that already exist as label and vice versa. Discussion was on the list.

Now we search for organizations by name and label.

@bk - I had to redo your patch - creating was find, but updating was big deal.
