### PR TITLE
foreman 404 error configure fix - missing dep

### DIFF
--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -76,7 +76,9 @@ class foreman::config {
       content => template("foreman/httpd.conf.erb"),
       owner   => $foreman::user,
       group   => $foreman::user,
-      mode    => "600";
+      mode    => "600",
+      notify  => Exec["reload-apache2"],
+      before  => Class["apache2::service"];
   }
 
   exec {"foreman_migrate_db":


### PR DESCRIPTION
So this should fix the ocassional error 404 when configuring foreman.

Again, I am not able to test this, because my testing boxes are not expericing this issue. But I tested puppet compiles and k-c is working fine.
