### PR TITLE
866972 - katello-debug needs to take headpin into consideration

### DIFF
--- a/cli/bin/katello-debug-certificates
+++ b/cli/bin/katello-debug-certificates
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 PREFIX='  '
-PERMS=0 
+PERMS=0
 
 function cert_info() {
   CERT=$1
   DESCR=$2
   [[ -n "$DESCR" ]] && echo -e "$DESCR"
-  if [[ -n "$CERT" ]]; then 
+  if [[ -n "$CERT" ]]; then
     SERIAL=$(echo "$CERT" | grep "Serial Number" -A1 | tail -n1 | awk '{print $1}')
     DN=$(echo "$CERT" | grep "Subject:" | sed 's/\s*Subject: //')
     CA=$(echo "$CERT" | grep "CA" | head -n1 | awk '{print $1}')
@@ -25,7 +25,7 @@ function certutils_cert_info() {
   CERT=$1
   DESCR=$2
   [[ -n "$DESCR" ]] && echo -e "$DESCR"
-  if [[ -n "$CERT" ]]; then 
+  if [[ -n "$CERT" ]]; then
     SERIAL=$(echo "$CERT" | grep "Serial Number" -A1 | head -n2 | tail -n1 | awk '{print $1}')
     DN=$(echo "$CERT" | grep "Subject:" | sed 's/\s*Subject: //')
     CA=$(echo "$CERT" | grep "Certificate Basic Constraints" -A1| tail -n1 | sed 's/^\s*Data: //')
@@ -45,20 +45,22 @@ function cert_file_info() {
     CERT=$( openssl x509 -noout -text -in "$CERTFILE" )
     cert_info "$CERT" "$CERTFILE"
     path_perms "$CERTFILE"
-  else 
+  else
     cert_info "" "$CERTFILE"
   fi
 }
 
 function nss_info() {
-  echo "NSS DB - Broker Key"
-  echo -e "$PREFIX$(certutil -d /etc/pki/katello/nssdb -K -f /etc/katello/nss_db_password-file|grep broker)\n"
-  path_perms "/etc/katello/nss_db_password-file"
-  certutils_cert_info "$(certutil -d /etc/pki/katello/nssdb -L -n ca)" 'NSS DB - CA'
-  certutils_cert_info "$(certutil -d /etc/pki/katello/nssdb -L -n broker)" 'NSS DB - Broker'
-  for f in `ls /etc/pki/katello/nssdb/*`; do
-    path_perms "$f"
-  done
+  if [ -d "/etc/pki/katello/nssdb" ]; then
+    echo "NSS DB - Broker Key"
+    echo -e "$PREFIX$(certutil -d /etc/pki/katello/nssdb -K -f /etc/katello/nss_db_password-file|grep broker)\n"
+    path_perms "/etc/katello/nss_db_password-file"
+    certutils_cert_info "$(certutil -d /etc/pki/katello/nssdb -L -n ca)" 'NSS DB - CA'
+    certutils_cert_info "$(certutil -d /etc/pki/katello/nssdb -L -n broker)" 'NSS DB - Broker'
+    for f in $(ls /etc/pki/katello/nssdb/*); do
+      path_perms "$f"
+    done
+  fi
 }
 
 function keystore_info() {
@@ -68,11 +70,13 @@ function keystore_info() {
 function path_perms() {
     if [ $PERMS = 1 ]; then
         CERTPATH=$1
-        while [ "$CERTPATH" != '/' ]; do
-            LSOUT=$(ls -lahd "$CERTPATH")
-            echo "$PREFIX$LSOUT"
-            CERTPATH=$(dirname "$CERTPATH")
-        done 
+        if [ -e "$CERTPATH" ]; then
+            while [ "$CERTPATH" != '/' ]; do
+                LSOUT=$(ls -lahd "$CERTPATH")
+                echo "$PREFIX$LSOUT"
+                CERTPATH=$(dirname "$CERTPATH")
+            done
+        fi
     fi
     echo ""
 }

--- a/src/script/katello-debug
+++ b/src/script/katello-debug
@@ -47,8 +47,6 @@ end
 puts "detected deployment: \t#{deployment}"
 
 # Define what we want to collect
-sources = []
-
 MISC = [
 "/var/log/audit/audit.log",
 "/var/log/httpd",
@@ -74,7 +72,7 @@ KATELLO_HEADPIN = [
 "/etc/katello/thin.yml",
 "/etc/katello/katello-configure.conf",
 "/etc/httpd/conf.d/katello.conf",
-"/etc/katello/environment.db"
+"/etc/katello/environment.rb"
 ]
 
 ELASTIC_SEARCH = [
@@ -106,6 +104,7 @@ EXCLUDES = [
 
 
 # sources list for katello or headpin deployment
+sources = []
 sources += MISC
 sources += KATELLO_HEADPIN
 sources += ELASTIC_SEARCH
@@ -179,7 +178,7 @@ if deployment == 'katello'
 end
 
 # Create certificates report
-output = `katello-debug-certificates >> #{File.join(target_dir, "certificates")}`
+output = `katello-debug-certificates --perms >> #{File.join(target_dir, "certificates")}`
 
 # Add list of ssl-build dir
 output = `find /root/ssl-build -ls | sort -k 11 > #{File.join(target_dir, "ssl_build_dir")}`


### PR DESCRIPTION
-fixing filename typo (environment.rb)
-fencing nss_info from headpin
-fencing path_perms to check for file existence
-adding "--perms" option to katello-debug-certificates call to output
file permissions
-automatic whitespace removal
