### PR TITLE
requiring specific older version of pdf-reader

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -45,14 +45,15 @@ gem 'simple-navigation', '>= 3.3.4'
 gem 'gettext_i18n_rails'
 gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
 
-
-gem 'pdf-reader', '<= 1.1.1'   #Does not pull in  hashery, matches RPM
 # Reports
 if system('rpm -q rubygem-ruport >/dev/null')
   gem 'ruport' , '>=1.7.0'
 else
   gem 'ruport' , '>=1.7.0', :git => 'git://github.com/ruport/ruport.git'
 end
+#not an actual katello dependency, but 
+#Does not pull in  hashery, matches RPM
+gem 'pdf-reader', '<= 1.1.1' 
 
 gem 'prawn'
 gem 'acts_as_reportable', '>=1.1.1'


### PR DESCRIPTION
newer version requires hashery which ends up breaking manifest import due to
-  Hashery adds an alias  :read  for []
          to all Hash objects
-  Rest client sees that a hash has a :read attribute
       and tries to stream the manifest as a multipart form
- Candlepin cannot handle multipart forms
