### PR TITLE
add  rubygem-ref to comps

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -90,6 +90,7 @@
        <packagereq type="default">rubygem-parallel</packagereq>
        <packagereq type="default">rubygem-parallel_tests</packagereq>
        <packagereq type="default">rubygem-rails-dev-boost</packagereq>
+       <packagereq type="default">rubygem-ref</packagereq>
        <packagereq type="default">rubygem-ruby-prof</packagereq>
        <packagereq type="default">rubygem-systemu</packagereq>
        <packagereq type="default">rubygem-therubyracer</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-server-fedora17.xml
@@ -83,6 +83,7 @@
        <packagereq type="default">rubygem-parallel</packagereq>
        <packagereq type="default">rubygem-parallel_tests</packagereq>
        <packagereq type="default">rubygem-rails-dev-boost</packagereq>
+       <packagereq type="default">rubygem-ref</packagereq>
        <packagereq type="default">rubygem-ruby-prof</packagereq>
        <packagereq type="default">rubygem-simplecov</packagereq>
        <packagereq type="default">rubygem-simplecov-html</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -133,6 +133,7 @@
        <packagereq type="default">rubygem-parallel</packagereq>
        <packagereq type="default">rubygem-parallel_tests</packagereq>
        <packagereq type="default">rubygem-rails-dev-boost</packagereq>
+       <packagereq type="default">rubygem-ref</packagereq>
        <packagereq type="default">rubygem-rspec-core</packagereq>
        <packagereq type="default">rubygem-rspec-expectations</packagereq>
        <packagereq type="default">rubygem-rspec-mocks</packagereq>


### PR DESCRIPTION
addressing:

```
Error: Package: rubygem-therubyracer-0.11.0-0.9.beta5.el6.x86_64 (katello)
           Requires: rubygem(ref)
```
