### PR TITLE
880116 - pool was referencing a non-existant instance variable

### DIFF
--- a/src/app/models/glue/candlepin/pool.rb
+++ b/src/app/models/glue/candlepin/pool.rb
@@ -53,7 +53,7 @@ module Glue::Candlepin::Pool
     end
 
     def organization
-      Organization.find_by_name(@owner["key"])
+      Organization.find_by_name(self.owner["key"])
     end
 
     # if defined +load_remote_data+ will be used by +lazy_accessors+


### PR DESCRIPTION
owner is lazy-loaded, must be accessed by self.owner before reading
