### PR TITLE
content views - ui - initial code for the view definition -> Views pane

### DIFF
--- a/src/app/views/content_view_definitions/_publish.html.haml
+++ b/src/app/views/content_view_definitions/_publish.html.haml
@@ -1,0 +1,18 @@
+= javascript :subpanel_new
+
+= content_for :title do
+  #{_("Publish View Definition")}
+
+= content_for :subcontent do
+
+  = kt_form_for ContentView.new, :url => publish_content_view_definition_path(@view_definition.id), :remote => true, :html => {:id => 'new_subpanel'} do |form|
+
+    = form.text_field :name, :label => _("Name"), :class => :name_input
+
+    = form.field :label, :label => _('Label') do
+      = text_field_tag 'content_view[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_content_view_definitions_path
+      = image_tag 'embed/icons/spinner.gif', :class => 'label_spinner hidden'
+
+    = form.text_area :description, :size => "40x5", :label => _('Description')
+
+    = form.submit _('Publish'), :disable_with => _('Publishing...'), :class => 'publish_button subpanel_create'

--- a/src/app/views/content_view_definitions/_views.html.haml
+++ b/src/app/views/content_view_definitions/_views.html.haml
@@ -10,4 +10,23 @@
 
 = content_for :content do
 
-  .grid_10#view_definition
+  #content_view_definition_views
+    %table
+      %thead
+        %tr{:style => "background-color: #F5FAFA;"}
+          %td{:colspan => 3, :style => "vertical-align:middle; font-size:130%;"}
+            #{_("Publish new content view from this view definition")}
+          %td
+            %input.fr.button.subpanel_element{:type=>'button', :value=>_("Publish"), 'data-url' => publish_setup_content_view_definition_path(view_definition.id)}
+        %tr
+          %th #{_("Name")}
+          %th #{_("Version")}
+          %th{:colspan => 2} #{_("Published")}
+      %tbody.views
+        - view_definition.content_views.each do |view|
+          - view.versions.each do |view_version|
+            %tr
+              %td #{view.name}
+              %td #{view_version.version}
+              %td #{view_version.created_at}
+              %td

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -73,6 +73,8 @@ Src::Application.routes.draw do
     end
     member do
       get :views
+      get :publish_setup
+      post :publish
       get :content
       post :update_content
       get :filter


### PR DESCRIPTION
This commit contains initial code for the Views pane for a
Content View Definition.  It allows the user to publish
the view and see the list of previously published views
off of this definition.

Note:
- there is currently an issue where user cannot publish the definition
  multiple times; however, that is not related changes in this commit.
