### PR TITLE
move helper functions from bin/katello-configure to functions.rb

### DIFF
--- a/katello-configure/bin/katello-configure
+++ b/katello-configure/bin/katello-configure
@@ -224,19 +224,6 @@ if show_resulting_answer_file
 	exit
 end
 
-# Prints a warning if FQDN is not set, returns error when
-# localhost or hostname cannot be resolved (/etc/hosts entry is missing).
-def check_hostname
-  hostname = Socket.gethostname
-  Socket.gethostbyname hostname
-  Socket.gethostbyname 'localhost'
-	$stderr.puts "WARNING: FQDN is not set!" unless hostname.index '.'
-rescue SocketError => e
-  puts "Error"
-	$stderr.puts "Unable to resolve '#{hostname}' or 'localhost'. Check your DNS and /etc/hosts settings."
-  exit_with :hostname_error
-end
-
 # check if running as root and change current dir
 unless Process.uid == 0
   $stderr.puts "You must run katello-configure as root"

--- a/katello-configure/lib/util/functions.rb
+++ b/katello-configure/lib/util/functions.rb
@@ -234,3 +234,16 @@ def _request_option_interactively(title, regex, default_value, non_interactive_v
     puts "Your entry has to match regular expression: /#{regex}/"
   end
 end
+
+# Prints a warning if FQDN is not set, returns error when
+# localhost or hostname cannot be resolved (/etc/hosts entry is missing).
+def check_hostname
+  hostname = Socket.gethostname
+  Socket.gethostbyname hostname
+  Socket.gethostbyname 'localhost'
+  $stderr.puts "WARNING: FQDN is not set!" unless hostname.index '.'
+rescue SocketError => e
+  puts "Error"
+  $stderr.puts "Unable to resolve '#{hostname}' or 'localhost'. Check your DNS and /etc/hosts settings."
+  exit_with :hostname_error
+end


### PR DESCRIPTION
This is first them to make code resuable for foreman-proxy-installer
