### PR TITLE
Provide the headers for when pinging Foreman

### DIFF
--- a/src/app/models/ping.rb
+++ b/src/app/models/ping.rb
@@ -76,7 +76,7 @@ class Ping
 
       # foreman - ping with oauth
       exception_watch(result[:status][:foreman_auth]) do
-        Resources::Foreman::Home.status
+        Resources::Foreman::Home.status({}, Resources::ForemanModel.header)
       end
 
       # katello jobs - TODO we should not spawn processes


### PR DESCRIPTION
Otherwise the authentication fails due to missing user mapping.

If you wonder why it worked so far, the answer is here:

https://github.com/theforeman/foreman/pull/274

After the fix in Foreman, it would correctly start failing. 
