### PR TITLE
content views - on changesets page, allow user to see view details

### DIFF
--- a/src/app/controllers/content_view_versions_controller.rb
+++ b/src/app/controllers/content_view_versions_controller.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+class ContentViewVersionsController < ApplicationController
+
+  before_filter :find_environment
+  before_filter :find_content_view_version
+  before_filter :authorize
+
+  def rules
+    readable = lambda{ @view_version.content_view.readable? }
+    {
+      :show => readable,
+      :content => readable
+    }
+  end
+
+  def show
+    render :partial=>"show", :layout => "tupane_layout"
+  end
+
+  def content
+    render :partial=>"content", :layout => "tupane_layout",
+           :locals => {:view_repos => @view_version.repos_ordered_by_product(@environment)}
+  end
+
+  private
+
+  def find_environment
+    @environment = KTEnvironment.find(params[:environment_id])
+  end
+
+  def find_content_view_version
+    @view_version = ContentViewVersion.find(params[:id])
+  end
+end

--- a/src/app/controllers/promotions_controller.rb
+++ b/src/app/controllers/promotions_controller.rb
@@ -251,7 +251,7 @@ class PromotionsController < ApplicationController
     next_env_view_version_ids = @next_environment.nil? ? [].to_set :
                                 @next_environment.content_view_versions.non_default_view.pluck(:id).to_set
 
-    render :partial=>"content_views", :locals => {:content_view_versions => view_versions,
+    render :partial=>"content_views", :locals => {:environment => @environment, :content_view_versions => view_versions,
                                                   :next_env_view_version_ids => next_env_view_version_ids}
   end
 

--- a/src/app/models/content_view_version.rb
+++ b/src/app/models/content_view_version.rb
@@ -27,6 +27,14 @@ class ContentViewVersion < ActiveRecord::Base
     self.repositories.in_environment(env)
   end
 
+  def repos_ordered_by_product(env)
+    # The repository model has a default scope that orders repositories by name;
+    # however, for content views, it is desirable to order the repositories
+    # based on the name of the product the repository is part of.
+    Repository.send(:with_exclusive_scope) {self.repositories.joins(:environment_product => :product).
+        in_environment(env).order('products.name asc')}
+  end
+
   def self.in_environment(env)
     joins(:content_view_version_environments).where('content_view_version_environments.environment_id'=>env.id)
   end

--- a/src/app/views/content_view_versions/_content.html.haml
+++ b/src/app/views/content_view_versions/_content.html.haml
@@ -1,0 +1,36 @@
+= javascript :treetable, :filtertable
+
+- content_view = @view_version.content_view
+
+= content_for :title do
+  #{content_view.name}
+
+= content_for :navigation do
+  = render_menu(1..2, promotion_content_view_navigation)
+
+= content_for :content do
+  .grid_8
+    .fr
+      = render :partial => "common/filter_table"
+
+  .grid_8
+    %table#content_view_content.filter_table
+      %thead
+        %tr
+          %th #{_("Products & Repositories")}
+      %tbody
+        - current_product = nil
+        - if view_repos.length > 0
+          - view_repos.each do |repo|
+            - if current_product.blank? || current_product != repo.product
+              - current_product = repo.product
+              - cssclass = cycle("", "alt")
+              %tr{:id => "product_#{current_product.id}", :class => 'parent ' + cssclass}
+                %td
+                  %label #{_("Product")}:
+                  #{current_product.name}
+
+            %tr{:class => "child-of-product_#{current_product.id} " + cssclass}
+              %td
+                %label #{_("Repository")}:
+                #{repo.name}

--- a/src/app/views/content_view_versions/_show.html.haml
+++ b/src/app/views/content_view_versions/_show.html.haml
@@ -1,0 +1,25 @@
+= content_for :title do
+  #{@view_version.content_view.name}
+
+= content_for :navigation do
+  = render_menu(1..2, promotion_content_view_navigation)
+
+= content_for :content do
+  .clear
+  %fieldset
+    .grid_2.ra
+      %label #{_("Name")}:
+    .grid_5.la
+      = @view_version.content_view.name
+
+  %fieldset
+    .grid_2.ra
+      %label #{_("Version")}:
+    .grid_5.la
+      = @view_version.version
+
+  %fieldset
+    .grid_2.ra
+      %label #{_("Description")}:
+    .grid_5.la
+      = @view_version.content_view.description

--- a/src/app/views/promotions/_content_views.html.haml
+++ b/src/app/views/promotions/_content_views.html.haml
@@ -6,7 +6,8 @@
 
     - content_view_versions.each do |view_version|
 
-      %li.no_slide.block
+      %li.no_slide.block{:id => view_version.id, 'data-ajax_url' => organization_environment_content_view_version_path(environment.organization, environment, view_version.id)}
+
         - view = view_version.content_view
         - promoted = next_env_view_version_ids.include?(view_version.id)
 

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -377,6 +377,11 @@ Src::Application.routes.draw do
         get :system_templates
         get :products
       end
+      resources :content_view_versions, :only => [:show] do
+        member do
+          get :content
+        end
+      end
     end
   end
   match '/organizations/:id/edit' => 'organizations#update', :via => :put

--- a/src/lib/navigation/content_management.rb
+++ b/src/lib/navigation/content_management.rb
@@ -19,6 +19,7 @@ module Navigation
         helper_method :promotion_packages_navigation
         helper_method :promotion_errata_navigation
         helper_method :promotion_distribution_navigation
+        helper_method :promotion_content_view_navigation
         helper_method :package_filter_navigation
         helper_method :gpg_keys_navigation
         helper_method :subscriptions_navigation
@@ -308,6 +309,23 @@ module Navigation
           :if => lambda{@distribution},
           :options => {:class=>"panel_link"}
         }
+      ]
+    end
+
+    def promotion_content_view_navigation
+      [
+          { :key => :promotion_content_view_content,
+            :name =>_("Content"),
+            :url => lambda{content_organization_environment_content_view_version_path(@view_version.id)},
+            :if => lambda{@view_version},
+            :options => {:class=>"panel_link"}
+          },
+          { :key => :promotion_content_view_details,
+            :name =>_("Details"),
+            :url => lambda{organization_environment_content_view_version_path(@view_version.id)},
+            :if => lambda{@view_version},
+            :options => {:class=>"panel_link"}
+          }
       ]
     end
 

--- a/src/public/javascripts/promotion.js
+++ b/src/public/javascripts/promotion.js
@@ -1920,6 +1920,14 @@ $(document).ready(function() {
               $('#save_changeset_button').trigger('click');
           });
         }
+        if ($("#content_view_content").length > 0) {
+            $("#content_view_content").treeTable({
+                expandable: true,
+                initialState: "collapsed",
+                clickableNodeNames: true,
+                onNodeShow: function(){$.sparkline_display_visible()}
+            });
+        }
     });
 
     //set function for env selection callback


### PR DESCRIPTION
This commit has changes so that when a user is on the Changesets
page and navigates to a content view in the Content Tree, they
can click the view and see details on it.  Currently, it shows
generic 'Details' and 'Content' (i.e. products & repositories).
The basic structure similar to what is shown on Content View
Definitions; however, it may change as we add more details
to the view definition (e.g. addition of filters).
