### PR TITLE
Fixing katello reset-dbs

### DIFF
--- a/src/app/models/content_view_definition.rb
+++ b/src/app/models/content_view_definition.rb
@@ -51,7 +51,8 @@ class ContentViewDefinition < ActiveRecord::Base
     repos = []
     tasks = []
     self.products.each do |prod|
-      prod.repos(organization.library).enabled.original.each { |r| repos << r }
+      prod_repos = prod.repos(organization.library).enabled
+      prod_repos.select{|r| r.in_default_view?}.each{|r| repos << r}
     end
     repos.concat(self.repositories)
     repos.uniq!

--- a/src/app/models/content_view_version.rb
+++ b/src/app/models/content_view_version.rb
@@ -23,6 +23,10 @@ class ContentViewVersion < ActiveRecord::Base
   scope :default_view, joins(:content_view).where('content_views.default = ?', true)
   scope :non_default_view, joins(:content_view).where('content_views.default = ?', false)
 
+  def has_default_content_view?
+    ContentViewVersion.default_view.pluck(:id).include?(self.id)
+  end
+
   def repos(env)
     self.repositories.in_environment(env)
   end

--- a/src/app/models/kt_environment.rb
+++ b/src/app/models/kt_environment.rb
@@ -118,8 +118,6 @@ class KTEnvironment < ActiveRecord::Base
   after_destroy :unset_users_with_default
    ERROR_CLASS_NAME = "Environment"
 
-  scope :library, where(:library => true)
-
   def library?
     self.library
   end

--- a/src/app/models/repository.rb
+++ b/src/app/models/repository.rb
@@ -52,8 +52,6 @@ class Repository < ActiveRecord::Base
 
   default_scope :order => 'name ASC'
   scope :enabled, where(:enabled => true)
-  scope :original, where(
-    :content_view_version_id => KTEnvironment.library.map{|l| l.default_view_version.id})
 
   def product
     self.environment_product.product
@@ -77,6 +75,10 @@ class Repository < ActiveRecord::Base
 
   def self.in_product(product)
     joins(:environment_product).where("environment_products.product_id" => product.id)
+  end
+
+  def in_default_view?
+    content_view_version && content_view_version.has_default_content_view?
   end
 
   def other_repos_with_same_product_and_content


### PR DESCRIPTION
Fixed katell reset-dbs script by reworking `ContentViewDefinition#generate_repos`.
