### PR TITLE
katello-configure - stop foreman before dropping the database

### DIFF
--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -104,7 +104,7 @@ class foreman::config {
 
   if $foreman::reset_data == 'YES' {
    exec {"reset_foreman_db":
-      command => "rm -f /var/lib/katello/foreman_db_migrate_done",
+      command => "rm -f /var/lib/katello/foreman_db_migrate_done; /usr/sbin/service-wait foreman stop",
       path    => "/sbin:/bin:/usr/bin",
       before  => Exec["foreman_migrate_db"],
     } ~>


### PR DESCRIPTION
Fixing --reset-data=YES option for Foreman
