### PR TITLE
Fix build_pxe_default call

### DIFF
--- a/src/app/models/foreman/config_template.rb
+++ b/src/app/models/foreman/config_template.rb
@@ -42,6 +42,6 @@ class Foreman::ConfigTemplate < Resources::ForemanModel
   end
 
   def self.build_pxe_default
-    resource.build_pxe_default(header).first
+    resource.build_pxe_default({}, header).first
   end
 end


### PR DESCRIPTION
It was passing header where params should be placed instead.
