### PR TITLE
bundler.d - not distributing build gem group

### DIFF
--- a/src/bundler.d/build.rb
+++ b/src/bundler.d/build.rb
@@ -1,3 +1,6 @@
+#
+# This group file is not distributed as RPM (but used during build phase).
+#
 group :build do
   unless defined? JRUBY_VERSION
     # for apipie (it is in default group)

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -419,6 +419,9 @@ mkdir -p %{buildroot}/%{_mandir}/man8
 # clean the application directory before installing
 [ -d tmp ] && rm -rf tmp
 
+# remove build gem group
+rm -f bundler.d/build.rb
+
 #copy the application to the target directory
 mkdir .bundle
 cp -R .bundle Gemfile.in bundler.d Rakefile app autotest ca config config.ru db integration_spec lib locale public script spec vendor %{buildroot}%{homedir}
@@ -490,6 +493,7 @@ chmod a+r %{buildroot}%{homedir}/ca/redhat-uep.pem
 install -m 644 man/katello-service.8 %{buildroot}/%{_mandir}/man8
 
 %post common
+
 #Add /etc/rc*.d links for the script
 /sbin/chkconfig --add %{name}
 /sbin/chkconfig --add %{name}-jobs
@@ -560,7 +564,6 @@ test -f $TOKEN || (echo $(</dev/urandom tr -dc A-Za-z0-9 | head -c128) > $TOKEN 
 
 %files common
 %doc README LICENSE
-%{homedir}/bundler.d/build.rb
 %{_sbindir}/service-wait
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %attr(600, katello, katello) %{_sysconfdir}/%{name}/%{name}.yml


### PR DESCRIPTION
Ok, round 2, fight!

No need to distribute bundler.d/build.rb - it is only build phase. Actually it was blocking Katello from stopping. Katello-jobs was failing with "redcarpet - not found".

We have still two packaging issues with "v8" aka "therubyracer" and "ruby-prof". If you try to install katello-devel-all and restart katello, it will fail. Use BUNDLER_EXT_NOSTRICT to start it up properly or do not install the following groups: checking and profiling.
