### PR TITLE
nightly fix - moving ci group into build.rb

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -65,9 +65,3 @@ gem "apipie-rails", '>= 0.0.13'
 Dir[File.expand_path('bundler.d/*.rb', File.dirname(__FILE__))].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle), bundle)
 end
-
-# The following groups are not packaged as RPMs and are used only in Bundler mode
-group :ci do
-  # needed by hudson
-  gem 'ci_reporter', '~> 1.7.2', :require => 'ci/reporter/core'
-end

--- a/src/bundler.d/build.rb
+++ b/src/bundler.d/build.rb
@@ -1,5 +1,5 @@
 #
-# This group file is not distributed as RPM (but used during build phase).
+# This group file is not distributed as RPM (but used during build or dev phase).
 #
 group :build do
   unless defined? JRUBY_VERSION
@@ -8,3 +8,7 @@ group :build do
   end
 end
 
+group :ci do
+  # needed by hudson
+  gem 'ci_reporter', '~> 1.7.2', :require => 'ci/reporter/core'
+end


### PR DESCRIPTION
This fixes nightly installation failure, but it is still busted because of latest converge ui changes. I am gonna merge it right away.
