### PR TITLE
880710 - api - updates to use org id or label when retrieving org

### DIFF
--- a/src/app/controllers/api/activation_keys_controller.rb
+++ b/src/app/controllers/api/activation_keys_controller.rb
@@ -122,13 +122,6 @@ class Api::ActivationKeysController < Api::ApiController
   end
 
   private
-  def find_organization
-    return unless params.has_key?(:organization_id)
-
-    @organization = Organization.first(:conditions => {:label => params[:organization_id].tr(' ', '_')})
-    raise HttpErrors::NotFound, _("Couldn't find organization '%s'") % params[:organization_id]  if @organization.nil?
-    @organization
-  end
 
   def find_environment
     return unless params.has_key?(:environment_id)

--- a/src/app/controllers/api/api_controller.rb
+++ b/src/app/controllers/api/api_controller.rb
@@ -98,6 +98,7 @@ class Api::ApiController < ActionController::Base
   def find_optional_organization
     if params[:organization_id]
       @organization = Organization.first(:conditions => {:name => params[:organization_id]})
+      @organization = Organization.first(:conditions => {:label => params[:organization_id]}) if @organization.nil?
       raise HttpErrors::NotFound, _("Couldn't find organization '%s'") % params[:organization_id] if @organization.nil?
       @organization
     end

--- a/src/app/controllers/api/organizations_controller.rb
+++ b/src/app/controllers/api/organizations_controller.rb
@@ -12,8 +12,7 @@
 
 class Api::OrganizationsController < Api::ApiController
 
-  before_filter :find_organization, :only => [:show, :update, :destroy, :products]
-  before_filter :find_organization, :only => [:show, :update, :destroy, :products, :providers]
+  before_filter :find_organization, :only => [:show, :update, :destroy]
 
   respond_to :json
   before_filter :authorize
@@ -24,14 +23,11 @@ class Api::OrganizationsController < Api::ApiController
     read_test = lambda{@organization.readable?}
     edit_test = lambda{@organization.editable?}
     delete_test = lambda{@organization.deletable?}
-    products_test = lambda{Product.any_readable?(@organization)}
-
 
     {:index =>  index_test,
       :show => read_test,
       :create => create_test,
       :update => edit_test,
-      :products => products_test,
       :destroy => delete_test,
     }
   end

--- a/src/app/controllers/api/proxies_controller.rb
+++ b/src/app/controllers/api/proxies_controller.rb
@@ -20,14 +20,14 @@ class Api::ProxiesController < Api::ApiController
       # route names are defined in routes.rb (:as => :name)
       case route.name
       when :api_proxy_owner_pools_path
-        find_organization
+        find_optional_organization
         if params[:consumer]
           (User.consumer? or @organization.readable?) and current_user.uuid == params[:consumer]
         else
           (User.consumer? or @organization.readable?)
         end
       when :api_proxy_owner_servicelevels_path
-        find_organization
+        find_optional_organization
         (User.consumer? or @organization.readable?)
       when :api_proxy_consumer_certificates_path, :api_proxy_consumer_releases_path, :api_proxy_certificate_serials_path,
            :api_proxy_consumer_entitlements_path, :api_proxy_consumer_entitlements_post_path, :api_proxy_consumer_entitlements_delete_path,
@@ -75,15 +75,6 @@ class Api::ProxiesController < Api::ApiController
   def drop_api_namespace(original_request_path)
     prefix = "#{ENV["RAILS_RELATIVE_URL_ROOT"]}/api"
     original_request_path.gsub(prefix, '')
-  end
-
-  protected
-
-  def find_organization
-    return unless (params.has_key?(:organization_id))
-    @organization = Organization.first(:conditions => {:label => params[:organization_id].tr(' ', '_')})
-    raise HttpErrors::NotFound, _("Couldn't find organization '%s'") % id if @organization.nil?
-    @organization
   end
 
 end


### PR DESCRIPTION
In a previous commit, there was a change to ensure
that org labels and names are 'unique'.   In other words,
an org cannot be created where either it's label or name
matches the label or name of another organization.

With that, a change was also made to ensure that when we
queried for organization, we attempt to first retrieve it
using name and then label (if not found using name).  The
issue was that the change was made in the specific api controller
(e.g. organizations_controller); however, the find_organization
was being invoked on the api_controller which had not been updated.

This commit simply updates the find_organization in the api_controller
to support the before mentioned algorithm.  It also attempts to remove
or change some of the find_organization calls that are currently
in the lower level controllers (e.g. if they aren't doing anything other
than what's already provided by api_controller).
