### PR TITLE
cli smoke tests - adding support for beaker lib

### DIFF
--- a/scripts/system-test/cli-system-test
+++ b/scripts/system-test/cli-system-test
@@ -11,6 +11,18 @@ export TESTDIR=$script_dir
 
 . $script_dir/helpers
 
+# fake beaker environment and load it if present
+function rlPhaseStartTest() {
+    return 0
+}
+function rlPhaseEnd() {
+    return 0
+}
+function rlFail() {
+    return 0
+}
+[ -f /usr/bin/rhts-environment.sh ] && . /usr/bin/rhts-environment.sh
+[ -f /usr/lib/beakerlib/beakerlib.sh ] && . /usr/lib/beakerlib/beakerlib.sh
 
 USER='admin'
 PASSWORD='admin'
@@ -197,6 +209,9 @@ function test_cmd() {
     test_success=$1; shift
     test_name=$1; shift
 
+    # beaker
+    rlPhaseStartTest "$test_name"
+
     if [ $PRINT_ALL -eq 1 ]; then
         echo $*
     fi
@@ -234,6 +249,8 @@ function test_cmd() {
             msg_status "$test_name" "${txtred}FAILED${txtrst}"
             printf "%s\n" "$*"
             printf "%s\n" "$result"
+            # beaker
+            rlFail
         fi
         let failed_cnt+=1
         let "TERMINATE=$TERMINATE - 1"
@@ -246,6 +263,11 @@ function test_cmd() {
     fi
     log_test_result "$status" "$test_name" "$result"
     let test_cnt+=1
+
+    # beaker
+    rlPhaseEnd
+
+    # termination support
     if [ $status -eq 0 -a $TERMINATE -le 0 ]; then
         # immediate termination
         echo "Failure, exiting:"


### PR DESCRIPTION
This changes nothing while running cli tests without beakerlib, but it will show particular test results in the Beaker UI.
