### PR TITLE
remove requires rubygem(execjs) and rubygem(multi_json)

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -292,8 +292,6 @@ Requires:        %{name} = %{version}-%{release}
 Requires:        rubygem(therubyracer)
 Requires:        rubygem(ref)
 Requires:        rubygem(jshintrb)
-Requires:        rubygem(execjs)
-Requires:        rubygem(multi_json)
 
 %description devel-checking
 Rake tasks and dependecies for Katello developers, which enables


### PR DESCRIPTION
We do not use them directly, this is transitively required by rubygem(jshintrb), which has correct requires.
In fact it has more better requires, because multi_json should be in >= 1.3.
Lets leave those requirements where they should be (in rubygem-jshintrb) and remove them from here.
