### PR TITLE
Ruby19 - Fixes issue with array symbols appearing in UI

### DIFF
--- a/src/app/helpers/layout_helper.rb
+++ b/src/app/helpers/layout_helper.rb
@@ -13,6 +13,7 @@
 module LayoutHelper
   def stylesheet(*args)
     args.map { |arg| content_for(:stylesheets) { include_stylesheets(arg) } }
+    return ""
   end
 
   def javascript(*args, &block)
@@ -22,5 +23,6 @@ module LayoutHelper
     if args
       args.map { |arg| content_for(:javascripts) { include_javascripts(arg) } }
     end
+    return ""
   end
 end


### PR DESCRIPTION
when running on Ruby 1.9+.

Ref: https://github.com/Katello/katello/issues/1224
