### PR TITLE
rubygem-scoped_search is now part of Fedora

### DIFF
--- a/rel-eng/comps/comps-katello-foreman-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora16.xml
@@ -54,7 +54,6 @@
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
-       <packagereq type="default">rubygem-scoped_search</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>
        <packagereq type="default">rubygem-virt</packagereq>
        <packagereq type="default">rubygem-will_paginate</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
@@ -50,7 +50,6 @@
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
-       <packagereq type="default">rubygem-scoped_search</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>
        <packagereq type="default">rubygem-virt</packagereq>
        <packagereq type="default">rubygem-wirb</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
@@ -61,7 +61,6 @@
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
-       <packagereq type="default">rubygem-scoped_search</packagereq>
        <packagereq type="default">rubygem-trollop</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>
        <packagereq type="default">rubygem-virt</packagereq>


### PR DESCRIPTION
https://admin.fedoraproject.org/updates/FEDORA-2012-19714/rubygem-scoped_search-2.4.0-5.fc17
https://admin.fedoraproject.org/updates/FEDORA-2012-19731/rubygem-scoped_search-2.4.0-5.fc16
