### PR TITLE
Use maruku instead of redcarpet for markdown -> html

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -87,6 +87,7 @@
        <packagereq type="default">rubygem-libv8</packagereq>
        <packagereq type="default">rubygem-logical-insight</packagereq>
        <packagereq type="default">rubygem-macaddr</packagereq>
+       <packagereq type="default">rubygem-maruku</packagereq>
        <packagereq type="default">rubygem-minitest-rails</packagereq>
        <packagereq type="default">rubygem-minitest</packagereq>
        <packagereq type="default">rubygem-minitest_tu_shim</packagereq>
@@ -96,6 +97,7 @@
        <packagereq type="default">rubygem-rails-dev-boost</packagereq>
        <packagereq type="default">rubygem-ref</packagereq>
        <packagereq type="default">rubygem-ruby-prof</packagereq>
+       <packagereq type="default">rubygem-syntax</packagereq>
        <packagereq type="default">rubygem-systemu</packagereq>
        <packagereq type="default">rubygem-therubyracer</packagereq>
        <packagereq type="default">rubygem-uuid</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -130,6 +130,7 @@
        <packagereq type="default">rubygem-logical-insight</packagereq>
        <packagereq type="default">rubygem-libv8</packagereq>
        <packagereq type="default">rubygem-macaddr</packagereq>
+       <packagereq type="default">rubygem-maruku</packagereq>
        <packagereq type="default">rubygem-minitest-rails</packagereq>
        <packagereq type="default">rubygem-minitest</packagereq>
        <packagereq type="default">rubygem-minitest_tu_shim</packagereq>

--- a/src/app/controllers/api/activation_keys_controller.rb
+++ b/src/app/controllers/api/activation_keys_controller.rb
@@ -66,7 +66,7 @@ class Api::ActivationKeysController < Api::ApiController
   api :POST, "/activation_keys", "Create an activation key"
   api :POST, "/environments/:environment_id/activation_keys", "Create an activation key"
   param :activation_key, Hash do
-    param :name, :identifier, :desc => "activation key identifier (alphanum characters, space, - and _)"
+    param :name, :identifier, :desc => "activation key identifier (alphanum characters, space, _ and -)"
     param :description, String, :allow_nil => true
   end
   def create

--- a/src/bundler.d/build.rb
+++ b/src/bundler.d/build.rb
@@ -2,10 +2,8 @@
 # This group file is not distributed as RPM (but used during build or dev phase).
 #
 group :build do
-  unless defined? JRUBY_VERSION
-    # for apipie (it is in default group)
-    gem 'redcarpet'
-  end
+  # for apipie (it is in default group)
+  gem 'maruku'
 end
 
 group :ci do

--- a/src/config/initializers/apipie.rb
+++ b/src/config/initializers/apipie.rb
@@ -10,8 +10,15 @@ Apipie.configure do |config|
   config.use_cache = Rails.env.production?
   config.validate = false
 
-  unless config.use_cache? or defined? JRUBY_VERSION
-    config.markup = Apipie::Markup::Markdown.new
+  unless config.use_cache?
+    require 'maruku'
+    class Katello::MarkdownMaruku
+      def self.to_html(text)
+        Maruku.new(text).to_html
+      end
+    end
+
+    config.markup = Katello::MarkdownMaruku
   end
 end
 

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -141,7 +141,7 @@ BuildRequires:       rubygem(tire) >= 0.3.0
 BuildRequires:       rubygem(tire) < 0.4
 BuildRequires:       rubygem(ldap_fluff)
 BuildRequires:       rubygem(apipie-rails) >= 0.0.12
-BuildRequires:       rubygem(redcarpet)
+BuildRequires:       rubygem(maruku)
 BuildRequires:       rubygem(foreman_api)
 
 
@@ -264,7 +264,7 @@ Requires:        rubygem(sexp_processor)
 # dependencies from bundler.d/development_boost.rb
 Requires:        rubygem(rails-dev-boost)
 # dependencies from bundler.d/apipie.rb
-Requires:        rubygem(redcarpet)
+Requires:        rubygem(maruku)
 
 %description devel
 Rake tasks and dependecies for Katello developers


### PR DESCRIPTION
Redcarpet includes a C-based extension, that causes segfault
problems on some systems. Since we don't need the efficiency of
C for generating the documentation, switching to maruku renderer
to do the job. The HTML output of API documentation should stay the same.

DO NOT MERGE YET, waiting for deps to finish building
