### PR TITLE
758813: Disable basic and trusted auth in the candlepin engine since it ...

### DIFF
--- a/katello-configure/modules/candlepin/templates/etc/candlepin/candlepin.conf.erb
+++ b/katello-configure/modules/candlepin/templates/etc/candlepin/candlepin.conf.erb
@@ -12,9 +12,11 @@ jpa.config.hibernate.connection.username=<%= scope.lookupvar("candlepin::params:
 jpa.config.hibernate.connection.password=<%= scope.function_katello_passencrypt([scope.lookupvar("candlepin::params::db_pass")]) %>
 candlepin.consumer_system_name_pattern = .+
 candlepin.environment_content_filtering=<%= scope.lookupvar("candlepin::params::env_filtering_enabled") %>
+candlepin.auth.basic.enable = false
+candlepin.auth.trusted.enable = false
 <% if scope.lookupvar("candlepin::params::katello_oauth_key") != "" -%>
 module.config.katello=org.candlepin.katello.KatelloModule
-candlepin.auth.oauth.enabled = true
+candlepin.auth.oauth.enable = true
 candlepin.auth.oauth.consumer.<%= scope.lookupvar("candlepin::params::katello_oauth_key") %>.secret = <%= scope.lookupvar("candlepin::params::katello_oauth_secret") %>
 candlepin.crl.file = <%= scope.lookupvar("candlepin::params::crl_file") %>
 <%- end -%>


### PR DESCRIPTION
...is not required.

This manifested as an an error seen by curl which when using basic auth there was an error
contacting the user service. Basic auth should never be used. With these settings, the output
is

[root@samdev ~]# curl -k -u admin:admin https://localhost:8443/candlepin/owners
{"displayMessage":"Invalid credentials."}

Note, this will make development harder since people may use curl to access candlepin.
Developers can set these to true and then restart candlepin

I HAVE NOT BEEN ABLE TO TEST THIS. Would be good to have a full dev/install cycle.
