### PR TITLE
Setting haml-rails version to 0.3.4

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -36,7 +36,7 @@ gem 'uuidtools'
 
 # Stuff for view/display/frontend
 gem 'haml', '>= 3.1.2'
-gem 'haml-rails'
+gem 'haml-rails', "= 0.3.4"
 gem 'compass', '>= 0.11.5', '< 0.12'
 gem 'compass-960-plugin', '>= 0.10.4', :require => 'ninesixty'
 gem 'simple-navigation', '>= 3.3.4'


### PR DESCRIPTION
Setting haml-rails version to 0.3.4 to fix the following error.

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    haml-rails (= 0.3.5) ruby depends on
      activesupport (< 4.1, >= 3.1) ruby

    rails (~> 3.0.10) ruby depends on
      activesupport (3.0.17)
```
