### PR TITLE
stop foreman only if it is running

### DIFF
--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -107,7 +107,7 @@ class foreman::config {
 
   if $foreman::reset_data == 'YES' {
    exec {"reset_foreman_db":
-      command => "rm -f /var/lib/katello/foreman_db_migrate_done; /usr/sbin/service-wait foreman stop",
+      command => "rm -f /var/lib/katello/foreman_db_migrate_done; service foreman status && /usr/sbin/service-wait foreman stop",
       path    => "/sbin:/bin:/usr/bin",
       before  => Exec["foreman_migrate_db"],
     } ~>


### PR DESCRIPTION
addressing:

```
katello-configure --reset-data=YES
Starting Katello configuration
The top-level log file is [/var/log/katello/katello-configure-20121217-102554/main.log]
err: /Stage[main]/Foreman::Config/Exec[reset_foreman_db]/returns: change from notrun to 0 failed: rm -f /var/lib/katello/foreman_db_migrate_done; /usr/sbin/service-wait foreman stop returned 1 instead of one of [0] at /usr/share/katello/install/puppet/modules/foreman/manifests/config.pp:113
```
