### PR TITLE
784326 fix for mixed locale for admin

### DIFF
--- a/src/app/controllers/users_controller.rb
+++ b/src/app/controllers/users_controller.rb
@@ -167,7 +167,7 @@ class UsersController < ApplicationController
     locale = params[:locale][:locale]
     if AppConfig.available_locales.include? locale
       @user.default_locale = locale
-      I18n.locale          = locale
+      I18n.locale          = locale if @user.id == current_user.id
     else
       @user.default_locale = nil
     end


### PR DESCRIPTION
Change current user locale makes sense only if current user is updated
user at the same time. E.g. admin changing locale for another user
should his current locale configuration untouched.
