### PR TITLE
806096 fix - display checkboxes to readonly users

### DIFF
--- a/src/app/views/providers/redhat/_children.html.haml
+++ b/src/app/views/providers/redhat/_children.html.haml
@@ -8,10 +8,11 @@
   - repo = child[:item]
   %tr{:class=>child[:class], :id=>child[:id], "data-product_id="=>repo.product.id, "data-id"=>repo.id}
     %td
-      -if can_enable_repo?
-        = image_tag( "embed/icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{repo.id}", :style=>"margin-right:1px;")
-        =check_box_tag "repo", repo.id, repo.enabled?,{:id=>"input_repo_#{repo.id}",
-              "data-url" => enable_repo_path(repo.id), :disabled =>(repo.promoted?), :class=>'fl'}
+      =image_tag( "embed/icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{repo.id}", :style=>"margin-right:1px;")
+      =check_box_tag "repo", repo.id, repo.enabled?,{:id=>"input_repo_#{repo.id}",
+            "data-url" => enable_repo_path(repo.id),
+            :disabled =>(repo.promoted? || !can_enable_repo?),
+            :class=>'fl'}
       %label.fl{:for=>"input_repo_#{repo.id}"}
         #{repo.name}
 - else


### PR DESCRIPTION
When user with readonly access lists RH repos he sees checkboxes for
each one but they are disabled. He knows whether repository is enabled
or not but he can't change it.
