### PR TITLE
839394 - Changes wording on sync management page when no repositories

### DIFF
--- a/src/app/views/sync_management/_products.html.haml
+++ b/src/app/views/sync_management/_products.html.haml
@@ -15,7 +15,7 @@
       - else
         %tr
           %td{:colspan=>(@show_org ? 6 : 5)}
-            #{_("There are no custom products or repositories enabled. Try enabling via Content Providers.")}
+            = (_("There are no products or repositories enabled. Try enabling via %{custom} or %{redhat}.") % {:custom => link_to(_("Custom Content Repositories"), providers_path), :redhat => link_to(_(" Red Hat Repositories"), redhat_provider_providers_path)}).html_safe
 
   - if syncable?
     = submit_tag _('Synchronize Now'), :class => 'button fr', :id => 'sync_button'


### PR DESCRIPTION
are enabled to cross-link to custom repos and red hat provider link.
