### PR TITLE
Enable fuzzy strings

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -130,7 +130,7 @@ end
 old_fast_gettext = !defined?(FastGettext::Version) ||
     (FastGettext::Version.split('.').map(&:to_i) <=> [0, 6, 8]) == -1 # compare versions x.x.x <= 0.6.7
 
-FastGettext.add_text_domain('app', { :path => 'locale', :type => :po, :ignore_fuzzy => true }.
+FastGettext.add_text_domain('app', { :path => 'locale', :type => :po, :ignore_fuzzy => false }.
     update(old_fast_gettext ? { :ignore_obsolete => true } : { :report_warning => false }))
 
 FastGettext.default_text_domain = 'app'


### PR DESCRIPTION
Fuzzy is a note to the translator. We should continue to show them in the UI. See
http://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html for more info.
