### PR TITLE
843421 - systems - include summary when removing system groups using bul...

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -410,7 +410,7 @@ class SystemsController < ApplicationController
         end
       end
       action = _("Systems Bulk Action: Add to system group(s): %s") % @system_groups.collect{|g| g.name}.join(', ')
-      notify_bulk_action action, successful_systems, failed_systems
+      notify_bulk_action(action, successful_systems, failed_systems)
     end
 
     render :nothing => true
@@ -457,7 +457,7 @@ class SystemsController < ApplicationController
                      {:system_name => system.name, :system_group_names => system_groups.join(', ')})
       end
 
-      notify_bulk_action action, successful_systems, failed_systems, details.join("\n")
+      notify_bulk_action(action, successful_systems, failed_systems, details.join("\n"))
     end
 
     render :nothing => true
@@ -495,7 +495,7 @@ class SystemsController < ApplicationController
       action_text = _("Systems Bulk Action: Schedule install of package group(s): %s") % params[:groups].join(', ')
     end
 
-    notify_bulk_action action_text, successful_systems, failed_systems
+    notify_bulk_action(action_text, successful_systems, failed_systems)
     render :nothing => true
   end
 
@@ -527,7 +527,7 @@ class SystemsController < ApplicationController
         action_text = _("Systems Bulk Action: Schedule update of package(s): %s") % params[:packages].join(', ')
     end
 
-    notify_bulk_action action_text, successful_systems, failed_systems
+    notify_bulk_action(action_text, successful_systems, failed_systems)
     render :nothing => true
   end
 
@@ -562,7 +562,7 @@ class SystemsController < ApplicationController
       action_text = _("Systems Bulk Action: Schedule uninstall of package group(s): %s") % params[:groups].join(', ')
     end
 
-    notify_bulk_action action_text, successful_systems, failed_systems
+    notify_bulk_action(action_text, successful_systems, failed_systems)
     render :nothing => true
   end
 
@@ -585,7 +585,7 @@ class SystemsController < ApplicationController
     end
 
     action = _("Systems Bulk Action: Schedule install of errata(s): %s") % params[:errata].join(', ')
-    notify_bulk_action action, successful_systems, failed_systems
+    notify_bulk_action(action, successful_systems, failed_systems)
     render :nothing => true
   end
 
@@ -628,7 +628,7 @@ class SystemsController < ApplicationController
 
   include SortColumnList
 
-  def notify_bulk_action action, successful_systems, failed_systems, details = ""
+  def notify_bulk_action(action, successful_systems, failed_systems, details = nil)
     # generate a notice for a bulk action
 
     success_msg = _("Successful for system(s): ")


### PR DESCRIPTION
...k action

This commit contains changes so that when a user performs a 'bulk
remove system groups' action from the systems page, the notice
generated will include a summary that lists the systems and
the system groups removed from each of those systems.

Note: it is possible for the user to list groups that do not apply
to a given system when performing the bulk action; therefore, this
lets the user know exactly which groups were removed from each system.

For example:
## The notice text might include:

Systems Bulk Action: Remove from system group(s): group 1, group 2, group 3, group 4, group 5, group 6
Successful for system(s): system 1, system 2, system 3, system 4
## With the (i) details for the notice containing:

System: system 2, System Groups Removed: group 2
System: system 3, System Groups Removed: group 1, group 2, group 3
System: system 4, System Groups Removed:
System: system 1, System Groups Removed: group 1
