### PR TITLE
808461 - prevent from creating a repo in rh providers

### DIFF
--- a/src/app/controllers/api/repositories_controller.rb
+++ b/src/app/controllers/api/repositories_controller.rb
@@ -57,6 +57,7 @@ class Api::RepositoriesController < Api::ApiController
   see "gpg_keys#index"
   def create
     raise HttpErrors::BadRequest, _('Invalid Url') if !kurl_valid?(params[:url])
+    raise HttpErrors::BadRequest, _("Repository can be only created for custom provider.") unless @product.custom?
 
     if params[:gpg_key_name].present?
       gpg = GpgKey.readable(@product.organization).find_by_name!(params[:gpg_key_name])

--- a/src/app/controllers/repositories_controller.rb
+++ b/src/app/controllers/repositories_controller.rb
@@ -57,6 +57,8 @@ class RepositoriesController < ApplicationController
   def create
     repo_params = params[:repo]
     repo_params[:label], label_assigned = generate_label(repo_params[:name], _('repository')) if repo_params[:label].blank?
+    
+    raise HttpErrors::BadRequest, _("Repository can be only created for custom provider.") unless @product.custom?
 
     raise URI::InvalidURIError.new _('Invalid Url') if !kurl_valid?(repo_params[:feed])
     gpg = GpgKey.readable(current_organization).find(repo_params[:gpg_key]) if repo_params[:gpg_key] and repo_params[:gpg_key] != ""


### PR DESCRIPTION
Finally, so we do not want to allow users to create custom repos in red hat providers. This was possible from the CLI, UI has no buttons (but the check is there too).

I have tried hard to implement this kind of validation in our model, but since we are creating lots of repos during import, I have decided to move this particular check into controller. Because then I'd had to re-do like 200 tests and also it does really only make sense in the API controller (repo - create) and nowhere else.
