### PR TITLE
844708 - update panel action confirmation dialog to close on 'yes' click

### DIFF
--- a/src/public/javascripts/panel.js
+++ b/src/public/javascripts/panel.js
@@ -681,7 +681,6 @@ KT.panel = (function ($) {
                     action.find(".trigger").click(function() {
                         var params = action_list[action.attr("data-id")];
                         var success = function() {
-                            options.slideUp('fast');
                             action.find("input").removeClass("disabled");
                             if (params.success_cb){
                                 params.success_cb(getSelected());
@@ -695,6 +694,8 @@ KT.panel = (function ($) {
                         };
 
                         if ($(this).hasClass("disabled")){return}
+
+                        options.slideUp('fast');
 
                         if(params.ajax_cb) {
                             params.ajax_cb(getSelected(), current_request_action, options);


### PR DESCRIPTION
Panel actions allow the user to perform an action (e.g. package install)
on a group of objects (e.g. systems).  When an action is performed,
the user is presented with a yes/no dialog to confirm that they want
to proceed.  Prior to this change, when the user clicked 'yes' the
confirmation dialog would remain open until the action was completed.
With this change, the dialog is closed as soon as 'yes' is clicked.
