### PR TITLE
848553 - tupane - remove 'do_not_open' on copy

### DIFF
--- a/src/app/views/common/_common_i18n.html.haml
+++ b/src/app/views/common/_common_i18n.html.haml
@@ -33,7 +33,6 @@
     "unlimited": '#{escape_javascript(_('Unlimited'))}',
     "name": '#{escape_javascript(_('Name'))}',
     "description": '#{escape_javascript(_('Description'))}',
-    "do_not_open_copy": '#{escape_javascript(_('Do not open the copy upon completion'))}',
     "import_in_progress": function(m){ return '#{escape_javascript(_("Import in progress (%M)"))}'.replace("%M", m);},
     "current_default_org" : '#{escape_javascript(_('This is your default organization.'))}',
     "make_default_org" : '#{escape_javascript(_('Make this your default organization.'))}'

--- a/src/public/javascripts/panel.js
+++ b/src/public/javascripts/panel.js
@@ -825,7 +825,7 @@ KT.panel.copy = (function () {
     perform_copy = function(event) {
         event.preventDefault();
 
-        var copy_form = $('#copy_form'), copy_button = $('#copy_button'), do_not_open = $('#do_not_open').is(':checked');
+        var copy_form = $('#copy_form'), copy_button = $('#copy_button');
         copy_button.attr('disabled', 'disabled');
 
         $.ajax({
@@ -835,12 +835,7 @@ KT.panel.copy = (function () {
             cache: false,
             success: function(data) {
                 $('.pane_action.copy-tipsy').tipsy('hide');
-
-                if (do_not_open) {
-                    list.add(data);
-                } else {
-                    KT.panel.list.createSuccess(data);
-                }
+                KT.panel.list.createSuccess(data);
             },
             error: function(data) {
                 copy_button.removeAttr('disabled');

--- a/src/public/javascripts/widgets/tipsy.custom.js
+++ b/src/public/javascripts/widgets/tipsy.custom.js
@@ -182,7 +182,6 @@ KT.tipsy.templates = (function(){
         html += '<form id="copy_form" data-url="' + element.data('url') + '">';
         html += '<fieldset><div><label>' + i18n.name + '</label></div><div><input id="name_input" type="text" size="25" name="name"></div></fieldset>';
         html += '<fieldset><div><label>' + i18n.description + '</label></div><div><textarea id="description_input" rows="1" cols="31" name="description"></textarea></div></fieldset>';
-        html += '<fieldset><div><label style="font-weight:normal;"><input id="do_not_open" type="checkbox" style="margin-right:10px;"/>' + i18n.do_not_open_copy + '</label></div></fieldset>';
         html += '<input id="copy_button" type="submit" class="fr button" value="' + i18n.copy + '">';
         html += '<input id="cancel_copy_button" type="button" class="fr button" value="' + i18n.cancel + '">';
         html += '<form>';


### PR DESCRIPTION
As part of system groups, a 'copy' capability was added to the
panel.  This copy allows the user to have an object (e.g. system group)
open and create a 'copy' of it.  As part of that capability,
there was a checkbox added to the copy form so that the user
has the choice of either opening the new object (i.e. the copy)
or keeping the originating object open, after the copy is executed.

Based on user feedback, this commit will remove that option from
the copy form.  The result will be that the new object will
always be opened when the copy is completed.
