### PR TITLE
Fixes 790216 running changesets concurently

### DIFF
--- a/src/app/models/promotion_changeset.rb
+++ b/src/app/models/promotion_changeset.rb
@@ -21,11 +21,6 @@ class PromotionChangeset < Changeset
     self.state == Changeset::REVIEW or
         raise _("Cannot promote the changeset '%s' because it is not in the review phase.") % self.name
 
-    #check for other changesets promoting
-    if self.environment.promoting_to?
-      raise _("Cannot promote the changeset '%{changeset}' while another changeset (%{another_changeset}) is being promoted.") % {:changeset => self.name, :another_changeset => self.environment.promoting.first.name}
-    end
-
     # check that solitare repos in the changeset and its templates
     # will have its associated product in the env as well after promotion
     repos_to_be_promoted.each do |repo|
@@ -38,8 +33,14 @@ class PromotionChangeset < Changeset
     validate_content! self.packages
     validate_content! self.distributions
 
-    self.state = Changeset::PROMOTING
-    self.save!
+    # check no collision exists
+    if (collision = Changeset.started.colliding(self).first)
+      raise _("Cannot promote the changeset '%{changeset}' while another colliding changeset (%{another_changeset}) is being promoted.") %
+                { :changeset => self.name, :another_changeset => collision.name }
+    else
+      self.state = Changeset::PROMOTING
+      self.save!
+    end
 
     if options[:async]
       task             = self.async(:organization => self.environment.organization).promote_content(options[:notify])


### PR DESCRIPTION
Instead of disallow creation of changeset immediately check whether new
promotion/deletion is conflicting with any other that is currently
running. If it is not it's registered and run. Conflicting promotions
and deletion are refused in same way they were up to now. There are good
reasons for this - see bugzilla for more.

Conflicting (collision) is considered another runnin changeset (in state
promoting or deleting) which fits to one of these conditions:
- starts and ends on same environment
- starts on environment that is end for current changest
- ends on environment that is start for current changeset

All other cases are considered safe. With more than one worker they can
even run concurently.
