### PR TITLE
Revert "Ruby 1.9.3 - Adds relative path to lib files to fix unittest failures on"

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -6,7 +6,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "active_resource/railtie"
 require "rails/test_unit/railtie"
-require "./lib/util/boot_util"
+require "lib/util/boot_util"
 
 # If you have a Gemfile, require the gems listed there, including any gems
 # you've limited to :test, :development, or :production.

--- a/src/config/initializers/app_config.rb
+++ b/src/config/initializers/app_config.rb
@@ -2,7 +2,7 @@
 # are not available in all initializers starting with 'a' letter.
 require 'ostruct'
 require 'yaml'
-require "./lib/util/boot_util"
+require "lib/util/boot_util"
 
 module ApplicationConfiguration
 


### PR DESCRIPTION
This reverts commit 61027e8f76ace5a47394d7ba2eabab6426765fc1.

With the change from 61027e8f, it is possible that it works on Ruby 1.9.3, but katello-upgrade on RHEL6 fails with:

```
12/20/12 15:24:52 Successfuly finished step: Reindex search index
12/20/12 15:24:52 Step:        Create first Foreman user (13/16)
12/20/12 15:24:52 Runs:        once
12/20/12 15:24:52 Starting step Create first Foreman user
12/20/12 15:24:53 /usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require': no such file to load -- ./lib/util/boot_util (LoadError)
12/20/12 15:24:53       from /usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
12/20/12 15:24:53       from /usr/share/katello/config/application.rb:9
12/20/12 15:24:53       from /usr/share/katello/config/environment.rb:2:in `require'
12/20/12 15:24:53       from /usr/share/katello/config/environment.rb:2
12/20/12 15:24:53       from /usr/share/katello/install/upgrade-scripts/0720_create_foreman_users.rb:10:in `require'
12/20/12 15:24:53       from /usr/share/katello/install/upgrade-scripts/0720_create_foreman_users.rb:10
12/21/12 03:56:05 tomcat6 (pid 5644) is running...[  OK  ]^M
```

With this revert it works without problem.
I tried to put there `../lib/util/boot_util` but it does not work either (because that require is run in `/usr/lib/ruby/site_ruby/1.8/rubygems/` so the path is evaluated relative to this directory.

@ehelms  can you either rework 61027e8f as soon as possible or ACK this revert? And we would probably need to backport it to Katello 1.2, because upgrades does not work.
