### PR TITLE
885261 - katello-configure now always loads answer file

### DIFF
--- a/katello-configure/bin/katello-configure
+++ b/katello-configure/bin/katello-configure
@@ -50,8 +50,12 @@ end
 # After having read the default option list, we parse the
 # command line options.
 options = {}
+
+# answer file is always loaded by default
+FileUtils.touch result_config_path
+options['answer_file'] = result_config_path
+
 option_parser = OptionParser.new
-answer_file = nil
 show_resulting_answer_file = false
 nobars = false
 debug_stdout = false

--- a/katello-configure/lib/util/functions.rb
+++ b/katello-configure/lib/util/functions.rb
@@ -286,7 +286,7 @@ def parse_answer_option(answer_file, default_options)
   final_options = {}
   if answer_file != nil
     if not File.file?(answer_file)
-      $stderr.puts "Answer file [#{answer_file}] does seem to exist"
+      $stderr.puts "Answer file [#{answer_file}] does not seem to exist"
       exit_with :answer_missing
     end
     final_options, __unused, error = read_answer_file(answer_file)

--- a/katello-configure/man/katello-configure.pod
+++ b/katello-configure/man/katello-configure.pod
@@ -20,6 +20,14 @@ on the command line. The values from user answer file override the
 default configuration values, and they are further overriden by
 options specified on the command line.
 
+All configuration options provided are stored in the
+/etc/katello/katello-configure.conf file which is always loaded 
+on subsequent executions of katello-configure. To override a value,
+provide it on the commandline or edit the configuration file.
+
+All the default options are stored in the
+/usr/share/katello/install/default-answer-file.
+
 =head1 COMMAND LINE PARAMETERS
 
 =over 4
@@ -46,6 +54,21 @@ collected from user answer files and command line options.
 Display short summary of all options.
 
 =back
+
+=head1 EXAMPLE
+
+First Katello configuration with the most typical options:
+
+  katello-configure --user-name=superadmin \
+    --user-pass=MyPassWord123 \
+    --user-email=my.email@foobar.com \
+    --org-name=foobar_inc
+
+Additional change of ElasticSearch heap memory value:
+
+  katello-configure --es-min-mem=512m --es-max-mem=1024m
+
+All the parameters are kept in the answer file.
 
 =head1 VERSION
 


### PR DESCRIPTION
We do not load answer file /etc/katello/katello-configure.conf by default in the katello-configure. Now it is loaded automatically, so users will not override first org, username and other settings by running katello-configure without params.

Fix is part of the data integrity bugzilla - I think in this case it made things even worse and recovery was not possible.
