### PR TITLE
853385: Display the environment in the output of system info

### DIFF
--- a/cli/src/katello/client/core/system.py
+++ b/cli/src/katello/client/core/system.py
@@ -130,10 +130,12 @@ class Info(SystemAction):
             system['host'] = system['host']['name']
         if 'guests' in system:
             system["guests"] = "[ "+ ", ".join([guest["name"] for guest in system["guests"]]) +" ]"
+        if 'environment' in system:
+            system['environment'] = system['environment']['name']
 
 
         batch_add_columns(self.printer, {'name': _("Name")}, {'ipv4_address': _("IPv4 Address")}, \
-            {'uuid': _("UUID")}, {'location': _("Location")})
+            {'uuid': _("UUID")}, {'environment': _("Environment")}, {'location': _("Location")})
         self.printer.add_column('created_at', _("Registered"), formatter=format_date)
         self.printer.add_column('updated_at', _("Last Updated"), formatter=format_date)
         self.printer.add_column('description', _("Description"), multiline=True)


### PR DESCRIPTION
https://github.com/Katello/katello/pull/1310 was unable to auto-merge due to some changes to 'batch_add_columns"
