### PR TITLE
add rubygem-sexp_processor to comps

### DIFF
--- a/rel-eng/comps/comps-katello-foreman-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora16.xml
@@ -54,6 +54,7 @@
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
+       <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>
        <packagereq type="default">rubygem-virt</packagereq>
        <packagereq type="default">rubygem-will_paginate</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
@@ -50,6 +50,7 @@
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
+       <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>
        <packagereq type="default">rubygem-virt</packagereq>
        <packagereq type="default">rubygem-wirb</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
@@ -44,6 +44,7 @@
        <packagereq type="default">rubygem-rabl</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
+       <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>
        <packagereq type="default">rubygem-virt</packagereq>
        <packagereq type="default">rubygem-wirb</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
@@ -61,6 +61,7 @@
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
+       <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-trollop</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>
        <packagereq type="default">rubygem-virt</packagereq>


### PR DESCRIPTION
we need it because new rubygem-safemode require version, which is not yet in Fedora/RHEL
