### PR TITLE
add rubygem-ruby2ruby to comps

### DIFF
--- a/rel-eng/comps/comps-katello-foreman-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora16.xml
@@ -53,6 +53,7 @@
        <packagereq type="default">rubygem-ruby-hmac</packagereq>
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
+       <packagereq type="default">rubygem-ruby2ruby</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
        <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
@@ -49,6 +49,7 @@
        <packagereq type="default">rubygem-ruby-hmac</packagereq>
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
+       <packagereq type="default">rubygem-ruby2ruby</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
        <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
@@ -43,6 +43,7 @@
        <packagereq type="default">rubygem-hirb-unicode</packagereq>
        <packagereq type="default">rubygem-rabl</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
+       <packagereq type="default">rubygem-ruby2ruby</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
        <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-unicode-display_width</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
@@ -60,6 +60,7 @@
        <packagereq type="default">rubygem-ruby-hmac</packagereq>
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
+       <packagereq type="default">rubygem-ruby2ruby</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>
        <packagereq type="default">rubygem-sexp_processor</packagereq>
        <packagereq type="default">rubygem-trollop</packagereq>


### PR DESCRIPTION
addressing:
Could not find gem 'ruby2ruby (>= 2.0.1)', required by 'safemode (~> 1.1.0)', in any of the sources

and Fedora contains 2.0.1 only in Fedora 19
