### PR TITLE
add rubygem-rbovirt back to comps as new Foreman requires newer version ...

### DIFF
--- a/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora17.xml
@@ -46,6 +46,7 @@
        <packagereq type="default">rubygem-hirb-unicode</packagereq>
        <packagereq type="default">rubygem-jquery-rails</packagereq>
        <packagereq type="default">rubygem-rabl</packagereq>
+       <packagereq type="default">rubygem-rbovirt</packagereq>
        <packagereq type="default">rubygem-ruby-hmac</packagereq>
        <packagereq type="default">rubygem-ruby-libvirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
@@ -42,6 +42,7 @@
        <packagereq type="default">rubygem-hirb</packagereq>
        <packagereq type="default">rubygem-hirb-unicode</packagereq>
        <packagereq type="default">rubygem-rabl</packagereq>
+       <packagereq type="default">rubygem-rbovirt</packagereq>
        <packagereq type="default">rubygem-ruby_parser</packagereq>
        <packagereq type="default">rubygem-ruby2ruby</packagereq>
        <packagereq type="default">rubygem-safemode</packagereq>


### PR DESCRIPTION
...then is availbale in Fedora
