### PR TITLE
Allowing for local gem groups

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -25,3 +25,4 @@ vendor/ruby
 coverage
 public/assets
 .rvmrc
+bundler.d/local*.rb


### PR DESCRIPTION
Allowing developers to include gems for development in bundler.d/local*.rb files. This is so we don't have to require gems manually anymore.
