### PR TITLE
879094 - fixing %post error in spec

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -507,7 +507,7 @@ test -f $TOKEN || (echo $(</dev/urandom tr -dc A-Za-z0-9 | head -c128) > $TOKEN 
 %post headpin
 usermod -a -G katello-shared tomcat
 
-%post katello
+%post
 usermod -a -G katello-shared tomcat
 
 %files


### PR DESCRIPTION
0 packages and 1 specfiles checked; 0 errors
