### PR TITLE
Fixing bundle install

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -11,7 +11,7 @@ require File.expand_path("../lib/util/boot_util.rb", __FILE__)
 # With a pull request, send also link to our (or Fedora) koji with RPMs.
 source 'http://rubygems.org'
 
-gem 'rails', '~> 3.0.10'
+gem 'rails', '3.0.10'
 gem 'json'
 gem 'rest-client', :require => 'rest_client'
 gem 'jammit', '>= 0.5.4'


### PR DESCRIPTION
Setting the Rails version was the only thing I could find that worked for both Ruby 1.8 and 1.9. I checked and it looks like F16, F17, and EPEL6 all have 3.0.10.
