### PR TITLE
ignore rvmrc* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cli/cover
 cli/doc/build
 *.swp
 .rbenv*
+.rvmrc*


### PR DESCRIPTION
Adding RVM rbvrc to gitignores
