### PR TITLE
Fix post install scriptlet

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -508,10 +508,10 @@ test -f $TOKEN || (echo $(</dev/urandom tr -dc A-Za-z0-9 | head -c128) > $TOKEN 
 %posttrans common
 /sbin/service %{name} condrestart >/dev/null 2>&1 || :
 
-%post headpin
+%post headpin-all
 usermod -a -G katello-shared tomcat
 
-%post
+%post all
 usermod -a -G katello-shared tomcat
 
 %files


### PR DESCRIPTION
We need to add the tomcat user to katello-shared for katello-all and
headpin-all, because that are the packages with a dependency on
tomcat.

Otherwise the scriptlet are run before tomcat is even installed, which
causes cpinit to fail in katello-configure.
