### PR TITLE
generate token for foreman

### DIFF
--- a/katello-configure/modules/foreman/manifests/config.pp
+++ b/katello-configure/modules/foreman/manifests/config.pp
@@ -86,6 +86,7 @@ class foreman::config {
     environment => ["RAILS_ENV=${foreman::environment}", "BUNDLER_EXT_NOSTRICT=1"],
     command     => "rake security:generate_token",
     path        => "/bin:/usr/bin",
+    creates     => "${foreman::app_root}/config/initializers/local_secret_token.rb",
   }
 
   exec {"foreman_migrate_db":


### PR DESCRIPTION
this relate to recent change in foreman:
http://theforeman.org/issues/2109

addressing:

```
130108-20:15:11 debug: Executing '/usr/bin/ruby /usr/share/foreman/script/foreman-config -k oauth_active -v 'true'                              -k foreman_url -v '10-16-120-136.dhcp.rhq.lab.eng.bos.redhat.com'                              -k token_duration -v '60'                              -k manage_puppetca -v false                              -k oauth_consumer_key -v 'katello'                              -k oauth_consumer_secret -v 'u5l76IGiuHiL5BuxlPoRIUlPmA51GtCi'                              -k oauth_map_users -v 'true'                              -k administrator -v 'root@localhost.localdomain''
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns: /usr/share/foreman/config/initializers/secret_token.rb:6:in `read': Permission denied - /usr/share/foreman/tmp/secret_token (Errno::EACCES)
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/share/foreman/config/initializers/secret_token.rb:6
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:201:in `load'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:201
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:200:in `each'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:200
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:25:in `instance_exec'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:25:in `run'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:50:in `run_initializers'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:49:in `each'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:49:in `run_initializers'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:134:in `initialize!'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:77:in `send'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:77:in `method_missing'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/share/foreman/config/environment.rb:5
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:239:in `require'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:239:in `require'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:225:in `load_dependency'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:593:in `new_constants_in'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:225:in `load_dependency'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:239:in `require'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:103:in `require_environment!'
130108-20:15:16 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/share/foreman/script/foreman-config:75
130108-20:15:16 err: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns: change from notrun to 0 failed: /usr/bin/ruby /usr/share/foreman/script/foreman-config -k oauth_active -v 'true'                              -k foreman_url -v '10-16-120-136.dhcp.rhq.lab.eng.bos.redhat.com'                              -k token_duration -v '60'                              -k manage_puppetca -v false                              -k oauth_consumer_key -v 'katello'                              -k oauth_consumer_secret -v 'u5l76IGiuHiL5BuxlPoRIUlPmA51GtCi'                              -k oauth_map_users -v 'true'                              -k administrator -v 'root@localhost.localdomain' returned 1 instead of one of [0] at /usr/share/katello/install/puppet/modules/foreman/manifests/config.pp:106
130108-20:15:16 debug: Exec[foreman_config](provider=posix): Executing '/usr/bin/ruby /usr/share/foreman/script/foreman-config -k oauth_active -v 'true'                              -k foreman_url -v '10-16-120-136.dhcp.rhq.lab.eng.bos.redhat.com'                              -k token_duration -v '60'                              -k manage_puppetca -v false                              -k oauth_consumer_key -v 'katello'                              -k oauth_consumer_secret -v 'u5l76IGiuHiL5BuxlPoRIUlPmA51GtCi'                              -k oauth_map_users -v 'true'                              -k administrator -v 'root@localhost.localdomain''
130108-20:15:16 debug: Executing '/usr/bin/ruby /usr/share/foreman/script/foreman-config -k oauth_active -v 'true'                              -k foreman_url -v '10-16-120-136.dhcp.rhq.lab.eng.bos.redhat.com'                              -k token_duration -v '60'                              -k manage_puppetca -v false                              -k oauth_consumer_key -v 'katello'                              -k oauth_consumer_secret -v 'u5l76IGiuHiL5BuxlPoRIUlPmA51GtCi'                              -k oauth_map_users -v 'true'                              -k administrator -v 'root@localhost.localdomain''
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns: /usr/share/foreman/config/initializers/secret_token.rb:6:in `read': Permission denied - /usr/share/foreman/tmp/secret_token (Errno::EACCES)
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/share/foreman/config/initializers/secret_token.rb:6
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:201:in `load'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:201
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:200:in `each'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/engine.rb:200
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:25:in `instance_exec'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:25:in `run'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:50:in `run_initializers'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:49:in `each'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/initializable.rb:49:in `run_initializers'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:134:in `initialize!'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:77:in `send'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:77:in `method_missing'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/share/foreman/config/environment.rb:5
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:239:in `require'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:239:in `require'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:225:in `load_dependency'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:593:in `new_constants_in'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:225:in `load_dependency'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/activesupport-3.0.10/lib/active_support/dependencies.rb:239:in `require'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/lib/ruby/gems/1.8/gems/railties-3.0.10/lib/rails/application.rb:103:in `require_environment!'
130108-20:15:21 notice: /Stage[main]/Foreman::Config/Exec[foreman_config]/returns:      from /usr/share/foreman/script/foreman-config:75
130108-20:15:21 err: /Stage[main]/Foreman::Config/Exec[foreman_config]: Failed to call refresh: /usr/bin/ruby /usr/share/foreman/script/foreman-config -k oauth_active -v 'true'
```
