### PR TITLE
emails - add default From to login/password emails

### DIFF
--- a/katello-configure/modules/katello/templates/etc/katello/katello.yml.erb
+++ b/katello-configure/modules/katello/templates/etc/katello/katello.yml.erb
@@ -44,7 +44,12 @@ common:
 
   password_reset_expiration: 120
 
-  # Availabe language locale choices. (Note: Syntax for yaml requires a space after each comma ', ')
+  # email_reply_address is used to specify the "From:" address included
+  # in emails sent from the Server.  If not specified, it will default to
+  # no-reply@host, where host is the value specified above.
+  email_reply_address:
+
+  # Available language locale choices. (Note: Syntax for yaml requires a space after each comma ', ')
   # Default available locales are below
   available_locales: ["bn", "de", "en", "es", "fr", "gu", "hi", "it", "ja", "kn", "ko", "mr", "or", "pa", "pt-BR",
   "ru", "ta", "te", "zh-CN", "zh-TW"]

--- a/src/app/mailers/user_mailer.rb
+++ b/src/app/mailers/user_mailer.rb
@@ -13,6 +13,8 @@
 class UserMailer < ActionMailer::Base
   include AsyncOrchestration
 
+  default :from => Katello.config.email_reply_address
+
   def send_password_reset(user)
     # TODO: temporarily hardcoding org to the first org... this will be changed to use the user's default org, once
     # that logic is merged in

--- a/src/config/katello.template.yml
+++ b/src/config/katello.template.yml
@@ -43,7 +43,12 @@ common:
 
   password_reset_expiration: 120
 
-  # Availabe language locale choices. (Note: Syntax for yaml requires a space after each comma ', ')
+  # email_reply_address is used to specify the "From:" address included
+  # in emails sent from the Server.  If not specified, it will default to
+  # no-reply@host, where host is the value specified above.
+  email_reply_address:
+
+  # Available language locale choices. (Note: Syntax for yaml requires a space after each comma ', ')
   # Default available locales are below
   available_locales: ["bn", "de", "en", "es", "fr", "gu", "hi", "it", "ja", "kn", "ko", "mr", "or", "pa", "pt-BR",
   "ru", "ta", "te", "zh-CN", "zh-TW"]

--- a/src/lib/katello_config.rb
+++ b/src/lib/katello_config.rb
@@ -322,6 +322,9 @@ module Katello
         config[:use_pulp] = config.katello? if config[:use_pulp].nil?
         config[:use_foreman] = config.katello? if config[:use_foreman].nil?
 
+        config[:email_reply_address] = config[:email_reply_address] ?
+            config[:email_reply_address] : "no-reply@"+config[:host]
+
         load_version config
       end
 
@@ -358,7 +361,7 @@ module Katello
                     cloud_forms use_pulp cdn_proxy use_ssl warden katello? url_prefix foreman
                     search use_foreman password_reset_expiration redhat_repository_url port
                     elastic_url rest_client_timeout elastic_index allow_roles_logging
-                    katello_version pulp tire_log log_level log_level_sql)
+                    katello_version pulp tire_log log_level log_level_sql email_reply_address)
 
       has_values :app_mode, %w(katello headpin)
       has_values :url_prefix, %w(/headpin /sam /cfse /katello)


### PR DESCRIPTION
It was observed that with the nightly build the password reset
and login emails were no longer being sent for RHEL server
configurations.

During investigation, found the following in the delayed_jobs.log:

2013-01-10T12:10:41-0500: [Worker(delayed_job host:katello.com pid:28884)]
Class#logins failed with ArgumentError: A sender (Return-Path, Sender or From)
required to send a message - 0 failed attempts

In order to address this, we are adding a configuration property
(email_reply_address) to the katello.yml that may be used to specify
the address. If not specified, a default of 'no-reply@host' will be
used, where host is the value specified for that property.

Note: in the future, we may want to add this to the UI in the
form of a database attribute; however, we might want to consider
having the email specified at different levels possibly based on
org or classification of email (e.g. login related emails, consumer
related emails...etc)
