### PR TITLE
cli completion - fix in sed expression

### DIFF
--- a/cli/etc/katello.completion.sh
+++ b/cli/etc/katello.completion.sh
@@ -5,7 +5,8 @@
 #
 
 _katello() {
-  COMPREPLY=($(_complete_katello "${COMP_WORDS[*]}" | sed 's/^[^a-z\-]*\w//'))
+  # we have to sed out utf characters produced by the python completer so that they don't appear on not utf ready terminals
+  COMPREPLY=($(_complete_katello "${COMP_WORDS[*]}" | sed -e 's/^[^a-z \-]\+\w//' -e 's/^[ ]*//'))
   return 0
 }
 


### PR DESCRIPTION
Previous sed was cutting first characters of completed words on utf ready terminals.
