### PR TITLE
Setting the min_messages level to warning

### DIFF
--- a/src/config/katello.template.yml
+++ b/src/config/katello.template.yml
@@ -182,6 +182,7 @@ development:
     random_password: false
   database:
     database: katello
+    min_messages: WARNING
 
 #
 # Test environment configuration
@@ -191,6 +192,7 @@ development:
 test:
   database:
     database: katello-test<%= ENV['TEST_ENV_NUMBER'] %>
+    min_messages: WARNING
 
 
 # Blank configuration for build environment


### PR DESCRIPTION
Setting the min_messages level in development and test to suppress notices in
postgres.
