### PR TITLE
881847 - allow system group names with spaces and other characters

### DIFF
--- a/src/app/models/system_group.rb
+++ b/src/app/models/system_group.rb
@@ -65,7 +65,7 @@ class SystemGroup < ActiveRecord::Base
   belongs_to :organization
 
   before_validation(:on=>:create) do
-    self.pulp_id ||= "#{self.organization.label}-#{self.name}-#{SecureRandom.hex(4)}"
+    self.pulp_id ||= "#{self.organization.label}-#{Katello::ModelUtils::labelize(self.name)}-#{SecureRandom.hex(4)}"
   end
 
   default_scope :order => 'name ASC'


### PR DESCRIPTION
pulpv2 does not support spaces and other non alpha-numeric
characters in the id, so in order to create a group in katello
with those characters we just need to labelize the name when
constructing the pulpId
