### PR TITLE
Content views: create/edit content views for systems in the UI

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -78,13 +78,16 @@ class SystemsController < ApplicationController
   def param_rules
     update_check = lambda do
       if params[:system]
-        sys_rules = {:system => [:name, :description, :location, :releaseVer, :serviceLevel, :environment_id] }
+        sys_rules = {:system => [:name, :description, :location, :releaseVer, :serviceLevel, :environment_id, :content_view_id] }
         check_hash_params(sys_rules, params)
       else
         check_array_params([:id], params)
       end
     end
-    {   :create => {:arch => [:arch_id],:system=>[:sockets, :name, :environment_id], :system_type =>[:virtualized]},
+    {   :create => {:arch => [:arch_id],
+                    :system=>[:sockets, :name, :environment_id, :content_view_id],
+                    :system_type =>[:virtualized]
+                   },
         :update => update_check
     }
   end
@@ -113,6 +116,7 @@ class SystemsController < ApplicationController
     @system.name= params["system"]["name"]
     @system.cp_type = "system"
     @system.environment = KTEnvironment.find(params["system"]["environment_id"])
+    @system.content_view = ContentView.find_by_id(params["system"].try(:[], "content_view_id"))
     #create it in candlepin, parse the JSON and create a new ruby object to pass to the view
     #find the newly created system
     if @system.save!

--- a/src/app/helpers/systems_helper.rb
+++ b/src/app/helpers/systems_helper.rb
@@ -41,13 +41,32 @@ module SystemsHelper
 
   def architecture_select
     select(:arch, "arch_id", System.architectures.invert,
-             {:prompt => _('Select Architecture'), :id=>"arch_field"}, {:tabindex => 2})
+             {:prompt => _('Select Architecture'), :id=>"arch_field"}, {:tabindex => 3})
+  end
+
+  def content_view_select(org)
+    views = ContentView.readable(org).non_default
+    choices = views.map {|v| [v.name, v.id]}
+    select(:system, "content_view_id", choices,
+             {:prompt => _('Select Content View'), :id=>"content_view_field"},
+             {:tabindex => 2})
+  end
+
+  def system_content_view_opts
+    keys = {}
+    ContentView.readable(current_organization).non_default.each do |view|
+      keys[view.id] = view.name
+    end
+    keys[""] = ""
+    keys["selected"] = @system.content_view_id || ""
+
+    keys.to_json
   end
 
   def virtual_buttons
-    raw [radio_button("system_type","virtualized", "physical", :checked=>true, :tabindex => 4 ),
+    raw [radio_button("system_type","virtualized", "physical", :checked=>true, :tabindex => 5 ),
     content_tag(:label, _("Physical"), :for => 'system_type_virtualized_physical'),
-    radio_button("system_type","virtualized", "virtual", :tabindex => 5 ),
+    radio_button("system_type","virtualized", "virtual", :tabindex => 6 ),
     content_tag(:label, _("Virtual"), :for => 'system_type_virtualized_virtual')].join(' ')
   end
 

--- a/src/app/models/content_view.rb
+++ b/src/app/models/content_view.rb
@@ -60,6 +60,10 @@ class ContentView < ActiveRecord::Base
     end
   end
 
+  def to_s
+    name
+  end
+
   def promoted?
     # if the view exists in more than 1 environment, it has been promoted
     self.environments.length > 1 ? true : false

--- a/src/app/views/systems/_edit.html.haml
+++ b/src/app/views/systems/_edit.html.haml
@@ -100,6 +100,10 @@
           = label :arch, :arch, _("Environment")
         .grid_5.la#environment_path_selector{'name'=> 'system[environment_id]', :class=>("editable" if editable), 'data-url'=>system_path(system.id)}
           %span #{system_environment_name system}
+      %fieldset
+        .grid_2.ra.fieldset
+          = label :content_view, :content_view, _("Content View")
+        .grid_5.la#system_content_view{'name' => 'system[content_view_id]', :class=>("editable edit_select" if editable), 'data-url'=>system_path(system.id), 'data-options' => system_content_view_opts} #{system.content_view}
 
     .clear
     .grid_8

--- a/src/app/views/systems/_new.html.haml
+++ b/src/app/views/systems/_new.html.haml
@@ -18,6 +18,9 @@
         .grid_8#new_system
           = form.text_field :name, :label => _("Name of Your System:")
 
+          = form.field :content_view_id, :label => _("Content View:") do
+            = content_view_select(current_organization)
+
           = form.field :arch, :label => _("Architecture:") do
             = architecture_select
 


### PR DESCRIPTION
For right now, the system will let you select any view but if the view is not in the environment, it'll show an error. I'm planning on limiting the content views shown in the checkbox but that'll be in another commit/PR.
