### PR TITLE
895735 - [RFE] Specifying the keyname when removing custom info from

### DIFF
--- a/cli/src/katello/client/core/system_custom_info.py
+++ b/cli/src/katello/client/core/system_custom_info.py
@@ -34,6 +34,7 @@ class BaseSystemCustomInfo(SystemAction):
         validator.require_at_least_one_of(('name', 'uuid'))
         validator.mutually_exclude('name', 'uuid')
         validator.mutually_exclude('environment', 'uuid')
+        validator.require('keyname')
 
 
 class AddCustomInfo(BaseSystemCustomInfo):


### PR DESCRIPTION
a system should be required
