### PR TITLE
bundler_ext - renaming namespace

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -19,8 +19,8 @@ require 'katello_config'
 if File.exist?(File.expand_path('../../Gemfile.in', __FILE__))
   # In bundler_ext mode we always load all groups except the testing group
   # which can cause problems mocking objects for production or development envs.
-  require 'aeolus/ext/bundler_ext'
-  Aeolus::Ext::BundlerExt.system_require(File.expand_path('../../Gemfile.in', __FILE__), :all)
+  require 'bundler_ext'
+  BundlerExt.system_require(File.expand_path('../../Gemfile.in', __FILE__), :all)
 
   # Webmock rubygem have very strong default setting - it blocks all HTTP connections
   # after it is required. Therefore we want to turn off this behavior for all environments


### PR DESCRIPTION
BundlerExt renamed namespace, this fixes it.

Packages are on the way and will be part of the next nightly build, please merge.

```
Submitting build with: koji -c ~/.koji/katello-config build --nowait katello-thirdparty-rhel6 /tmp/tito/rubygem-bundler_ext-0.3.0-2.el6.src.rpm
Uploading srpm: /tmp/tito/rubygem-bundler_ext-0.3.0-2.el6.src.rpm
[====================================] 100% 00:00:00   9.48 KiB  11.82 KiB/sec
Created task: 19636
Task info: http://koji.katello.org/koji/taskinfo?taskID=19636
Wrote: /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc16.src.rpm

Submitting build with: koji -c ~/.koji/katello-config build --nowait katello-thirdparty-fedora16 /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc16.src.rpm
Uploading srpm: /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc16.src.rpm
[====================================] 100% 00:00:00   9.48 KiB  12.12 KiB/sec
Created task: 19637
Task info: http://koji.katello.org/koji/taskinfo?taskID=19637
Wrote: /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc17.src.rpm

Submitting build with: koji -c ~/.koji/katello-config build --nowait katello-thirdparty-fedora17 /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc17.src.rpm
Uploading srpm: /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc17.src.rpm
[====================================] 100% 00:00:00   9.48 KiB  12.32 KiB/sec
Created task: 19638
Task info: http://koji.katello.org/koji/taskinfo?taskID=19638
Wrote: /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc18.src.rpm

Submitting build with: koji -c ~/.koji/katello-config build --nowait katello-thirdparty-fedora18 /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc18.src.rpm
Uploading srpm: /tmp/tito/rubygem-bundler_ext-0.3.0-2.fc18.src.rpm
[====================================] 100% 00:00:00   9.48 KiB  12.44 KiB/sec
Created task: 19639
Task info: http://koji.katello.org/koji/taskinfo?taskID=19639
```
