### PR TITLE
fixing test runs for jenkins and travis

### DIFF
--- a/scripts/ci/katello_pull_request_tests.sh
+++ b/scripts/ci/katello_pull_request_tests.sh
@@ -17,4 +17,4 @@ psql -c "ALTER ROLE katello WITH CREATEDB" -U postgres
 psql -c "CREATE DATABASE katello_test OWNER katello;" -U postgres
 bundle exec rake parallel:create VERBOSE=false
 bundle exec rake parallel:migrate VERBOSE=alse
-bundle exec rake "ptest:spec['', 2]"
+bundle exec rake ptest:spec

--- a/src/lib/tasks/hudson.rake
+++ b/src/lib/tasks/hudson.rake
@@ -3,7 +3,7 @@
 begin
   require 'ci/reporter/rake/rspec'
   namespace :hudson do
-    task :spec => ["rake:configuration", "hudson:setup:rspec", 'parallel:spec']
+    task :spec => ["rake:configuration", "hudson:setup:rspec", 'ptest:spec']
 
     namespace :setup do
       task :pre_ci do

--- a/src/lib/tasks/test.rake
+++ b/src/lib/tasks/test.rake
@@ -11,7 +11,7 @@ namespace "ptest" do
   end
 
   def tests(env, task_args, rspec_args)
-    task_args.with_defaults(:pattern => '\'\'', :threads => 4)
+    task_args.with_defaults(:pattern => '\'\'', :threads => 0)
 
     pattern_search = task_args[:pattern] != '\'\''
 


### PR DESCRIPTION
When calling 'parallel:spec' with full options, one must specify the
number of cores to split the tests to. At first, I was manually giving
the number of CPUs, but then discovered I can pass '0' and parallel:spec
will auto-detect the maximum number of cores on a machine.
