### PR TITLE
rails 3.2 removed ActiveSupport::SecureRandom in favor of SecureRandom

### DIFF
--- a/src/config/initializers/secret_token.rb
+++ b/src/config/initializers/secret_token.rb
@@ -1,4 +1,8 @@
-require 'active_support/secure_random'
+if RUBY_VERSION >= "1.9.3"
+  require 'securerandom'
+else 
+  require 'active_support/secure_random'
+end
 
 begin
   # Read token string from the file.
@@ -10,5 +14,5 @@ rescue Exception => e
   # Katello is not configured correctly for any reason (but session is lost
   # after each restart).
   Rails.logger.warn "Using randomly generated secure token: #{e.message}"
-  Src::Application.config.secret_token = ActiveSupport::SecureRandom.hex(80)
+  Src::Application.config.secret_token = RUBY_VERSION >= "1.9.3" ? SecureRandom.hex(80) : ActiveSupport::SecureRandom.hex(80)
 end


### PR DESCRIPTION
http://edgeguides.rubyonrails.org/3_2_release_notes.html#active-support

addressing:

```
+ rake apipie:static --trace
** Invoke apipie:static (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
cannot load such file -- active_support/secure_random
/usr/share/rubygems/rubygems/custom_require.rb:36:in `require'
/usr/share/rubygems/rubygems/custom_require.rb:36:in `require'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `block in require'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `require'
/tmp/tito-build/rpmbuild-katello-80d9bc4c0eaf59ba8dee370fb17328876118332eahBsfL/BUILD/katello-git-29.80d9bc4/config/initializers/secret_token.rb:1:in `<top (required)>'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:245:in `load'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:245:in `block in load'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:245:in `load'
/usr/share/gems/gems/railties-3.2.8/lib/rails/engine.rb:588:in `block (2 levels) in <class:Engine>'
/usr/share/gems/gems/railties-3.2.8/lib/rails/engine.rb:587:in `each'
/usr/share/gems/gems/railties-3.2.8/lib/rails/engine.rb:587:in `block in <class:Engine>'
/usr/share/gems/gems/railties-3.2.8/lib/rails/initializable.rb:30:in `instance_exec'
/usr/share/gems/gems/railties-3.2.8/lib/rails/initializable.rb:30:in `run'
/usr/share/gems/gems/railties-3.2.8/lib/rails/initializable.rb:55:in `block in run_initializers'
/usr/share/gems/gems/railties-3.2.8/lib/rails/initializable.rb:54:in `each'
/usr/share/gems/gems/railties-3.2.8/lib/rails/initializable.rb:54:in `run_initializers'
/usr/share/gems/gems/railties-3.2.8/lib/rails/application.rb:136:in `initialize!'
/usr/share/gems/gems/railties-3.2.8/lib/rails/railtie/configurable.rb:30:in `method_missing'
/tmp/tito-build/rpmbuild-katello-80d9bc4c0eaf59ba8dee370fb17328876118332eahBsfL/BUILD/katello-git-29.80d9bc4/config/environment.rb:5:in `<top (required)>'
/usr/share/rubygems/rubygems/custom_require.rb:36:in `require'
/usr/share/rubygems/rubygems/custom_require.rb:36:in `require'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `block in require'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:236:in `load_dependency'
/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/dependencies.rb:251:in `require'
/usr/share/gems/gems/railties-3.2.8/lib/rails/application.rb:103:in `require_environment!'
/usr/share/gems/gems/railties-3.2.8/lib/rails/application.rb:295:in `block (2 levels) in initialize_tasks'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:228:in `call'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:228:in `block in execute'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:223:in `each'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:223:in `execute'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:166:in `block in invoke_with_call_chain'
/usr/share/ruby/monitor.rb:211:in `mon_synchronize'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:159:in `invoke_with_call_chain'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:187:in `block in invoke_prerequisites'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:185:in `each'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:185:in `invoke_prerequisites'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:165:in `block in invoke_with_call_chain'
/usr/share/ruby/monitor.rb:211:in `mon_synchronize'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:159:in `invoke_with_call_chain'
/usr/share/gems/gems/rake-0.9.6/lib/rake/task.rb:152:in `invoke'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:143:in `invoke_task'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:101:in `block (2 levels) in top_level'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:101:in `each'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:101:in `block in top_level'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:110:in `run_with_threads'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:95:in `top_level'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:73:in `block in run'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:160:in `standard_exception_handling'
/usr/share/gems/gems/rake-0.9.6/lib/rake/application.rb:70:in `run'
/usr/share/gems/gems/rake-0.9.6/bin/rake:37:in `<top (required)>'
/usr/bin/rake:23:in `load'
/usr/bin/rake:23:in `<main>'
Tasks: TOP => apipie:static => environment
error: Bad exit status from /var/tmp/rpm-tmp.uDaumA (%build)
```
