### PR TITLE
896258 - replace agent config with rpm update

### DIFF
--- a/agent/katello-agent.spec
+++ b/agent/katello-agent.spec
@@ -39,7 +39,7 @@ cp src/katello/agent/katelloplugin.py %{buildroot}/%{_prefix}/lib/gofer/plugins
 rm -rf %{buildroot}
 
 %files
-%config(noreplace) %{_sysconfdir}/gofer/plugins/katelloplugin.conf
+%config %{_sysconfdir}/gofer/plugins/katelloplugin.conf
 %{_prefix}/lib/gofer/plugins/katelloplugin.*
 %doc LICENSE
 


### PR DESCRIPTION
Due to port change of QPIDD, we need to deploy this into 

/etc/gofer/plugins/katelloplugin.conf

file. And we do have this statement in the katello-agent spec file:

%config(noreplace) %{_sysconfdir}/gofer/plugins/katelloplugin.conf

Since users will unlikely change the contents of this file, it is highly recommended to remove this option to overwrite the change with the correct number (saving old config file as .rpmsave of course).
