### PR TITLE
872528 - restart gofer after katello-agent upgrade

### DIFF
--- a/agent/katello-agent.spec
+++ b/agent/katello-agent.spec
@@ -38,6 +38,9 @@ cp src/katello/agent/katelloplugin.py %{buildroot}/%{_prefix}/lib/gofer/plugins
 %clean
 rm -rf %{buildroot}
 
+%postun
+LC_ALL=C service goferd status | grep 'is running' && service goferd restart
+
 %files
 %config(noreplace) %{_sysconfdir}/gofer/plugins/katelloplugin.conf
 %{_prefix}/lib/gofer/plugins/katelloplugin.*


### PR DESCRIPTION
since gofer does not support condrestart command we have to workaround it
