### PR TITLE
do not use ZenTest 4.8.4

### DIFF
--- a/src/bundler.d/test.rb
+++ b/src/bundler.d/test.rb
@@ -1,5 +1,5 @@
 group :test do
-  gem 'ZenTest', '>= 4.4.0', :require => "autotest"
+  gem 'ZenTest', '>= 4.4.0', '< 4.8.4', :require => "autotest"
   gem 'autotest-rails', '>= 4.1.0'
   
   # (also appears in development group)


### PR DESCRIPTION
addressing:
324RUNNING: RAILS_ENV=development bundle exec compass compile

325Invalid gemspec in [/home/travis/.rvm/gems/ruby-1.8.7-p371/specifications/ZenTest-4.8.4.gemspec]: Illformed requirement ["< 2.1, >= 1.8"]

326sh: 1: rpm: not found

327Invalid gemspec in [/home/travis/.rvm/gems/ruby-1.8.7-p371/specifications/ZenTest-4.8.4.gemspec]: Illformed requirement ["< 2.1, >= 1.8"]

328Invalid gemspec in [/home/travis/.rvm/gems/ruby-1.8.7-p371/specifications/ZenTest-4.8.4.gemspec]: Illformed requirement ["< 2.1, >= 1.8"]

329sh: 1: rpm: not found

330Invalid gemspec in [/home/travis/.rvm/gems/ruby-1.8.7-p371/specifications/ZenTest-4.8.4.gemspec]: Illformed requirement ["< 2.1, >= 1.8"]

Workaround for
https://github.com/seattlerb/zentest/issues/28
