### PR TITLE
887095 - cli locale was not set properly

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -169,7 +169,7 @@ class ApplicationController < ActionController::Base
     if current_user && current_user.default_locale
       I18n.locale = current_user.default_locale
     else
-      I18n.locale = ApplicationController.extract_locale_from_accept_language_header
+      I18n.locale = ApplicationController.extract_locale_from_accept_language_header parse_locale
     end
 
     logger.debug "Setting locale: #{I18n.locale}"
@@ -219,8 +219,8 @@ class ApplicationController < ActionController::Base
   # Look for match to list of locales specified in request. If not found, try matching just
   # first two letters. Finally, default to english if no matches at all.
   # eg. [en_US, en] would match en
-  def self.extract_locale_from_accept_language_header
-    locales = parse_locale
+  # Expects list of locales to search as an array (use parse_locale for that)
+  def self.extract_locale_from_accept_language_header locales
 
     # Look for full match
     locales.each {|locale|
@@ -304,8 +304,8 @@ class ApplicationController < ActionController::Base
   end
 
   # adapted from http_accept_lang gem, return list of browser locales
-  def self.parse_locale
-    locale_lang = env['HTTP_ACCEPT_LANGUAGE'].split(/\s*,\s*/).collect do |l|
+  def parse_locale
+    locale_lang = request.env['HTTP_ACCEPT_LANGUAGE'].split(/\s*,\s*/).collect do |l|
       l += ';q=1.0' unless l =~ /;q=\d+\.\d+$/
       l.split(';q=')
     end.sort do |x,y|

--- a/src/app/models/async_operation.rb
+++ b/src/app/models/async_operation.rb
@@ -36,7 +36,10 @@ AsyncOperation = Struct.new(:status_id, :username, :object, :method_name, :args)
     if User.current && User.current.default_locale
       I18n.locale = User.current.default_locale
     else
-      I18n.locale = ApplicationController.extract_locale_from_accept_language_header
+      # if user did not set his locale we are not able to detect browser setting here and we have to
+      # fall back to system language or English
+      system_lang = ENV['LC_LANG'] || 'en'
+      I18n.locale = ApplicationController.extract_locale_from_accept_language_header [system_lang]
     end
     Rails.logger.debug "Setting locale: #{I18n.locale}"
 


### PR DESCRIPTION
Ok this patch completely replace ApiController.set_locale. It now properly parses locale coming from our CLI client and accept both UNIX locale format (cs_CZ) as well as HTTP standard one (cs-CZ).

Then it uses ApplicationController#extract_locale_from_accept_language_header method to properly find the right locale.

Also this patch correct ApplicationContoller#parse_locale method which is again instance method so it can access request environment and removes extract_locale_from_accept_language_header call from backend jobs (which will always return "en" anyway).

https://bugzilla.redhat.com/show_bug.cgi?id=887095
https://bugzilla.redhat.com/show_bug.cgi?id=896251
