### PR TITLE
896074 - fixing remove deletion permissions

### DIFF
--- a/src/app/controllers/api/proxies_controller.rb
+++ b/src/app/controllers/api/proxies_controller.rb
@@ -32,7 +32,8 @@ class Api::ProxiesController < Api::ApiController
             consumer_gone = true
           end
         end
-        User.consumer? || consumer_gone || consumer_live
+        system = System.find_by_uuid params[:id]
+        User.consumer? || (system && system.editable? && (consumer_gone || consumer_live))
       when :api_proxy_owner_pools_path
         find_optional_organization
         if params[:consumer]


### PR DESCRIPTION
When user without remove system permissions calls CLI command "system remove_deletion", it finishes successfully without any warning.

https://bugzilla.redhat.com/show_bug.cgi?id=896074
