### PR TITLE
uuid - now works with Rails 3.2

### DIFF
--- a/src/lib/util/threadsession.rb
+++ b/src/lib/util/threadsession.rb
@@ -73,8 +73,6 @@ module Katello
         end
       end
 
-      # TODO - once we upgrade to 3.2 we need to test if request.uuid works (check the orchestration log)
-      raise "Please test request.uuid with Rails 3.2+ ^^^" if Rails.version.starts_with? "3.2"
       def thread_locals
         # store request uuid (for Rails 3.2+ we can use Request.uuid)
         Thread.current[:request_uuid] = request.respond_to?(:uuid) ? request.uuid : SecureRandom.hex(16)


### PR DESCRIPTION
This removes the check for Rails 3.2.

Can someone with working Rails 3.2 check if there are logs with unique uuids in the log/*_orchestration.log ? Then we can merge.
