### PR TITLE
858877 Allow selection of all listem items when applying packages to a system group

### DIFF
--- a/src/app/stylesheets/katello.scss
+++ b/src/app/stylesheets/katello.scss
@@ -832,6 +832,13 @@ fieldset {
     margin: 5px 0 0 0;
     overflow: auto;
     padding: 10px;
+
+    .selection_group {
+      height: 30px;
+      width: 160px;
+      float: right;
+      padding-right: 50px;
+    }
   }
   .tupane_header {
     overflow: auto;

--- a/src/app/views/system_groups/errata/_index.html.haml
+++ b/src/app/views/system_groups/errata/_index.html.haml
@@ -63,4 +63,11 @@
     %span.fr
       %button.button.disabled{:id => 'run_errata_button', 'data-url' => system_group_errata_path(@group.id) }
         #{_('Install')}
-
+    .selection_group
+      %span.fr
+        %button.button{:id => 'deselect_all_button'}
+          #{_('Deselect all')}
+      %span.fr
+        %button.button{:id => 'select_all_button'}
+          #{_('Select all')}
+    

--- a/src/public/javascripts/system_errata.js
+++ b/src/public/javascripts/system_errata.js
@@ -65,7 +65,9 @@ KT.system.errata = function() {
     		$('#select_all_errata').bind('change', select_all_errata);
     		$('#errata_state_radio_applied').bind('change', fetch_errata);
     		$('#errata_state_radio_outstanding').bind('change', fetch_errata);
-            $('#run_errata_button').bind('click', add_errata);
+        $('#run_errata_button').bind('click', add_errata);
+        $('#select_all_button').bind('click', select_all);
+        $('#deselect_all_button').bind('click', deselect_all);
     		load_more.bind('click', { clear_items : false }, fetch_errata);
     	},
         init_status_check = function(){
@@ -117,6 +119,14 @@ KT.system.errata = function() {
     			checkboxes.attr('checked', false);
     		}
     	},
+        select_all = function(){
+            var checkboxes = table_body.find(':checkbox');
+            checkboxes.attr('checked', true);
+        },
+        deselect_all = function(){
+            var checkboxes = table_body.find(':checkbox');
+            checkboxes.attr('checked', false);
+        },
         add_errata = function(){
             var selected_errata = errata_container.find(':checkbox:checked'),
                 errata_ids = [],


### PR DESCRIPTION
Added select_all and deselect_all button for system group when all erratas
wanted to be checked.
