### PR TITLE
887095 - fixing API breakage

### DIFF
--- a/src/app/controllers/api/api_controller.rb
+++ b/src/app/controllers/api/api_controller.rb
@@ -62,7 +62,8 @@ class Api::ApiController < ActionController::Base
   end
 
   def parse_locale
-    first, second = request.env['HTTP_ACCEPT_LANGUAGE'].split(/[-_]/)
+    hal = request.env['HTTP_ACCEPT_LANGUAGE'] || 'en'
+    first, second = hal.split(/[-_]/)
     if second.nil?
       return [first.downcase]
     else


### PR DESCRIPTION
This fixes my latest change in the API controller which broke all API calls when locale was not set. Resolves:

```
private method `split' called for nil:NilClass
```

Please do not merge yet, still testing this.
