### PR TITLE
880125 - Errors message when no key can be found

### DIFF
--- a/cli/src/katello/client/core/activation_key.py
+++ b/cli/src/katello/client/core/activation_key.py
@@ -229,6 +229,7 @@ class Update(ActivationKeyAction):
 
         keys = self.api.activation_keys_by_organization(orgName, keyName)
         if len(keys) == 0:
+            print >> sys.stderr, _("Could not find activation key [ %s ]") % keyName
             return os.EX_DATAERR
         key = keys[0]
 
@@ -271,7 +272,7 @@ class Delete(ActivationKeyAction):
 
         keys = self.api.activation_keys_by_organization(orgName, keyName)
         if len(keys) == 0:
-            #TODO: not found?
+            print >> sys.stderr, _("Could not find activation key [ %s ]") % keyName
             return os.EX_DATAERR
 
         self.api.delete(orgName, keys[0]['id'])


### PR DESCRIPTION
Print an error message when deleting or updating activation
key via CLI and user specifies wrong key name.
