### PR TITLE
880019 - [ja_JP][headpin CLI] error: 'ascii' codec can't encode

### DIFF
--- a/cli/src/katello/client/constants.py
+++ b/cli/src/katello/client/constants.py
@@ -45,7 +45,6 @@ DELETION = 'DELETION'
 # Help string for optparser
 OPT_HELP_PROMOTION = _("changeset type promotion: pushes changes to the next environment [DEFAULT]")
 OPT_HELP_DELETION = _("changeset type deletion: deletes items in changeset from current environment")
-OPT_ERR_PROMOTION_OR_DELETE = _("specify either --promotion or --deletion but not both")
 OPT_ERR_SYSTEM_AMBIGUOUS = _("Ambiguous systems found, please specify with --uuid options")
 OPT_HELP_SYSTEM_UUID = _("system uuid")
 OPT_ARCHITECTURE_NAME = _("architecture name (required)")

--- a/cli/src/katello/client/core/base.py
+++ b/cli/src/katello/client/core/base.py
@@ -462,7 +462,7 @@ def check_bool(option, opt, value):
     if value.lower() in ["true","false"]:
         return (value.lower() == "true")
     else:
-        raise OptionValueError(_("option %(opt)s: invalid boolean value: %(value)r") % {'opt':opt, 'value':value})
+        raise OptionValueError("option %(opt)s: invalid boolean value: %(value)r" % {'opt':opt, 'value':value})
 
 def check_insensitive_choice(option, opt, value):
     if option.case_sensitive is False:
@@ -475,9 +475,7 @@ def check_insensitive_choice(option, opt, value):
         return value
     else:
         choices = ", ".join(option.choices)
-        raise OptionValueError(
-            _("option %s: invalid choice: %r (choose from %s)")
-            % (opt, value, choices))
+        raise OptionValueError("option %s: invalid choice: %r (choose from %s)" % (opt, value, choices))
 
 def check_list(option, opt, value):
     if not option.delimiter:
@@ -498,16 +496,16 @@ def check_url(option, opt, value):
     url_parsed = urlparse(value)
     if not url_parsed.scheme in schemes:                                 # pylint: disable=E1101
         formatted_schemes = " or ".join([s+"://" for s in schemes])
-        raise OptionValueError(_('option %(opt)s: has to start with %(formatted_schemes)s') \
+        raise OptionValueError('option %(opt)s: has to start with %(formatted_schemes)s' \
             % {'opt':opt, 'formatted_schemes':formatted_schemes})
     elif not url_parsed.netloc and not url_parsed.path:                  # pylint: disable=E1101
-        raise OptionValueError(_('option %s: invalid format') % (opt))
+        raise OptionValueError('option %s: invalid format' % (opt))
     return value
 
 def check_ip(option, opt, value):
 
     def raise_exception():
-        raise OptionValueError(_('option %s: invalid ip address format') % (opt))
+        raise OptionValueError('option %s: invalid ip address format' % (opt))
 
     parts = value.strip().split('.')
     if len(parts) != 4:

--- a/cli/src/katello/client/core/changeset.py
+++ b/cli/src/katello/client/core/changeset.py
@@ -142,12 +142,14 @@ class Create(ChangesetAction):
         parser.add_option('--promotion', dest='type_promotion', action="store_true", default=False,
                                help=constants.OPT_HELP_PROMOTION)
         parser.add_option('--deletion', dest='type_deletion', action="store_true", default=False,
-                               help=constants.OPT_ERR_PROMOTION_OR_DELETE)
+                               help=constants.OPT_HELP_DELETION)
 
 
 
     def check_options(self, validator):
         validator.require(('org', 'name', 'environment'))
+        validator.require_at_least_one_of(('type_promotion', 'type_deletion'))
+        validator.mutually_exclude('type_promotion', 'type_deletion')
 
     def run(self):
         orgName = self.get_option('org')
@@ -156,20 +158,17 @@ class Create(ChangesetAction):
         csDescription = self.get_option('description')
         csType = constants.PROMOTION
 
-        # Check for duplicate type flags
-        if self.get_option('type_promotion') and self.get_option('type_deletion'):
-            raise OptionValueError(constants.OPT_ERR_PROMOTION_OR_DELETE)
         if self.get_option('type_promotion'):
             csType = constants.PROMOTION
-        elif self.get_option('type_deletion'):
+        else:
             csType = constants.DELETION
 
         env = get_environment(orgName, envName)
         cset = self.api.create(orgName, env["id"], csName, csType, csDescription)
         test_record(cset,
-            _("Successfully created changeset [ %(csName)s ] for environment [ %(env_name)s ]") 
+            _("Successfully created changeset [ %(csName)s ] for environment [ %(env_name)s ]")
                 % {'csName':csName, 'env_name':env["name"]},
-            _("Could not create changeset [ %(csName)s ] for environment [ %(env_name)s ]") 
+            _("Could not create changeset [ %(csName)s ] for environment [ %(env_name)s ]")
                 % {'csName':csName, 'env_name':env["name"]}
         )
 
@@ -335,7 +334,7 @@ class UpdateContent(ChangesetAction):
         if (parser.values.from_product == None) and \
            (parser.values.from_product_label == None) and \
            (parser.values.from_product_id == None):
-            raise OptionValueError(_("%s must be preceded by %s, %s or %s") %
+            raise OptionValueError("%s must be preceded by %s, %s or %s" %
                   (option, "--from_product", "--from_product_label", "--from_product_id"))
 
         if self.current_product_option == 'product_label':

--- a/cli/src/katello/client/core/template.py
+++ b/cli/src/katello/client/core/template.py
@@ -285,7 +285,7 @@ class Update(TemplateAction):
 
     def _store_parameter_value(self, option, opt_str, value, parser):
         if self.current_parameter == None:
-            raise OptionValueError(_("each %(option)s must be preceeded by %(paramater)s") \
+            raise OptionValueError("each %(option)s must be preceeded by %(parameter)s" \
                 % {'option':option, 'parameter':"--add_parameter"} )
 
         self.items['add_parameters'][self.current_parameter] = u_str(value)
@@ -300,7 +300,7 @@ class Update(TemplateAction):
         if (parser.values.from_product == None) and \
            (parser.values.from_product_label == None) and \
            (parser.values.from_product_id == None):
-            raise OptionValueError(_("%s must be preceded by %s, %s or %s") %
+            raise OptionValueError("%s must be preceded by %s, %s or %s" % \
                   (option, "--from_product", "--from_product_label", "--from_product_id"))
 
         if self.current_product_option == 'from_product_label':


### PR DESCRIPTION
characters in position 0-4 for user create module with invalid boolean
value to --disabled.

OptParser does not handle unicode strings in error messages.

raising OptionValueError(_("this is a unicode string")) in a locale
other than English causes optparse to barf in katello:

```
'ascii' codec can't encode characters in position 0-4: ordinal not in range(128)
```

I removed all the internationalized strings that are given to
OptionValueError so that optparse doesn't die.
