### PR TITLE
Locking down js-routes version

### DIFF
--- a/src/bundler.d/development.rb
+++ b/src/bundler.d/development.rb
@@ -8,7 +8,7 @@ group :development do
   gem 'yard', '>= 0.5.3'
 
   # generates routes in javascript
-  gem "js-routes", :require => 'js_routes'
+  gem "js-routes", '~> 0.6.2', :require => 'js_routes'
 
   # for generating i18n files - TODO do we need ruby_parser here?
   gem 'gettext', '>= 1.9.3', :require => false


### PR DESCRIPTION
Locking down js-routes to 0.6.x as 0.7.5 generates this:

``` javascript
organizations_path: function(options) {
  return Utils.build_path(0, ["/organizations"], arguments)
},
```

Whereas js-routes 0.6.2 generates this:

``` javascript
organizations_path: function(options) {
  return Utils.build_path(1, ["/organizations"], arguments)
},
```

Our javascript relies on the 0.6.2 route.
