### PR TITLE
Content views: fixed bug where product arg was not unique

### DIFF
--- a/cli/src/katello/client/core/content_view_definition.py
+++ b/cli/src/katello/client/core/content_view_definition.py
@@ -286,7 +286,7 @@ class AddRemoveProduct(ContentViewDefinitionAction):
         product_label  = self.get_option('product')
 
         view    = get_cv_definition(org_name, def_label, def_name, def_id)
-        product = get_product(org_name, product_label)
+        product = get_product(org_name, prodLabel=product_label)
 
         products = self.def_api.products(org_name, view['id'])
         products = [f['id'] for f in products]


### PR DESCRIPTION
Product argument was not unique so if there were dupe product names, you
couldn't add either to a definition. Eventually we should support multiple
product arguments (id, name) in addition to label. That's on my TODO list.
