### PR TITLE
790064 - Fix for manifest import in headpin mode

### DIFF
--- a/src/app/models/glue/pulp/repos.rb
+++ b/src/app/models/glue/pulp/repos.rb
@@ -20,8 +20,6 @@ module Glue::Pulp::Repos
     base.class_eval do
       before_save :save_repos_orchestration
       before_destroy :destroy_repos_orchestration
-
-      scope :repositories_cdn_import_failed, where(:cdn_import_success => false)
     end
   end
 

--- a/src/app/models/product.rb
+++ b/src/app/models/product.rb
@@ -147,6 +147,8 @@ class Product < ActiveRecord::Base
 
   scope :all_in_org, lambda{|org| ::Product.joins(:provider).where('providers.organization_id = ?', org.id)}
 
+  scope :repositories_cdn_import_failed, where(:cdn_import_success => false)
+
   def assign_unique_label
     self.label = Katello::ModelUtils::labelize(self.name) if self.label.blank?
 


### PR DESCRIPTION
A scope must be defined also in headpin mode. Moving into product model.
