### PR TITLE
Fix setting environment without usage RAILS_ENV

### DIFF
--- a/src/config/environments/test.rb
+++ b/src/config/environments/test.rb
@@ -39,3 +39,7 @@ Src::Application.configure do
   Dir.mkdir "#{Rails.root}/log" unless File.directory? "#{Rails.root}/log"
   config.active_record.logger = Logger.new("#{Rails.root}/log/test_sql.log")
 end
+
+# test running optimization
+Password.password_rounds = 1
+

--- a/src/lib/util/password.rb
+++ b/src/lib/util/password.rb
@@ -93,10 +93,16 @@ module Password
     decrypted
   end
 
-  if defined?(Rails) and Rails.env.test?
-    PASSWORD_ROUNDS = 1
-  else
-    PASSWORD_ROUNDS = 500
+  # this option is intended for altering the behaviour
+  # of hashin (such as faster passowrd hashing when running tests)
+  # should be used with caution (setting to 1 in testing environment
+  # is probably the only reasonable usage)
+  def Password.password_rounds=(value)
+    @password_rounds = value
+  end
+
+  def Password.password_rounds
+    @password_rounds || 500
   end
 
   # Generates a psuedo-random 64 character string
@@ -107,7 +113,7 @@ module Password
   # Generates a 128 character hash
   def Password.hash(password, salt)
     digest = "#{password}:#{salt}"
-    PASSWORD_ROUNDS.times { digest = Digest::SHA512.hexdigest(digest) }
+    password_rounds.times { digest = Digest::SHA512.hexdigest(digest) }
     digest
   end
 


### PR DESCRIPTION
Running

```
rails s -e production
```

or

```
rails c production
```

didn't work correctly: the environment was still set still on
development. The reason was, that `lib/util/password.rb` was loaded
form `lib/katello_config.rb` before Rails environment was initialized.
Because in password.rb load phase, `Rails.env` was called, it set the
environment before the `-e` option was processed.

Setting the rounds value in `config/environments/test.rb` probably
makes more sense, leaving the `util/password.rb` file independent from
knowing anything about Rails env.
