### PR TITLE
create a distributor for disabled repos

### DIFF
--- a/src/app/models/glue/pulp/repo.rb
+++ b/src/app/models/glue/pulp/repo.rb
@@ -126,7 +126,7 @@ module Glue::Pulp::Repo
         importer = Runcible::Extensions::YumImporter.new
       end
 
-      distributors = self.enabled? ? [generate_distributor] : []
+      distributors =  [generate_distributor]
 
       Runcible::Extensions::Repository.create_with_importer_and_distributors(self.pulp_id,
           importer,


### PR DESCRIPTION
otherwise we would need to create it upon
being enabled, and there is no harm
in enabling it now anyways, much simpler
