### PR TITLE
removing copyright notice from template

### DIFF
--- a/katello-configure/modules/pulp/templates/etc/httpd/conf.d/pulp.conf.erb
+++ b/katello-configure/modules/pulp/templates/etc/httpd/conf.d/pulp.conf.erb
@@ -4,19 +4,6 @@
 #
 
 # Apache configuration file for pulp web services and repositories
-#
-# Copyright © 2010 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public License,
-# version 2 (GPLv2). There is NO WARRANTY for this software, express or
-# implied, including the implied warranties of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
-# along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-#
-# Red Hat trademarks are not licensed under GPLv2. No permission is
-# granted to use or replicate Red Hat trademarks that are incorporated
-# in this software or its documentation.
 
 AddType application/x-pkcs7-crl .crl
 AddType application/x-x509-ca-cert .crt


### PR DESCRIPTION
ascii character caused error on install
none of our other templates have copyright notices
or licenses
