### PR TITLE
880019 - learn optparser how to handle unicode errors

### DIFF
--- a/cli/src/katello/client/i18n_optparse.py
+++ b/cli/src/katello/client/i18n_optparse.py
@@ -27,6 +27,7 @@ http://bugs.python.org/issue4319
 import sys
 
 from optparse import OptionParser as _OptionParser
+from optparse import BadOptionError, OptionValueError
 
 class OptionParserExitError(Exception):
     """
@@ -34,7 +35,6 @@ class OptionParserExitError(Exception):
     Takes error code as it's only argument.
     """
     pass
-
 
 # pylint: disable=R0904
 class OptionParser(_OptionParser):
@@ -68,6 +68,13 @@ class OptionParser(_OptionParser):
         _("show program's version number and exit")
 
     displayed_help = False
+
+
+    def _process_args(self, largs, rargs, values):
+        try:
+            _OptionParser._process_args(self, largs, rargs, values)
+        except (BadOptionError, OptionValueError), err:
+            self.error(err.__str__())
 
     def print_help(self, out_file=None):
         if out_file is None:

--- a/cli/src/katello/client/lib/utils/encoding.py
+++ b/cli/src/katello/client/lib/utils/encoding.py
@@ -16,6 +16,7 @@
 import collections
 import codecs
 import sys
+from optparse import OptParseError
 
 stdout_origin = sys.stdout
 
@@ -43,6 +44,8 @@ def u_str(value):
     """
     Casts value to unicode string.
     """
+    if isinstance(value, OptParseError):
+        value = value.__str__()
     if not isinstance(value, basestring):
         value = str(value)
     if not isinstance(value, unicode):


### PR DESCRIPTION
addressing:

```
2013-02-04 00:29:37,299 [ERROR][MainThread] error() @ base.py:191 - Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/katello/client/cli/base.py", line 203, in main
    ret_code = super(KatelloCLI, self).main(args, command_name, parent_usage)
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 312, in main
    return subcommand.main(self.args[1:], self.args[0], self._get_usage_line(command_name, parent_usage))
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 312, in main
    return subcommand.main(self.args[1:], self.args[0], self._get_usage_line(command_name, parent_usage))
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 389, in main
    self.setup_action(args, command_name, parent_usage)
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 375, in setup_action
    self.process_options(parser, args)
  File "/usr/lib/python2.6/site-packages/katello/client/core/base.py", line 225, in process_options
    self.opts, self.args = parser.parse_args(args)
  File "/usr/lib64/python2.6/optparse.py", line 1396, in parse_args
    self.error(str(err))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-4: ordinal not in range(128)
```

The problem is as follows:
Variable err (in optparse.py +1396) is instance of OptionError. str(err) will just
call err.__str__ (which just return self.msg), but then it will also try to encode and then decode
to/from default systemencoding, which is in RHEL6 "ascii". And that will fail.
Passing encoded utf-8 does not help, because it will fail during decoding.
And changing default system encoding is not nice.

So we just bypass str() and call __str__() directly without that encodede/decode() stuff, which is not needed anyway.
