### PR TITLE
Refactoring of http error handling

### DIFF
--- a/src/app/controllers/api/api_controller.rb
+++ b/src/app/controllers/api/api_controller.rb
@@ -23,8 +23,8 @@ class Api::ApiController < ActionController::Base
   before_filter :verify_ldap
   before_filter :add_candlepin_version_header
 
-  rescue_from StandardError, :with => proc { |e| render_exception(500, e) } # catch-all
-  rescue_from HttpErrors::WrappedError, :with => proc { |e| render_wrapped_exception(500, e) }
+  rescue_from StandardError, :with => proc { |e| render_exception(HttpErrors::INTERNAL_ERROR, e) } # catch-all
+  rescue_from HttpErrors::WrappedError, :with => proc { |e| render_wrapped_exception(e) }
 
   rescue_from RestClient::ExceptionWithResponse, :with => :exception_with_response
   rescue_from ActiveRecord::RecordInvalid, :with => :process_invalid
@@ -33,20 +33,15 @@ class Api::ApiController < ActionController::Base
     rescue_from Resources::ForemanModel::Invalid, :with => :process_invalid
     rescue_from Resources::ForemanModel::NotFound, :with => :record_not_found
   end
-  rescue_from Errors::NotFound, :with => proc { |e| render_exception(404, e) }
-
-  rescue_from HttpErrors::NotFound, :with => proc { |e| render_wrapped_exception(404, e) }
-  rescue_from HttpErrors::BadRequest, :with => proc { |e| render_wrapped_exception(400, e) }
-  rescue_from HttpErrors::Conflict, :with => proc { |e| render_wrapped_exception(409, e) }
-  rescue_from HttpErrors::UnprocessableEntity, :with => proc { |e| render_wrapped_exception(422, e) }
+  rescue_from Errors::NotFound, :with => proc { |e| render_exception(HttpErrors::NOT_FOUND, e) }
 
   rescue_from(Errors::SecurityViolation, :with => proc do |e|
     logger.warn pp_exception(e, :with_body => false, :with_backtrace => false)
-    render_exception_without_logging(403, e)
+    render_exception_without_logging(HttpErrors::FORBIDDEN, e)
   end)
-  rescue_from Errors::ConflictException, :with => proc { |e| render_exception(409, e) }
-  rescue_from Errors::UnsupportedActionException, :with => proc { |e| render_exception(400, e) }
-  rescue_from Errors::UsageLimitExhaustedException, :with => proc { |e| render_exception_without_logging(409, e) }
+  rescue_from Errors::ConflictException, :with => proc { |e| render_exception(HttpErrors::CONFLICT, e) }
+  rescue_from Errors::UnsupportedActionException, :with => proc { |e| render_exception(HttpErrors::BAD_REQUEST, e) }
+  rescue_from Errors::UsageLimitExhaustedException, :with => proc { |e| render_exception_without_logging(HttpErrors::CONFLICT, e) }
 
   # support for session (thread-local) variables must be the last filter in this class
   include Katello::ThreadSession::Controller
@@ -155,7 +150,7 @@ class Api::ApiController < ActionController::Base
     params.delete('auth_password')
   rescue => e
     logger.error "failed to authenticate API request: " << pp_exception(e)
-    head :status => 500 and return false
+    head :status => HttpErrors::INTERNAL_ERROR and return false
   end
 
   protected
@@ -163,6 +158,7 @@ class Api::ApiController < ActionController::Base
   def exception_with_response(exception)
     logger.error "exception when talking to a remote client: #{exception.message} " << pp_exception(exception)
     if request_from_katello_cli?
+      # TODO: why not use http_code from the exception???
       render :json => format_subsys_exception_hash(exception), :status => 400
     else
       render :text => exception.response , :status => exception.http_code
@@ -180,7 +176,7 @@ class Api::ApiController < ActionController::Base
   end
 
   def render_403(e)
-    render :text => pp_exception(e) , :status => 403
+    render :text => pp_exception(e) , :status => HttpErrors::FORBIDDEN
   end
 
   def process_invalid(exception)
@@ -200,8 +196,8 @@ class Api::ApiController < ActionController::Base
     end
 
     respond_to do |format|
-      format.json { render :json => {:displayMessage => exception.message, :errors => [exception.message] }, :status => 400 }
-      format.all  { render :text => pp_exception(exception, :with_class => false), :status => 400 }
+      format.json { render :json => {:displayMessage => exception.message, :errors => [exception.message] }, :status => HttpErrors::UNPROCESSABLE_ENTITY }
+      format.all  { render :text => pp_exception(exception, :with_class => false), :status => HttpErrors::UNPROCESSABLE_ENTITY }
     end
   end
 
@@ -210,20 +206,20 @@ class Api::ApiController < ActionController::Base
     logger.debug exception.backtrace.join("\n")
 
     respond_to do |format|
-      format.json { render :json => {:displayMessage => exception.message, :errors => [exception.message] }, :status => 404 }
-      format.all  { render :text => pp_exception(exception, :with_class => false), :status => 404 }
+      format.json { render :json => {:displayMessage => exception.message, :errors => [exception.message] }, :status => HttpErrors::NOT_FOUND }
+      format.all  { render :text => pp_exception(exception, :with_class => false), :status => HttpErrors::NOT_FOUND }
     end
   end
 
-  def render_wrapped_exception(status_code, ex)
-    logger.error "*** ERROR: #{ex.message} (#{status_code}) ***"
+  def render_wrapped_exception(ex)
+    logger.error "*** ERROR: #{ex.message} (#{ex.status_code}) ***"
     logger.error "REQUEST URL: #{request.fullpath}"
     logger.error pp_exception(ex.original.nil? ? ex : ex.original)
     orig_message = (ex.original.nil? && '') || ex.original.message
     format_text_orig_message = (orig_message.blank?) ? '' : " (#{orig_message})"
     respond_to do |format|
-      format.json { render :json => {:displayMessage => ex.message, :errors => [ ex.message, orig_message ]}, :status => status_code }
-      format.all { render :text => "#{ex.message}#{format_text_orig_message}", :status => status_code }
+      format.json { render :json => {:displayMessage => ex.message, :errors => [ ex.message, orig_message ]}, :status => ex.status_code }
+      format.all { render :text => "#{ex.message}#{format_text_orig_message}", :status => ex.status_code }
     end
   end
 

--- a/src/app/controllers/api/changesets_controller.rb
+++ b/src/app/controllers/api/changesets_controller.rb
@@ -79,7 +79,7 @@ class Api::ChangesetsController < Api::ApiController
     elsif params[:changeset][:type] == 'DELETION'
       @changeset = DeletionChangeset.new(params[:changeset])
     else
-      raise HttpErrors::ApiError, _("Unknown changeset type, must be PROMOTION or DELETION: %s") % csType
+      raise HttpErrors::UnprocessableEntity, _("Unknown changeset type, must be PROMOTION or DELETION: %s") % csType
     end
 
     @changeset.environment = @environment

--- a/src/app/controllers/api/providers_controller.rb
+++ b/src/app/controllers/api/providers_controller.rb
@@ -105,7 +105,8 @@ class Api::ProvidersController < Api::ApiController
     if @provider.destroyed?
       render :text => _("Deleted provider [ %s ]") % @provider.name , :status => 200
     else
-      raise HttpErrors::ApiError, _("Error while deleting provider [ %{name} ]: %{error}") % {:name => @provider.name, :error => @provider.errors.full_messages}
+      # TOOO: should probably be more specific?
+      raise HttpErrors::InternalError, _("Error while deleting provider [ %{name} ]: %{error}") % {:name => @provider.name, :error => @provider.errors.full_messages}
     end
   end
 

--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -95,7 +95,7 @@ class ApplicationController < ActionController::Base
     execute_rescue(exception, lambda{|exception| render_403})
   end
 
-  rescue_from Errors::BadParameters do |exception|
+  rescue_from HttpErrors::UnprocessableEntity do |exception|
     execute_rescue(exception, lambda{|exception| render_bad_parameters(exception)})
   end
   # support for session (thread-local) variables must be the last filter (except authorize)in this class
@@ -346,20 +346,18 @@ class ApplicationController < ActionController::Base
   end
 
   # render bad params
-  def render_bad_parameters(exception = nil)
+  def render_bad_parameters(exception)
     if exception
-        logger.error _("Rendering 400:") + " #{exception.message}"
+        logger.error _("Rendering 422:") + " #{exception.message}"
         notify.exception(
             _("Invalid parameters sent in the request for this operation. Please contact a system administrator."),
             exception)
     end
     respond_to do |format|
-      #format.html { render :template => "common/400", :layout => "katello", :status => 400,
-      #                          :locals=>{:error=>exception} }
-      format.html { render :template => "common/400", :layout => !request.xhr?, :status => 400 }
-      format.atom { head 400 }
-      format.xml  { head 400 }
-      format.json { head 400 }
+      format.html { render :template => "common/400", :layout => !request.xhr?, :status => exception.status_code }
+      format.atom { head exception.status_code }
+      format.xml  { head exception.status_code }
+      format.json { head exception.status_code }
     end
     User.current = nil
   end

--- a/src/app/controllers/http_errors.rb
+++ b/src/app/controllers/http_errors.rb
@@ -12,7 +12,16 @@
 
 module HttpErrors
 
+  BAD_REQUEST          = 400
+  UNAUTHORIZED         = 401
+  FORBIDDEN            = 403
+  NOT_FOUND            = 404
+  CONFLICT             = 409
+  UNPROCESSABLE_ENTITY = 422
+  INTERNAL_ERROR       = 500
+
   class WrappedError < StandardError
+    class_attribute :status_code
     attr_reader :original
 
     def initialize(msg, original=$!)
@@ -21,14 +30,32 @@ module HttpErrors
     end
   end
 
-  # application general errors
-  class AppError < WrappedError; end
-  class ApiError < AppError; end
+  class BadRequest < WrappedError
+    self.status_code = BAD_REQUEST
+  end
 
-  # specific errors
-  class NotFound < WrappedError; end
-  class BadRequest < WrappedError; end
-  class Conflict < WrappedError; end
-  class UnprocessableEntity < WrappedError; end
+  class Unauthorized < WrappedError
+    self.status_code = UNAUTHORIZED
+  end
 
+  class Forbidden < WrappedError
+    self.status_code = FORBIDDEN
+  end
+
+  class NotFound < WrappedError
+    self.status_code = NOT_FOUND
+  end
+
+
+  class Conflict < WrappedError
+    self.status_code = CONFLICT
+  end
+
+  class UnprocessableEntity < WrappedError
+    self.status_code = UNPROCESSABLE_ENTITY
+  end
+
+  class InternalError < WrappedError
+    self.status_code = INTERNAL_ERROR
+  end
 end

--- a/src/app/models/errors.rb
+++ b/src/app/models/errors.rb
@@ -15,20 +15,6 @@ module Errors
 
   # unauthorized access
   class SecurityViolation < StandardError; end
-  class BadParameters < HttpErrors::BadRequest
-    attr_accessor :broken_params, :params
-    def initialize broken_params, params
-      @broken_params = broken_params
-      @params = Util::Support.scrub(Util::Support.deep_copy(params)) do |key, value|
-        String === value && key.to_s.downcase =~ /password|authenticity_token/
-      end
-      super BadParameters.generate_message @broken_params, @params
-    end
-
-    def self.generate_message broken_params, params
-      _("Wrong/Invalid parameters sent for %{controller}/%{action}.\n Wrong Parameters: \n%{params}\n Parameters Received:\n %{all_params} ") % {:controller => params[:controller], :action => params[:action], :params => broken_params.inspect, :all_params => params.inspect}
-    end
-  end
 
   class UserNotSet < SecurityViolation; end
 

--- a/src/lib/authorization_rules.rb
+++ b/src/lib/authorization_rules.rb
@@ -35,7 +35,7 @@ module AuthorizationRules
     raise Errors::SecurityViolation,"Rules not defined for  #{current_user.username} for #{params[:controller]}/#{params[:action]}"
   end
 
-# authorize the user for the requested action
+  # TODO: should be moved out of authorization module
   def params_match(ctrl = params[:controller], action = self.action_name)
     logger.debug "Checking  params  for #{ctrl}/#{action}"
 
@@ -52,7 +52,14 @@ module AuthorizationRules
       bad_params = check_hash_params(rule, params)
     end
     return true if bad_params.empty?
-    raise Errors::UnprocessableEntity.new(bad_params, params)
+    raise HttpErrors::UnprocessableEntity.new(build_bad_params_error_msg(bad_params, params))
+  end
+
+  def build_bad_params_error_msg(bad_params, params)
+    scrubbed_params = Util::Support.scrub(Util::Support.deep_copy(params)) do |key, value|
+      String === value && key.to_s.downcase =~ /password|authenticity_token/
+    end
+    _("Wrong/Invalid parameters sent for %{controller}/%{action}.\n Wrong Parameters: \n%{params}\n Parameters Received:\n %{all_params} ") % {:controller => params[:controller], :action => params[:action], :params => bad_params.inspect, :all_params => scrubbed_params.inspect}
   end
 
   def check_hash_params(rule, params)
@@ -77,9 +84,6 @@ module AuthorizationRules
   def param_rules
     {}
   end
-
-
-
 
 end
 

--- a/src/spec/controllers/api/custom_info_controller_spec.rb
+++ b/src/spec/controllers/api/custom_info_controller_spec.rb
@@ -68,7 +68,7 @@ describe Api::CustomInfoController do
     it "should require key + value pairs" do
       System.find(@system.id).custom_info.empty?.should == true
       post :create, :informable_id => @system.id, :informable_type => "system"
-      response.code.should == "400"
+      response.status.should == HttpErrors::UNPROCESSABLE_ENTITY
       System.find(@system.id).custom_info.empty?.should == true
     end
   end

--- a/src/spec/controllers/api/repositories_controller_spec.rb
+++ b/src/spec/controllers/api/repositories_controller_spec.rb
@@ -280,7 +280,7 @@ describe Api::RepositoriesController, :katello => true do
 
         it "should fail with bad request" do
           put :update, {:id => '1', :repository => {:gpg_key_name => "gpg_key", :name => "another name"}}
-          response.code.should eq("400")
+          response.status.should == HttpErrors::UNPROCESSABLE_ENTITY
         end
 
       end

--- a/src/spec/controllers/users_controller_spec.rb
+++ b/src/spec/controllers/users_controller_spec.rb
@@ -110,7 +110,7 @@ describe UsersController do
     it "should not change the username" do
        put 'update', {:id => @user.id, :user => {:username=>"FOO"}}
        response.should_not be_success
-       response.status.should == 400
+       response.status.should == HttpErrors::UNPROCESSABLE_ENTITY
        assert User.where(:username=>"FOO").empty?
        assert !User.where(:username=>@user.username).empty?
     end

--- a/src/spec/support/shared_examples/protected_action_shared_examples.rb
+++ b/src/spec/support/shared_examples/protected_action_shared_examples.rb
@@ -78,7 +78,7 @@ shared_examples_for "bad request" do
   context "action" do
     it "should fail" do
       req
-      response.status.should == 400
+      response.status.should == HttpErrors::UNPROCESSABLE_ENTITY
     end
   end
 end


### PR DESCRIPTION
- replaced 400 (Invalid Request) error with 422 (Unprocessable Entity) ones (in most cases). - removed Errors::BadRequest and replaced its instanceds with HttpErrors::UnprocessableEntity
- Http error codes are now part of HttpErrors

Please note  a couple of todo's left in the code; pls. reply with your suggestions/thoughts, I'll amend the PR correspondingly.
