### PR TITLE
fixing jenkins runcible module issue

### DIFF
--- a/src/lib/util/threadsession.rb
+++ b/src/lib/util/threadsession.rb
@@ -53,7 +53,7 @@ module Katello
             if user_id
               uri = URI.parse(Katello.config.pulp.url)
 
-              Runcible::Base.config = {
+              ::Runcible::Base.config = {
                 :url      => "#{uri.scheme}://#{uri.host}",
                 :api_path => uri.path,
                 :user     => user_id,


### PR DESCRIPTION
should fix odd jekins issue during dbmigrate:

uninitialized constant Katello::ThreadSession::UserModel::Runcible
/usr/share/katello/lib/util/threadsession.rb:56:in `set_pulp_config'
/usr/share/katello/lib/util/threadsession.rb:48:in`current='
/usr/share/katello/db/migrate/20120702175532_add_repository_library_id.rb:9:in `up_without_benchmarks'
/usr/lib/ruby/gems/1.8/gems/activerecord-3.0.10/lib/active_record/migration.rb:314:in`send'
