### PR TITLE
add new dependencies for client

### DIFF
--- a/rel-eng/comps/comps-katello-client-fedora16.xml
+++ b/rel-eng/comps/comps-katello-client-fedora16.xml
@@ -12,6 +12,11 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">katello-agent</packagereq>
+       <packagereq type="default">pulp-rpm-handlers</packagereq>
+       <packagereq type="default">python-isodate</packagereq>
+       <packagereq type="default">python-pulp-agent-lib</packagereq>
+       <packagereq type="default">python-pulp-common</packagereq>
+       <packagereq type="default">python-pulp-rpm-common</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/rel-eng/comps/comps-katello-client-fedora17.xml
+++ b/rel-eng/comps/comps-katello-client-fedora17.xml
@@ -12,6 +12,11 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">katello-agent</packagereq>
+       <packagereq type="default">pulp-rpm-handlers</packagereq>
+       <packagereq type="default">python-isodate</packagereq>
+       <packagereq type="default">python-pulp-agent-lib</packagereq>
+       <packagereq type="default">python-pulp-common</packagereq>
+       <packagereq type="default">python-pulp-rpm-common</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/rel-eng/comps/comps-katello-client-fedora18.xml
+++ b/rel-eng/comps/comps-katello-client-fedora18.xml
@@ -12,6 +12,11 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">katello-agent</packagereq>
+       <packagereq type="default">pulp-rpm-handlers</packagereq>
+       <packagereq type="default">python-isodate</packagereq>
+       <packagereq type="default">python-pulp-agent-lib</packagereq>
+       <packagereq type="default">python-pulp-common</packagereq>
+       <packagereq type="default">python-pulp-rpm-common</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/rel-eng/comps/comps-katello-client-rhel6.xml
+++ b/rel-eng/comps/comps-katello-client-rhel6.xml
@@ -12,6 +12,11 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">katello-agent</packagereq>
+       <packagereq type="default">pulp-rpm-handlers</packagereq>
+       <packagereq type="default">python-isodate</packagereq>
+       <packagereq type="default">python-pulp-agent-lib</packagereq>
+       <packagereq type="default">python-pulp-common</packagereq>
+       <packagereq type="default">python-pulp-rpm-common</packagereq>
     </packagelist>
   </group>
 </comps>


### PR DESCRIPTION
addressing:

```
yum upgrade katello-agent
...
--> Finished Dependency Resolution
Error: Package: katello-agent-1.3.1-1.git.476.f8f2f08.fc18.noarch (katello)
           Requires: python-pulp-agent-lib >= 2.0.5
Error: Package: katello-agent-1.3.1-1.git.476.f8f2f08.fc18.noarch (katello)
           Requires: pulp-rpm-handlers >= 2.0.5
 You could try using --skip-broken to work around the problem
```
