### PR TITLE
Cli gettext script

### DIFF
--- a/cli/katello-cli.spec
+++ b/cli/katello-cli.spec
@@ -74,6 +74,9 @@ https://fedorahosted.org/katello/wiki/TestingHowto
     PYTHONPATH=src/ pylint --rcfile=/etc/spacewalk-pylint.rc --additional-builtins=_ katello
 %endif
 
+# check for malformed gettext strings
+scripts/check-gettext.sh
+
 # generate usage docs and incorporate it into the man page
 pushd man
 PYTHONPATH=../src python ../scripts/usage.py "katello" >katello-usage.txt

--- a/cli/scripts/check-gettext.sh
+++ b/cli/scripts/check-gettext.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+grep -inr "_(\(.*\(%[sdr]\)\)\{2,\}" ../src/katello/client | grep -vin "#dont_check_gettext"
+
+exit_code=`grep -inr "_(\(.*\(%[sdr]\)\)\{2,\}" ../src/katello/client | grep -vin "#dont_check_gettext" | wc -l`
+echo
+echo "Number of hits: $exit_code"
+echo
+exit $exit_code
+

--- a/cli/src/katello/client/core/base.py
+++ b/cli/src/katello/client/core/base.py
@@ -476,8 +476,8 @@ def check_insensitive_choice(option, opt, value):
     else:
         choices = ", ".join(option.choices)
         raise OptionValueError(
-            _("option %s: invalid choice: %r (choose from %s)")
-            % (opt, value, choices))
+            _("option %(opt)s: invalid choice: %(value)r (choose from %(choices)s)")
+            % {'opt':opt, 'value':value, 'choices':choices})
 
 def check_list(option, opt, value):
     if not option.delimiter:

--- a/cli/src/katello/client/core/changeset.py
+++ b/cli/src/katello/client/core/changeset.py
@@ -337,8 +337,10 @@ class UpdateContent(ChangesetAction):
         if (parser.values.from_product == None) and \
            (parser.values.from_product_label == None) and \
            (parser.values.from_product_id == None):
-            raise OptionValueError(_("%s must be preceded by %s, %s or %s") %
-                  (option, "--from_product", "--from_product_label", "--from_product_id"))
+            raise OptionValueError(_("%(option)s must be preceded by %(from_product)s, \
+                %(from_product_label)s or %(from_product_id)s") 
+                    % {'option':option, 'from_product':"--from_product",
+                    'from_product_label':"--from_product_label", 'from_product_id':"--from_product_id"})
 
         if self.current_product_option == 'product_label':
             self.items[option.dest].append({"name": u_str(value), "product_label": self.current_product})

--- a/cli/src/katello/client/core/template.py
+++ b/cli/src/katello/client/core/template.py
@@ -303,8 +303,10 @@ class Update(TemplateAction):
         if (parser.values.from_product == None) and \
            (parser.values.from_product_label == None) and \
            (parser.values.from_product_id == None):
-            raise OptionValueError(_("%s must be preceded by %s, %s or %s") %
-                  (option, "--from_product", "--from_product_label", "--from_product_id"))
+            raise OptionValueError(_("%(option)s must be preceded by %(from_product)s, \
+                %(from_product_label)s or %(from_product_id)s") 
+                    % {'option':option, 'from_product':"--from_product",
+                    'from_product_label':"--from_product_label", 'from_product_id':"--from_product_id"})
 
         if self.current_product_option == 'from_product_label':
             self.items[option.dest].append({"name": u_str(value), "from_product_label": self.current_product})

--- a/cli/src/katello/client/i18n_optparse.py
+++ b/cli/src/katello/client/i18n_optparse.py
@@ -52,16 +52,16 @@ class OptionParser(_OptionParser):
 
         # stuff for option value sanity checking
         _("no such option: %s")
-        _("ambiguous option: %s (%s?)")
+        _("ambiguous option: %s (%s?)")#dont_check_gettext
         _("%s option requires an argument")
-        _("%s option requires %d arguments")
+        _("%s option requires %d arguments")#dont_check_gettext
         _("%s option does not take a value")
         _("integer")
         _("long integer")
         _("floating-point")
         _("complex")
-        _("option %s: invalid %s value: %r")
-        _("option %s: invalid choice: %r (choose from %s)")
+        _("option %s: invalid %s value: %r")#dont_check_gettext
+        _("option %s: invalid choice: %r (choose from %s)")#dont_check_gettext
 
         # default options
         _("show this help message and exit")

--- a/cli/src/katello/client/lib/utils/option_validator.py
+++ b/cli/src/katello/client/lib/utils/option_validator.py
@@ -120,11 +120,11 @@ class OptionValidator(object):
             elif colliding_opts:
                 colliding_flags = ', '.join(self.__get_option_strings(colliding_opts))
                 if len(colisions) > 1:
-                    self.add_option_error(_('Options %s are colliding with %s; please see --help') % \
-                        (flags, colliding_flags))
+                    self.add_option_error(_('Options %(flags)s are colliding with %(coll_f)s; please see --help') % \
+                        {'flags':flags, 'coll_f':colliding_flags})
                 else:
-                    self.add_option_error(_('Option %s is colliding with %s; please see --help') % \
-                        (flags, colliding_flags))
+                    self.add_option_error(_('Option %(flags)s is colliding with %(coll_f)s; please see --help') % \
+                        {'flags':flags, 'coll_f':colliding_flags})
             else:
                 if len(colisions) > 1:
                     self.add_option_error(_('Options %s can\'t be used in this command; please see --help') % flags)


### PR DESCRIPTION
Adding script to /cli and also to katello-cli.spec
The script checks for malformed gettext strings with multiple placeholders.
Also fixed malformed gettext found by the script.
