### PR TITLE
844389 - unsuccessful repo deletion rollbacking

### DIFF
--- a/src/app/controllers/http_errors.rb
+++ b/src/app/controllers/http_errors.rb
@@ -19,6 +19,7 @@ module HttpErrors
   CONFLICT             = 409
   UNPROCESSABLE_ENTITY = 422
   INTERNAL_ERROR       = 500
+  SERVICE_UNAVAILABLE  = 503
 
   class WrappedError < StandardError
     class_attribute :status_code
@@ -46,7 +47,6 @@ module HttpErrors
     self.status_code = NOT_FOUND
   end
 
-
   class Conflict < WrappedError
     self.status_code = CONFLICT
   end
@@ -57,5 +57,9 @@ module HttpErrors
 
   class InternalError < WrappedError
     self.status_code = INTERNAL_ERROR
+  end
+
+  class ServiceUnavailable < WrappedError
+    self.status_code = SERVICE_UNAVAILABLE
   end
 end

--- a/src/app/controllers/repositories_controller.rb
+++ b/src/app/controllers/repositories_controller.rb
@@ -70,8 +70,8 @@ class RepositoriesController < ApplicationController
     notify.message label_assigned unless label_assigned.blank? unless params[:ignore_success_notice]
 
     render :nothing => true
-  rescue Errors::ConflictException, ActiveRecord::RecordInvalid => e
-    notify.error e.message
+  rescue Errors::ConflictException, ActiveRecord::RecordInvalid, PulpErrors::ServiceUnavailable => e
+    notify.exception e
     execute_after_filters
     render :nothing => true, :status => :bad_request
   end

--- a/src/app/models/glue/candlepin/content.rb
+++ b/src/app/models/glue/candlepin/content.rb
@@ -31,7 +31,9 @@ module Glue::Candlepin::Content
 
     def save_content_orchestration
       if self.new_record? && !self.product.provider.redhat_provider? && self.environment.library?
-        pre_queue.create(:name => "create content : #{self.name}", :priority => 2, :action => [self, :create_content])
+        pre_queue.create(:name => "create content : #{self.name}", :priority => 2, :action => [self, :create_content],
+            :action_rollback => [self, :del_content]
+        )
       elsif !self.new_record? && should_update_content?
         pre_queue.create(:name => "update content : #{self.name}", :priority => 2, :action => [self, :update_content])
       end
@@ -50,7 +52,7 @@ module Glue::Candlepin::Content
       return true unless self.content_id
       if other_repos_with_same_product_and_content.empty?
         self.product.remove_content_by_id self.content_id
-        if other_repos_with_same_content.empty? && !self.product.provider.redhat_provider?
+        unless self.product.provider.redhat_provider?
           Resources::Candlepin::Content.destroy(self.content_id)
         end
       end

--- a/src/app/models/glue/elastic_search/repository.rb
+++ b/src/app/models/glue/elastic_search/repository.rb
@@ -56,7 +56,7 @@ module Glue::ElasticSearch::Repository
 
         import pkgs do |documents|
           documents.each do |document|
-            if document["repoids"].length > 1
+            if !document["repoids"].nil? && document["repoids"].length > 1
               # if there is more than 1 repo associated w/ the pkg, remove this repo
               document["repoids"].delete(pulp_id)
             end
@@ -89,7 +89,7 @@ module Glue::ElasticSearch::Repository
 
         import errata do |documents|
           documents.each do |document|
-            if document["repoids"].length > 1
+            if !document["repoids"].nil? && document["repoids"].length > 1
               # if there is more than 1 repo associated w/ the errata, remove this repo
               document["repoids"].delete(pulp_id)
             end

--- a/src/app/models/glue/pulp/pulp_errors.rb
+++ b/src/app/models/glue/pulp/pulp_errors.rb
@@ -1,0 +1,15 @@
+#
+# Copyright 2011 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module PulpErrors
+  class ServiceUnavailable < HttpErrors::ServiceUnavailable; end
+end

--- a/src/app/models/glue/pulp/repo.rb
+++ b/src/app/models/glue/pulp/repo.rb
@@ -132,6 +132,9 @@ module Glue::Pulp::Repo
           importer,
           distributors,
           {:display_name=>self.name})
+    rescue RestClient::ServiceUnavailable => e
+      message = _("Pulp service unavailable during creating repository '%s', please try again later.") % self.name
+      raise PulpErrors::ServiceUnavailable.new(message, e)
     end
 
     def generate_distributor

--- a/src/spec/controllers/repositories_controller_spec.rb
+++ b/src/spec/controllers/repositories_controller_spec.rb
@@ -94,7 +94,7 @@ describe RepositoriesController, :katello => true do
 
     describe "Create a Repo" do
       it "should reject invalid urls" do
-        controller.should notify.error
+        controller.should notify.exception
         post :create, invalidrepo
         response.should_not be_success
       end


### PR DESCRIPTION
If pulp was is unavailable during repository deletion a process failed
without rollbacking changes in candlepin. Now we delete content in
candlepin in such case so there is no inconsistency and you can try to
add repository again.

Also we display a better error notification to user instructing him to
try again. All backtrace is however stored in notification.

One minor fix regarding elastic search indexed models. Some strings can
be nil so we must check their presence, not their length.
