### PR TITLE
841013 - Allow same name distributions in changeset

### DIFF
--- a/src/app/models/changeset_distribution.rb
+++ b/src/app/models/changeset_distribution.rb
@@ -15,7 +15,7 @@ class ChangesetDistribution < ActiveRecord::Base
 
   belongs_to :changeset, :inverse_of => :distributions
   belongs_to :product
-  validates :distribution_id, :uniqueness => { :scope => :changeset_id }
+  validates :distribution_id, :uniqueness => { :scope => [:changeset_id, :product_id] }
   validates_with Validators::ChangesetDistributionValidator
 
   def repositories

--- a/src/db/migrate/20130131094411_fix_changeset_distribution_unique_index.rb
+++ b/src/db/migrate/20130131094411_fix_changeset_distribution_unique_index.rb
@@ -1,0 +1,11 @@
+class FixChangesetDistributionUniqueIndex < ActiveRecord::Migration
+  def self.up
+    remove_index(:changeset_distributions, :name =>"index_cs_distro_distro_id_cs_id")
+    add_index(:changeset_distributions, [:distribution_id, :changeset_id, :product_id], :name => "index_cs_distro_distro_id_cs_id_p_id", :unique => true)
+  end
+
+  def self.down
+    remove_index(:changeset_distributions, :name =>"index_cs_distro_distro_id_cs_id_p_id")
+    add_index(:changeset_distributions, [:distribution_id, :changeset_id], :name => "index_cs_distro_distro_id_cs_id", :unique => true)
+  end
+end


### PR DESCRIPTION
If you add two distributions with same name to a changeset it should be
allowed if they come from different products.

https://bugzilla.redhat.com/show_bug.cgi?id=841013
