### PR TITLE
851331 - Add organization label attribute

### DIFF
--- a/src/app/models/provider.rb
+++ b/src/app/models/provider.rb
@@ -174,6 +174,10 @@ class Provider < ActiveRecord::Base
     write_attribute(:discovery_url, value)
   end
 
+  def as_json(*args)
+    super.merge('organization_label' => self.organization.label)
+  end
+
   protected
 
    def sanitize_repository_url


### PR DESCRIPTION
Provider JSON now includes organization_label attribute so it can be
used in other actions. No need to list all organizations to find out
label for given organization id anymore.

https://bugzilla.redhat.com/show_bug.cgi?id=851331
