### PR TITLE
cli completion - fixed import path to 'fix_io_encoding'

### DIFF
--- a/cli/bin/_complete_katello
+++ b/cli/bin/_complete_katello
@@ -20,7 +20,7 @@ from katello.client.completion import Completion
 
 # Change encoding of output streams when no encoding is forced via $PYTHONIOENCODING
 # or setting in lib/python{version}/site-packages
-from katello.client.utils.encoding import fix_io_encoding
+from katello.client.lib.utils.encoding import fix_io_encoding
 fix_io_encoding()
 
 # Set correct locale


### PR DESCRIPTION
The library structure has changed and the function was moved into another directory.
