### PR TITLE
844389 - Revert of content deletion checking removal

### DIFF
--- a/src/app/models/glue/candlepin/content.rb
+++ b/src/app/models/glue/candlepin/content.rb
@@ -52,7 +52,7 @@ module Glue::Candlepin::Content
       return true unless self.content_id
       if other_repos_with_same_product_and_content.empty?
         self.product.remove_content_by_id self.content_id
-        unless self.product.provider.redhat_provider?
+        if other_repos_with_same_content.empty? && !self.product.provider.redhat_provider?
           Resources::Candlepin::Content.destroy(self.content_id)
         end
       end


### PR DESCRIPTION
It's required to check whether content that is being deleted is not used
by another product.
