### PR TITLE
Fixed issue with connecting to pulp db

### DIFF
--- a/katello-configure/modules/pulp/templates/etc/pulp/server.conf.erb
+++ b/katello-configure/modules/pulp/templates/etc/pulp/server.conf.erb
@@ -53,14 +53,15 @@ task_state_poll_interval: 0.1
 #                         datamodel changes
 # name: (string) name of the database to use
 # seeds: (comma separated list) list of hostname:port of database replica seed
-#                               hosts
+#                               hosts, do NOT use localhost which may cause connection 
+#                               issues in some cases, use 127.0.0.1 instead
 # operation_retries: (integer) number of retries on database operations to
 #                              conduct before giving up and reporting an error
 
 [database]
 auto_migrate: false
 name: pulp_database
-seeds: localhost:27017
+seeds: 127.0.0.1:27017
 operation_retries: 2
 
 


### PR DESCRIPTION
On some instance pulp was getting connection refused from mongo db. I was unable to investigate why it behaves like this but it seems related to [1]. When the connector code was extracted from Pulp to separate file it worked (WSGI perhaps?). It also worked when bind_ip in mongo config was commented out as was suggested in some comments on SO.c

Some log showing the behaviour [2]

[1] http://stackoverflow.com/questions/6499268/mongodb-connection-refused
[2] http://fpaste.org/KWE0/
