### PR TITLE
869378 - API does not list providedProducts for custom content

### DIFF
--- a/cli/src/katello/client/core/system.py
+++ b/cli/src/katello/client/core/system.py
@@ -590,7 +590,10 @@ class Subscriptions(SystemAction):
                 for entitlement in result['entitlements']:
                     entitlement_ext = entitlement.copy()
                     provided_products = ', '.join([e['name'] for e in entitlement_ext['providedProducts']])
-                    entitlement_ext['providedProductsFormatted'] = provided_products
+                    if provided_products:
+                        entitlement_ext['providedProductsFormatted'] = _('Not Applicable')
+                    else:
+                        entitlement_ext['providedProductsFormatted'] = provided_products
                     serial_ids = ', '.join([u_str(s['id']) for s in entitlement_ext['serials']])
                     entitlement_ext['serialIds'] = serial_ids
                     yield entitlement_ext
@@ -616,7 +619,10 @@ class Subscriptions(SystemAction):
                 for pool in result['pools']:
                     pool_ext = pool.copy()
                     provided_products = ', '.join([p['productName'] for p in pool_ext['providedProducts']])
-                    pool_ext['providedProductsFormatted'] = provided_products
+                    if provided_products:
+                        pool_ext['providedProductsFormatted'] = _('Not Applicable')
+                    else:
+                        pool_ext['providedProductsFormatted'] = provided_products
 
                     if pool_ext['quantity'] == -1:
                         pool_ext['quantity'] = _('Unlimited')


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=869378 shows that Provided products are not set for custom products.

Provided products are just marketing products which are not used for custom subscriptions. We could either hide this field for this case, or put N/A there. This patch does the latter, because the way we structure our python code does not allow hiding individual fields.
