### PR TITLE
852849 - fixing redirect of expired sessoin

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -271,13 +271,15 @@ class ApplicationController < ActionController::Base
   end
 
   def require_user
-    if current_user
-      #user logged in
 
-      #redirect to originally requested page
-      if !session[:original_uri].nil? && !matches_no_redirect?(session[:original_uri])
-        redirect_to session[:original_uri]
-        session[:original_uri] = nil
+    if current_user
+      #don't redirect if the user is trying to set an org
+      if params[:action] != 'set_org' && params[:controller] != 'user_sessions'
+        #redirect to originally requested page
+        if !session[:original_uri].nil? && !matches_no_redirect?(session[:original_uri])
+          redirect_to session[:original_uri]
+          session[:original_uri] = nil
+        end
       end
 
       return true


### PR DESCRIPTION
previously if you had more than 1 org and
tried to access a url while being logged out
katello would redirect you to the url when you tried
to set your org, but since the org had not been set
you would get an error
