### PR TITLE
add factory_girl_rails to requirements of katello-devel

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -132,6 +132,8 @@
        <packagereq type="default">rubygem-ci_reporter</packagereq>
        <packagereq type="default">rubygem-columnize</packagereq>
        <packagereq type="default">rubygem-execjs</packagereq>
+       <packagereq type="default">rubygem-factory_girl</packagereq>
+       <packagereq type="default">rubygem-factory_girl_rails</packagereq>
        <packagereq type="default">rubygem-js-routes</packagereq>
        <packagereq type="default">rubygem-jshintrb</packagereq>
        <packagereq type="default">rubygem-logical-insight</packagereq>
@@ -172,6 +174,8 @@
        <packagereq type="optional">rubygem-activemodel-doc</packagereq>
        <packagereq type="optional">rubygem-arel-doc</packagereq>
        <packagereq type="optional">rubygem-bundler-doc</packagereq>
+       <packagereq type="default">rubygem-factory_girl-doc</packagereq>
+       <packagereq type="default">rubygem-factory_girl_rails-doc</packagereq>
        <packagereq type="optional">rubygem-foreman_api-doc</packagereq>
        <packagereq type="optional">rubygem-fssm-doc</packagereq>
        <packagereq type="optional">rubygem-hoe-doc</packagereq>

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -284,6 +284,7 @@ Requires:        rubygem(js-routes)
 Requires:        rubygem(gettext) >= 1.9.3
 Requires:        rubygem(ruby_parser)
 Requires:        rubygem(sexp_processor)
+Requires:        rubygem(factory_girl_rails) >= 1.4.0
 # dependencies from bundler.d/development_boost.rb
 Requires:        rubygem(rails-dev-boost)
 # dependencies from bundler.d/apipie.rb


### PR DESCRIPTION
this was forgotten in commit be22aec0 and the version was lovered to 1.4.0
due https://github.com/Katello/katello/pull/1566
