### PR TITLE
886718 - allow better translation of one string

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -122,14 +122,34 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # this is intentionally dead code, it just mark some strings for gettext
+  # so generate_label and default_label_assigned can use them
+  def n_gettext_for_generate_label
+    # the same string for repository, product, organization, environment (see BZ 886718)
+    N_("A label was not provided during repository creation; therefore, a label of '%{label}' was " +
+      "automatically assigned. If you would like a different label, please delete the " +
+      "repository and recreate it with the desired label.")
+    N_("A label was not provided during product creation; therefore, a label of '%{label}' was " +
+      "automatically assigned. If you would like a different label, please delete the " +
+      "product and recreate it with the desired label.")
+    N_("A label was not provided during organization creation; therefore, a label of '%{label}' was " +
+      "automatically assigned. If you would like a different label, please delete the " +
+      "organization and recreate it with the desired label.")
+    N_("A label was not provided during environment creation; therefore, a label of '%{label}' was " +
+      "automatically assigned. If you would like a different label, please delete the " +
+      "environment and recreate it with the desired label.")
+  end
+
   # Generate a label using the name provided, returning the label and a string with text that may be
   # sent to the user (e.g. via a notice).
   def generate_label object_name, object_type
     # user didn't provide a label, so generate one using the name
     label = Katello::ModelUtils::labelize(object_name)
-    label_assigned_text = _("A label was not provided during %s creation; therefore, a label of '%s' was " +
-                            "automatically assigned. If you would like a different label, please delete the " +
-                            "%s and recreate it with the desired label.") % [object_type, label, object_type]
+    # if you modify this string you have to modify it in n_gettext_for_generate_label as well
+    label_assigned_text = "A label was not provided during #{object_type} creation; therefore, a label of '%{label}' was " +
+      "automatically assigned. If you would like a different label, please delete the " +
+      "#{object_type} and recreate it with the desired label."
+    label_assigned_text = _(label_assigned_text) % {:label => label}
     return label, label_assigned_text
   end
 
@@ -137,9 +157,11 @@ class ApplicationController < ActionController::Base
   # a label was automatically assigned to the object.
   def default_label_assigned new_object
     object_type = new_object.class.name.downcase
-    _("A label was not provided during %s creation; therefore, a label of '%s' was " +
+    # if you modify this string you have to modify it in n_gettext_for_generate_label as well
+    msg = "A label was not provided during #{object_type} creation; therefore, a label of '%{label}' was " +
       "automatically assigned. If you would like a different label, please delete the " +
-      "%s and recreate it with the desired label.") % [object_type, new_object.label, object_type]
+      "#{object_type} and recreate it with the desired label."
+    return _(msg) % {:label => new_object.label}
   end
 
   # Generate a message that may be sent to the user (e.g. via a notice) to inform them that

--- a/src/app/controllers/environments_controller.rb
+++ b/src/app/controllers/environments_controller.rb
@@ -75,7 +75,7 @@ class EnvironmentsController < ApplicationController
               :label => params[:kt_environment][:label],
               :organization_id => @organization.id}
 
-    env_params[:label], label_assigned = generate_label(env_params[:name], _('environment')) if env_params[:label].blank?
+    env_params[:label], label_assigned = generate_label(env_params[:name], 'environment') if env_params[:label].blank?
 
     @environment = KTEnvironment.new env_params
     @environment.save!

--- a/src/app/controllers/organizations_controller.rb
+++ b/src/app/controllers/organizations_controller.rb
@@ -76,7 +76,7 @@ class OrganizationsController < ApplicationController
   def create
     org_label_assigned = ""
     org_params = params[:organization]
-    org_params[:label], org_label_assigned = generate_label(org_params[:name], _('organization')) if org_params[:label].blank?
+    org_params[:label], org_label_assigned = generate_label(org_params[:name], 'organization') if org_params[:label].blank?
     @organization = Organization.new(:name => org_params[:name], :label => org_params[:label], :description => org_params[:description])
     @organization.save!
 
@@ -84,7 +84,7 @@ class OrganizationsController < ApplicationController
     env_params = params[:environment]
     if env_params[:name].present?
       if env_params[:label].blank?
-        env_params[:label], env_label_assigned = generate_label(env_params[:name], _('environment')) if env_params[:label].blank?
+        env_params[:label], env_label_assigned = generate_label(env_params[:name], 'environment') if env_params[:label].blank?
       end
 
       @new_env = KTEnvironment.new(:name => env_params[:name], :label => env_params[:label], :description => env_params[:description])

--- a/src/app/controllers/products_controller.rb
+++ b/src/app/controllers/products_controller.rb
@@ -48,7 +48,7 @@ class ProductsController < ApplicationController
   def create
     product_params = params[:product]
     requested_label = String.new(product_params[:label]) unless product_params[:label].blank?
-    product_params[:label], label_assigned = generate_label(product_params[:name], _('product')) if product_params[:label].blank?
+    product_params[:label], label_assigned = generate_label(product_params[:name], 'product') if product_params[:label].blank?
 
 
     gpg = GpgKey.readable(current_organization).find(product_params[:gpg_key]) if product_params[:gpg_key] and product_params[:gpg_key] != ""

--- a/src/app/controllers/repositories_controller.rb
+++ b/src/app/controllers/repositories_controller.rb
@@ -56,7 +56,7 @@ class RepositoriesController < ApplicationController
 
   def create
     repo_params = params[:repo]
-    repo_params[:label], label_assigned = generate_label(repo_params[:name], _('repository')) if repo_params[:label].blank?
+    repo_params[:label], label_assigned = generate_label(repo_params[:name], 'repository') if repo_params[:label].blank?
 
     raise HttpErrors::BadRequest, _("Repository can be only created for custom provider.") unless @product.custom?
 


### PR DESCRIPTION
Original string has different translation depending on object_type.
I created several new strings with hardcoded object_type and
only left as variable in string "label".

This is quite ugly code, but I prefer it over ugly sentence as suggested
in:
https://bugzilla.redhat.com/show_bug.cgi?id=886718#c7
(even if it is grammatical correct).
