### PR TITLE
minitest-rails belongs to bundler.d/test.rb

### DIFF
--- a/src/bundler.d/development.rb
+++ b/src/bundler.d/development.rb
@@ -22,10 +22,5 @@ group :development do
   gem 'ruby_parser'
   gem 'sexp_processor'
 
-  gem 'minitest-rails'
-  if RUBY_VERSION == "1.8.7"
-    gem 'minitest_tu_shim'
-  end
-
   gem 'factory_girl_rails', "~> 1.4.0"
 end

--- a/src/bundler.d/test.rb
+++ b/src/bundler.d/test.rb
@@ -14,6 +14,9 @@ group :test do
   gem 'webmock'
   gem 'minitest', '<=4.5.0', :require => "hoe/minitest"
   gem 'minitest-rails'
+  if RUBY_VERSION == "1.8.7"
+    gem 'minitest_tu_shim'
+  end
 
   # make our specs go faster (also appears in development group)
   gem "parallel_tests"


### PR DESCRIPTION
This is required for unit tests and unit test are in devel-test subpackage.

Additionally do not require this gem, or the katello will not start with katello-devel package installed.
