### PR TITLE
we need tomcat in %post section

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -163,7 +163,7 @@ Requires:       %{name}-configure
 Requires:       %{name}-cli
 Requires:       postgresql-server
 Requires:       postgresql
-Requires:       candlepin-tomcat6
+Requires(post): candlepin-tomcat6
 Requires:       candlepin-selinux
 # the following backend engine deps are required by <katello-configure>
 Requires:       mongodb mongodb-server
@@ -234,7 +234,7 @@ Requires:       katello-configure
 Requires:       katello-cli
 Requires:       postgresql-server
 Requires:       postgresql
-Requires(post):       candlepin-tomcat6
+Requires(post): candlepin-tomcat6
 Requires:       thumbslug
 Requires:       thumbslug-selinux
 


### PR DESCRIPTION
this was introduced in commit 10b0a7f4592f86cb1e02bcd15eb88746f27150e0
and later (accidentally) removed during Pulpv2 merge

Putting it back
