### PR TITLE
do not require minitest_tu_shim

### DIFF
--- a/src/bundler.d/development.rb
+++ b/src/bundler.d/development.rb
@@ -24,7 +24,7 @@ group :development do
 
   gem 'minitest-rails'
   if RUBY_VERSION == "1.8.7"
-    gem 'minitest_tu_shim'
+    gem 'minitest_tu_shim', :require => false
   end
 
   gem 'factory_girl_rails', "~> 1.4.0"


### PR DESCRIPTION
This happen when you start katello in production mode with katello-devel installed

addressing:

```
/var/log/katello/thin-log.5000.log:
...
>> Exiting!
/usr/lib/ruby/gems/1.8/gems/bundler_ext-0.3.0/lib/bundler_ext/bundler_ext.rb:30:in `strict_error': Gem loading error: no such file to load -- minitest_tu_shim (RuntimeError)
        from /usr/lib/ruby/gems/1.8/gems/bundler_ext-0.3.0/lib/bundler_ext/bundler_ext.rb:56:in `system_require'
        from /usr/lib/ruby/gems/1.8/gems/bundler_ext-0.3.0/lib/bundler_ext/bundler_ext.rb:35:in `each'
        from /usr/lib/ruby/gems/1.8/gems/bundler_ext-0.3.0/lib/bundler_ext/bundler_ext.rb:35:in `system_require'
        from /usr/share/katello/config/application.rb:24
        from /usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
        from /usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
        from /usr/share/katello/config/environment.rb:2
        from /usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
        from /usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
        from /usr/share/katello/config.ru:3
        from /usr/lib/ruby/gems/1.8/gems/rack-1.3.0/lib/rack/builder.rb:51:in `instance_eval'
        from /usr/lib/ruby/gems/1.8/gems/rack-1.3.0/lib/rack/builder.rb:51:in `initialize'
        from /usr/share/katello/config.ru:1:in `new'
        from /usr/share/katello/config.ru:1
```
