### PR TITLE
jruby - rpm installation is not supported on jruby yet

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -45,7 +45,7 @@ gem 'gettext_i18n_rails'
 gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
 
 # Reports - TODO this is hack that needs to be removed once ruport is officially released
-if system('rpm -q rubygem-ruport >/dev/null')
+if system('rpm -q rubygem-ruport >/dev/null') && ! defined? JRUBY_VERSION
   gem 'ruport', '>=1.7.0'
 else
   gem 'ruport', '>=1.7.0', :git => 'git://github.com/ruport/ruport.git'


### PR DESCRIPTION
Small fix for JRuby - RPM is never found there. This does not change current behavior.
