### PR TITLE
912442-candlepin-cert - do not overwrite candlepin-upstream-ca.crt

### DIFF
--- a/katello-configure/modules/certs/manifests/config.pp
+++ b/katello-configure/modules/certs/manifests/config.pp
@@ -152,16 +152,6 @@ class certs::config {
   }
 
 
-  file { "${certs::params::candlepin_certs_dir}/candlepin-upstream-ca.crt":
-    ensure => link,
-    owner => "root",
-    group => "katello",
-    mode => 644,
-    target => "${certs::params::candlepin_certs_dir}/candlepin-ca.crt",
-    require => File["${certs::params::candlepin_certs_dir}/candlepin-ca.crt"]
-  }
-
-
   require "katello::params"
 
   if ($katello::params::deployment != 'headpin') {


### PR DESCRIPTION
With candlepin 0.7.25, manifests signature checking is turned on by default. 'katello-configure' was incorrectly overwriting candlepin-upstream-ca.crt put down by the candlepin RPM with a symlink.

https://bugzilla.redhat.com/show_bug.cgi?id=912442
