### PR TITLE
912442 - correcting failed installer for candlepin-ca cert

### DIFF
--- a/katello-configure/modules/candlepin/manifests/service.pp
+++ b/katello-configure/modules/candlepin/manifests/service.pp
@@ -12,8 +12,7 @@ class candlepin::service {
       Class["candlepin::config"],
       Class["postgres::service"],
       File[$certs::params::katello_keystore],
-      File["/usr/share/tomcat6/conf/keystore"],
-      File["${certs::params::candlepin_certs_dir}/candlepin-upstream-ca.crt"]
+      File["/usr/share/tomcat6/conf/keystore"]
     ]
   }
 


### PR DESCRIPTION
Fixes

```
Could not find dependency File[/etc/candlepin/certs/candlepin-upstream-ca.crt] for Service[tomcat6] at /usr/share/katello/install/puppet/modules/candlepin/manifests/service.pp:18
```

introduced by

https://github.com/Katello/katello/pull/1613

Acking, merging, building, composing.
