### PR TITLE
content views - fix query that failed on older postgresql

### DIFF
--- a/src/app/models/content_view.rb
+++ b/src/app/models/content_view.rb
@@ -59,8 +59,12 @@ class ContentView < ActiveRecord::Base
 
   def self.promoted(safe = false)
     # retrieve the view, if it has been promoted (i.e. exists in more than 1 environment)
-    relation = self.joins(:content_view_versions => :environments).group('"content_views"."id"').
-        having('count("environments"."id") > 1')
+    relation = self.joins(:content_view_versions => :environments).
+                    group("content_views.id, content_views.name, content_views.label,"\
+                          "content_views.description, content_views.content_view_definition_id,"\
+                          "content_views.organization_id, content_views.default, content_views.created_at,"\
+                          "content_views.updated_at").
+                    having('count(environments.id) > 1')
 
     if safe
       # do not include group and having in returned relation


### PR DESCRIPTION
The query before this change worked ok for katello on F17; however,
on RHEL 6.3 it would generate the error below.  It appears that the newer
version (9.1.7-1) of postgres is more lenient on the 'group by' than the older
version (8.4.13-1).

PGError: ERROR: column "content_views.name" must appear in the GROUP BY clause or be used in an aggregate function LINE 1: SELECT "content_views".\* FROM "content_views" INNER JOIN "c... ^ : SELECT "content_views".\* FROM "content_views" INNER JOIN "content_view_versions" ON "content_view_versions"."content_view_id" = "content_views"."id" INNER JOIN "content_view_version_environments" ON "content_view_versions"."id" = "content_view_version_environments"."content_view_version_id" INNER JOIN "environments" ON "environments"."id" = "content_view_version_environments"."environment_id" WHERE ("content_views".content_view_definition_id = 1) GROUP BY "content_views"."id" HAVING count("environments"."id") > 1 LIMIT 1 (ActiveRecord::StatementInvalid)
