### PR TITLE
Katello-Configure - Changes the SSLRenegBufferSize for the Apache

### DIFF
--- a/katello-configure/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
+++ b/katello-configure/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
@@ -68,7 +68,7 @@ NameVirtualHost *:443
   <Location /subscription>
     RequestHeader set SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"
     SSLVerifyClient optional
-    SSLRenegBufferSize 16777216
+    SSLRenegBufferSize 1048576
     SSLVerifyDepth 2
     ProxyPass balancer://thinservers/api
     ProxyPassReverse balancer://thinservers/api


### PR DESCRIPTION
configuration to 1MB to reflect the change that Pulp made as part
of bug 908082.
