### PR TITLE
comp resources - fixed system tests

### DIFF
--- a/scripts/system-test/cli_tests/compute_resource.sh
+++ b/scripts/system-test/cli_tests/compute_resource.sh
@@ -6,7 +6,7 @@ header "Compute resources"
 if rpm -q foreman >> /dev/null; then
 
   #PROVIDERS=( "EC2" "LIBVIRT" "OPENSTACK" "OVIRT" "RACKSPACE" "VMWARE" )
-  PROVIDERS=( "LIBVIRT" "OVIRT" "RACKSPACE" )
+  PROVIDERS=( "OVIRT" "RACKSPACE" )
   OPENSTACK_OPTS="--user=user --password=passwd --tenant=tenant"
   OVIRT_OPTS="--user=user --password=passwd --uuid=uuid"
   VMWARE_OPTS="--user=user --password=passwd --uuid=uuid --server=server"
@@ -25,8 +25,8 @@ if rpm -q foreman >> /dev/null; then
 	test_success "compute_resource list" compute_resource list
 
   #update resource's name there and back
-  CR_NAME="LIBVIRT_$RAND"
-  NEW_CR_NAME="LIBVIRT_2_$RAND"
+  CR_NAME="OVIRT_$RAND"
+  NEW_CR_NAME="OVIRT_2_$RAND"
 	test_success "compute_resource update" compute_resource update --name="$CR_NAME" --new_name="$NEW_CR_NAME"
 	test_success "compute_resource update" compute_resource update --name="$NEW_CR_NAME" --new_name="$CR_NAME"
 

--- a/src/app/models/foreman/compute_resource/ovirt.rb
+++ b/src/app/models/foreman/compute_resource/ovirt.rb
@@ -13,7 +13,6 @@
 class Foreman::ComputeResource::Ovirt < Foreman::ComputeResource
 
   attributes :user, :password, :uuid
-  validates :user, :password, :uuid, :presence => true
 
   resource_name :compute_resource
   resource Resources::Foreman::ComputeResource


### PR DESCRIPTION
Fix for system tests to run also on machines without installed libvirt support.

I removed requirement constraint from password in OVirt model. It was required also for updates which is something we don't want.
