### PR TITLE
DRY common apipie param descriptions into param groups

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -58,7 +58,7 @@ gem 'prawn'
 gem 'acts_as_reportable', '>=1.1.1', :require => 'ruport/acts_as_reportable'
 
 # Documentation
-gem "apipie-rails", '>= 0.0.13'
+gem "apipie-rails", '>= 0.0.18'
 
 
 

--- a/src/app/controllers/api/activation_keys_controller.rb
+++ b/src/app/controllers/api/activation_keys_controller.rb
@@ -47,6 +47,14 @@ class Api::ActivationKeysController < Api::ApiController
     }
   end
 
+  def_param_group :activation_key do
+    param :activation_key, Hash, :required => true, :action_aware => true do
+      param :name, :identifier, :required => true, :desc => "activation key identifier (alphanum characters, space, _ and -)"
+      param :description, String, :allow_nil => true
+      param :content_view_id, :identifier, :desc => "content view id"
+    end
+  end
+
   api :GET, "/activation_keys", "List activation keys"
   api :GET, "/environments/:environment_id/activation_keys", "List activation keys"
   api :GET, "/organizations/:organization_id/activation_keys", "List activation keys"
@@ -65,11 +73,7 @@ class Api::ActivationKeysController < Api::ApiController
 
   api :POST, "/activation_keys", "Create an activation key"
   api :POST, "/environments/:environment_id/activation_keys", "Create an activation key"
-  param :activation_key, Hash do
-    param :name, :identifier, :desc => "activation key identifier (alphanum characters, space, _ and -)"
-    param :description, String, :allow_nil => true
-    param :content_view_id, :identifier, :desc => "content view id", :allow_nil => true
-  end
+  param_group :activation_key
   def create
     created = ActivationKey.create!(params[:activation_key]) do |ak|
       ak.environment = @environment
@@ -80,6 +84,10 @@ class Api::ActivationKeysController < Api::ApiController
   end
 
   api :PUT, "/activation_keys/:id", "Update an activation key"
+  param_group :activation_key
+  param :activation_key, Hash do
+    param :environment_id, :identifier, :allow_nil => true
+  end
   def update
     @activation_key.update_attributes!(params[:activation_key])
     render :json => ActivationKey.find(@activation_key.id)

--- a/src/app/controllers/api/changesets_controller.rb
+++ b/src/app/controllers/api/changesets_controller.rb
@@ -36,6 +36,13 @@ class Api::ChangesetsController < Api::ApiController
 
   respond_to :json
 
+  def_param_group :changeset do
+    param :changeset, Hash, :required => true, :action_aware => true do
+      param :name, String, :desc => "The name of the changeset", :required => true
+      param :description, String, :desc => "The description of the changeset"
+    end
+  end
+
   api :GET, "/organizations/:organization_id/environments/:environment_id/changesets", "List changesets in an environment"
   param :name, String, :desc => "An optional changeset name to filter upon"
   def index
@@ -51,10 +58,7 @@ class Api::ChangesetsController < Api::ApiController
   end
 
   api :PUT, "/changesets/:id", "Update a changeset"
-  param :changeset, Hash do
-    param :description, String, :desc => "The description of the changeset"
-    param :name, String, :desc => "The name of the changeset"
-  end
+  param_group :changeset
   def update
     @changeset.attributes = params[:changeset].slice(:name, :description)
     @changeset.save!
@@ -68,9 +72,9 @@ class Api::ChangesetsController < Api::ApiController
   end
 
   api :POST, "/organizations/:organization_id/environments/:environment_id/changesets", "Create a changeset"
+  param_group :changeset
   param :changeset, Hash do
-    param :description, String, :allow_nil => true, :desc => "The description of the changeset"
-    param :name, String, :desc => "The name of the changeset"
+    param :type, ["PROMOTION", "DELETION"], :required => true
   end
   def create
     csType = params[:changeset][:type]

--- a/src/app/controllers/api/content_view_definitions_controller.rb
+++ b/src/app/controllers/api/content_view_definitions_controller.rb
@@ -48,6 +48,13 @@ class Api::ContentViewDefinitionsController < Api::ApiController
     }
   end
 
+  def_param_group :content_view_definition do
+    param :content_view_definition, Hash, :required => true, :action_aware => true do
+      param :name, String, :desc => "Content view definition name", :required => true
+      param :description, String, :desc => "Definition description"
+    end
+  end
+
   api :GET, "/organizations/:organization_id/content_view_definitions",
     "List content view definitions"
   param :organization_id, :identifier, :desc => "organization identifier"
@@ -64,11 +71,9 @@ class Api::ContentViewDefinitionsController < Api::ApiController
   api :POST, "/content_view_definitions",
     "Create a content view definition"
   param :organization_id, :identifier, :desc => "organization identifier"
+  param_group :content_view_definition
   param :content_view_definition, Hash do
-    param :name, String, :desc => "Content view definition name",
-      :required => true
     param :label, String, :desc => "Content view identifier"
-    param :description, String, :desc => "Definition description"
   end
   def create
     attrs = params[:content_view_definition]
@@ -81,10 +86,7 @@ class Api::ContentViewDefinitionsController < Api::ApiController
   api :PUT, "/organizations/:org/content_view_definitions/:id", "Update a definition"
   param :id, :number, :desc => "Definition identifer", :required => true
   param :org, String, :desc => "Organization name", :required => true
-  param :content_view_definition, Hash do
-    param :name, String, :desc => "Content view definition name"
-    param :description, String, :desc => "Definition description"
-  end
+  param_group :content_view_definition
   def update
     @definition.update_attributes!(params[:content_view_definition])
     render :json => @definition.to_json

--- a/src/app/controllers/api/distributors_controller.rb
+++ b/src/app/controllers/api/distributors_controller.rb
@@ -53,26 +53,27 @@ class Api::DistributorsController < Api::ApiController
     }
   end
 
+  def_param_group :distributors do
+    param :name, String, :desc => "Name of the distributor", :required => true, :action_aware => true
+    param :facts, Hash, :desc => "Key-value hash of distributor-specific facts"
+    param :installedProducts, Array, :desc => "List of products installed on the distributor"
+    param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT"
+    param :releaseVer, String, :desc => "Release of the os. The $releasever variable in repo url will be replaced with this value"
+    param :location, String, :desc => "Physical of the distributor"
+  end
+
   # this method is called from katello cli client and it does not work with activation keys
   # for activation keys there is method activate (see custom routes)
   api :POST, "/environments/:environment_id/distributors", "Register a distributor in environment"
-  param :facts, Hash, :desc => "Key-value hash of distributor-specific facts"
-  param :installedProducts, Array, :desc => "List of products installed on the distributor"
-  param :name, String, :desc => "Name of the distributor", :required => true
+  param_group :distributors
   param :type, String, :desc => "Type of the distributor, it should always be 'distributor'", :required => true
-  param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT"
   def create
     distributor = Distributor.create!(params.merge({:environment => @environment, :serviceLevel => params[:service_level]}))
     render :json => distributor.to_json
   end
 
   api :PUT, "/distributors/:id", "Update distributor information"
-  param :facts, Hash, :desc => "Key-value hash of distributor-specific facts"
-  param :installedProducts, Array, :desc => "List of products installed on the distributor"
-  param :name, String, :desc => "Name of the distributor"
-  param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT"
-  param :releaseVer, String, :desc => "Release of the os. The $releasever variable in repo url will be replaced with this value"
-  param :location, String, :desc => "Physical of the distributor"
+  param_group :distributors
   def update
     @distributor.update_attributes!(params.slice(:name, :description, :location, :facts, :guestIds, :installedProducts, :releaseVer, :serviceLevel, :environment_id))
     render :json => @distributor.to_json

--- a/src/app/controllers/api/foreman/architectures_controller.rb
+++ b/src/app/controllers/api/foreman/architectures_controller.rb
@@ -20,6 +20,12 @@ class Api::Foreman::ArchitecturesController < Api::Foreman::SimpleCrudController
 
   self.foreman_model = ::Foreman::Architecture
 
+  def_param_group :architecture do
+    param :architecture, Hash, :desc => "architecture info", :required => true, :action_aware => true do
+      param :name, String, "architecture name", :required => true
+    end
+  end
+
   api :GET, "/architectures", "Get list of architectures available in Foreman"
   def index
     super
@@ -32,18 +38,14 @@ class Api::Foreman::ArchitecturesController < Api::Foreman::SimpleCrudController
   end
 
   api :POST, "/architecture", "Create new architecture in Foreman"
-  param :architecture, Hash, :desc => "architecture info" do
-    param :name, String, "architecture name"
-  end
+  param_group :architecture
   def create
     super
   end
 
   api :PUT, "/architectures/:id", "Update an architecture record in Foreman"
   param :id, String, "architecture name"
-  param :architecture, Hash, :desc => "architecture info" do
-    param :name, String, "architecture name"
-  end
+  param_group :architecture
   def update
     super
   end

--- a/src/app/controllers/api/foreman/compute_resources_controller.rb
+++ b/src/app/controllers/api/foreman/compute_resources_controller.rb
@@ -18,6 +18,21 @@ class Api::Foreman::ComputeResourcesController < Api::Foreman::SimpleCrudControl
     DOC
   end
 
+  def_param_group :compute_resource do
+    param :compute_resource, Hash, :desc => "compute resource info", :required => true, :action_aware => true do
+      param :name, String, :required => true
+      param :provider, String, :desc => "Providers include #{::Foreman::ComputeResource::PROVIDERS.join(', ')}", :required => true
+      param :url, String, :desc => "URL for Libvirt, Ovirt, and Openstack", :required => true
+      param :description, String
+      param :user, String, :desc => "Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2."
+      param :password, String, :desc => "Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2"
+      param :uuid, String, :desc => "for Ovirt, Vmware Datacenter"
+      param :region, String, :desc => "for EC2 only"
+      param :tenant, String, :desc => "for Openstack only"
+      param :server, String, :desc => "for Vmware"
+    end
+  end
+
   self.foreman_model = ::Foreman::ComputeResource
 
   def common_json_options
@@ -36,18 +51,7 @@ class Api::Foreman::ComputeResourcesController < Api::Foreman::SimpleCrudControl
   end
 
   api :POST, "/compute_resources", "Create new compute resource in Foreman"
-  param :compute_resource, Hash, :desc => "compute resource info" do
-    param :name, String, :required => true
-    param :provider, String, :desc => "Providers include #{::Foreman::ComputeResource::PROVIDERS.join(', ')}", :required => true
-    param :url, String, :desc => "URL for Libvirt, Ovirt, and Openstack", :required => true
-    param :description, String
-    param :user, String, :desc => "Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2."
-    param :password, String, :desc => "Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2"
-    param :uuid, String, :desc => "for Ovirt, Vmware Datacenter"
-    param :region, String, :desc => "for EC2 only"
-    param :tenant, String, :desc => "for Openstack only"
-    param :server, String, :desc => "for Vmware"
-  end
+  param_group :compute_resource
   def create
     res = ::Foreman::ComputeResource.new_provider(params[:compute_resource])
     render :json => res.as_json(common_json_options) if res.save!
@@ -55,18 +59,7 @@ class Api::Foreman::ComputeResourcesController < Api::Foreman::SimpleCrudControl
 
   api :PUT, "/compute_resources/:id", "Update an compute resource record in Foreman"
   param :id, String, "compute resource name", :required => true
-  param :compute_resource, Hash, :desc => "compute resource info" do
-    param :name, String
-    param :provider, String, :desc => "Providers include #{::Foreman::ComputeResource::PROVIDERS.join(', ')}"
-    param :url, String, :desc => "URL for Libvirt, Ovirt, and Openstack"
-    param :description, String
-    param :user, String, :desc => "Username for Ovirt, EC2, Vmware, Openstack. Access Key for EC2."
-    param :password, String, :desc => "Password for Ovirt, EC2, Vmware, Openstack. Secret key for EC2"
-    param :uuid, String, :desc => "for Ovirt, Vmware Datacenter"
-    param :region, String, :desc => "for EC2 only"
-    param :tenant, String, :desc => "for Openstack only"
-    param :server, String, :desc => "for Vmware"
-  end
+  param_group :compute_resource
   def update
     super
   end

--- a/src/app/controllers/api/foreman/config_templates_controller.rb
+++ b/src/app/controllers/api/foreman/config_templates_controller.rb
@@ -19,6 +19,17 @@ class Api::Foreman::ConfigTemplatesController < Api::Foreman::SimpleCrudControll
 
   self.foreman_model = ::Foreman::ConfigTemplate
 
+  def_param_group :config_template do
+    param :config_template, Hash, :action_aware => true, :required => true do
+      param :name, String, :required => true, :desc => "template name"
+      param :template, [String, File], :required => true
+      param :snippet, :bool
+      param :audit_comment, String
+      param :template_kind_id, :number, :desc => "not relevant for snippet"
+      param :template_combinations_attributes, Array, :desc => "Array of template combinations (hostgroup_id, environment_id)"
+    end
+  end
+
   api :GET, "/config_templates/", "List templates"
   param :search, String, :desc => "filter results"
   param :order, String, :desc => "sort results"
@@ -32,27 +43,13 @@ class Api::Foreman::ConfigTemplatesController < Api::Foreman::SimpleCrudControll
   end
 
   api :POST, "/config_templates/", "Create a template"
-  param :config_template, Hash, :required => true do
-    param :name, String, :required => true, :desc => "template name"
-    param :template, [String, File], :required => true
-    param :snippet, :bool
-    param :audit_comment, String
-    param :template_kind_id, :number, :desc => "not relevant for snippet"
-    param 'template_combinations_attributes', Array, :desc => "Array of template combinations (hostgroup_id, environment_id)"
-  end
+  param_group :config_template
   def create
     super
   end
 
   api :PUT, "/config_templates/:id", "Update a template"
-  param :config_template, Hash, :required => true do
-    param :name, String, :required => true, :desc => "template name"
-    param :template, [String, File], :required => true
-    param :snippet, :bool
-    param :audit_comment, String
-    param :template_kind_id, :number, :desc => "not relevant for snippet"
-    param 'template_combinations_attributes', Array, :desc => "Array of template combinations (hostgroup_id, environment_id)"
-  end
+  param_group :config_template
   def update
     super
   end

--- a/src/app/controllers/api/foreman/domains_controller.rb
+++ b/src/app/controllers/api/foreman/domains_controller.rb
@@ -25,6 +25,15 @@ class Api::Foreman::DomainsController < Api::Foreman::SimpleCrudController
     DOC
   end
 
+  def_param_group :domain do
+    param :domain, Hash, :required => true, :action_aware => true do
+      param :name, String, :required => true, :desc => "The full DNS Domain name"
+      param :fullname, String, :desc => "Full name describing the domain"
+      param :dns_id, :number, :desc => "DNS Proxy to use within this domain"
+      param :domain_parameters_attributes, Array, :desc => "Array of parameters (name, value)"
+    end
+  end
+
   self.foreman_model = ::Foreman::Domain
 
   api :GET, "/domains/", "List of domains"
@@ -46,23 +55,13 @@ class Api::Foreman::DomainsController < Api::Foreman::SimpleCrudController
     and other pages that refer to domains, and also available as
     an external node parameter
   DOC
-  param :domain, Hash, :required => true do
-    param :name, String, :required => true, :desc => "The full DNS Domain name"
-    param :fullname, String, :required => false, :desc => "Full name describing the domain"
-    param :dns_id, :number, :required => false, :desc => "DNS Proxy to use within this domain"
-    param :domain_parameters_attributes, Array, :required => false, :desc => "Array of parameters (name, value)"
-  end
+  param_group :domain
   def create
     super
   end
 
   api :PUT, "/domains/:id/", "Update a domain."
-  param :domain, Hash, :required => true do
-    param :name, String, :required => true, :desc => "The full DNS Domain name"
-    param :fullname, String, :required => false, :desc => "Full name describing the domain"
-    param :dns_id, :number, :required => false, :desc => "DNS Proxy to use within this domain"
-    param :domain_parameters_attributes, Array, :required => false, :desc => "Array of parameters (name, value)"
-  end
+  param_group :domain
   def update
     super
   end

--- a/src/app/controllers/api/foreman/hardware_models_controller.rb
+++ b/src/app/controllers/api/foreman/hardware_models_controller.rb
@@ -18,6 +18,15 @@ class Api::Foreman::HardwareModelsController < Api::Foreman::SimpleCrudControlle
     DOC
   end
 
+  def_param_group :hardware_model do
+    param :hardware_model, Hash, :desc => "hardware model info", :required => true, :action_aware => true do
+      param :name, String, :required => true
+      param :info, String
+      param :vendor_class, String
+      param :hardware_model, String
+    end
+  end
+
   self.foreman_model = ::Foreman::HardwareModel
 
   api :GET, "/hardware_models", "Get list of hardware models available in Foreman"
@@ -32,24 +41,14 @@ class Api::Foreman::HardwareModelsController < Api::Foreman::SimpleCrudControlle
   end
 
   api :POST, "/hardware_models", "Create new hardware model in Foreman"
-  param :hardware_model, Hash, :desc => "hardware model info", :required => true do
-    param :name, String, :required => true
-    param :info, String, :required => false
-    param :vendor_class, String, :required => false
-    param :hardware_model, String, :required => false
-  end
+  param_group :hardware_model
   def create
     super
   end
 
   api :PUT, "/hardware_models/:id", "Update an hardware model record in Foreman"
   param :id, String, "hardware model name"
-  param :hardware_model, Hash, :desc => "hardware model info", :required => true do
-    param :name, String, :required => true
-    param :info, String, :required => false
-    param :vendor_class, String, :required => false
-    param :hardware_model, String, :required => false
-  end
+  param_group :hardware_model
   def update
     super
   end

--- a/src/app/controllers/api/foreman/smart_proxies_controller.rb
+++ b/src/app/controllers/api/foreman/smart_proxies_controller.rb
@@ -30,6 +30,13 @@ class Api::Foreman::SmartProxiesController < Api::Foreman::SimpleCrudController
     DOC
   end
 
+  def_param_group :smart_proxy do
+    param :smart_proxy, Hash, :required => true, :action_aware => true do
+      param :name, String, :required => true, :desc => "The smart proxy name"
+      param :url, String, :required => true, :desc => "The smart proxy URL starting with 'http://' or 'https://'"
+    end
+  end
+
   self.foreman_model = ::Foreman::SmartProxy
 
   api :GET, "/smart_proxies/", "List of smart proxies"
@@ -55,19 +62,13 @@ class Api::Foreman::SmartProxiesController < Api::Foreman::SimpleCrudController
     and other pages that refer to domains, and also available as
     an external node parameter
   DOC
-  param :smart_proxy, Hash, :required => true do
-    param :name, String, :required => true, :desc => "The smart proxy name"
-    param :url, String, :required => true, :desc => "The smart proxy URL starting with 'http://' or 'https://'"
-  end
+  param_group :smart_proxy
   def create
     super
   end
 
   api :PUT, "/smart_proxies/:id/", "Update a smart proxy."
-  param :smart_proxy, Hash, :required => true do
-    param :name, String, :required => false, :desc => "The smart proxy name"
-    param :url, String, :required => false, :desc => "The smart proxy URL starting with 'http://' or 'https://'"
-  end
+  param_group :smart_proxy
   def update
     super
   end

--- a/src/app/controllers/api/foreman/subnets_controller.rb
+++ b/src/app/controllers/api/foreman/subnets_controller.rb
@@ -18,6 +18,12 @@ class Api::Foreman::SubnetsController < Api::Foreman::SimpleCrudController
     DOC
   end
 
+  def_param_group :subnet do
+    param :subnet, Hash, :desc => "subnet info", :required => true, :action_aware => true do
+      param :name, String, "subnet name", :required => true
+    end
+  end
+
   self.foreman_model = ::Foreman::Subnet
 
   api :GET, "/subnets", "Get list of subnets available in Foreman"
@@ -32,18 +38,14 @@ class Api::Foreman::SubnetsController < Api::Foreman::SimpleCrudController
   end
 
   api :POST, "/subnet", "Create new subnet in Foreman"
-  param :subnet, Hash, :desc => "subnet info" do
-    param :name, String, "subnet name"
-  end
+  param_group :subnet
   def create
     super
   end
 
   api :PUT, "/subnets/:id", "Update an subnet record in Foreman"
   param :id, String, "subnet name"
-  param :subnet, Hash, :desc => "subnet info" do
-    param :name, String, "subnet name"
-  end
+  param_group :subnet
   def update
     super
   end

--- a/src/app/controllers/api/gpg_keys_controller.rb
+++ b/src/app/controllers/api/gpg_keys_controller.rb
@@ -40,6 +40,13 @@ class Api::GpgKeysController < Api::ApiController
     }
   end
 
+  def_param_group :gpg_key do
+    param :gpg_key, Hash, :required => true, :action_aware => true do
+      param :name, :identifier, :required => true, :desc => "identifier of the gpg key"
+      param :content, String, :required => true,  :desc => "public key block in DER encoding"
+    end
+  end
+
   api :GET, "/organizations/:organization_id/gpg_keys", "List gpg keys"
   param :organization_id, :identifier, :desc => "organization identifier"
   param :name, :identifier, :desc => "identifier of the gpg key"
@@ -56,17 +63,14 @@ class Api::GpgKeysController < Api::ApiController
 
   api :POST, "/organizations/:organization_id/gpg_keys", "Create a gpg key"
   param :organization_id, :identifier, :desc => "organization identifier"
-  param :gpg_key, Hash do
-    param :name, :identifier, :desc => "identifier of the gpg key"
-    param :content, String, :desc => "public key block in DER encoding"
-  end
+  param_group :gpg_key
   def create
     gpg_key = @organization.gpg_keys.create!(params[:gpg_key].slice(:name, :content))
     render :json => gpg_key
   end
 
   api :PUT, "/gpg_keys/:id", "Update a gpg key"
-  see "gpg_keys#create"
+  param_group :gpg_key
   def update
     @gpg_key.update_attributes!(params[:gpg_key].slice(:name, :content))
     render :json => @gpg_key

--- a/src/app/controllers/api/organizations_controller.rb
+++ b/src/app/controllers/api/organizations_controller.rb
@@ -42,10 +42,14 @@ class Api::OrganizationsController < Api::ApiController
     }
   end
 
+  def_param_group :organization do
+    param :name, String, :desc => "name for the organization", :required => true, :action_aware => true
+    param :description, String
+  end
+
   api :GET, "/organizations", "List organizations"
-  param :name, String, :desc => "name for filtering"
+  param_group :organization
   param :label, String, :desc => "label for filtering"
-  param :description, String, :desc => "description"
   def index
     render :json => (Organization.without_deleting.readable.where query_params).to_json
   end
@@ -57,9 +61,7 @@ class Api::OrganizationsController < Api::ApiController
   end
 
   api :POST, "/organizations", "Create an organization"
-  param :name, String, :desc => "name for the organization"
-  param :label, String, :desc => "ASCII label to identify the organization"
-  param :description, String, :desc => "description"
+  param_group :organization
   def create
     label = labelize_params(params)
     render :json => Organization.create!(:name => params[:name], :description => params[:description], :label => label).to_json
@@ -67,7 +69,7 @@ class Api::OrganizationsController < Api::ApiController
 
   api :PUT, "/organizations/:id", "Update an organization"
   param :organization, Hash do
-    param :description, String, :desc => "description"
+    param_group :organization, Api::OrganizationsController
   end
   def update
     render :json => @organization.update_attributes!(params[:organization]).to_json

--- a/src/app/controllers/api/products_controller.rb
+++ b/src/app/controllers/api/products_controller.rb
@@ -47,6 +47,13 @@ class Api::ProductsController < Api::ApiController
     }
   end
 
+  def_param_group :product do
+    param :product, Hash, :required => true, :action_aware => true do
+      param :gpg_key_name, :identifier, :desc => "identifier of the gpg key"
+      param :description, String, :desc => "Product description"
+    end
+  end
+
   api :GET, "/organizations/:organization_id/products/:id", "Show a product"
   param :organization_id, :identifier, :desc => "organization identifier"
   param :id, :number, :desc => "product numeric identifier"
@@ -57,8 +64,8 @@ class Api::ProductsController < Api::ApiController
   api :PUT, "/organizations/:organization_id/products/:id", "Update a product"
   param :organization_id, :identifier, :desc => "organization identifier"
   param :id, :number, :desc => "product numeric identifier"
+  param_group :product
   param :product, Hash do
-    param :gpg_key_name, :identifier, :desc => "identifier of the gpg key"
     param :recursive, :bool, :desc => "set to true to recursive update gpg key"
   end
   def update

--- a/src/app/controllers/api/providers_controller.rb
+++ b/src/app/controllers/api/providers_controller.rb
@@ -51,6 +51,14 @@ class Api::ProvidersController < Api::ApiController
     }
   end
 
+  def_param_group :provider do
+    param :provider, Hash, :required => true, :action_aware => true do
+      param :name, String, :desc => "Provider name", :required => true
+      param :description, String, :desc => "Provider description"
+      param :repository_url, String, :desc => "Repository URL"
+    end
+  end
+
   api :GET, "/organizations/:organization_id/providers", "List providers"
   param :organization_id, :identifier, :desc => "Organization identifier", :required => true
   param :name, String, :desc => "Filter providers by name"
@@ -67,11 +75,9 @@ class Api::ProvidersController < Api::ApiController
 
   api :POST, "/providers", "Create a provider"
   param :organization_id, :identifier, :desc => "Organization identifier", :required => true
-  param :provider, Hash, :required => true do
-    param :name, String, :desc => "Provider name", :required => true
-    param :description, String, :desc => "Provider description"
+  param_group :provider
+  param :provider, Hash do
     param :provider_type, ["Red Hat", "Custom"], :required => true
-    param :repository_url, String, :desc => "Repository URL"
   end
   def create
     provider = Provider.create!(params[:provider]) do |p|
@@ -82,12 +88,7 @@ class Api::ProvidersController < Api::ApiController
 
   api :PUT, "/providers/:id", "Update a provider"
   param :id, :number, :desc => "Provider numeric identifier", :required => true
-  param :provider, Hash, :required => true do
-    param :name, String, :desc => "Provider name", :required => true
-    param :description, String, :desc => "Provider description"
-    param :provider_type, ["Red Hat", "Custom"], :required => true
-    param :repository_url, String, :desc => "Repository URL"
-  end
+  param_group :provider
   def update
     @provider.update_attributes!(params[:provider])
     render :json => @provider.to_json and return
@@ -182,10 +183,10 @@ class Api::ProvidersController < Api::ApiController
 
   api :POST, "/providers/:id/product_create", "Create a new product in custom provider"
   param :id, :number, :desc => "Provider numeric identifier", :required => true
+  param_group :product, Api::ProductsController, :as => :create
   param :product, Hash, :required => true do
     param :name, String, :desc => "Product name", :required => true
-    param :description, String, :desc => "Product description"
-    param :gpg_key_name, String, :desc => "GPG key name"
+    param :label, String
   end
   def product_create
     raise HttpErrors::BadRequest, _("It is not allowed to create products in Red Hat provider.") if @provider.redhat_provider?

--- a/src/app/controllers/api/roles_controller.rb
+++ b/src/app/controllers/api/roles_controller.rb
@@ -41,6 +41,13 @@ class Api::RolesController < Api::ApiController
      }
   end
 
+  def_param_group :role do
+    param :role, Hash, :required => true, :action_aware => true do
+      param :name, String, :required => true
+      param :description, String, :allow_nil => true
+    end
+  end
+
   api :GET, "/roles", "List roles"
   api :GET, "/users/:user_id/roles", "List roles assigned to a user"
   param :name, :undef
@@ -56,20 +63,14 @@ class Api::RolesController < Api::ApiController
 
   api :POST, "/roles", "Create a role"
   api :POST, "/users/:user_id/roles", "Create a role"
-  param :role, Hash do
-    param :description, String, :allow_nil => true
-    param :name, String, :required => true
-  end
+  param_group :role
   def create
     render :json => Role.create!(params[:role]).to_json
   end
 
   api :PUT, "/roles/:id", "Update a role"
   api :PUT, "/users/:user_id/roles/:id", "Update a role"
-  param :role, Hash do
-    param :description, String, :allow_nil => true
-    param :name, String
-  end
+  param_group :role
   def update
     @role.update_attributes!(params[:role])
     @role.save!

--- a/src/app/controllers/api/sync_plans_controller.rb
+++ b/src/app/controllers/api/sync_plans_controller.rb
@@ -45,6 +45,15 @@ class Api::SyncPlansController < Api::ApiController
     }
   end
 
+  def_param_group :sync_plan do
+    param :sync_plan, Hash, :required => true, :action_aware => true do
+      param :name, String, :desc => "sync plan name", :required => true
+      param :interval, ['none', 'hourly', 'daily', 'weekly'], :desc => "how often synchronization should run"
+      param :sync_date, String, :desc => "start datetime of synchronization"
+      param :description, String, :desc => "sync plan description"
+    end
+  end
+
   api :GET, "/organizations/:organization_id/sync_plans", "List sync plans"
   param :name, String, :desc => "filter by name"
   param :sync_date, String, :desc => "filter by sync date"
@@ -62,12 +71,7 @@ class Api::SyncPlansController < Api::ApiController
 
 
   api :POST, "/organizations/:organization_id/sync_plans", "Create a sync plan"
-  param :sync_plan, Hash, :required => true do
-    param :description, :undef, :desc => "sync plan description"
-    param :interval, ['none', 'hourly', 'daily', 'weekly'], :desc => "how often synchronization should run"
-    param :name, String, :desc => "sync plan name", :required => true
-    param :sync_date, String, :desc => "start datetime of synchronization"
-  end
+  param_group :sync_plan
   def create
     sync_date = params[:sync_plan][:sync_date].to_time
 
@@ -81,12 +85,7 @@ class Api::SyncPlansController < Api::ApiController
 
   api :PUT, "/organizations/:organization_id/sync_plans/:id", "Update a sync plan"
   param :id, :number, :desc => "sync plan numeric identifier", :required => true
-  param :sync_plan, Hash, :required => true do
-    param :description, :undef, :desc => "sync plan description"
-    param :interval, ['none', 'hourly', 'daily', 'weekly'], :desc => "how often synchronization should run"
-    param :name, String, :desc => "sync plan name", :required => true
-    param :sync_date, String, :desc => "start datetime of synchronization"
-  end
+  param_group :sync_plan
   def update
     sync_date = params[:sync_plan][:sync_date].to_time
 

--- a/src/app/controllers/api/system_group_packages_controller.rb
+++ b/src/app/controllers/api/system_group_packages_controller.rb
@@ -36,8 +36,7 @@ class Api::SystemGroupPackagesController < Api::ApiController
   end
 
   api :POST, "/organizations/:organization_id/system_groups/:system_group_id/packages", "Install packages remotely"
-  param :packages, Array, :desc => "List of package names to install", :required => false
-  param :groups, Array, :desc => "List of package group names to install", :required => false
+  param_group :packages_or_groups, Api::SystemPackagesController
   def create
     if params[:packages]
       packages = validate_package_list_format(params[:packages])
@@ -53,8 +52,7 @@ class Api::SystemGroupPackagesController < Api::ApiController
   end
 
   api :PUT, "/organizations/:organization_id/system_groups/:system_group_id/packages", "Update packages remotely"
-  param :packages, Array, :desc => "List of package names to install", :required => false
-  param :groups, Array, :desc => "List of package group names to install", :required => false
+  param_group :packages_or_groups, Api::SystemPackagesController
   def update
     if params[:packages]
       packages = validate_package_list_format(params[:packages])
@@ -70,8 +68,7 @@ class Api::SystemGroupPackagesController < Api::ApiController
   end
 
   api :DELETE, "/organizations/:organization_id/system_groups/:system_group_id/packages", "Uninstall packages remotely"
-  param :packages, Array, :desc => "List of package names to install", :required => false
-  param :groups, Array, :desc => "List of package group names to install", :required => false
+  param_group :packages_or_groups, Api::SystemPackagesController
   def destroy
     if params[:packages]
       packages = validate_package_list_format(params[:packages])

--- a/src/app/controllers/api/system_groups_controller.rb
+++ b/src/app/controllers/api/system_groups_controller.rb
@@ -52,6 +52,14 @@ class Api::SystemGroupsController < Api::ApiController
 
   respond_to :json
 
+  def_param_group :system_group do
+    param :system_group, Hash, :required => true, :action_aware => true do
+      param :name, String, :required => true, :desc => "System group name"
+      param :description, String
+      param :max_systems, Integer, :desc => "Maximum number of systems in the group"
+    end
+  end
+
   api :GET, "/organizations/:organization_id/system_groups", "List system groups"
   param :organization_id, :identifier, :desc => "organization identifier", :required => true
   param :name, String, :desc => "System group name to filter by"
@@ -70,11 +78,7 @@ class Api::SystemGroupsController < Api::ApiController
   api :PUT, "/organizations/:organization_id/system_groups/:id", "Update a system group"
   param :organization_id, :identifier, :desc => "organization identifier", :required => true
   param :id, :identifier, :desc => "Id of the system group", :required => true
-  param :system_group, Hash, :required => true do
-    param :name, String, :desc => "System group name"
-    param :description, String
-    param :max_systems, Integer, :desc => "Maximum number of systems in the group"
-  end
+  param_group :system_group
   def update
     grp_param = params[:system_group]
     if grp_param[:system_ids]
@@ -140,11 +144,7 @@ class Api::SystemGroupsController < Api::ApiController
 
   api :POST, "/organizations/:organization_id/system_groups", "Create a system group"
   param :organization_id, :identifier, :desc => "organization identifier", :required => true
-  param :system_group , Hash , :required => true do
-      param :name, String, :desc => "System group name", :required => true
-      param :description, String
-      param :max_systems, Integer, :desc => "Maximum number of systems in the group", :required => true
-  end
+  param_group :system_group
   def create
     grp_param = params[:system_group]
     if grp_param[:system_ids]

--- a/src/app/controllers/api/system_packages_controller.rb
+++ b/src/app/controllers/api/system_packages_controller.rb
@@ -32,10 +32,14 @@ class Api::SystemPackagesController < Api::ApiController
     }
   end
 
+  def_param_group :packages_or_groups do
+    param :packages, Array, :desc => "List of package names", :required => false
+    param :groups, Array, :desc => "List of package group names", :required => false
+  end
+
   # install packages remotely
   api :POST, "/systems/:system_id/packages", "Install packages remotely"
-  param :groups, Array, :desc => "list of groups names"
-  param :packages, Array, :desc => "list of packages names"
+  param_group :packages_or_groups
   def create
     if params[:packages]
       packages = validate_package_list_format(params[:packages])
@@ -63,8 +67,7 @@ class Api::SystemPackagesController < Api::ApiController
 
   # uninstall packages remotely
   api :DELETE, "/systems/:system_id/packages", "Uninstall packages remotely"
-  param :groups, Array, :desc => "list of groups names"
-  param :packages, Array, :desc => "list of packages names"
+  param_group :packages_or_groups
   def destroy
     if params[:packages]
       packages = validate_package_list_format(params[:packages])

--- a/src/app/controllers/api/systems_controller.rb
+++ b/src/app/controllers/api/systems_controller.rb
@@ -72,15 +72,22 @@ class Api::SystemsController < Api::ApiController
     }
   end
 
+  def_param_group :system do
+    param :facts, Hash, :desc => "Key-value hash of system-specific facts", :action_aware => true
+    param :installedProducts, Array, :desc => "List of products installed on the system", :action_aware => true
+    param :name, String, :desc => "Name of the system", :required => true, :action_aware => true
+    param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true, :action_aware => true
+    param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT", :action_aware => true
+    param :location, String, :desc => "Physical of the system"
+    param :content_view_id, :identifier
+    param :environment_id, :identifier
+  end
+
   # this method is called from katello cli client and it does not work with activation keys
   # for activation keys there is method activate (see custom routes)
   api :POST, "/environments/:environment_id/consumers", "Register a system in environment (compatibility reason)"
   api :POST, "/environments/:environment_id/systems", "Register a system in environment"
-  param :facts, Hash, :desc => "Key-value hash of system-specific facts"
-  param :installedProducts, Array, :desc => "List of products installed on the system"
-  param :name, String, :desc => "Name of the system", :required => true
-  param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true
-  param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT"
+  param_group :system
   def create
     system = System.create!(params.merge({:environment => @environment,
                                           :content_view => @content_view,
@@ -105,11 +112,7 @@ DESC
   api :POST, "/consumers", "Register a system with activation key (compatibility)"
   api :POST, "/organizations/:organization_id/systems", "Register a system with activation key"
   param :activation_keys, String, :required => true
-  param :facts, Hash, :desc => "Key-value hash of system-specific facts"
-  param :installedProducts, Array, :desc => "List of products installed on the system"
-  param :name, String, :desc => "Name of the system", :required => true
-  param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true
-  param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT"
+  param_group :system, :as => :create
   def activate
     # Activation keys are userless by definition so use the internal generic user
     # Set it before calling find_activation_keys to allow communication with candlepin
@@ -148,13 +151,7 @@ DESC
 
   api :PUT, "/consumers/:id", "Update system information (compatibility)"
   api :PUT, "/systems/:id", "Update system information"
-  param :facts, Hash, :desc => "Key-value hash of system-specific facts"
-  param :installedProducts, Array, :desc => "List of products installed on the system"
-  param :name, String, :desc => "Name of the system"
-  param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT"
-  param :releaseVer, String, :desc => "Release of the os. The $releasever variable in repo url will be replaced with this value"
-  param :location, String, :desc => "Physical of the system"
-  param :content_view_id, :identifier, :desc => "content view id"
+  param_group :system
   def update
     @system.update_attributes!(params.slice(:name, :description, :location,
                                             :facts, :guestIds, :installedProducts,

--- a/src/app/controllers/api/templates_controller.rb
+++ b/src/app/controllers/api/templates_controller.rb
@@ -53,6 +53,14 @@ class Api::TemplatesController < Api::ApiController
     }
   end
 
+  def_param_group :template do
+    param :template, Hash, :required => true, :action_aware => true do
+      param :name, :identifier, :desc => "new template name", :required => true
+      param :parent_id, :number, :desc => "parent template numeric identifier"
+      param :description, String, :desc => "template description"
+    end
+  end
+
   api :GET, "/environments/:environment_id/templates", "List system templates for given environment."
   param :environment_id, :number, :desc => "environment numeric identifier", :required => true
   param :name, :identifier, :desc => "system template identifier"
@@ -69,11 +77,7 @@ class Api::TemplatesController < Api::ApiController
 
   api :POST, "/templates", "Create a template"
   param :environment_id, :number, :desc => "environment numeric identifier", :required => true
-  param :template, Hash do
-    param :description, String, :desc => "template description"
-    param :name, :identifier, :desc => "new template name", :required => true
-    param :parent_id, :number, :desc => "parent template numeric identifier"
-  end
+  param_group :template
   def create
     raise HttpErrors::BadRequest, _("New templates can be created only in the '%s' environment") % "Library" if not @environment.library?
 
@@ -86,10 +90,7 @@ class Api::TemplatesController < Api::ApiController
 
   api :PUT, "/templates/:id", "Update a template"
   param :id, :number, :desc => "template numeric identifier", :required => true
-  param :template, Hash do
-    param :description, String, :desc => "template new description"
-    param :name, :identifier, :desc => "template new name"
-  end
+  param_group :template
   def update
     raise HttpErrors::BadRequest, _("Templates can be updated only in the '%s' environment") % "Library" if not @template.environment.library?
 
@@ -116,11 +117,7 @@ class Api::TemplatesController < Api::ApiController
   api :POST, "/templates/import", "Import a template"
   param :environment_id, :number, :desc => "environment numeric identifier", :required => true
   param :template_file, File, :desc => "template file to import", :required => true
-  param :template, Hash do
-    param :description, String, :desc => "template description"
-    param :name, :identifier, :desc => "new template name", :required => true
-    param :parent_id, :number, :desc => "parent template numeric identifier"
-  end
+  param_group :template, :as => :create
   def import
     raise HttpErrors::BadRequest, _("New templates can be imported only into the '%s' environment") % "Library" if not @environment.library?
 

--- a/src/app/controllers/api/users_controller.rb
+++ b/src/app/controllers/api/users_controller.rb
@@ -47,6 +47,13 @@ class Api::UsersController < Api::ApiController
     }
   end
 
+  def_param_group :user do
+    param :email, String, :required => true, :action_aware => true
+    param :password, String, :required => true, :action_aware => true
+    param :default_environment_id, Integer, :action_aware => true
+    param :disabled, :bool, :action_aware => true
+  end
+
   api :GET, "/users", "List users"
   param :email, String, :desc => "filter by email"
   param :disabled, :bool, :desc => "filter by disabled flag"
@@ -61,11 +68,8 @@ class Api::UsersController < Api::ApiController
   end
 
   api :POST, "/users", "Create an user"
-  param :disabled, :bool
-  param :email, String, :required => true
-  param :password, String, :required => true
   param :username, String, :required => true
-  param :default_environment_id, Integer
+  param_group :user
   def create
     # warning - request already contains "username" and "password" (logged user)
     user = User.create!(:username => params[:username],
@@ -85,10 +89,7 @@ class Api::UsersController < Api::ApiController
   end
 
   api :PUT, "/users/:id", "Update an user"
-  param :disabled, :bool
-  param :email, String
-  param :password, String
-  param :default_environment_id, Integer
+  param_group :user
   def update
     user_params = params[:user].reject { |k, _| k == 'default_environment_id' }
 

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -85,7 +85,7 @@ Requires:       rubygem(tire) < 0.4
 Requires:       rubygem(ldap_fluff)
 Requires:       rubygem(foreman_api) >= 0.0.7
 Requires:       rubygem(anemone)
-Requires:       rubygem(apipie-rails) >= 0.0.16
+Requires:       rubygem(apipie-rails) >= 0.0.18
 Requires:       lsof
 
 %if 0%{?rhel} == 6
@@ -150,7 +150,7 @@ BuildRequires:       rubygem(sass)
 BuildRequires:       rubygem(tire) >= 0.3.0
 BuildRequires:       rubygem(tire) < 0.4
 BuildRequires:       rubygem(ldap_fluff)
-BuildRequires:       rubygem(apipie-rails) >= 0.0.16
+BuildRequires:       rubygem(apipie-rails) >= 0.0.18
 BuildRequires:       rubygem(maruku)
 BuildRequires:       rubygem(foreman_api)
 
@@ -205,7 +205,7 @@ BuildArch:      noarch
 Summary:         Katello connection classes for the Foreman backend
 Requires:        %{name}-common
 # dependencies from bundler.d/foreman.rb
-Requires:       rubygem(foreman_api) >= 0.0.10
+Requires:       rubygem(foreman_api) >= 0.0.18
 
 %description glue-foreman
 Katello connection classes for the Foreman backend


### PR DESCRIPTION
Often there are the same params (or majority of them) on some actions, 
typically `create` and `update` on resource. New apipie-rails supports 
extracting this kind of params into param_group.

Also, params thare are required on creation, are not required, on update (only
can't be nil). `:action_aware => true` achieves this.
