### PR TITLE
Katello-Configure - Changes the SSLRenegBufferSize for the Pulp Apache

### DIFF
--- a/katello-configure/modules/pulp/templates/etc/httpd/conf.d/pulp.conf.erb
+++ b/katello-configure/modules/pulp/templates/etc/httpd/conf.d/pulp.conf.erb
@@ -31,7 +31,7 @@ WSGIImportScript /srv/pulp/webservices.wsgi process-group=pulp application-group
     WSGIPassAuthorization On
     WSGIProcessGroup pulp
     WSGIApplicationGroup pulp
-    SSLRenegBufferSize  2147483648
+    SSLRenegBufferSize  1048576
     SSLRequireSSL
     SSLVerifyDepth 3
     SSLOptions +StdEnvVars +ExportCertData


### PR DESCRIPTION
configuration to 1MB to reflect the change that Pulp made as part
of bug 908082.

Please review this one.  I encountered this error with a slightly newer version of Pulp whereby Apache won't start without this change to reflect the change they made within their own conf files.  

@lzap 
@mccun934 
@iNecas 
