### PR TITLE
custominfo-tupane-fix - fixed tupane layout for custominfo

### DIFF
--- a/src/app/controllers/systems_controller.rb
+++ b/src/app/controllers/systems_controller.rb
@@ -348,7 +348,7 @@ class SystemsController < ApplicationController
   end
 
   def custom_info
-    render :partial => "edit_custom_info", :layout => "tupane_layout"
+    render :partial => "edit_custom_info"
   end
 
   def show

--- a/src/app/views/systems/_edit_custom_info.html.haml
+++ b/src/app/views/systems/_edit_custom_info.html.haml
@@ -5,3 +5,5 @@
          :locals => { :informable => @system,
                       :informable_type => "system",
                       :informable_id => @system.id }
+
+= render :template => "layouts/tupane_layout"


### PR DESCRIPTION
tupane layout was moved from controllers to partial; this one was missed
