### PR TITLE
Fixes #1661 - add request_type to notices retrieved using client polling

### DIFF
--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -167,7 +167,7 @@ class User < ActiveRecord::Base
     notices.each { |notice| notice.user_notices.each(&:read!) }
 
     return notices.map do |notice|
-      { :text => notice.text, :level => notice.level }
+      { :text => notice.text, :level => notice.level, :request_type => notice.request_type }
     end
   end
 


### PR DESCRIPTION
When client polled for notices, the 'request_type' was not included
in the json returned.  This addresses that issue.
