### PR TITLE
env paths - sort paths by env name

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -439,7 +439,6 @@ class ApplicationController < ActionController::Base
     # reject any paths that don't have accessible envs
     @paths.reject!{|path|  (path & accessible).empty?}
 
-    @paths = @paths.sort_by{|p| p[1].name}
     @paths = [[org.library]] if @paths.empty?
 
     if @environment and !@environment.library?
@@ -470,7 +469,6 @@ class ApplicationController < ActionController::Base
 
   def environment_paths(library, environment_path_element_generator)
     paths = current_organization.promotion_paths
-    paths = paths.sort_by{|p| p[0].name}
     to_ret = []
     paths.each do |path|
       path = path.collect{ |e| environment_path_element_generator.call(e) }

--- a/src/app/models/organization.rb
+++ b/src/app/models/organization.rb
@@ -80,7 +80,7 @@ class Organization < ActiveRecord::Base
 
   def promotion_paths
     #I'm sure there's a better way to do this
-    self.environments.joins(:priors).where("prior_id = #{self.library.id}").collect do |env|
+    self.environments.joins(:priors).where("prior_id = #{self.library.id}").order(:name).collect do |env|
       env.path
     end
   end


### PR DESCRIPTION
This commit is provide a common behavior for the ordering
of the environment paths.

The initial issue observed was similar to:
- paths:
  - dev, test, prod
  - dev-2, test-2
- When a user would go to Changesets page, they would
  see the first path (dev, test, prod); however, the
  'next environment' would be dev-2.  The reason being
  the path ordering listed was sorted, but the determination
  of next environment used the paths unsorted.  This
  could result in the user creating a changeset and
  the content being promoted to dev-2; however, the user
  might assume it is going to dev, since that is the env
  path being displayed.

This change provides for a consistent behavior in the
various places where an env (or promotion) path is involved,
such as:
- changesets
- changeset history
- activation keys
- systems
- organization
  ...
