### PR TITLE
Fixes #1656 - Sets a minimum width on the body to reflect that hard

### DIFF
--- a/src/app/stylesheets/katello.scss
+++ b/src/app/stylesheets/katello.scss
@@ -19,6 +19,10 @@
 @import "widgets/env_select";
 @import "katello_sprites";
 
+body {
+  min-width: $static_width;
+}
+
 pre  { text-indent: 18px; }
 a { outline: 0 none;}
 strong { font-weight: bold; }


### PR DESCRIPTION
width set on the content section.

@thomasmckay - I could not reproduce your issue.
@omaciel -This should fix the weird issues you saw with the menu and the application appearing to be cut off when shrinking the window size.
