### PR TITLE
katello-configure - Include param name into wrong param error message

### DIFF
--- a/katello-configure/bin/katello-configure
+++ b/katello-configure/bin/katello-configure
@@ -124,7 +124,7 @@ ssl_ca_password_file_option = _get_valid_option_value('ssl_ca_password_file', $d
 mandatory.each do |key, mand|
   if (not $final_options.has_key?(key) and mandatory[key]) or
   (not $final_options[key].nil? and not $final_options[key].to_s() =~ Regexp.new(regex[key]))
-    $final_options[key] = _request_option_interactively($titles[key], regex[key], _get_valid_option_value(key, $default_options, $final_options), _is_option_true(non_interactive_option))
+    $final_options[key] = _request_option_interactively(key, $titles[key], regex[key], _get_valid_option_value(key, $default_options, $final_options), _is_option_true(non_interactive_option))
     if not $default_options_order.include?(key)
       $default_options_order.push(key)
     end

--- a/katello-configure/lib/util/functions.rb
+++ b/katello-configure/lib/util/functions.rb
@@ -210,11 +210,11 @@ def _read_password()
   return input
 end
 
-def _request_option_interactively(title, regex, default_value, non_interactive_value)
+def _request_option_interactively(param, title, regex, default_value, non_interactive_value)
   default_value_ok = default_value.to_s() =~ Regexp.new(regex)
   if non_interactive_value
     if default_value.nil? or not default_value_ok
-      $stderr.puts "Option: [#{title}] not correctly specified."
+      $stderr.puts "Option: [#{title} (--#{param.gsub("_", "-")})] not correctly specified."
       exit 7
     else
       return default_value


### PR DESCRIPTION
Compare:

```
 Option: [Katello user's password] not correctly specified.
```

with

```
 Option: [Katello user's password (--user_pass)] not correctly specified.
```
