### PR TITLE
db-seeds-headpin-fence - fence pulp call

### DIFF
--- a/src/db/seeds.rb
+++ b/src/db/seeds.rb
@@ -83,4 +83,6 @@ if Provider.count == 0
   })
 end
 
-Repository.ensure_sync_notification
+if Katello.config.use_pulp
+  Repository.ensure_sync_notification
+end


### PR DESCRIPTION
Needed to allow katello-configure --deployment=headpin to run
