### PR TITLE
Add packages from ruby193 software collection

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -218,6 +218,18 @@
        <packagereq type="default">ruby193-build</packagereq>
        <packagereq type="default">ruby193-runtime</packagereq>
 
+       <packagereq type="default">ruby193-ruby-irb</packagereq>
+       <packagereq type="default">ruby193-rubygem-minitest</packagereq>
+       <packagereq type="default">ruby193-rubygem-rake</packagereq>
+       <packagereq type="default">ruby193-ruby-devel</packagereq>
+       <packagereq type="default">ruby193-ruby-doc</packagereq>
+       <packagereq type="default">ruby193-ruby-libs</packagereq>
+       <packagereq type="default">ruby193-ruby-tcltk</packagereq>
+       <packagereq type="default">ruby193-rubygem-bigdecimal</packagereq>
+       <packagereq type="default">ruby193-rubygem-io-console</packagereq>
+       <packagereq type="default">ruby193-rubygem-json</packagereq>
+       <packagereq type="default">ruby193-ruby-debuginfo</packagereq>
+
 
     </packagelist>
   </group>


### PR DESCRIPTION
This very probably include some packages which are buildrequire only and not needed in runtime and some packages are probably missing.
But it is _much_ easier to download it from repo than downloading each individually from koji.
