### PR TITLE
CLI - Updates to setup.py to switch to distutils and the inclusion

### DIFF
--- a/cli/README
+++ b/cli/README
@@ -12,3 +12,11 @@ Run unit tests (install python-mock - available in Fedora 17+)
 Compile a test RPM:
 
   tito build --rpm --test --rpmbuild-options=--nodeps
+
+Installing via pip into a virtualenv:
+
+Locally:
+  env SWIG_FEATURES="-cpperraswarn -includeall -D__`uname -m`__ -I/usr/include/openssl" pip install -r requirements.txt
+
+From the virtualenv:
+  env SWIG_FEATURES="-cpperraswarn -includeall -D__`uname -m`__ -I/usr/include/openssl" pip install -r <env-name>/etc/katello-cli/requirements.txt

--- a/cli/requirements.pip
+++ b/cli/requirements.pip
@@ -1,0 +1,5 @@
+M2Crypto
+kerberos
+iniparse
+simplejson
+python-dateutil

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from distutils.core import setup
 import os
 
 packages = [
@@ -12,31 +12,34 @@ packages = [
     "katello.client.lib.utils"
 ]
 
-install_requires = [
+requires = (
     "kerberos",
     "M2Crypto",
     "iniparse",
     "simplejson",
-    "python-dateutil"
-]
+    "dateutil"
+)
 
-data_files = [(os.path.join('share', 'locale', lang, 'LC_MESSAGES'),
-                [os.path.join('locale', lang, lang + '.po')]) 
-                    for lang in os.listdir('locale') if os.path.isdir(lang)]
+def data_files():
+    data_files = [(os.path.join('share', 'locale', lang, 'LC_MESSAGES'),
+                    [os.path.join('locale', lang, 'katello-cli.po')]) 
+                        for lang in os.listdir('locale') if os.path.isdir('locale/' + lang)]
+    data_files.extend([
+        ('etc/katello-cli', ['etc/client.conf']),
+        ('etc/katello-cli', ['requirements.pip'])
+    ])
 
-data_files.extend([
-    ('/etc/katello', ['etc/client.conf'])
-])
+    return data_files
 
 setup(
-    name            = "katello-cli",
-    version         = "1.3",
-    description     = "Command line interface for the Katello System's Management Project.",
-    home_page       = "http://www.katello.org",
-    license         = "GPL",
-    packages        = packages,
-    package_dir     = { "katello" : "src/katello" },
-    scripts         = ['bin/katello'],
-    data_files      = data_files,
-    install_requires= install_requires
+    name        = "katello-cli",
+    version     = "1.3",
+    description = "Command line interface for the Katello System's Management Project.",
+    home_page   = "http://www.katello.org",
+    license     = "GPL",
+    packages    = packages,
+    package_dir = { "katello" : "src/katello" },
+    scripts     = ['bin/katello'],
+    data_files  = data_files(),
+    requires    = requires
 )


### PR DESCRIPTION
of a requirements.pip file for installing into a virtualenv with pip.
Fixes incorrect inclusion of locale files in setup.py.

This build is currently available and can be installed into a virtualenv via pip - https://pypi.python.org/pypi/katello-cli/1.3

There are some updates to documentation, description, etc. that we can do over time, but this is a good first, working start.
