### PR TITLE
Add logging as build dependency

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -40,6 +40,7 @@ Requires:        %{name}-selinux
 Conflicts:       %{name}-headpin
 Requires:        rubygem(bundler_ext)
 BuildRequires:   rubygem(bundler_ext)
+BuildRequires:   rubygem(logging) >= 1.8.0
 BuildRequires:   asciidoc
 BuildRequires:   /usr/bin/getopt
 


### PR DESCRIPTION
During build a rake tasks (apipie) is run so we require logging during
build time.
