### PR TITLE
add rubygem-little-plugger to rhel6 repos

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -68,6 +68,7 @@
        <packagereq type="default">rubygem-i18n_data</packagereq>
        <packagereq type="default">rubygem-jammit</packagereq>
        <packagereq type="default">rubygem-ldap_fluff</packagereq>
+       <packagereq type="default">rubygem-little-plugger</packagereq>
        <packagereq type="default">rubygem-mail</packagereq>
        <packagereq type="default">rubygem-multi_json</packagereq>
        <packagereq type="default">rubygem-net-ldap</packagereq>


### PR DESCRIPTION
This gem exists in fedora, but we need it for RHEL 6.  Its already in koji, this should fix the nightly.
