### PR TITLE
Added other dependencies to comps files

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora16.xml
+++ b/rel-eng/comps/comps-katello-server-fedora16.xml
@@ -59,6 +59,7 @@
        <packagereq type="default">rubygem-tire</packagereq>
        <packagereq type="default">rubygem-yui-compressor</packagereq>
        <packagereq type="default">rubygem-runcible</packagereq>
+       <packagereq type="default">rubygem-little-plugger</packagereq>
        <packagereq type="default">rubygem-logging</packagereq>
        <packagereq type="default">sigar-java</packagereq>
        <packagereq type="default">sigar</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -57,6 +57,7 @@
        <packagereq type="default">rubygem-delayed_job</packagereq>
        <packagereq type="default">rubygem-erubis</packagereq>
        <packagereq type="default">rubygem-fast_gettext</packagereq>
+       <packagereq type="default">rubygem-flexmock</packagereq>
        <packagereq type="default">rubygem-foreman_api</packagereq>
        <packagereq type="default">rubygem-fssm</packagereq>
        <packagereq type="default">rubygem-gettext_i18n_rails</packagereq>


### PR DESCRIPTION
This should fix katello nightly, flexmock is another logging dependency for RHEL. @lzap could you please check and ACK?
