### PR TITLE
917033 - setting maximum length for system name to 250

### DIFF
--- a/src/app/models/system.rb
+++ b/src/app/models/system.rb
@@ -44,6 +44,7 @@ class System < ActiveRecord::Base
   validates_with Validators::NonLibraryEnvironmentValidator, :attributes => :environment
   # multiple systems with a single name are supported
   validates :name, :presence => true
+  validates_length_of :name, :maximum => 250
   validates_with Validators::NoTrailingSpaceValidator, :attributes => :name
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_length_of :location, :maximum => 255


### PR DESCRIPTION
We need to limit system.name field to 250 (because this is the hard limit of Candlepin).

https://bugzilla.redhat.com/show_bug.cgi?id=917033
