### PR TITLE
906859-import-messages - cleaned up error messages for both import and delete manifest

### DIFF
--- a/src/app/helpers/subscriptions_helper.rb
+++ b/src/app/helpers/subscriptions_helper.rb
@@ -22,6 +22,8 @@ module SubscriptionsHelper
   def subscriptions_system_link_helper host_id
     system = System.first(:conditions => { :uuid => host_id })
     link_to system.name, root_path + "systems#panel=system_#{system.id}"
+  rescue
+    _('System with uuid %s not found') % host_id
   end
 
   def subscriptions_activation_key_link_helper key

--- a/src/app/lib/resources/candlepin.rb
+++ b/src/app/lib/resources/candlepin.rb
@@ -153,7 +153,10 @@ module Resources
         end
 
         def export uuid
-          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'export'), self.default_headers)
+          # Export is a zip file
+          headers = self.default_headers
+          headers['accept'] = 'application/zip'
+          response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'export'), headers)
           response
         end
 

--- a/src/app/models/glue/provider.rb
+++ b/src/app/models/glue/provider.rb
@@ -219,7 +219,7 @@ module Glue::Provider
       import_logger.add_appenders(output)
 
       options.merge!(:import_logger => import_logger)
-      [Rails.logger, import_logger].each { |l| l.debug "Importing manifest for provider #{name}" }
+      [Rails.logger, import_logger].each { |l| l.debug "Importing manifest for provider #{self.name}" }
 
       begin
         pre_queue.create(:name     => "import manifest #{zip_file_path} for owner: #{self.organization.name}",
@@ -255,24 +255,7 @@ module Glue::Provider
                          :details      => output.read
         end
       rescue => error
-        if error.respond_to?(:response)
-          display_message = error.response # fix add parse displayMessage
-        elsif error.message
-          display_message = error.message
-        else
-          display_message = ""
-        end
-        display_message = ApplicationController.parse_display_message(display_message)
-
-        if options[:notify]
-          Notify.exception import_error_message(display_message), error,
-                           :request_type => 'providers__update_redhat_provider',
-                           :organization => self.organization
-        end
-
-        Rails.logger.error "error uploading subscriptions."
-        Rails.logger.error error
-        Rails.logger.error error.backtrace.join("\n")
+        display_manifest_message('import', error, options)
         raise error
       end
     end
@@ -381,8 +364,12 @@ module Glue::Provider
     end
 
     def queue_delete_manifest options
+      output        = StringIO.new
+      import_logger = Logger.new(output)
+      options.merge!(:import_logger => import_logger)
+      [Rails.logger, import_logger].each { |l| l.debug "Deleting manifest for provider #{self.name}" }
+
       begin
-        Rails.logger.debug "Deleting manifest for provider #{name}"
         pre_queue.create(:name     => "delete manifest for owner: #{self.organization.name}",
                          :priority => 3, :action => [self, :exec_delete_manifest],
                          :action_rollback => [self, :rollback_delete_manifest])
@@ -395,37 +382,54 @@ module Glue::Provider
                          :organization => self.organization
         end
       rescue Exception => error
-        if error.respond_to?(:response)
-          display_message = error.response # fix add parse displayMessage
-        elsif error.message
-          display_message = error.message
-        else
-          display_message = ""
-        end
-        display_message = ApplicationController.parse_display_message(display_message)
-
-        if options[:notify]
-          Notify.exception import_error_message(display_message), error,
-                           :request_type => 'providers__update_redhat_provider',
-                           :organization => self.organization
-        end
-
-        Rails.logger.error "error uploading subscriptions."
-        Rails.logger.error error
-        Rails.logger.error error.backtrace.join("\n")
+        display_manifest_message('delete', error, options)
         raise error
       end
     end
 
-    def delete_error_message display_message
-      error_texts = [
-          _("Subscription manifest delete for provider '%s' failed.") % self.name,
-          (_("Reason: %s") % display_message unless display_message.blank?)
-      ].compact
-      error_texts.join('<br />')
-    end
-
     protected
+
+    # Display appropriate messages when manifest import or delete fails
+    def display_manifest_message(type, error, options)
+
+      # Clean up response from candlepin
+      if error.respond_to?(:response)
+        error_response = error.response # fix add parse displayMessage
+      elsif error.message
+        error_response = "{'displayMessage' => #{error.message}, 'conflicts' => ['UNKNOWN']}"
+      else
+        error_response = "{'displayMessage' => #{_('Manifest import failed')}, 'conflicts' => ['UNKNOWN']}"
+      end
+
+      Rails.logger.error "Error during manifest #{type}: #{error_response}"
+
+      results = JSON.parse(error_response) rescue {'displayMessage' => _('Manifest %s failed') %
+                      (type == 'import') ? _('import') : _('delete'), 'conflicts' => []}
+
+      if options[:notify]
+
+        # For MANIFEST_SAME simply inform that no action was taken
+        if !results['conflicts'].nil? && results['conflicts'].include?('MANIFEST_SAME')
+          error_texts = [
+              _("Subscription manifest import for provider '%s' skipped") % self.name,
+              _("Reason: %s") % _("Manifest subscriptions unchanged from previous")
+              ]
+          error_texts.join('<br />')
+          Notify.message(error_texts, :request_type => 'providers__update_redhat_provider',
+                         :organization => self.organization)
+        else
+          error_texts = [
+              _("Subscription manifest %s for provider '%s' failed") %
+                         [(type == 'import') ? _('import') : _('delete'), self.name],
+              (_("Reason: %s") % results['displayMessage'] unless results['displayMessage'].blank?)
+              ].compact
+          error_texts.join('<br />')
+
+          Notify.error(error_texts, :request_type => 'providers__update_redhat_provider',
+                       :organization => self.organization)
+        end
+      end
+    end
 
     # There are two types of products in Candlepin: marketing and engineering.
     # When promoting, we care only about the engineering products. These are

--- a/src/app/views/subscriptions/_history.html.haml
+++ b/src/app/views/subscriptions/_history.html.haml
@@ -28,5 +28,5 @@
               %tr{:class => cycle_class}
                 %td{:colspan => 2}
                   &nbsp; &nbsp; &nbsp;
-                  = _('Manifest from ') % status['webAppPrefix']
+                  = _('Manifest from %s') % status['upstreamName']
                   = link_to status['webAppPrefix'], "http://#{status['webAppPrefix']}#{status['upstreamId']}", :target => '_blank'

--- a/src/app/views/subscriptions/_history_items.html.haml
+++ b/src/app/views/subscriptions/_history_items.html.haml
@@ -27,7 +27,7 @@
                 %tr{:class => cycle_class}
                   %td{:colspan => 2}
                     &nbsp; &nbsp; &nbsp;
-                    = _('Manifest from ') % status['webAppPrefix']
+                    = _('Manifest from %s') % status['upstreamName']
                     = subscriptions_manifest_link_helper status
 
 = render :template => "layouts/tupane_layout"

--- a/src/app/views/subscriptions/_new.html.haml
+++ b/src/app/views/subscriptions/_new.html.haml
@@ -29,7 +29,7 @@
           .grid_3.ra.fieldset
             =label :uuid, :uuid, _("Upstream Distributor")
           .grid_9.la.fl
-            = subscriptions_manifest_link_helper({'webAppPrefix'=>@details[:webAppPrefix], 'upstreamId'=>@details['upstreamUuid']}, @details['upstreamUuid'])
+            = subscriptions_manifest_link_helper({'webAppPrefix'=>@details[:webAppPrefix], 'upstreamId'=>@details['upstreamUuid']}, @details['displayName'])
         - if @provider.editable? && Katello.config.headpin?
           - if !@provider.manifest_task || @provider.manifest_task.finished?
             = form_for @provider, :html => {:method => :post, :id => :delete_manifest}, :remote => true, :url => delete_manifest_subscriptions_path do |f|
@@ -104,7 +104,7 @@
                 %tr{:class => cycle_class}
                   %td{:colspan => 2}
                     &nbsp; &nbsp; &nbsp;
-                    = _('Manifest from ') % status['webAppPrefix']
+                    = _('Manifest from %s') % status['upstreamName']
                     = subscriptions_manifest_link_helper status
 
           - if @statuses.length > 3

--- a/src/test/fixtures/models/providers.yml
+++ b/src/test/fixtures/models/providers.yml
@@ -9,3 +9,9 @@ redhat:
   description: Provider of all your red hat needs
   organization: acme_corporation
   provider_type: 'Red Hat'
+
+candlepin_redhat:
+  name: Red Hat Provider
+  description: Provider of all your red hat needs
+  organization: candlepin_org
+  provider_type: 'Red Hat'

--- a/src/test/fixtures/vcr_cassettes/glue_candlepin_provider.yml
+++ b/src/test/fixtures/vcr_cassettes/glue_candlepin_provider.yml
@@ -1,0 +1,83 @@
+--- 
+recorded_with: VCR 2.4.0
+http_interactions: 
+- request: 
+    method: post
+    uri: https://localhost:8443/candlepin/owners/
+    body: 
+      string: "{\"displayName\":\"Candlepin_Org\",\"key\":\"candlepin_org_label\",\"contentPrefix\":\"/candlepin_org_label/$env\"}"
+    headers: 
+      Accept: 
+      - "*/*; q=0.5, application/xml"
+      Authorization: 
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello", oauth_nonce="UGpVnuE4qryR05y6vDp53HMqvAK6dMBOUklEYPbyY", oauth_signature="xcDBjnbyFIASedClQb1OeaYQV1U%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1362490743", oauth_version="1.0"
+      Content-Length: 
+      - "103"
+      Cp-User: 
+      - admin
+      Accept-Encoding: 
+      - gzip, deflate
+      Accept-Language: 
+      - en
+      Content-Type: 
+      - application/json
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Tue, 05 Mar 2013 13:39:03 GMT
+      X-Candlepin-Version: 
+      - 0.7.26-1
+      Content-Length: 
+      - "379"
+      Server: 
+      - Apache-Coyote/1.1
+      Content-Type: 
+      - application/json
+    body: 
+      string: |-
+        {
+          "created" : "2013-03-05T13:39:03.515+0000",
+          "updated" : "2013-03-05T13:39:03.515+0000",
+          "parentOwner" : null,
+          "id" : "ff8080813d373ef7013d3ac6dadb0005",
+          "key" : "candlepin_org_label",
+          "displayName" : "Candlepin_Org",
+          "contentPrefix" : "/candlepin_org_label/$env",
+          "defaultServiceLevel" : null,
+          "upstreamUuid" : null,
+          "href" : "/owners/candlepin_org_label"
+        }
+    http_version: 
+  recorded_at: Tue, 05 Mar 2013 13:39:03 GMT
+- request: 
+    method: delete
+    uri: https://localhost:8443/candlepin/owners/candlepin_org_label
+    body: 
+      string: ""
+    headers: 
+      Accept: 
+      - "*/*; q=0.5, application/xml"
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="f8Jek8Sssrb1p4Rji1EhQTm38m33yWJ7PeHvZWkhaqE", oauth_signature="b5cGbNORNvKRAF6qqBpV5EO%2FKtU%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1362490743", oauth_version="1.0"
+      Cp-User: 
+      - admin
+      Accept-Encoding: 
+      - gzip, deflate
+  response: 
+    status: 
+      code: 204
+      message: No Content
+    headers: 
+      Date: 
+      - Tue, 05 Mar 2013 13:39:03 GMT
+      X-Candlepin-Version: 
+      - 0.7.26-1
+      Server: 
+      - Apache-Coyote/1.1
+    body: 
+      string: ""
+    http_version: 
+  recorded_at: Tue, 05 Mar 2013 13:39:03 GMT

--- a/src/test/glue/candlepin/provider_test.rb
+++ b/src/test/glue/candlepin/provider_test.rb
@@ -1,0 +1,114 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'minitest_helper'
+require 'mocha'
+require './test/support/user_support'
+
+
+class GlueCandlepinProviderTestBase < MiniTest::Rails::ActiveSupport::TestCase
+  extend  ActiveRecord::TestFixtures
+
+  fixtures :all
+
+  def self.before_suite
+    load_fixtures
+    # TODO: RAILS32 remove top reference to load_fixtures
+    if @loaded_fixtures.nil?
+      @loaded_fixtures = load_fixtures
+    end
+
+    services  = ['Pulp', 'ElasticSearch', 'Foreman']
+    models    = ['User', 'KTEnvironment', 'Organization', 'Product']
+    disable_glue_layers(services, models)
+
+    User.current = User.find(@loaded_fixtures['users']['admin']['id'])
+    VCR.insert_cassette('glue_candlepin_provider', :match_requests_on => [:path, :params, :method, :body_json])
+
+    @@dev      = KTEnvironment.find(@loaded_fixtures['environments']['candlepin_dev']['id'])
+    @@org      = Organization.find(@loaded_fixtures['organizations']['candlepin_org']['id'])
+    @@provider = Provider.find(@loaded_fixtures['providers']['candlepin_redhat']['id'])
+
+    @@org.set_owner
+  end
+
+  def self.after_suite
+    @@org.del_owner
+  ensure
+    VCR.eject_cassette
+  end
+
+end
+
+class GlueCandlepinProviderTestImport < GlueCandlepinProviderTestBase
+
+  def self.before_suite
+    super
+  end
+
+  def self.after_suite
+    super
+  end
+
+  def setup
+    super
+  end
+
+  #def test_manifest_import_nonexistent
+  #  assert_raises(RestClient::Gone) do
+  #    @@provider.queue_import_manifest("#{Dir.pwd}/fixtures/manifests/nonexistent.zip", {:notify => true})
+  #  end
+  #end
+
+  def test_manifest_import
+    skip "Need testable manifests"
+
+    # Import the newest org1 manifest - should work
+    manifest = 'minitest-org1-v2'
+    VCR.use_cassette("support/candlepin/provider_#{manifest}", :match_requests_on => [:path, :params, :method]) do
+      @@provider.queue_import_manifest("test/fixtures/manifests/#{manifest}.zip", {:notify => true})
+      notice = Notice.find_by_text("Subscription manifest uploaded successfully for provider 'Red Hat Provider'. Please enable the repositories you want to sync by selecting 'Enable Repositories' and selecting individual repositories to be enabled.")
+      assert notice, "Notice of successful import of #{manifest}.zip missing"
+      notice.destroy if notice # clean up
+    end
+
+    # Import the older org1 manifest - should fail
+    manifest = 'minitest-org1-v1'
+    VCR.use_cassette("support/candlepin/provider_#{manifest}", :match_requests_on => [:path, :params, :method]) do
+      assert_raises(RestClient::Conflict) do
+        @@provider.queue_import_manifest("test/fixtures/manifests/#{manifest}.zip", {:notify => true})
+      end
+      notice = Notice.find_by_text("Subscription manifest uploaded successfully for provider 'Red Hat Provider'. Please enable the repositories you want to sync by selecting 'Enable Repositories' and selecting individual repositories to be enabled.")
+      assert notice, "Notice of successful import of #{manifest}.zip missing"
+      notice.destroy if notice # clean up
+    end
+
+    # Import different org2 manifest - should fail
+    manifest = 'minitest-org2-v1'
+    VCR.use_cassette("support/candlepin/provider_#{manifest}", :match_requests_on => [:path, :params, :method]) do
+      @@provider.queue_import_manifest("test/fixtures/manifests/#{manifest}.zip", {:notify => true})
+      notice = Notice.find_by_text("Subscription manifest uploaded successfully for provider 'Red Hat Provider'. Please enable the repositories you want to sync by selecting 'Enable Repositories' and selecting individual repositories to be enabled.")
+      assert notice, "Notice of successful import of #{manifest}.zip missing"
+      notice.destroy if notice # clean up
+    end
+
+    manifest = 'minitest-org1-v2'
+    VCR.use_cassette("support/candlepin/provider_#{manifest}", :match_requests_on => [:path, :params, :method]) do
+      @@provider.queue_delete_manifest({:notify => true})
+      notice = Notice.find_by_text("Subscription manifest deleted successfully for provider 'Red Hat Provider'.")
+      assert notice, "Notice of successful delete of #{manifest}.zip missing"
+      notice.destroy if notice # clean up
+    end
+
+  end
+
+end


### PR DESCRIPTION
Minitest is skipped until non-private manifests can be created to excercise the code and be checked into git
