### PR TITLE
917639 - cli - fix changeset update add_repo command

### DIFF
--- a/cli/src/katello/client/core/changeset.py
+++ b/cli/src/katello/client/core/changeset.py
@@ -234,8 +234,8 @@ class UpdateContent(ChangesetAction):
 
         def repo_id(self, options):
             prod_opts = self.product_options(options)
-            repo = get_repo(self.org_name, prod_opts['name'], prod_opts['label'], prod_opts['id'],
-                options['name'], self.env_name)
+            repo = get_repo(self.org_name, options['name'], prod_opts['name'],
+                prod_opts['label'], prod_opts['id'], self.env_name)
             return repo['id']
 
         def template_id(self, options):


### PR DESCRIPTION
It appears tha the ordering of the arguments to get_repo
may have been altered during a merge.  This fixes it so that
the user may now execute the following:

changeset update --from_product product --add_repo "repo 1"
   --org ACME_Corporation --name cs --environment dev
