### PR TITLE
917608 - cli - fix activation key update

### DIFF
--- a/cli/src/katello/client/core/activation_key.py
+++ b/cli/src/katello/client/core/activation_key.py
@@ -255,7 +255,9 @@ class Update(ActivationKeyAction):
 
         if view_label is not None:
             view = get_content_view(orgName, view_label)
-        view_id = view['id'] if view else None
+            view_id = view['id']
+        else:
+            view_id = None
 
         try:
             templateId = self.get_template_id(key['environment_id'], templateName)


### PR DESCRIPTION
Prior to this commit user would get error similar to :
   error: local variable 'view' referenced before assignment

when executing command like:
   activation_key update --org ACME_Corporation --name key1 --limit 2
