### PR TITLE
Fixes #1658 - Removes all user notifications regarding login due

### DIFF
--- a/src/app/controllers/user_sessions_controller.rb
+++ b/src/app/controllers/user_sessions_controller.rb
@@ -100,26 +100,16 @@ class UserSessionsController < ApplicationController
       if current_organization.nil?
         if orgs.length == 1
           params[:org_id] = orgs[0].id
-          # notice the user
-          notify.success _("Login Successful")
           set_org
         elsif !user_default_org.nil? && orgs.include?(user_default_org)
           params[:org_id] = user_default_org.id
-          # notice the user
-          notify.success _("Login Successful, logging into '%s' ") % user_default_org.name
           set_org
         elsif orgs.length < 1
-          # notice the user, please choose an org
-          notify.success _("Login Successful, please contact administrator to get permission to access an organization.")
           render :partial =>"/user_sessions/interstitial.js", :locals=> {:num_orgs => orgs.length, :redir_path => dashboard_index_path}
         else
-          # notice the user, please choose an org
-          notify.success _("Login Successful, please choose an Organization")
           render :partial =>"/user_sessions/interstitial.js", :locals=> {:num_orgs => orgs.length, :redir_path => dashboard_index_path}
         end
       else
-        # notice the user, please choose an org
-        notify.success _("Login Successful, please choose an Organization")
         render :partial =>"/user_sessions/interstitial.js", :locals=> {:num_orgs => orgs.length, :redir_path => dashboard_index_path}
       end
     end

--- a/src/app/stylesheets/katello.scss
+++ b/src/app/stylesheets/katello.scss
@@ -1291,3 +1291,15 @@ footer a {
     width: $static_width - 20;
   }
 }
+
+.flash_hud {
+  margin: 5px 0;
+}
+.flash_messages {
+  background-color: $helptip-background_color;
+  display: block; 
+  padding: 12px;
+  border: 1px solid $helptip-border_color;
+  margin: 10px auto 5px auto;
+  @extend .clearfix;
+}

--- a/src/app/views/dashboard/index.html.haml
+++ b/src/app/views/dashboard/index.html.haml
@@ -1,6 +1,10 @@
+= javascript :scroll_pane, :dashboard
 
-=javascript :scroll_pane, :dashboard
-
+- if current_user.allowed_organizations.length == 0
+  .grid_16.flash_hud
+    %ul.flash_messages.warning
+      %li
+        = _("You do not currently have access to any organizations.  Please contact an administrator to get permission to access an organization.")
 
 .sixty
   - if current_organization && current_organization.readable?


### PR DESCRIPTION
to redundancy and adds a helptip style message on the dashboard
for users without access to any organizations to let them know what
their next steps are.

![user_no_perms_notice](https://f.cloud.github.com/assets/293363/238510/92b25b7c-883a-11e2-86ea-3041bf13e94d.png)
