### PR TITLE
getting rid of that pesky deprecated message

### DIFF
--- a/src/lib/katello/load_configuration.rb
+++ b/src/lib/katello/load_configuration.rb
@@ -45,7 +45,7 @@ module Katello
               has_keys 'root'
               validate :root do
                 has_keys 'level'
-                if config.type == 'file'
+                if config[:type] == 'file'
                   has_keys *%w(age keep pattern filename)
                   has_keys 'path' unless early?
                 end


### PR DESCRIPTION
'/home/user/katello/src/lib/katello/load_configuration.rb:48: warning: Object#type is deprecated; use Object#class'
