### PR TITLE
Fixing "Error loading plugin 'yard-activerecord'" noise

### DIFF
--- a/src/.yardopts
+++ b/src/.yardopts
@@ -5,7 +5,7 @@
 --markup markdown
 --template default
 --template-path ./yard-template
---plugin yard-activerecord
+#--plugin yard-activerecord
 --load ./lib/monkeys/yard_svg_fix.rb
 --output-dir=./yardoc/
 --main=README.md


### PR DESCRIPTION
I think that if we have yard-activerecord commented out in bundler.d/development.rb, that we should also comment out the option in yardopts so we don't get these warning messages.
