### PR TITLE
adding ruby193-rubygem-hpricot to el6 comp

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -161,6 +161,7 @@
        <packagereq type="default">ruby193-rubygem-hike</packagereq>
        <packagereq type="default">ruby193-rubygem-hoe</packagereq>
        <packagereq type="default">ruby193-rubygem-hooks</packagereq>
+       <packagereq type="default">ruby193-rubygem-hpricot</packagereq>
        <packagereq type="default">ruby193-rubygem-http_connection</packagereq>
        <packagereq type="default">ruby193-rubygem-i18n</packagereq>
        <packagereq type="default">ruby193-rubygem-i18n_data</packagereq>


### PR DESCRIPTION
SSIA Resolving:

```
--> Finished Dependency Resolution
Error: Package: ruby193-rubygem-haml-3.1.6-2.el6.noarch (katello)
           Requires: ruby193-rubygem(ruby_parser)
Error: Package: ruby193-rubygem-haml-3.1.6-2.el6.noarch (katello)
           Requires: ruby193-rubygem(hpricot)
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```
