### PR TITLE
force loading of glue module before defining any other modules in Glue namespace

### DIFF
--- a/src/app/lib/glue/queue.rb
+++ b/src/app/lib/glue/queue.rb
@@ -13,6 +13,10 @@
 # this forces loading of glue.rb and its methods
 # otherwise we end up with an empty Glue module
 # when caching of classes is Rails is on
+#
+# PLEASE DO NOT REMOVE WITHOUT TESTING WITH
+# config.cache_classes = true
+#
 require "glue"
 
 # represents tasks queue for glue


### PR DESCRIPTION
Or we end up with an empty Glue module when class caching in Rails is turned on
