### PR TITLE
DO NOT MERGE - Remove ZenTest and autotest

### DIFF
--- a/src/bundler.d/test.rb
+++ b/src/bundler.d/test.rb
@@ -1,8 +1,4 @@
 group :test do
-  # NOTE: ZenTest-4.8.4 contains a spec parsing error
-  gem 'ZenTest', '>= 4.4.0', '< 4.8.4', :require => "autotest"
-  gem 'autotest-rails', '>= 4.1.0'
-
   # (also appears in development group)
   gem 'rspec-rails', '>= 2.0.0'
 

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -365,8 +365,6 @@ BuildArch:       noarch
 Requires:        %{name} = %{version}-%{release}
 Requires:        %{name}-devel = %{version}-%{release}
 # dependencies from bundler.d/test.rb
-Requires:        rubygem(ZenTest) >= 4.4.0
-Requires:        rubygem(autotest-rails) >= 4.1.0
 Requires:        rubygem(rspec-rails) >= 2.0.0
 Requires:        rubygem(webrat) >= 0.7.3
 Requires:        rubygem(nokogiri) >= 0.9.9


### PR DESCRIPTION
This is to just see if our project will be fixed in TravisCI. I've emailed the devel list and we should wait to hear if people are using these before merging.
