### PR TITLE
Fixing Travis by not using parallel_tests

### DIFF
--- a/scripts/ci/katello_pull_request_tests.sh
+++ b/scripts/ci/katello_pull_request_tests.sh
@@ -24,9 +24,15 @@ echo "********* Katello RSPEC Unit Tests ****************"
 psql -c "CREATE USER katello WITH PASSWORD 'katello';" -U postgres
 psql -c "ALTER ROLE katello WITH CREATEDB" -U postgres
 psql -c "CREATE DATABASE katello_test OWNER katello;" -U postgres
-bundle exec rake parallel:create VERBOSE=false
-bundle exec rake parallel:load_schema VERBOSE=false > /dev/null
-bundle exec rake ptest:spec
+
+# once this is fixed, use ptests again http://tinyurl.com/ptestfix
+#bundle exec rake parallel:create VERBOSE=false
+#bundle exec rake parallel:load_schema VERBOSE=false > /dev/null
+#bundle exec rake ptest:spec
+
+RAILS_ENV=test bundle exec rake db:create
+bundle exec rake db:test:load > /dev/null
+bundle exec rake spec
 if [ $? -ne 0 ]
 then
   exit 1

--- a/src/bundler.d/test.rb
+++ b/src/bundler.d/test.rb
@@ -1,6 +1,6 @@
 group :test do
   # NOTE: ZenTest-4.8.4 contains a spec parsing error
-  gem 'ZenTest', '>= 4.4.0', '< 4.8.4', :require => "autotest"
+  #gem 'ZenTest', '>= 4.4.0', '< 4.8.4', :require => "autotest"
   gem 'autotest-rails', '>= 4.1.0'
 
   # (also appears in development group)


### PR DESCRIPTION
This is to remove parallel_tests from Travis all together until the gem supports bundler 1.3.
