### PR TITLE
Never warp navigation items

### DIFF
--- a/src/app/stylesheets/_menu.scss
+++ b/src/app/stylesheets/_menu.scss
@@ -9,6 +9,7 @@ nav {
     min-height: 15px;
     height: 35px;
     overflow: hidden;
+    white-space: nowrap;
     .arrow_icon_menu {
       height: 11px;
       width: 13px;


### PR DESCRIPTION
Otherwise it might happen that some menu item just disappears to 
overwrite:hidden area. It's better to show at least part of it (and ideally
customize the widths so that it fits into the screen).

This commit fixes a problem, when 'Changeset Management' navigation is not
visible when on Content tab.
