### PR TITLE
Destroy default content view on cascade when deleting environment

### DIFF
--- a/src/app/models/kt_environment.rb
+++ b/src/app/models/kt_environment.rb
@@ -56,7 +56,7 @@ class KTEnvironment < ActiveRecord::Base
   has_many :content_view_version_environments, :foreign_key=>:environment_id
   has_many :content_view_versions, :through=>:content_view_version_environments, :inverse_of=>:environments
 
-  has_one :default_content_view, :class_name => "ContentView", :foreign_key => :environment_default_id
+  has_one :default_content_view, :class_name => "ContentView", :foreign_key => :environment_default_id, :dependent => :destroy, :validate => true
 
   has_many :users, :foreign_key => :default_environment_id, :inverse_of => :default_environment, :dependent => :nullify
 
@@ -281,7 +281,8 @@ class KTEnvironment < ActiveRecord::Base
       content_view_version = ContentViewVersion.new(:version => 1, :content_view => content_view)
       content_view_version.environments << self
 
-      content_view_version.save! # saves both content_view and content_view_version
+      # content_view is saved with this as well
+      content_view_version.save!
     end
   end
 end

--- a/src/test/models/content_view_test.rb
+++ b/src/test/models/content_view_test.rb
@@ -16,7 +16,7 @@ class ContentViewTest < MiniTest::Rails::ActiveSupport::TestCase
   fixtures :all
 
   def self.before_suite
-    models = ["Organization", "KTEnvironment", "User", "ContentViewEnvironment"]
+    models = ["Organization", "KTEnvironment", "User", "ContentViewEnvironment", "Repository", "System"]
     services = ["Candlepin", "Pulp", "ElasticSearch"]
     disable_glue_layers(services, models)
   end
@@ -104,6 +104,30 @@ class ContentViewTest < MiniTest::Rails::ActiveSupport::TestCase
     content_view = content_view.reload
     assert_equal content_view.environment_default.id, env.id
     assert_equal content_view, env.default_content_view
+  end
+
+  def test_environment_default_content_view_destroy
+    env = @dev
+    content_view = FactoryGirl.create(:content_view, :default => true)
+    env.default_content_view = content_view
+    env.save!
+    env.destroy
+    assert_nil ContentView.find_by_id(content_view.id)
+  end
+
+  def test_environment_default_content_view_invalid
+    new_env_name = "EnvWithInvalidContentView"
+    content_view = FactoryGirl.create(:content_view,
+                                      :organization_id => @dev.organization_id,
+                                      :default => true,
+                                      :name => "Default View for #{new_env_name}")
+    env = KTEnvironment.new(@dev.attributes.merge("name" => new_env_name,
+                                                  "label" => new_env_name,
+                                                  "prior" => @library))
+    exception = assert_raises(ActiveRecord::RecordInvalid) { env.save! }
+    content_view_errors = exception.record.environments.first.
+      default_content_view.errors.full_messages.join(", ")
+    assert_match(/Name has already been taken/, content_view_errors)
   end
 
   def test_changesets


### PR DESCRIPTION
Also save the default content_view explicitly. Here is what happened without
this changes:
1. Create environment (default content view and content_view_version was
   crated)
2. Delete the environment (`content_view` stayed there because
   `:dependent=> :destroy` was missing)
3. When creating an environment with the
   same name, the content_view was not created, because another content view with
   the same name already existed. However, because the content_view was being
   saved as part of saving content_view_version, the exception was not thrown
   (and the content_view_version was saved successfully without association to 
   any content_view)
4. When promoting some time after this incident (that
   happened unnoticed), "nil pointer exception" occurred while promoting, because 
   the default content view was not there.
