### PR TITLE
uninitialized constant Resources::AbstractModel::Invalid

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -607,11 +607,7 @@ usermod -a -G katello-shared tomcat
 %{homedir}/app/lib/navigation
 %{homedir}/app/lib/notifications
 %{homedir}/app/lib/validators
-%dir %{homedir}/app/lib/resources
 %{homedir}/app/lib/resources/cdn.rb
-%{homedir}/app/lib/resources/abstract_model.rb
-%dir %{homedir}/app/lib/resources/abstract_model
-%{homedir}/app/lib/resources/abstract_model/indexed_model.rb
 %{homedir}/lib/tasks
 %exclude %{homedir}/lib/tasks/rcov.rake
 %exclude %{homedir}/lib/tasks/yard.rake
@@ -664,6 +660,10 @@ usermod -a -G katello-shared tomcat
 %{homedir}/db/schema.rb
 %dir %{homedir}/lib
 %dir %{homedir}/app/lib
+%dir %{homedir}/app/lib/resources
+%{homedir}/app/lib/resources/abstract_model.rb
+%dir %{homedir}/app/lib/resources/abstract_model
+%{homedir}/app/lib/resources/abstract_model/indexed_model.rb
 %{homedir}/lib/util
 %{homedir}/app/lib/util
 %{homedir}/script/service-wait
@@ -731,7 +731,6 @@ usermod -a -G katello-shared tomcat
 %{homedir}/lib/monkeys
 %{homedir}/app/lib/navigation
 %{homedir}/app/lib/notifications
-%{homedir}/app/lib/resources
 %{homedir}/app/lib/validators
 %exclude %{homedir}/app/lib/resources/candlepin.rb
 %exclude %{homedir}/app/lib/resources/abstract_model.rb


### PR DESCRIPTION
Installed today's nightly build and when I click on the User link (next to Notifications count, upper right corner), the page I see displays: 

```
NameError in UsersController#index

uninitialized constant Resources::AbstractModel::Invalid

Rails.root: /usr/share/katello
Application Trace | Framework Trace | Full Trace

app/lib/notifications/notifier.rb:76:in `exception'
app/controllers/application_controller.rb:412:in `render_error'
app/controllers/application_controller.rb:55:in `__bind_1363273867_580831'
app/controllers/application_controller.rb:672:in `call'
app/controllers/application_controller.rb:672:in `execute_rescue'
app/controllers/application_controller.rb:55:in `__bind_1363273867_580831'

Request

Parameters:

{"only"=>"true",
 "id"=>"1"}

Show session dump

Show env dump
Response

Headers:

None
```
