### PR TITLE
Do not use two %s in translation string

### DIFF
--- a/src/app/models/glue/provider.rb
+++ b/src/app/models/glue/provider.rb
@@ -419,8 +419,9 @@ module Glue::Provider
                          :organization => self.organization)
         else
           error_texts = [
-              _("Subscription manifest %s for provider '%s' failed") %
-                         [(type == 'import') ? _('import') : _('delete'), self.name],
+              ((type == 'import') ? _("Subscription manifest import for provider '%{name}' failed") % {:name => self.name} :
+                  _("Subscription manifest delete for provider '%{name}' failed") % {:name => self.name}
+              ),
               (_("Reason: %s") % results['displayMessage'] unless results['displayMessage'].blank?)
               ].compact
           error_texts.join('<br />')


### PR DESCRIPTION
Introduced in commit b435a7a2.
Two %s are hard to translate.
Addressing:
Found 1 malformed strings
app/models/glue/provider.rb: _("Subscription manifest %s for provider '%s' failed") %
RPM build errors:
error: Bad exit status from /var/tmp/rpm-tmp.E0AL96 (%build)
    Bad exit status from /var/tmp/rpm-tmp.E0AL96 (%build)

Additionally building string from two translated strings are very often hard for translators
to manage.
See BZ 886718 for example of such case.
