### PR TITLE
i18n - fixing regression in gettext packaging for cli

### DIFF
--- a/cli/locale/Makefile
+++ b/cli/locale/Makefile
@@ -2,6 +2,7 @@
 SRC_DIR = ../src/katello
 POFILES = $(shell find . -name '*.po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
+POXFILES = $(patsubst %.po,%.pox,$(POFILES))
 
 .PHONY: POTFILES.in
 
@@ -9,11 +10,22 @@ MOFILES = $(patsubst %.po,%.mo,$(POFILES))
 %.mo: %.po
 	msgfmt -o $@ $<
 
+all-mo: $(MOFILES)
+
+# Check for malformed strings
+# TODO - enable endwhitespace, endpunc, puncspacing, options filters
+%.pox: %.po
+	msgfmt -c $<
+	pofilter --nofuzzy -t variables -t blank -t urls -t emails -t long -t newlines \
+		-t printf -t validchars --gnome $< > $@
+	! grep -q msgid $@
+
+check: $(POXFILES)
+
 POTFILES.in:
 	# Generate the POTFILES.in file expected by intltool. It wants one
 	# file per line.
 	find ${SRC_DIR}/ -name "*.py" | sed 's/^..\///g' > POTFILES.in
-
 
 gettext: POTFILES.in
 	# Extract strings from our source files. Any comments on the line above
@@ -31,11 +43,6 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
-
-all-mo: $(MOFILES)
-
 clean:
-	rm -f POTFILES.in
-	find . -name "*.mo" -exec rm '{}' ';'
-	rm -rf build
-
+	rm -f POTFILES.in messages.mo
+	find . \( -name "*.mo" -o -name "*.pox" \) -exec rm -f '{}' ';'


### PR DESCRIPTION
Our katello-cli was missing all MO files. This was due to %find_lang macro without file list used in %files.

I have fixed that. Also, I moved our pofilter check into Makefile and rewritten it so it can leverage full power of GNU Make on multicore systems, because this check was a little bit slow. On my system:

```
# make check
real 0m8.613s
user 0m7.577s
sys 0m0.627s
```

Now with my patch (assuming 4 core box):

```
# make check -j4
real 0m4.202s
user 0m12.715s
sys 0m0.850s
```

I am going to do this improvement also on katello and katello-disconnected.
