### PR TITLE
i18n - enabling katello domain and improving check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ src/config/katello.yml
 src/.DS_Store
 src/bundler.d/local*.rb
 katello-utils/po/*/*.mo
+katello-utils/po/*/*.pox
+katello-utils/po/*.mo
 katello-utils/redhat-uep.pem
 katello-utils/.rvmrc*
 src/doc/graphs/*.svg

--- a/katello-utils/bin/katello-disconnected
+++ b/katello-utils/bin/katello-disconnected
@@ -53,8 +53,10 @@ else
   locale_path = "#{DISCONNECTED_PREFIX}/locale"
   FastGettext.add_text_domain(APP_NAME, :path => locale_path)
 end
+# we also need katello domain for several translations from the katello lib
+FastGettext.add_text_domain("katello", :path => "#{KATELLO_PREFIX}/locale")
+# configure default domain and locales
 FastGettext.text_domain = APP_NAME
-# TODO - add katello ("app") text domain as well to translate katello/lib strings
 FastGettext.available_locales = ['en'] + Dir.entries(locale_path).reject {|d| d =~ /(^\.|pot$)/ }
 FastGettext.locale = (ENV['LC_ALL'] || ENV['LC_MESSAGES'] || ENV['LANG'] || 'en').sub(/\.\w+$/, "")
 

--- a/katello-utils/katello-utils.spec
+++ b/katello-utils/katello-utils.spec
@@ -69,9 +69,7 @@ cloud lifecycle management application.
 %{scl_ruby} -c bin/katello-disconnected
 
 # pack gettext i18n PO files into MO files
-pushd po
-    make
-popd
+make -C po check all-mo %{?_smp_mflags}
 
 # build katello-configure man page
 pushd man
@@ -92,8 +90,8 @@ install -d -m 0755 %{buildroot}%{_datadir}/katello-disconnected/locale
 pushd po
 for MOFILE in $(find . -name "*.mo"); do
     DIR=$(dirname "$MOFILE")
-    install -d -m 0755 %{buildroot}%{_datadir}/katello-disconnected/locale/$DIR
-    install -m 0644 $DIR/*.mo %{buildroot}%{_datadir}/katello-disconnected/locale/$DIR
+    install -d -m 0755 %{buildroot}%{_datadir}/katello-disconnected/locale/$DIR/LC_MESSAGES
+    install -m 0644 $DIR/*.mo %{buildroot}%{_datadir}/katello-disconnected/locale/$DIR/LC_MESSAGES
 done
 popd
 

--- a/katello-utils/po/Makefile
+++ b/katello-utils/po/Makefile
@@ -5,12 +5,22 @@
 POTFILE = katello-disconnected.pot
 POFILES = $(shell find . -name '*.po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
+POXFILES = $(patsubst %.po,%.pox,$(POFILES))
 
 %.mo: %.po
 	msgfmt -o $@ $<
 
 # Generate MO files from PO files
 all-mo: $(MOFILES)
+
+# Check for malformed strings
+%.pox: %.po
+	msgfmt -c $<
+	pofilter --nofuzzy -t variables -t blank -t urls -t emails -t long -t newlines \
+		-t endwhitespace -t endpunc -t puncspacing -t options -t printf -t validchars --gnome $< > $@
+	! grep -q msgid $@
+
+check: $(POXFILES)
 
 # Merge PO files
 update-po:
@@ -26,4 +36,5 @@ uniq-po:
 
 # Remove all MO files
 clean:
-	find . -name "*.mo" -exec rm '{}' ';'
+	-rm -f messages.mo
+	find . \( -name "*.mo" -o -name "*.pox" \) -exec rm -f '{}' ';'


### PR DESCRIPTION
And this patch adds Mirek's check to disconnected and also adds newly renamed "katello" domain into "katello-disconnected" domain because we use some katello libraries and we want these to be translated too.
