### PR TITLE
Katello Configure - Adds HTTPD templates for pulp and Katello that

### DIFF
--- a/katello-configure/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
+++ b/katello-configure/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
@@ -38,6 +38,9 @@ NameVirtualHost *:443
   ExpiresActive On
   <Directory "/usr/share/katello/public/">
     ExpiresDefault "access plus 1 year"
+    <%- if scope.lookupvar('operatingsystem') == 'Fedora' && scope.lookupvar('operatingsystemrelease') == '18' -%>
+    Require all granted
+    <%- end -%>
   </Directory>
 
   ProxyPass /<%= scope.lookupvar("katello::params::deployment_url") %>/assets !

--- a/katello-configure/modules/pulp/templates/etc/httpd/conf.d/pulp.conf.erb
+++ b/katello-configure/modules/pulp/templates/etc/httpd/conf.d/pulp.conf.erb
@@ -37,3 +37,13 @@ WSGIImportScript /srv/pulp/webservices.wsgi process-group=pulp application-group
     SSLOptions +StdEnvVars +ExportCertData
     SSLVerifyClient optional
 </Files>
+
+<%- if scope.lookupvar('operatingsystem') == 'Fedora' && scope.lookupvar('operatingsystemrelease') == '18' -%>
+<Directory /srv/pulp>
+  Require all granted
+</Directory> 
+
+<VirtualHost *:80>
+  Include /etc/pulp/vhosts80/*.conf
+</VirtualHost>
+<%- end -%>


### PR DESCRIPTION
are specific to the httpd version availabe in Fedora18.
