### PR TITLE
jeditable - update to trim datepicker content and reset data on options

### DIFF
--- a/src/public/javascripts/jquery.jeditable.custominputs.js
+++ b/src/public/javascripts/jquery.jeditable.custominputs.js
@@ -167,6 +167,10 @@ $(document).ready(function() {
             return input;
         },
 
+        content : function(string, settings, original) {
+            $(':input:first', this).val($.trim(string));
+        },
+
         /* attach jquery.ui.datepicker to the input element */
         plugin: function( settings, original ) {
             var form = this, input = form.find( "input" );

--- a/src/public/javascripts/jquery.jeditable.helpers.js
+++ b/src/public/javascripts/jquery.jeditable.helpers.js
@@ -47,6 +47,7 @@ KT.editable = (function(){
                 $(this).editable('destroy');
                 var settings = {
                     type        :  'text',
+                    data        :  null,
                     width       :  270,
                     name        :  $(this).attr('name'),
                     onsuccess   :  function(result, status, xhr) {
@@ -62,6 +63,7 @@ KT.editable = (function(){
                 $(this).editable('destroy');
                 $(this).editable($(this).attr('url'), {
                     type        :  'ajaxupload',
+                    data        :  null,
                     method      :  'PUT',
                     name        :  $(this).attr('name'),
                     cancel      :  i18n.cancel,
@@ -82,6 +84,7 @@ KT.editable = (function(){
                 $(this).editable('destroy');
                 var settings = {
                     type        :  'password',
+                    data        :  null,
                     width       :  270,
                     name        :  $(this).attr('name')
                 };
@@ -93,6 +96,7 @@ KT.editable = (function(){
                 $(this).editable('destroy');
                 var settings = {
                     type        :  'text',
+                    data        :  null,
                     width       :  270,
                     name        :  $(this).attr('name')
                 };
@@ -103,10 +107,11 @@ KT.editable = (function(){
             $('.edit_textarea').each(function() {
                 $(this).editable('destroy');
                 var settings = {
-                    type            :  'textarea',
-                    name            :  $(this).attr('name'),
-                    rows            :  8,
-                    cols            :  36
+                    type        :  'textarea',
+                    data        :  null,
+                    name        :  $(this).attr('name'),
+                    rows        :  8,
+                    cols        :  36
                 };
                 $(this).editable($(this).attr('data-url'), $.extend(common_settings, settings));
             });
@@ -148,6 +153,7 @@ KT.editable = (function(){
                 var settings = {
                     method          :  'POST',
                     type            :  'number',
+                    data            :  null,
                     value           :  $.trim($(this).html()),
                     height          :  10,
                     width           :  35,
@@ -181,6 +187,7 @@ KT.editable = (function(){
                 $(this).editable('destroy');
                 var settings = {
                     type        :  'datepicker',
+                    data        :  null,
                     width       :  100,
                     name        :  $(this).attr('name')
                 };
@@ -192,6 +199,7 @@ KT.editable = (function(){
                 $(this).editable('destroy');
                 $(this).editable($(this).attr('data-url'), {
                     type        :  'timepicker',
+                    data        :  null,
                     width       :  300,
                     method      :  'PUT',
                     name        :  $(this).attr('name'),


### PR DESCRIPTION
This commit contains 2 changes for issues observed while testing
some jeditable fields:
1. update the datapicker input to trim whitespace from the
   content input
2. update the options/settings on all input types to reset 'data'
   option to null.
