### PR TITLE
Comps - Adding httpd packages to comps for Fedora18.

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -12,6 +12,11 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">elasticsearch</packagereq>
+       <packagereq type="default">httpd</packagereq>
+       <packagereq type="default">httpd-devel</packagereq>
+       <packagereq type="default">httpd-manual</packagereq>
+       <packagereq type="default">httpd-tools</packagereq>
+       <packagereq type="default">httpd-debuginfo</packagereq>
        <packagereq type="default">katello</packagereq>
        <packagereq type="default">katello-agent</packagereq>
        <packagereq type="default">katello-all</packagereq>
@@ -35,6 +40,10 @@
        <packagereq type="default">katello-utils</packagereq>
        <packagereq type="default">lucene3</packagereq>
        <packagereq type="default">lucene3-contrib</packagereq>
+       <packagereq type="default">mod_ldap</packagereq>
+       <packagereq type="default">mod_proxy_html</packagereq>
+       <packagereq type="default">mod_session</packagereq>
+       <packagereq type="default">mod_ssl</packagereq>
        <packagereq type="default">rubygem-acts_as_reportable</packagereq>
        <packagereq type="default">rubygem-alchemy</packagereq>
        <packagereq type="default">rubygem-anemone</packagereq>


### PR DESCRIPTION
These packages are from what building the httpd package in your Koji produced - http://koji.katello.org/koji/buildinfo?buildID=3578
