### PR TITLE
Fixing bad check for undefined on activation keys page

### DIFF
--- a/src/app/controllers/activation_keys_controller.rb
+++ b/src/app/controllers/activation_keys_controller.rb
@@ -184,8 +184,12 @@ class ActivationKeysController < ApplicationController
     @environment = first_env_in_path(accessible_envs)
 
     @content_view_labels = [[no_content_view, '']]
-    @content_view_labels += ContentView.readable(@organization).non_default.
-      in_environment(@environment).collect {|cv| [cv.name, cv.id]}
+    if @environment
+      @content_view_labels += ContentView.readable(@organization).non_default.
+        in_environment(@environment).collect {|cv| [cv.name, cv.id]}
+    else
+      @content_view_labels = []
+    end
     @selected_content_view = no_content_view
 
     render :partial => "new", :locals => {:activation_key => activation_key,

--- a/src/public/javascripts/activation_key.js
+++ b/src/public/javascripts/activation_key.js
@@ -227,11 +227,11 @@ KT.activation_key = (function($) {
         // update the products box with the results
         var url = $('.path_link.active').attr('data-products_url');
 
-        if($("#activation_key_content_view_id").val()) {
-            url += ("?content_view_id=" + $("#activation_key_content_view_id").val());
-        }
-
         if (url !== undefined) {
+            if($("#activation_key_content_view_id").val()) {
+                url += ("?content_view_id=" + $("#activation_key_content_view_id").val());
+            }
+
             disable_buttons();
             $.ajax({
                 type: "GET",


### PR DESCRIPTION
For #1819, here is a snippet in which the undefined route that is being created in the Javascript:

``` javascript
var url;
url += ("?content_view_id=" + $("#activation_key_content_view_id").val()); // "undefined?content_view_id=1"
```

The following if statement then fails because url is never undefined (due to that last line with the +=).

``` javascript
if (url !== undefined) {
```

In order to fix this, we just need to check if url is undefined before we add something to it.

I also fixed another unrelated error in the activation_keys_controller.rb (where @environment is not defined). 
