### PR TITLE
Use service-wait for elasticsearch in katello-configure

### DIFF
--- a/katello-configure/modules/elasticsearch/manifests/service.pp
+++ b/katello-configure/modules/elasticsearch/manifests/service.pp
@@ -5,6 +5,10 @@ class elasticsearch::service {
     hasstatus => true,
     hasrestart => true,
     require => Class["elasticsearch::config"],
-    before => Exec["katello_seed_db"]
+    before => Exec["katello_seed_db"],
+    start      => '/usr/sbin/service-wait elasticsearch start',
+    stop       => '/usr/sbin/service-wait elasticsearch stop',
+    restart    => '/usr/sbin/service-wait elasticsearch restart',
+    status     => '/usr/sbin/service-wait elasticsearch status'
   }
 }


### PR DESCRIPTION
I hit an issue when elasticsearch was not ready for katello db seed.
