### PR TITLE
903388 - fix service-wait script

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -66,6 +66,11 @@ Requires:       httpd
 Requires:       mod_ssl
 Requires:       openssl
 Requires:       elasticsearch
+
+# service-wait dependency
+Requires:       wget
+Requires:       curl
+
 Requires:       %{?scl_prefix}rubygems
 Requires:       %{?scl_prefix}rubygem(rails) >= 3.0.10
 Requires:       %{?scl_prefix}rubygem(haml) >= 3.1.2

--- a/src/script/service-wait
+++ b/src/script/service-wait
@@ -49,6 +49,19 @@ FOREMAN_TEST_URL=${FOREMAN_TEST_URL:-http://localhost:5500/foreman/api}
 # for some services we add few extra seconds after start
 ADDITIONAL_SLEEP=5
 
+wait_for_url() {
+    # we use wget first because it's able to retry from connrefused situation
+    /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO-\
+                  --no-check-certificate $1 > /dev/null
+    # then we double check with curl that the service is really
+    # available. wget is not able to retry from 'Unable to establish
+    # SSL connection.' error, which happens for example with tomcat6
+    /usr/bin/curl -ks --retry $WAIT_MAX --retry-delay 1 $1 > /dev/null
+    if ! [ $? = '0' ]; then
+        RETVAL=5
+    fi
+}
+
 # before start or restart
 before_start() {
   test 1 -eq 1 # noop
@@ -59,16 +72,13 @@ after_start() {
   case "$SERVICE" in
     tomcat6|tomcat7)
       # RHBZ 789288 - wait until data port is avaiable
-      /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- --no-check-certificate $TOMCAT_TEST_URL >/dev/null
-      sleep $ADDITIONAL_SLEEP
+      wait_for_url $TOMCAT_TEST_URL
       ;;
     elasticsearch)
-      /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- --no-check-certificate $ELASTICSEARCH_TEST_URL >/dev/null
-      sleep $ADDITIONAL_SLEEP
+      wait_for_url $ELASTICSEARCH_TEST_URL
       ;;
     foreman)
-      /usr/bin/wget --timeout=1 --tries=$WAIT_MAX --retry-connrefused -qO- --no-check-certificate $FOREMAN_TEST_URL >/dev/null
-      sleep $ADDITIONAL_SLEEP
+      wait_for_url $FOREMAN_TEST_URL
       ;;
     mongod)
       # RHBZ 824405 - wait until service is avaiable


### PR DESCRIPTION
wget was not recovering from 'Unable to establish SSL connection.' type of
errors. That caused the script exited with success although the service was
not ready yet (the sleep timeout set for 5 seconds was not enough).

The fix is to use curl to double check the response for test url (curl is able
to retry form SSL issues).

Also the script exists with non-zero when the test url can't be reached: when
the script succeeds after start, we want to be sure that the service is really
up and running. Otherwise it should fail.

The curl fix should also make the `sleep $ADDITIONAL_TIME` useless (as this
was probably meant to fix the original issue with SSL). Removing, to eliminate
magic constants and speed up the script a bit.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=903388
