### PR TITLE
fixed a ActiveRecord::ReadOnlyRecord error occuring during the migration

### DIFF
--- a/src/db/migrate/20130318171849_migrate_environment_default_content_view_to_version.rb
+++ b/src/db/migrate/20130318171849_migrate_environment_default_content_view_to_version.rb
@@ -8,7 +8,7 @@ class MigrateEnvironmentDefaultContentViewToVersion < ActiveRecord::Migration
       (org.environments + [org.library]).each do |env|
          old_view = ContentView.where(:environment_default_id=>env.id).first
          cve = old_view.content_view_environments.first
-         version = old_view.version(env)
+         version = ContentViewVersion.find(old_view.version(env))
 
          version.content_view = default_view
          version.save!


### PR DESCRIPTION
Occurs on rails 3.2 with a db seeded with data.
