### PR TITLE
Improve bundle_ext handling to be able to drop katello-devel

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -8,62 +8,66 @@ require 'katello/load_configuration'
 # With a pull request, send also link to our (or Fedora) koji with RPMs.
 source 'http://rubygems.org'
 
-gem 'rails', '3.0.10'
-gem 'json'
-gem 'rest-client', :require => 'rest_client'
-gem 'jammit', '>= 0.5.4'
-gem 'rails_warden', '>= 0.5.2'
-gem 'net-ldap'
-gem 'oauth'
-gem 'ldap_fluff'
+group :production do
+  gem 'rails', '3.0.10'
+  gem 'json'
+  gem 'rest-client', :require => 'rest_client'
+  gem 'jammit', '>= 0.5.4'
+  gem 'rails_warden', '>= 0.5.2'
+  gem 'net-ldap'
+  gem 'oauth'
+  gem 'ldap_fluff'
+  gem 'bundler_ext', :require => false
 
-if defined? JRUBY_VERSION
-  gem 'jruby-openssl'
-  gem 'activerecord-jdbc-adapter'
-  gem 'jdbc-postgres', :require => false
-  gem 'activerecord-jdbcpostgresql-adapter', :require => false
-  gem 'tire', '>= 0.3.0'
-else
-  gem 'thin', '>= 1.2.8'
-  gem 'tire', '>= 0.3.0', '< 0.4'
-  gem 'pg'
+  if defined? JRUBY_VERSION
+    gem 'jruby-openssl'
+    gem 'activerecord-jdbc-adapter'
+    gem 'jdbc-postgres', :require => false
+    gem 'activerecord-jdbcpostgresql-adapter', :require => false
+    gem 'tire', '>= 0.3.0'
+  else
+    gem 'thin', '>= 1.2.8'
+    gem 'tire', '>= 0.3.0', '< 0.4'
+    gem 'pg'
+  end
+
+  gem 'delayed_job', '~> 2.1.4'
+  gem 'daemons', '>= 1.1.4'
+  gem 'uuidtools'
+
+  # Stuff for view/display/frontend
+  gem 'haml', '~> 3.1.2'
+  gem 'haml-rails', "= 0.3.4"
+  gem 'compass', '>= 0.11.5', '< 0.12'
+  gem 'compass-960-plugin', '>= 0.10.4', :require => 'ninesixty'
+  gem 'simple-navigation', '>= 3.3.4'
+
+  # Stuff for i18n
+  gem 'gettext_i18n_rails'
+  gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
+
+  # Reports - TODO this is hack that needs to be removed once ruport is officially released
+  if (`rpm -q rubygem-ruport` rescue "") =~ /^rubygem-ruport-1.7.0\S+/ && !defined? JRUBY_VERSION
+    gem 'ruport', '>=1.7.0'
+  else
+    gem 'ruport', '>=1.7.0', :git => 'git://github.com/ruport/ruport.git'
+  end
+  #not an actual katello dependency, but
+  #Does not pull in  hashery, matches RPM
+  gem 'pdf-reader', '<= 1.1.1'
+
+  gem 'prawn'
+  gem 'acts_as_reportable', '>=1.1.1', :require => 'ruport/acts_as_reportable'
+
+  # Documentation
+  gem "apipie-rails", '>= 0.0.18'
+
+  gem 'hooks'
+
+  # Better logging (syslog/rolling/trace)
+  gem 'logging', '>= 1.8.0'
+
 end
-
-gem 'delayed_job', '~> 2.1.4'
-gem 'daemons', '>= 1.1.4'
-gem 'uuidtools'
-
-# Stuff for view/display/frontend
-gem 'haml', '~> 3.1.2'
-gem 'haml-rails', "= 0.3.4"
-gem 'compass', '>= 0.11.5', '< 0.12'
-gem 'compass-960-plugin', '>= 0.10.4', :require => 'ninesixty'
-gem 'simple-navigation', '>= 3.3.4'
-
-# Stuff for i18n
-gem 'gettext_i18n_rails'
-gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
-
-# Reports - TODO this is hack that needs to be removed once ruport is officially released
-if (`rpm -q rubygem-ruport` rescue "") =~ /^rubygem-ruport-1.7.0\S+/ && ! defined? JRUBY_VERSION
-  gem 'ruport', '>=1.7.0'
-else
-  gem 'ruport', '>=1.7.0', :git => 'git://github.com/ruport/ruport.git'
-end
-#not an actual katello dependency, but
-#Does not pull in  hashery, matches RPM
-gem 'pdf-reader', '<= 1.1.1'
-
-gem 'prawn'
-gem 'acts_as_reportable', '>=1.1.1', :require => 'ruport/acts_as_reportable'
-
-# Documentation
-gem "apipie-rails", '>= 0.0.18'
-
-gem 'hooks'
-
-# Better logging (syslog/rolling/trace)
-gem 'logging', '>= 1.8.0'
 
 # Load all sub-gemfiles from bundler.d directory
 Dir[File.expand_path('bundler.d/*.rb', File.dirname(__FILE__))].each do |bundle|

--- a/src/config/boot.rb
+++ b/src/config/boot.rb
@@ -1,5 +1,9 @@
 require 'rubygems'
 
+path = File.expand_path("../lib", File.dirname(__FILE__))
+$LOAD_PATH << path unless $LOAD_PATH.include? path
+require 'katello/load_configuration'
+
 # Set up gems listed in the Gemfile.
 if ENV['BUNDLE_GEMFILE']
   gemfile = ENV['BUNDLE_GEMFILE']
@@ -9,8 +13,10 @@ end
 
 begin
   ENV['BUNDLE_GEMFILE'] = gemfile
-  require 'bundler'
-  Bundler.setup
+  if Katello.early_config.use_bundler
+    require 'bundler'
+    Bundler.setup
+  end
 rescue Bundler::GemNotFound => e
   STDERR.puts e.message
   STDERR.puts "Try running `bundle install`."

--- a/src/config/katello_defaults.yml
+++ b/src/config/katello_defaults.yml
@@ -22,6 +22,10 @@ common:
   use_elasticsearch: # set to true/false if you want to override default
   app_name: # set a name if you want to override default
 
+  # if true bundler is used to load gems
+  # if not bundler_ext will load the gems
+  use_bundler: true
+
   warden: database
   ldap_roles: false
   rest_client_timeout: 30

--- a/src/lib/katello/load_configuration.rb
+++ b/src/lib/katello/load_configuration.rb
@@ -33,7 +33,7 @@ module Katello
                     search use_foreman password_reset_expiration redhat_repository_url port
                     elastic_url rest_client_timeout elastic_index
                     katello_version pulp email_reply_address
-                    embed_yard_documentation logging)
+                    embed_yard_documentation logging use_bundler)
 
           has_values :app_mode, %w(katello headpin)
           has_values :url_prefix, %w(/headpin /sam /cfse /katello)
@@ -58,7 +58,7 @@ module Katello
           end
 
           are_booleans :use_cp, :use_foreman, :use_pulp, :use_elasticsearch, :use_ssl, :ldap_roles,
-                       :profiling
+                       :profiling, :use_bundler
 
           if !early? && environment != :build
             validate :database do


### PR DESCRIPTION
NOT READY
## TODO
- [ ] update puppet manifests to work with the changes
- [ ] test build, configure
