### PR TITLE
948754 - downcase the value for pulp url

### DIFF
--- a/katello-configure/lib/puppet/parser/functions/katello_pulp_url.rb
+++ b/katello-configure/lib/puppet/parser/functions/katello_pulp_url.rb
@@ -4,6 +4,6 @@ module Puppet::Parser::Functions
   newfunction(:katello_pulp_url, :type => :rvalue) do |args|
     host = lookupvar("::fqdn")
     host = "localhost" if host.nil? || host.empty?
-    "https://#{host}/pulp/api/v2/"
+    "https://#{host}/pulp/api/v2/".downcase
   end
 end

--- a/katello-configure/modules/pulp/templates/etc/pulp/server.conf.erb
+++ b/katello-configure/modules/pulp/templates/etc/pulp/server.conf.erb
@@ -233,7 +233,7 @@ consumer_cert_expiration: 3650
 # debugging_mode: (boolean) toggles Pulp's debugging capabilities
 
 [server]
-server_name: <%= has_variable?("fqdn") ? fqdn : hostname %>
+server_name: <%= (has_variable?("fqdn") ? fqdn : hostname).downcase %>
 relative_url: /pulp/repos
 key_url: /pulp/gpg
 ks_url: /pulp/ks


### PR DESCRIPTION
When hostname has some capital letters, rubygem-oauth uses the downcase
version when creating the signature. On pulp side, the original version is
used, leading to signatures mismatch.
