### PR TITLE
use pulp settings for default virtualhost

### DIFF
--- a/katello-configure/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
+++ b/katello-configure/modules/katello/templates/etc/httpd/conf.d/katello.conf.erb
@@ -84,4 +84,6 @@ NameVirtualHost *:80
   RewriteEngine On
   RewriteCond %{HTTPS} off
   RewriteRule /<%= scope.lookupvar("katello::params::deployment_url") %>(.*)$ https://%{HTTP_HOST}%{REQUEST_URI}
+
+  Include /etc/pulp/vhosts80/*.conf
 </VirtualHost>


### PR DESCRIPTION
we are defining our own default virtualhost,
so pulps are ignored, this includes all there settings as well
without this, normal http repos will not work
