### PR TITLE
Fix dependency on a JavaScript engine

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -76,6 +76,7 @@ Requires:       %{?scl_prefix}rubygem(haml-rails)
 Requires:       %{?scl_prefix}rubygem(json)
 Requires:       %{?scl_prefix}rubygem(rest-client)
 Requires:       %{?scl_prefix}rubygem(jammit)
+Requires:       %{?scl_prefix}rubygem(therubyracer) # required by jammit
 Requires:       %{?scl_prefix}rubygem(rails_warden)
 Requires:       %{?scl_prefix}rubygem(net-ldap)
 Requires:       %{?scl_prefix}rubygem(compass)


### PR DESCRIPTION
Without it, jammit fails in dependencies. This is a quickfix. The proper
solution is to get rid of jammit. I expect this to be fixed later.
