### PR TITLE
[DO NOT MERGE] Comps - Adding delayed_job_active_record needed to properly hook up

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -51,6 +51,7 @@
        <packagereq type="default">rubygem-closure-compiler</packagereq>
        <packagereq type="default">rubygem-daemons</packagereq>
        <packagereq type="default">rubygem-deface</packagereq>
+       <packagereq type="default">rubygem-delayed_job_active_record</packagereq>
        <packagereq type="default">rubygem-foreman_api</packagereq>
        <packagereq type="default">rubygem-foreman-katello-engine</packagereq>
        <packagereq type="default">rubygem-hooks</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -151,6 +151,7 @@
        <packagereq type="default">ruby193-rubygem-deface</packagereq>
        <packagereq type="default">ruby193-rubygem-devel</packagereq>
        <packagereq type="default">ruby193-rubygem-delayed_job</packagereq>
+       <packagereq type="default">ruby193-rubygem-delayed_job_active_record</packagereq>
        <packagereq type="default">ruby193-rubygem-diff-lcs</packagereq>
        <packagereq type="default">ruby193-rubygem-erubis</packagereq>
        <packagereq type="default">ruby193-rubygem-eventmachine</packagereq>

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -29,7 +29,8 @@ else
   gem 'pg'
 end
 
-gem 'delayed_job', '~> 2.1.4'
+gem 'delayed_job', '~> 3.0.2'
+gem 'delayed_job_active_record'
 gem 'daemons', '>= 1.1.4'
 gem 'uuidtools'
 


### PR DESCRIPTION
the active_record backend to delayed_job > 3.0.

@xsuchy Fedora18 contains delayed_job 3.0.2 but they didn't package the delayed_job_active_record gem which is needed to wire things up properly.  I have built this gem for F18 and tagged it into koji already and pushed the updates to katello-thirdparty git. We will need to do the same for the SCL, building delayed_job and delayed_job_active_record but I wasn't able to get the prefix working right when trying to tag the SCL versions.  If you could have a look in the morning and if this PR is accurate, ACK and merge at your leisure.
