### PR TITLE
cli custom_info restructure

### DIFF
--- a/cli/src/katello/client/core/system.py
+++ b/cli/src/katello/client/core/system.py
@@ -907,3 +907,6 @@ class RemoveSystemGroups(SystemAction):
 
 class System(Command):
     description = _('system specific actions in the katello server')
+
+class CustomInfo(Command):
+    description = _("make changes to custom info")

--- a/cli/src/katello/client/core/system_custom_info.py
+++ b/cli/src/katello/client/core/system_custom_info.py
@@ -20,11 +20,11 @@ from katello.client.api.utils import get_system
 from katello.client.lib.utils.data import test_record
 from katello.client.core.system import SystemAction
 
-class BaseSystemCustomInfo(SystemAction):
+class SystemCustomInfo(SystemAction):
     """ Base class for all *CustomInfo classes related to Systems with common code """
 
     def setup_parser(self, parser):
-        super(BaseSystemCustomInfo, self).setup_parser(parser)
+        super(SystemCustomInfo, self).setup_parser(parser)
         parser.add_option('--name', dest='name', help=_("System name (required)"))
         parser.add_option('--uuid', dest='uuid', help=constants.OPT_HELP_SYSTEM_UUID)
         parser.add_option('--keyname', dest='keyname', help=_("name to identify the custom info (required)"))
@@ -37,15 +37,15 @@ class BaseSystemCustomInfo(SystemAction):
         validator.require('keyname')
 
 
-class AddCustomInfo(BaseSystemCustomInfo):
+class AddSystemCustomInfo(SystemCustomInfo):
     description = _('add custom infomation to a system')
 
     def setup_parser(self, parser):
-        super(AddCustomInfo, self).setup_parser(parser)
+        super(AddSystemCustomInfo, self).setup_parser(parser)
         parser.add_option('--value', dest='value', help=_("the custom info"))
 
     def check_options(self, validator):
-        super(AddCustomInfo, self).check_options(validator)
+        super(AddSystemCustomInfo, self).check_options(validator)
         validator.require(('org', 'keyname'))
 
     def run(self):
@@ -72,10 +72,10 @@ class AddCustomInfo(BaseSystemCustomInfo):
         )
 
 
-class UpdateCustomInfo(BaseSystemCustomInfo):
+class UpdateSystemCustomInfo(SystemCustomInfo):
     description = _("update custom info for a system")
     def setup_parser(self, parser):
-        super(UpdateCustomInfo, self).setup_parser(parser)
+        super(UpdateSystemCustomInfo, self).setup_parser(parser)
         parser.add_option('--value', dest='value', help=_("replacement value"))
 
     def check_options(self, validator):
@@ -106,11 +106,11 @@ class UpdateCustomInfo(BaseSystemCustomInfo):
                 % {'keyname':keyname, 'ident':ident}
 
 
-class RemoveCustomInfo(BaseSystemCustomInfo):
+class RemoveSystemCustomInfo(SystemCustomInfo):
     description = _("remove custom info from a system")
 
     def setup_parser(self, parser):
-        super(RemoveCustomInfo, self).setup_parser(parser)
+        super(RemoveSystemCustomInfo, self).setup_parser(parser)
 
     def run(self):
         org_name = self.get_option('org')

--- a/cli/src/katello/client/main.py
+++ b/cli/src/katello/client/main.py
@@ -211,9 +211,11 @@ def setup_admin(katello_cmd, mode=get_katello_mode()):
         system_cmd.add_command('packages', system.InstalledPackages())
         system_cmd.add_command('add_to_groups', system.AddSystemGroups())
         system_cmd.add_command('remove_from_groups', system.RemoveSystemGroups())
-    system_cmd.add_command('add_custom_info', system_custom_info.AddCustomInfo())
-    system_cmd.add_command('update_custom_info', system_custom_info.UpdateCustomInfo())
-    system_cmd.add_command('remove_custom_info', system_custom_info.RemoveCustomInfo())
+    custom_info_cmd = system.CustomInfo()
+    custom_info_cmd.add_command('add', system_custom_info.AddSystemCustomInfo())
+    custom_info_cmd.add_command('update', system_custom_info.UpdateSystemCustomInfo())
+    custom_info_cmd.add_command('remove', system_custom_info.RemoveSystemCustomInfo())
+    system_cmd.add_command('custom_info', custom_info_cmd)
     katello_cmd.add_command('system', system_cmd)
 
     if mode == 'katello':

--- a/scripts/system-test/cli_tests/system.sh
+++ b/scripts/system-test/cli_tests/system.sh
@@ -60,3 +60,7 @@ test_success "limited ak create" activation_key create --name="$ACTIVATION_KEY_N
 test_success "system register with limited ak" system register --name="$SYSTEM_NAME_ADMIN" --org="$TEST_ORG" --activationkey="$ACTIVATION_KEY_NAME_3"
 test_failure "system register with limited ak" system register --name="$SYSTEM_NAME_ADMIN_2" --org="$TEST_ORG" --activationkey="$ACTIVATION_KEY_NAME_3"
 test_success "system unregister" system unregister --name="$SYSTEM_NAME_ADMIN" --org="$TEST_ORG"
+test_success "system add custom_info" system custom_info add --org="$TEST_ORG" --name="$SYSTEM_NAME_ADMIN" --keyname="asset_tag" --value="1234"
+test_success "system add_custom_info without a value" system custom_info add --org="$TEST_ORG" --name="$SYSTEM_NAME_ADMIN" --keyname="hello world"
+test_success "system update custom_info" system custom_info update --org="$TEST_ORG" --name="$SYSTEM_NAME_ADMIN" --keyname="hello world" --value="hello system-tests"
+test_success "system remove custom_info" system custom_info remove --org="$TEST_ORG" --name="$SYSTEM_NAME_ADMIN" --keyname="hello world"


### PR DESCRIPTION
now we have prettier custom_info commands

`$ katello ... system custom_info [add|update|remove] ...`
