### PR TITLE
katello-configure - fix script not failing when running with -b

### DIFF
--- a/katello-configure/lib/util/functions.rb
+++ b/katello-configure/lib/util/functions.rb
@@ -370,11 +370,9 @@ def main_puppet(puppet_cmd, nobars, default_progressbar_title, puppet_logfile_fi
             elsif line =~ /err:/
               puts "\n  Failed, please check [#{processing_logfile}]\n  Report errors using # katello-debug tool."
               processing_logfile = nil
-              seen_err = true
             end
           elsif line =~ /err:/
             print line
-            seen_err = true
           end
           if line =~ /debug: Executing \'(.+)/
             line_rest = $1
@@ -385,6 +383,10 @@ def main_puppet(puppet_cmd, nobars, default_progressbar_title, puppet_logfile_fi
               end
             end
           end
+        end
+
+        if line =~ /err:/
+          seen_err = true
         end
       end
       if not nobars


### PR DESCRIPTION
nobars option prevented from detecting the errors in puppet script.
