### PR TITLE
delayed jobs use active_record as backend

### DIFF
--- a/src/config/initializers/delayed_job.rb
+++ b/src/config/initializers/delayed_job.rb
@@ -1,6 +1,8 @@
 # Models have to use logger.info instead of Rails.logger.info in order for the desired log file to be used.
 Delayed::Worker.destroy_failed_jobs = false
 
+Delayed::Worker.backend = :active_record
+
 class Delayed::Worker
   def handle_failed_job_with_loggin(job, error)
     handle_failed_job_without_loggin(job,error)

--- a/src/katello.spec
+++ b/src/katello.spec
@@ -87,7 +87,8 @@ Requires:       %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
 Requires:       %{?scl_prefix}rubygem(gettext_i18n_rails)
 Requires:       %{?scl_prefix}rubygem(simple-navigation) >= 3.3.4
 Requires:       %{?scl_prefix}rubygem(pg)
-Requires:       %{?scl_prefix}rubygem(delayed_job) >= 2.1.4
+Requires:       %{?scl_prefix}rubygem(delayed_job) >= 3.0.2
+Requires:       %{?scl_prefix}rubygem(delayed_job_active_record)
 Requires:       %{?scl_prefix}rubygem(acts_as_reportable) >= 1.1.1
 Requires:       %{?scl_prefix}rubygem(ruport) >= 1.7.0
 Requires:       %{?scl_prefix}rubygem(prawn)
@@ -159,7 +160,6 @@ BuildRequires:       %{?scl_prefix}rubygem(i18n_data) >= 0.2.6
 BuildRequires:       %{?scl_prefix}rubygem(gettext_i18n_rails)
 BuildRequires:       %{?scl_prefix}rubygem(simple-navigation) >= 3.3.4
 BuildRequires:       %{?scl_prefix}rubygem(pg)
-BuildRequires:       %{?scl_prefix}rubygem(delayed_job) >= 2.1.4
 BuildRequires:       %{?scl_prefix}rubygem(acts_as_reportable) >= 1.1.1
 BuildRequires:       %{?scl_prefix}rubygem(ruport) >= 1.7.0
 BuildRequires:       %{?scl_prefix}rubygem(prawn)


### PR DESCRIPTION
addressing:

```
/opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:75:in `before_fork': undefined method `before_fork' for nil:NilClass (NoMethodError)
        from /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:86:in `run_process'
        from /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:80:in `block in daemonize'
        from /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:78:in `times'
        from /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:78:in `daemonize'
        from script/delayed_job:5:in `<main>'
```
