### PR TITLE
Delayed Jobs - Fixes an issue with the update to delayed jobs 3.0

### DIFF
--- a/src/app/models/async_operation.rb
+++ b/src/app/models/async_operation.rb
@@ -62,14 +62,6 @@ AsyncOperation = Struct.new(:status_id, :username, :object, :method_name, :args)
     Thread.current['current_delayed_job_task'] = nil
   end
 
-  def method_missing(symbol, *args)
-    object.send(symbol, *args)
-  end
-
-  def respond_to?(symbol, include_private=false)
-    super || object.respond_to?(symbol, include_private)
-  end
-
   # limit to one failure
   def max_attempts
     1


### PR DESCRIPTION
where to_yaml was being called on the target of AsyncOperation and
not the AsyncOperation itself.
