### PR TITLE
Get rubygem-oauth to yum repo

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -48,6 +48,7 @@
        <packagereq type="default">rubygem-hooks</packagereq>
        <packagereq type="default">rubygem-jammit</packagereq>
        <packagereq type="default">rubygem-katello_api</packagereq>
+       <packagereq type="default">rubygem-oauth</packagereq>
        <packagereq type="default">rubygem-pdf-writer</packagereq>
        <packagereq type="default">rubygem-prawn</packagereq>
        <packagereq type="default">rubygem-rcov</packagereq>


### PR DESCRIPTION
We need newer version of oauth gem on fedora 18.
