### PR TITLE
delayedjob-gemfile - lock to lower version of delayed_job_active_record

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -30,7 +30,7 @@ else
 end
 
 gem 'delayed_job', '~> 3.0.2'
-gem 'delayed_job_active_record'
+gem 'delayed_job_active_record', '~> 0.3.3'
 gem 'daemons', '>= 1.1.4'
 gem 'uuidtools'
 


### PR DESCRIPTION
Avoids error:

PG::Error: ERROR:  SELECT FOR UPDATE/SHARE is not allowed in subqueries
: UPDATE "delayed_jobs" SET locked_at = '2013-04-10 17:24:34.380950', locked_by = 'host:tomckay.csb pid:3167' WHERE id IN (SELECT  id FROM "delayed_jobs"  WHERE ((run_at <= '2013-04-10 17:24:34.372213' AND (locked_at IS NULL OR locked_at < '2013-04-10 13:24:34.372230') OR locked_by = 'host:tomckay.csb pid:3167') AND failed_at IS NULL) ORDER BY priority ASC, run_at ASC LIMIT 1 FOR UPDATE) RETURNING *

w/ postgresql 8.4.13 on RHEL
