### PR TITLE
Specifying table name with pluck to be safe

### DIFF
--- a/src/app/controllers/content_search_controller.rb
+++ b/src/app/controllers/content_search_controller.rb
@@ -398,7 +398,7 @@ class ContentSearchController < ApplicationController
     content_rows = []
     product_envs = {}
     product_envs.default = 0
-    accessible_env_ids = KTEnvironment.content_readable(current_organization).pluck(:id)
+    accessible_env_ids = KTEnvironment.content_readable(current_organization).pluck("environments.id")
     search_mode ||= process_search_mode
     environments ||= process_env_ids
 
@@ -438,7 +438,7 @@ class ContentSearchController < ApplicationController
   #
   def spanned_repo_content(view, library_repo, content_type, content_search_obj, offset=0, search_mode = :all, environments = [])
     spanning_repos = library_repo.environmental_instances(view)
-    accessible_env_ids = KTEnvironment.content_readable(current_organization).pluck(:id)
+    accessible_env_ids = KTEnvironment.content_readable(current_organization).pluck("environments.id")
 
     unless environments.nil? || environments.empty?
       spanning_repos.delete_if do |repo|
@@ -565,13 +565,13 @@ class ContentSearchController < ApplicationController
   def process_repos(repo_ids, product_ids)
     # is this neccessary?
     unless product_ids.blank?
-      product_ids = Product.readable(current_organization).where(:id => product_ids).pluck(:id)
+      product_ids = Product.readable(current_organization).where(:id => product_ids).pluck("products.id")
     end
 
     # repos were searched by string
     unless repo_ids.is_a? Array
       search_string = repo_ids
-      repo_ids      = Repository.enabled.libraries_content_readable(current_organization).pluck(:id)
+      repo_ids      = Repository.enabled.libraries_content_readable(current_organization).pluck("repositories.id")
     end
 
     repo_search(search_string, repo_ids, product_ids)

--- a/src/app/controllers/content_view_definitions_controller.rb
+++ b/src/app/controllers/content_view_definitions_controller.rb
@@ -257,7 +257,7 @@ class ContentViewDefinitionsController < ApplicationController
 
     if params[:repos]
       repo_ids = params[:repos].empty? ? [] : Repository.libraries_content_readable(current_organization).
-          where(:id => params[:repos].values.flatten).pluck(:id)
+          where(:id => params[:repos].values.flatten).pluck("repositories.id")
 
       @view_definition.repository_ids = repo_ids
     end

--- a/src/app/controllers/promotions_controller.rb
+++ b/src/app/controllers/promotions_controller.rb
@@ -251,7 +251,8 @@ class PromotionsController < ApplicationController
     # render the list of content views
     view_versions = @environment.content_view_versions.non_default_view || []
     next_env_view_version_ids = @next_environment.nil? ? [].to_set :
-                                @next_environment.content_view_versions.non_default_view.pluck(:id).to_set
+                                @next_environment.content_view_versions.non_default_view.
+                                pluck("content_view_versions.id").to_set
 
     render :partial=>"content_views", :locals => {:environment => @environment, :content_view_versions => view_versions,
                                                   :next_env_view_version_ids => next_env_view_version_ids}

--- a/src/app/lib/content_search/container_search.rb
+++ b/src/app/lib/content_search/container_search.rb
@@ -31,7 +31,7 @@ module ContentSearch
     end
 
     def readable_env_ids
-      KTEnvironment.content_readable(current_organization).pluck(:id)
+      KTEnvironment.content_readable(current_organization).pluck("environments.id")
     end
 
     def search_envs


### PR DESCRIPTION
Specifying table name in pluck when doing joins to avoid ambiguous column name errors.
