### PR TITLE
waive pylint warning

### DIFF
--- a/cli/src/katello/client/core/product.py
+++ b/cli/src/katello/client/core/product.py
@@ -345,6 +345,7 @@ class Create(ProductAction):
                                               description, url, assumeyes, nodiscovery, gpgkey, unprotected)
 
 
+    # pylint: disable=W0613
     def create_product_with_repos(self, provName, orgName, name, label, description,
                                   url, assumeyes, nodiscovery, gpgkey, unprotected):
         prov = get_provider(orgName, provName)


### PR DESCRIPTION
addressing:
************\* Module katello.client.core.product
R0913:348:Create.create_product_with_repos: Too many arguments (11/10)
