### PR TITLE
do not package app/models/content_search

### DIFF
--- a/src/katello.spec
+++ b/src/katello.spec
@@ -621,7 +621,6 @@ usermod -a -G katello-shared tomcat
 %{homedir}/app/models/*.rb
 %{homedir}/app/models/authorization/*.rb
 %{homedir}/app/models/candlepin
-%{homedir}/app/models/content_search
 %{homedir}/app/models/ext
 %{homedir}/app/models/roles_permissions
 %{homedir}/app/stylesheets


### PR DESCRIPTION
There is no such directory.
addressing:

```
Processing files: katello-1.3.14-1.git.1285.c5ac5f2.el6.noarch
error: File not found: /builddir/build/BUILDROOT/katello-1.3.14-1.git.1285.c5ac5f2.el6.noarch/usr/share/katello/app/models/content_search
```

@jlsherrill Did you forgot in #1840 commit some directory or you add this line to spec by error?
