### PR TITLE
[DO NOT MERGE] content view - ui - allow user to specify version info for pkg filter rule

### DIFF
--- a/src/app/controllers/filter_rules_controller.rb
+++ b/src/app/controllers/filter_rules_controller.rb
@@ -21,7 +21,7 @@ class FilterRulesController < ApplicationController
   before_filter :authorize #after find_content_view_definition, since the definition is required for authorization
   before_filter :find_filter
   before_filter :find_rule, :only => [:edit, :edit_inclusion, :edit_parameter_list, :edit_date_type_parameters,
-                                      :update, :add_parameter, :destroy_parameters]
+                                      :update, :add_parameter, :update_parameter, :destroy_parameters]
 
   respond_to :html
 
@@ -43,6 +43,7 @@ class FilterRulesController < ApplicationController
       :update => manage_rule,
 
       :add_parameter => manage_rule,
+      :update_parameter => manage_rule,
       :destroy_parameters => manage_rule,
 
       :destroy_rules => manage_rule,
@@ -125,7 +126,8 @@ class FilterRulesController < ApplicationController
                           :filter => @filter.name})
 
         render :partial => item_partial(@rule),
-               :locals => {:editable => @view_definition.editable?, :unit => params[:parameter][:unit]} and return
+               :locals => {:editable => @view_definition.editable?, :rule => @rule,
+                           :unit => params[:parameter][:unit]} and return
 
       else
         if params[:parameter][:date_range]
@@ -160,18 +162,37 @@ class FilterRulesController < ApplicationController
     render :nothing => true
   end
 
+  def update_parameter
+
+    unless params[:parameter].blank? || params[:parameter][:unit].blank?
+      parameter_name = params[:parameter][:unit][:name]
+
+      # replace the current parameters (e.g. version, min_version, max_version), with
+      # the new parameters received
+      @rule.parameters[:units].detect{|unit| unit[:name] == parameter_name}.try(:replace, params[:parameter][:unit])
+      @rule.save!
+
+      notify.success(_("Parameter %{parameter} successfully updated for filter %{filter} of type %{type}.") %
+                      {:parameter => parameter_name,
+                       :filter => @filter.name,
+                       :type => FilterRule::CONTENT_OPTIONS.index(@rule.content_type)})
+    end
+
+    render :nothing => true
+  end
+
   def destroy_parameters
     if params[:units] && @rule.parameters[:units]
       key_field = @rule.content_type == FilterRule::ERRATA ? 'id' : 'name'
-      params[:units].each_pair do |key, value|
-        @rule.parameters[:units].delete({key_field => key})
+      params[:units].each do |id|
+        @rule.parameters[:units].delete_if{|parameter| parameter[key_field] == id}
       end
     end
     @rule.save!
 
     notify.success(_("Rule parameters successfully deleted for rule type '%{type}'. Parameters deleted: %{parameters}.") %
                    {:type => FilterRule::CONTENT_OPTIONS.index(@rule.content_type),
-                    :parameters => params[:units].keys.join(', ')})
+                    :parameters => params[:units].join(', ')})
 
     render :nothing => true
   end

--- a/src/app/helpers/filter_rules_helper.rb
+++ b/src/app/helpers/filter_rules_helper.rb
@@ -23,4 +23,53 @@ module FilterRulesHelper
   def included_text(rule)
     rule.inclusion? ? _("Include") : _("Exclude")
   end
+
+  def version_options
+    {
+        _('All Versions') => 'all_versions',
+        _('Only Version') => 'version',
+        _('Newer Than') => 'min_version',
+        _('Older Than') => 'max_version',
+        _('Range') => 'version_range'
+    }
+  end
+
+  def version_selector_readonly(rule, unit)
+    version_selected = version_selected(unit)
+    value1, value2 = version_values(unit)
+
+    version_options.key(version_selected) +
+        (value1.blank? ? '' : ' ' + value1.to_s) +
+        (value2.blank? ? '' : ' - ' + value2.to_s)
+  end
+
+  def version_selected(unit)
+    if !unit[:version].blank?
+      'version'
+    elsif !unit[:min_version].blank? && !unit[:max_version].blank?
+      'version_range'
+    elsif !unit[:max_version].blank?
+      'max_version'
+    elsif !unit[:min_version].blank?
+      'min_version'
+    else
+      'all_versions'
+    end
+  end
+
+  def version_values(unit)
+    if !unit[:version].blank?
+      value1 = unit[:version]
+    elsif !unit[:min_version].blank? && !unit[:max_version].blank?
+      value1 = unit[:min_version]
+      value2 = unit[:max_version]
+    elsif !unit[:max_version].blank?
+      value1 = unit[:max_version]
+    elsif !unit[:min_version].blank?
+      value1 = unit[:min_version]
+    end
+
+    return value1, value2
+  end
+
 end

--- a/src/app/views/content_view_definitions/filters/rules/_package_item.html.haml
+++ b/src/app/views/content_view_definitions/filters/rules/_package_item.html.haml
@@ -1,7 +1,35 @@
 %tr
-  %td
+  %td.parameter_name{:style => 'vertical-align: middle;'}
+    .panel_link
+      - if editable
+        = check_box_tag "units[#{unit[:name]}]", unit[:name], false,
+          {:class => :parameter_checkbox, 'data-id' => unit[:name]}
+      %label
+        = unit[:name]
+
+  %td.version_selector
     - if editable
-      .panel_link
-        = check_box_tag "units[#{unit[:name]}]", unit[:name], false, {'data-id' => unit[:name]}
-        %label
-          = unit[:name]
+      - version_selected = version_selected(unit)
+      - value1, value2 = version_values(unit)
+
+      = select_tag("units[version_type]", options_for_select(version_options, version_selected(unit)),
+        :class => 'version_type')
+
+      = text_field_tag("units[version_value]", value1, :size => 4,
+        :class => 'version input' + (['version', 'min_version', 'max_version'].include?(version_selected) ? '' : ' hidden'))
+
+      = text_field_tag("units[version_value1]", value1, :size => 4,
+        :class => 'range input' + (['version_range'].include?(version_selected) ? '' : ' hidden'))
+
+      = label_tag(' - ', nil,
+        :class => 'range input' + (['version_range'].include?(version_selected) ? '' : ' hidden'))
+
+      = text_field_tag("units[version_value2]", value2, :size => 4,
+        :class => 'range input' + (['version_range'].include?(version_selected) ? '' : ' hidden'))
+
+      = link_to(_("Save"),
+        update_parameter_content_view_definition_filter_rule_path(rule.filter.content_view_definition.id,
+        rule.filter.id, rule.id), :class => 'save_version hidden')
+
+    - else
+      = version_selector_readonly(rule, unit)

--- a/src/app/views/content_view_definitions/filters/rules/_parameter_list.html.haml
+++ b/src/app/views/content_view_definitions/filters/rules/_parameter_list.html.haml
@@ -1,16 +1,15 @@
 #parameter_list
   = kt_form_for(view_definition,
-    :url => destroy_parameters_content_view_definition_filter_rule_path(view_definition.id, filter.id, rule.id),
     :html => {:id => "parameters_form"}) do |form|
 
     %table
       %thead
         %tr
-          %th #{_("Name")}
+          %th{:colspan => 2} #{_("Name")}
 
       %tbody
         %tr
-          %td
+          %td{:colspan => 2}
             - help_text = _("Enter %{type} Name...") % {:type => rule_type.singularize}
             %input{:type=>'text', :id=>'rule_input', :size=>'30', :placeholder => help_text,
                    :title => help_text, :tabindex => auto_tab_index}
@@ -19,12 +18,14 @@
                         'data-rule_type' => rule.content_type} #{_('+ Add')}
 
         %tr#empty_row{:class=>(:hidden unless rule.parameters[:units].blank?)}
-          %td
+          %td{:colspan => 2}
             = _("This rule does not currently have any parameters defined.")
 
         - if rule.parameters.has_key?(:units)
           - rule.parameters[:units].each do |unit|
-            = render :partial => item_partial, :locals => {:editable => editable, :unit => unit}
+            = render :partial => item_partial, :locals => {:rule => rule, :editable => editable, :unit => unit}
 
     - if editable
-      %input.button.fr.disabled{:type=>"button", :id=>"remove_button", :value=>_("Remove")}
+      %input.button.fr.disabled{:type => "button", :id => "remove_button", :value => _("Remove"),
+        'data-url' => destroy_parameters_content_view_definition_filter_rule_path(view_definition.id,
+                                                                                  filter.id, rule.id)}

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -128,6 +128,7 @@ Src::Application.routes.draw do
           get :edit_parameter_list
           get :edit_date_type_parameters
           put :add_parameter
+          put :update_parameter
           delete :destroy_parameters
         end
       end

--- a/src/public/javascripts/content_view_definition.js
+++ b/src/public/javascripts/content_view_definition.js
@@ -75,8 +75,7 @@ KT.content_view_definition = (function(){
         start_updater();
     },
     initialize_refresh = function() {
-        $('.refresh_action').unbind('click');
-        $('.refresh_action').bind('click', function(event) {
+        $('.refresh_action').unbind('click').bind('click', function(event) {
             event.preventDefault();
             $.ajax({
                 type: 'POST',
@@ -374,8 +373,7 @@ KT.content_view_definition_filters = (function(){
         if (pane.length === 0) {
             return;
         }
-        $('.inclusion').unbind('change');
-        $('.inclusion').change(function(){
+        $('.inclusion').unbind('change').change(function(){
             $('#update_form').ajaxSubmit({
                 type: "PUT",
                 cache: false,
@@ -388,8 +386,7 @@ KT.content_view_definition_filters = (function(){
             });
         });
 
-        $('.filter_method').unbind('change');
-        $('.filter_method').change(function() {
+        $('.filter_method').unbind('change').change(function() {
             $.ajax({
                 type: 'GET',
                 url: $(this).data('url'),
@@ -402,8 +399,94 @@ KT.content_view_definition_filters = (function(){
             });
         });
 
+        initialize_version_save($('.save_version'));
+        initialize_version_select($('.version_type'));
+        initialize_version_input($('.input.input'));
+
         initialize_common_rule_params();
         initialize_errata_rule_params();
+    },
+    initialize_version_save = function(version_save_button) {
+        version_save_button.unbind('click').click(function(e) {
+            // user clicked save to commit some changes to a pkg filter rule
+            e.preventDefault();
+            var parameter_name,
+                version_selector = $(this).parent('.version_selector'),
+                version,
+                min_version,
+                max_version,
+                range_inputs;
+
+            parameter_name = $(this).closest('tr').find('td.parameter_name').find('.parameter_checkbox').data('id');
+
+            type = version_selector.find('.version_type').val();
+            if (type === 'version') {
+                version = version_selector.find('input.version').val();
+            } else if (type === 'min_version') {
+                min_version = version_selector.find('input.version').val();
+            } else if (type === 'max_version') {
+                max_version = version_selector.find('input.version').val();
+            } else if (type === 'version_range') {
+                range_inputs = version_selector.find('input.range');
+                min_version = range_inputs.first().val();
+                max_version = range_inputs.last().val();
+            }
+
+            disable_version_selector(version_selector);
+
+            $.ajax({
+                type: 'PUT',
+                url: $(this).attr('href'),
+                data:
+                { 'parameter':
+                    { 'unit' :
+                        { 'name' : $(this).closest('tr').find('td.parameter_name').find('.parameter_checkbox').data('id'),
+                          'version' : version,
+                          'min_version' : min_version,
+                          'max_version' : max_version
+                        }
+                    }
+                },
+                cache: false,
+                success: function(html) {
+                    version_selector.find('.save_version').hide();
+                    if (type === 'all_versions') {
+                        version_selector.find('input.input').val('');
+                    } else if (type === 'version_range') {
+                        version_selector.find('input.version').val('');
+                    } else {
+                        version_selector.find('input.range').val('');
+                    }
+                    enable_version_selector(version_selector);
+                },
+                error: function() {
+                    enable_version_selector(version_selector);
+                }
+            });
+        });
+    },
+    initialize_version_select = function(version_select) {
+        version_select.unbind('change').change(function() {
+            // user changed the version type (e.g. all, older than..) on a pkg filter rule
+            var version_selector = $(this).parent('.version_selector');
+
+            if ($(this).val() === 'all_versions') {
+                version_selector.find('.input').hide();
+            } else if ($(this).val() === 'version_range') {
+                version_selector.find('.version').hide();
+                version_selector.find('.range').show();
+            } else {
+                version_selector.find('.range').hide();
+                version_selector.find('.version').show();
+            }
+            version_selector.find('.save_version').show();
+        });
+    },
+    initialize_version_input = function(version_input) {
+        version_input.unbind('keypress').keypress(function() {
+            var version_selector = $(this).parent('.version_selector');
+            version_selector.find('.save_version').show();
+        });
     },
     initialize_common_rule_params = function() {
         var pane = $("#parameter_list");
@@ -411,8 +494,7 @@ KT.content_view_definition_filters = (function(){
             return;
         }
 
-        $('#add_rule').unbind('click');
-        $('#add_rule').click(function() {
+        $('#add_rule').unbind('click').click(function() {
             var rule_input = $('input#rule_input').val(),
                 data;
 
@@ -432,8 +514,11 @@ KT.content_view_definition_filters = (function(){
                         empty_row.after(html);
                         empty_row.hide();
                         initialize_checkboxes($("#parameters_form"));
-                    },
-                    error: function() {
+
+                        var new_parameter = $('.parameter_checkbox[data-id=' + rule_input + ']').closest('tr');
+                        initialize_version_save(new_parameter.find('.save_version'));
+                        initialize_version_select(new_parameter.find('.version_type'));
+                        initialize_version_input(new_parameter.find('.input.input'));
                     }
                 });
             }
@@ -451,18 +536,22 @@ KT.content_view_definition_filters = (function(){
     },
     register_remove = function(form) {
         var remove_button = form.find("#remove_button");
-        remove_button.unbind('click');
-        remove_button.click(function(){
-            var btn = $(this);
+        remove_button.unbind('click').click(function(){
+            var btn = $(this), parameters = [];
             if(btn.hasClass("disabled")){
                 return;
             }
-            disable_button(remove_button);
+            disable(remove_button);
 
-            form.ajaxSubmit({
+            $('input.parameter_checkbox:checked').each(function() {
+                parameters.push($(this).val());
+            });
+
+            $.ajax({
                 type: "DELETE",
                 url: btn.data("url"),
                 cache: false,
+                data: {'units': parameters},
                 success: function(){
                     // remove the deleted filters from the table and show the 'empty' message
                     // if all filters have been deleted
@@ -470,20 +559,30 @@ KT.content_view_definition_filters = (function(){
                     if ($('input[type="checkbox"]').length === 0) {
                         $('tr#empty_row').show();
                     }
-                    disable_button(remove_button);
+                    disable(remove_button);
                 },
                 error: function(){
-                    enable_button(remove_button);
+                    enable(remove_button);
                 }
             });
         });
-        disable_button(remove_button);
+        disable(remove_button);
     },
-    disable_button = function(button) {
+    disable_version_selector = function(selector) {
+        disable(selector.find('select.version_type'));
+        disable(selector.find('input.input'));
+        disable(selector.find('a.save_version'))
+    },
+    enable_version_selector = function(selector) {
+        enable(selector.find('select.version_type'));
+        enable(selector.find('input.input'));
+        enable(selector.find('a.save_version'))
+    },
+    disable = function(button) {
         button.attr('disabled', 'disabled');
         button.addClass('disabled');
     },
-    enable_button = function(button) {
+    enable = function(button) {
         button.removeAttr('disabled');
         button.removeClass('disabled');
     },
@@ -491,13 +590,12 @@ KT.content_view_definition_filters = (function(){
         var checkboxes = $('input[type="checkbox"]'),
             button = form.find("#remove_button");
 
-        checkboxes.unbind('change');
-        checkboxes.each(function(){
+        checkboxes.unbind('change').each(function(){
             $(this).change(function(){
                 if($(this).is(":checked")) {
-                    enable_button(button);
+                    enable(button);
                 } else if($('input[type="checkbox"]:checked').length === 0) {
-                    disable_button(button);
+                    disable(button);
                 }
             });
         });

--- a/src/spec/controllers/filter_rules_controller_spec.rb
+++ b/src/spec/controllers/filter_rules_controller_spec.rb
@@ -142,6 +142,19 @@ describe FilterRulesController, :katello => true do
       it_should_behave_like "protected action"
     end
 
+    describe "PUT update_parameter" do
+      let(:action) { :update_parameter }
+      let(:req) { put :update_parameter, :content_view_definition_id => @definition.id, :filter_id => @filter.id,
+                      :id => @filter_rule.id}
+      let(:authorized_user) do
+        user_with_permissions { |u| u.can(:update, :content_view_definitions, @definition.id, @organization) }
+      end
+      let(:unauthorized_user) do
+        user_without_permissions
+      end
+      it_should_behave_like "protected action"
+    end
+
     describe "DELETE destroy_parameters" do
       let(:action) { :destroy_parameters }
       let(:req) { delete :destroy_parameters, :content_view_definition_id => @definition.id, :filter_id => @filter.id,

--- a/src/test/controllers/filter_rules_controller_test.rb
+++ b/src/test/controllers/filter_rules_controller_test.rb
@@ -244,6 +244,38 @@ class FilterRulesControllerTest < MiniTest::Rails::ActionController::TestCase
                                                            "end" => '01/31/2013'}}
   end
 
+  test "PUT update_parameter - for package rule version should be successful" do
+    @filter = filters(:populated_filter)
+    rule = PackageRule.where(:filter_id => @filter.id).first
+
+    # success notice created
+    notify = Notifications::Notifier.new
+    notify.expects(:success).at_least_once
+    @controller.expects(:notify).at_least_once.returns(notify)
+
+    put :update_parameter, :content_view_definition_id => @filter.content_view_definition.id, :filter_id => @filter.id,
+        :id => rule.id, :parameter => {:unit => {:name => 'xterm.*', :version => '6.0'}}
+
+    assert_response :success
+    assert_includes rule.reload.parameters[:units], {"name" => "xterm.*", "version" => "6.0"}
+  end
+
+  test "PUT update_parameter - for package rule min_version and max_version should be successful" do
+    @filter = filters(:populated_filter)
+    rule = PackageRule.where(:filter_id => @filter.id).first
+
+    # success notice created
+    notify = Notifications::Notifier.new
+    notify.expects(:success).at_least_once
+    @controller.expects(:notify).at_least_once.returns(notify)
+
+    put :update_parameter, :content_view_definition_id => @filter.content_view_definition.id, :filter_id => @filter.id,
+        :id => rule.id, :parameter => {:unit => {:name => 'xterm.*', :min_version => '7.0', :max_version => '10.0'}}
+
+    assert_response :success
+    assert_includes rule.reload.parameters[:units], {"name" => "xterm.*", "min_version" => "7.0", "max_version" => "10.0"}
+  end
+
   test "DELETE destroy_parameters - should be successful" do
     @filter = filters(:populated_filter)
     rule = ErratumRule.where(:filter_id => @filter.id).first
@@ -256,7 +288,7 @@ class FilterRulesControllerTest < MiniTest::Rails::ActionController::TestCase
     assert_equal rule.parameters[:units].length, 1
 
     delete :destroy_parameters, :content_view_definition_id => @filter.content_view_definition.id,
-           :filter_id => @filter.id, :id => rule.id, :units => {rule.parameters[:units].first[:id] => ""}
+           :filter_id => @filter.id, :id => rule.id, :units => [rule.parameters[:units].first[:id]]
 
     assert_response :success
     assert_empty rule.reload.parameters[:units]


### PR DESCRIPTION
Please review this PR, but do not merge it at this time.  This PR is generated against the content filters branch, which is currently under review; however, I'd like to receive and resolve comments on this one in parallel.

This commit primarily contains changes to allow a user
to specify version information on a pkg filter rule as
defined in wireframes from UXD.

The user can specify version similar to:
1. all versions (default) - where any version of pkg may be applied
2. only version (aka version) - where only the specified version may
   be applied
3. newer than (aka min_version) - where any version newer than specified
   may be applied
4. older than (aka max_version) - where any version older than specified
   may be applied
