### PR TITLE
1861 - don't use waitretry as it backs off and causes multi-minute waits

### DIFF
--- a/katello-configure/modules/mongodb/manifests/service.pp
+++ b/katello-configure/modules/mongodb/manifests/service.pp
@@ -7,7 +7,7 @@ class mongodb::service {
     start      => '/usr/sbin/service-wait mongod start',
     stop       => '/usr/sbin/service-wait mongod stop',
     restart    => '/usr/sbin/service-wait mongod restart',
-    status     => '/usr/bin/wget --timeout=30 --tries=20 --retry-connrefused -qO- http://localhost:27017/ --waitretry=20',
+    status     => '/usr/bin/wget --tries=30 --wait=2 --retry-connrefused -qO- http://localhost:27017/ --waitretry=0',
     require    => Class["mongodb::config"]
   }
 }


### PR DESCRIPTION
By switching to --wait=2 and --tries=30 we get a ~60 second wait time
to see if mongo starts up.  Before with --waitretry=30 you get a back
off algorithm which can cause katello-configure to take an extra 3-5
minutes to complete.
