### PR TITLE
issue 1955 - ui - open filter after create

### DIFF
--- a/src/app/controllers/filters_controller.rb
+++ b/src/app/controllers/filters_controller.rb
@@ -61,14 +61,15 @@ class FiltersController < ApplicationController
   end
 
   def create
-    Filter.create!(params[:filter]) do |filter|
+    filter = Filter.create!(params[:filter]) do |filter|
       filter.content_view_definition = @view_definition
     end
 
     notify.success(_("Filter '%{filter}' successfully created for content view definition '%{definition}'.") %
                     {:filter => params[:filter][:name], :definition => @view_definition.name})
 
-    render :nothing => true
+    render :partial => "common/post_action_close_subpanel",
+           :locals => {:path => edit_content_view_definition_filter_path(@view_definition, filter)}
   end
 
   def edit

--- a/src/app/views/content_view_definitions/filters/_new.html.haml
+++ b/src/app/views/content_view_definitions/filters/_new.html.haml
@@ -1,5 +1,3 @@
-= javascript 'widgets/subpanel_new'
-
 = content_for :title do
   #{_("New Filter")}
 
@@ -7,12 +5,10 @@
 
   #filter_create
 
-    = kt_form_for([view_definition, Filter.new], :remote => true, :html => {:id => "new_subpanel"}) do |form|
+    = kt_form_for([view_definition, Filter.new], :remote => true, :html => {:id => "filter_form"}) do |form|
 
       = form.text_field :name, :label => _("Name"), :class => :name_input
 
-      = form.submit _("Create"), :disable_with => _("Creating..."),
-        :class => 'create_button subpanel_create',
-        'data-url_after_submit' => content_view_definition_filters_path(view_definition.id)
+      = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'create_button'
 
 = render :template => "layouts/tupane_layout"


### PR DESCRIPTION
This commit contains a minor change so that after a user
creates a new filter, it is opened, so that that the user
may begin adding rules to it.
