### PR TITLE
fixing minitests

### DIFF
--- a/src/lib/tasks/test.rake
+++ b/src/lib/tasks/test.rake
@@ -25,6 +25,7 @@ namespace "ptest" do
 
 end
 
+=begin
 if defined?(MiniTest)
   namespace :minitest do
     Rake::Task["minitest"].clear
@@ -108,3 +109,4 @@ if defined?(MiniTest)
     end
   end
 end
+=end


### PR DESCRIPTION
partially reverting commit f60d47e3fd7d2b4143e7a561a6efc530c72b51fd
which disabled the minitest task in production
=begin and =end are still needed or the tests will not run
