### PR TITLE
issue 1935 - fix promotion failure after view refresh

### DIFF
--- a/src/app/models/content_view.rb
+++ b/src/app/models/content_view.rb
@@ -311,8 +311,12 @@ class ContentView < ActiveRecord::Base
   # aware that the view is no longer available for consumers.
   def remove_environment(env)
     unless env.library
-      view_env = self.content_view_environments.where(:environment_id=>env.id)
-      view_env.first.destroy unless view_env.blank?
+      # Do not remove the content view environment, if there is still a view
+      # version in the environment.
+      if self.versions.in_environment(env).blank?
+        view_env = self.content_view_environments.where(:environment_id=>env.id)
+        view_env.first.destroy unless view_env.blank?
+      end
     end
   end
 


### PR DESCRIPTION
This commit addresses an error that would occur in the following
scenario:
1. create definition with a repo
2. publish the definition as view1
3. promote view1 to dev and then test environments
4. refresh view 1
5. promote view 1 to dev

At step 5, an error would occur.  The reason for the error
was that as part of promoting the view, the code would
delete the candlepin environment for that view.  This is not
what we want in this case because we are simply placing a
new version of the view in to that environment.  The only
time that we should be deleting the candlepin environment
is if we have no other versions of the view in the environment.
