### PR TITLE
Make katello-configure use default database connection settings

### DIFF
--- a/katello-configure/default-answer-file
+++ b/katello-configure/default-answer-file
@@ -28,13 +28,13 @@ proxy_pass = NONE
 # Katello database name.
 # PostgreSQL database name used to store the Katello database
 # objects.
-db_name = katelloschema
+db_name = katello
 
 # Katello database user.
-db_user = katellouser
+db_user = katello
 
 # Katello database password.
-db_password = katellopw
+db_password = katello
 
 # Candlepin database user
 candlepin_db_user = candlepin


### PR DESCRIPTION
The installer creates a 'katelloschema' database owned by 'katellouser' while the config file specifies a user and database of 'katello'. This fixes the discrepancy in katello-configure.
