### PR TITLE
upgrade fix

### DIFF
--- a/src/db/migrate/20120814142911_repository_add_content_id.rb
+++ b/src/db/migrate/20120814142911_repository_add_content_id.rb
@@ -1,4 +1,14 @@
 class RepositoryAddContentId < ActiveRecord::Migration
+  class Repository < ActiveRecord::Base
+    
+    include Glue::Candlepin::Content if (Katello.config.use_cp and Katello.config.use_pulp)
+    include Glue::Pulp::Repo if Katello.config.use_pulp
+    include Glue::ElasticSearch::Repository if Katello.config.use_elasticsearch
+
+    include Glue if (Katello.config.use_cp || Katello.config.use_pulp)
+    include Authorization::Repository
+  end
+
   def self.up
     add_column :repositories, :content_id, :string, :null=>true
 


### PR DESCRIPTION
dont try to access pulp if we dont actually need to
this allows migrations to work on fresh machines
during db population (and for tests)
