### PR TITLE
rubygem-foreman_api is now available in Fedora 18

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -43,7 +43,6 @@
        <packagereq type="default">rubygem-daemons</packagereq>
        <packagereq type="default">rubygem-deface</packagereq>
        <packagereq type="default">rubygem-delayed_job_active_record</packagereq>
-       <packagereq type="default">rubygem-foreman_api</packagereq>
        <packagereq type="default">rubygem-foreman-katello-engine</packagereq>
        <packagereq type="default">rubygem-hooks</packagereq>
        <packagereq type="default">rubygem-jammit</packagereq>
@@ -107,7 +106,6 @@
     <description>Katello Server Documentation Packages</description>
     <uservisible>true</uservisible>
     <packagelist>
-       <packagereq type="optional">rubygem-foreman_api-doc</packagereq>
        <packagereq type="optional">rubygem-rcov-doc</packagereq>
     </packagelist>
   </group>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -61,7 +61,6 @@
        <packagereq type="default">rubygem-erubis</packagereq>
        <packagereq type="default">rubygem-fast_gettext</packagereq>
        <packagereq type="default">rubygem-flexmock</packagereq>
-       <packagereq type="default">rubygem-foreman_api</packagereq>
        <packagereq type="default">rubygem-foreman-katello-engine</packagereq>
        <packagereq type="default">rubygem-fssm</packagereq>
        <packagereq type="default">rubygem-gettext_i18n_rails</packagereq>
@@ -360,7 +359,6 @@
        <packagereq type="optional">rubygem-bundler-doc</packagereq>
        <packagereq type="default">rubygem-factory_girl-doc</packagereq>
        <packagereq type="default">rubygem-factory_girl_rails-doc</packagereq>
-       <packagereq type="optional">rubygem-foreman_api-doc</packagereq>
        <packagereq type="optional">rubygem-fssm-doc</packagereq>
        <packagereq type="optional">rubygem-hoe-doc</packagereq>
        <packagereq type="optional">rubygem-mail-doc</packagereq>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=921985
