### PR TITLE
Made repo clear contents also clear the search indices

### DIFF
--- a/src/app/models/glue/elastic_search/repository.rb
+++ b/src/app/models/glue/elastic_search/repository.rb
@@ -26,7 +26,7 @@ module Glue::ElasticSearch::Repository
       end
 
       after_save :update_related_index
-      before_destroy :update_packages_index, :update_errata_index, :update_package_group_index
+      before_destroy :clear_content_indices
     end
 
     def extended_index_attrs
@@ -146,5 +146,12 @@ module Glue::ElasticSearch::Repository
       self.index_package_groups
       true
     end
+
+    def clear_content_indices
+      update_packages_index
+      update_errata_index
+      update_package_group_index
+    end
+
   end
 end

--- a/src/app/models/glue/pulp/repo.rb
+++ b/src/app/models/glue/pulp/repo.rb
@@ -406,6 +406,7 @@ module Glue::Pulp::Repo
     end
 
     def clear_contents
+      self.clear_content_indices if Katello.config.use_elasticsearch
       Runcible::Extensions::Repository.unassociate_units(self.pulp_id)
     end
 


### PR DESCRIPTION
An issue cropped up where during the refresh of a content view
we cleared the contents of an existing repo but the old search indices
were still preserved. This caused issues when filters were applied
to the repo but did not get reflected in the indices.

This PR basically clears the search indices before clearing the contents.
