### PR TITLE
Reusing option parser content view function for add_view

### DIFF
--- a/cli/src/katello/client/core/content_view_definition.py
+++ b/cli/src/katello/client/core/content_view_definition.py
@@ -17,7 +17,7 @@
 import os
 
 from katello.client.api.content_view_definition import ContentViewDefinitionAPI
-from katello.client.cli.base import opt_parser_add_org
+from katello.client.cli.base import opt_parser_add_org, opt_parser_add_content_view
 from katello.client.core.base import BaseAction, Command
 from katello.client.api.utils import get_content_view, get_cv_definition, \
     get_product, get_repo
@@ -396,12 +396,7 @@ class AddRemoveContentView(ContentViewDefinitionAction):
     def setup_parser(self, parser):
         self._add_get_cvd_opts(parser)
         opt_parser_add_org(parser, required=1)
-        parser.add_option('--view_label', dest='view_label',
-                help=_("content view label"))
-        parser.add_option('--view_id', dest='view_id',
-                help=_("content view id"))
-        parser.add_option('--view_name', dest='view_name',
-                help=_("content view name"))
+        opt_parser_add_content_view(parser, required=1)
 
     def check_options(self, validator):
         self._add_get_cvd_opts_check(validator)

--- a/cli/test/katello/tests/core/content_view_definition/content_view_definition_add_remove_view_test.py
+++ b/cli/test/katello/tests/core/content_view_definition/content_view_definition_add_remove_view_test.py
@@ -16,13 +16,13 @@ from katello.client.api.utils import ApiDataError
 class RequiredCLIOptionsTest(object):
 
     disallowed_options = [
-        ('--label=def1', '--view_id=view1'),
-        ('--org=ACME', '--view_label=view1'),
-        ('--org=ACME', '--label=def1')
+        ('--label=def1', '--content_view_id=view1'),
+        ('--org=ACME', '--content_view_label=view1'),
+        ('--org=ACME', '--view_label=def1')
     ]
 
     allowed_options = [
-        ('--org=ACME', '--label=def1', '--view_name=view1')
+        ('--org=ACME', '--label=def1', '--content_view=view1')
     ]
 
 
@@ -44,7 +44,7 @@ class ContentDefinitionAddRemoveViewTest(object):
     OPTIONS = {
         'org': ORG['name'],
         'label': DEF['label'],
-        'view': VIEW['label']
+        'view_label': VIEW['label']
     }
 
     addition = True

--- a/scripts/system-test/cli_tests/content_view.sh
+++ b/scripts/system-test/cli_tests/content_view.sh
@@ -26,8 +26,8 @@ test_success "content definition publish ($DEF1 to $DEF1_VIEW2)" content definit
 test_success "content definition publish ($DEF1 to $DEF2_VIEW1)" content definition publish --org="$TEST_ORG" --view_name="$DEF2_VIEW1" --label="$DEF2"
 test_success "content definition publish ($DEF2 to $DEF2_VIEW2)" content definition publish --org="$TEST_ORG" --view_name="$DEF2_VIEW2" --name="$DEF2"
 
-test_success "content definition add_content_view ($DEF2_VIEW2 to $DEF3)" content definition add_view --org="$TEST_ORG" --label="$DEF3" --view_label="$DEF2_VIEW2"
-test_failure "content definition add_content_view ($DEF2_VIEW1 to $DEF3)" content definition add_view --org="$TEST_ORG" --label="$DEF3" --view_label="$DEF2_VIEW1"
+test_success "content definition add_content_view ($DEF2_VIEW2 to $DEF3)" content definition add_view --org="$TEST_ORG" --label="$DEF3" --content_view_label="$DEF2_VIEW2"
+test_failure "content definition add_content_view ($DEF2_VIEW1 to $DEF3)" content definition add_view --org="$TEST_ORG" --label="$DEF3" --content_view_label="$DEF2_VIEW1"
 test_success "content definition publish ($DEF3 to $DEF3_VIEW1)" content definition publish --org="$TEST_ORG" --view_name="$DEF3_VIEW1" --name="$DEF3"
 
 test_success "content view promote ($DEF1_VIEW1 to $TEST_ENV)" content view promote --org="$TEST_ORG" --name="$DEF1_VIEW1" --env="$TEST_ENV"


### PR DESCRIPTION
This could skip going in 1.3 but it changes the option names so it might be nice to have it in 1.3 so we don't get complaints later that we changed the options.
