### PR TITLE
Fixed filters cli to now associate partial products from cvd

### DIFF
--- a/cli/src/katello/client/api/content_view_definition.py
+++ b/cli/src/katello/client/api/content_view_definition.py
@@ -99,6 +99,12 @@ class ContentViewDefinitionAPI(KatelloAPI):
         data = self.server.PUT(path, {"products": products})[1]
         return data
 
+    def all_products(self, org, cvd_id):
+        path = "/api/organizations/%s/content_view_definitions/%s/products/all" % \
+                (u_str(org), u_str(cvd_id))
+        data = self.server.GET(path)[1]
+        return data
+
     def repos(self, org, cvd_id):
         path = "/api/organizations/%s/content_view_definitions/%s/repositories"\
                 % (u_str(org), u_str(cvd_id))

--- a/cli/src/katello/client/core/filter.py
+++ b/cli/src/katello/client/core/filter.py
@@ -226,17 +226,13 @@ class AddRemoveProduct(FilterAction):
         definition_label = self.get_option('definition_label')
         definition_name = self.get_option('definition_name')
         definition_id = self.get_option('definition_id')
-
-        cvd_api = ContentViewDefinitionAPI()
         cvd = get_cv_definition(org_name, definition_label,
                                 definition_name, definition_id)
-        cvd_products = cvd_api.products(org_name, cvd["id"])
 
-        product = self.identify_product(cvd, cvd_products, product_name, product_label, product_id)
+        product = self.identify_product(cvd, product_name, product_label, product_id)
 
         cvd_filter = get_filter(org_name, cvd["id"], filter_name)
         products = self.api.products(cvd_filter["id"], cvd["id"], org_name)
-
         products = [f['id'] for f in products]
 
         self.update_products(org_name, cvd["id"], cvd_filter, products, product)
@@ -255,8 +251,10 @@ class AddRemoveProduct(FilterAction):
         self.api.update_products(cvd_filter["id"], cvd, org_name, products)
         print message
 
-    def identify_product(self, cvd, cvd_products, product_name, product_label, product_id):
+    def identify_product(self, cvd, product_name, product_label, product_id):
         org_name = self.get_option('org')
+        cvd_api = ContentViewDefinitionAPI()
+        cvd_products = cvd_api.all_products(org_name, cvd["id"])
 
         products = [prod for prod in cvd_products if prod["id"] == product_id \
                              or prod["name"] == product_name or prod["label"] == product_label]

--- a/cli/test/katello/tests/core/content_view_definition/content_view_definition_data.py
+++ b/cli/test/katello/tests/core/content_view_definition/content_view_definition_data.py
@@ -76,3 +76,33 @@ DEFS =  [
             "organization_id": 1
             },
         ]
+FILTERS = [
+          {
+          'content_view_definition_id': 1,
+          'content_view_definition_label': 'Database',
+          'created_at': '2013-04-18T23:42:57Z',
+          'id': 16,
+          'name': 'filter',
+          'organization': 'ACME_Corporation',
+          'products': ['Product1'],
+          'repos': ['Repo4'],
+          'rules': [{'content': 'erratum',
+                      'created_at': '2013-04-19T16:19:04Z',
+                      'filter_id': 16,
+                      'id': 16,
+                      'inclusion': False,
+                      'rule': {'date_range': {'end': '2012-03-09T19:00:00-05:00',
+                                                'start': '2011-04-09T20:00:00-04:00'}},
+                      'type': 'excludes',
+                      'updated_at': '2013-04-19T16:19:04Z'},
+                     {'content': 'rpm',
+                      'created_at': '2013-04-19T15:48:04Z',
+                      'filter_id': 16,
+                      'id': 15,
+                      'inclusion': False,
+                      'rule': {'units': [{'name': 'wal*'}]},
+                      'type': 'excludes',
+                      'updated_at': '2013-04-19T15:48:04Z'}],
+           'updated_at': '2013-04-18T23:42:57Z'
+            }
+            ]

--- a/cli/test/katello/tests/core/filters/filter_add_remove_product_test.py
+++ b/cli/test/katello/tests/core/filters/filter_add_remove_product_test.py
@@ -1,0 +1,98 @@
+import unittest
+from mock import Mock
+import os
+
+from katello.tests.core.action_test_utils import CLIOptionTestCase,\
+        CLIActionTestCase
+from katello.tests.core.content_view_definition import content_view_definition_data
+from katello.tests.core.organization import organization_data
+from katello.tests.core.repo import repo_data
+from katello.tests.core.product import product_data
+import katello.client.core.filter
+from katello.client.api.content_view_definition import ContentViewDefinitionAPI
+from katello.client.core.filter import AddRemoveProduct
+from katello.client.api.utils import ApiDataError
+
+
+class RequiredCLIOptionsTest(object):
+
+    disallowed_options = [
+        ('--org=ACME', '--name=def1', "--definition=foo"),
+        ('--org=ACME', '--name=def1', '--product=photoshop'),
+        ('--namel=def1', '--product=photoshop', "--definition=foo")
+    ]
+
+    allowed_options = [
+        ('--org=ACME', '--name=def1',  '--product=photoshop', "--definition=foo")
+    ]
+
+class AddRequiredCLIOptionsTest(RequiredCLIOptionsTest, CLIOptionTestCase):
+    action = AddRemoveProduct(True)
+
+class RemoveRequiredCLIOptionsTest(RequiredCLIOptionsTest, CLIOptionTestCase):
+    action = AddRemoveProduct(False)
+
+class FilterAddRemoveProductTest(object):
+    ORG = organization_data.ORGS[0]
+    PRODUCT = product_data.PRODUCTS[0]
+    PRODUCTS = product_data.PRODUCTS
+    DEFINITION = content_view_definition_data.DEFS[0]
+    FILTER = content_view_definition_data.FILTERS[0]
+
+    OPTIONS = {
+        'org': ORG['name'],
+        'label': DEFINITION['label'],
+        'product': PRODUCT['label'],
+        'definition': DEFINITION["name"],
+    }
+
+    addition = True
+
+    def setUp(self):
+        self.set_action(AddRemoveProduct(self.addition))
+        self.set_module(katello.client.core.filter)
+        self.mock_printer()
+
+        self.mock_options(self.OPTIONS)
+
+        self.mock(self.module, 'get_cv_definition', self.DEFINITION)
+        self.mock(self.module, 'get_filter', self.FILTER)
+        self.mock(ContentViewDefinitionAPI, 'all_products', self.PRODUCTS)
+        self.mock(self.action.api, 'products', self.PRODUCTS)
+        self.mock(self.action.api, 'update_products')
+
+    def test_it_returns_with_error_if_no_def_was_found(self):
+        self.mock(self.module, 'get_cv_definition').side_effect = ApiDataError()
+        self.run_action(os.EX_DATAERR)
+
+    def test_it_returns_with_error_if_no_filter_was_found(self):
+        self.mock(self.module, 'get_filter').side_effect = ApiDataError()
+        self.run_action(os.EX_DATAERR)
+
+    def test_it_returns_with_error_if_product_was_not_found(self):
+        self.mock(self.action, 'identify_product').side_effect = ApiDataError()
+        self.run_action(os.EX_DATAERR)
+
+    def test_it_retrieves_all_definition_products(self):
+        self.mock(self.action, 'identify_product', return_value = self.PRODUCT)
+        self.run_action()
+        self.action.api.products.assert_called_once_with(self.FILTER['id'],
+                                 self.DEFINITION['id'], self.ORG['name'])
+        self.action.identify_product.assert_called_once_with(self.DEFINITION,
+                self.PRODUCT['name'], None, None)
+
+class FilterAddProductTest(FilterAddRemoveProductTest, CLIActionTestCase):
+    addition = True
+    def test_it_calls_update_api(self):
+        repos = [r['id'] for r in self.PRODUCTS + [self.PRODUCT]]
+        self.run_action()
+        self.action.api.update_products.assert_called_once_with(self.FILTER['id'],
+             self.DEFINITION['id'], self.ORG["name"], repos)
+
+class FilterRemoveProductTest(FilterAddRemoveProductTest, CLIActionTestCase):
+    addition = False
+    def test_it_calls_update_api(self):
+        repos = [r['id'] for r in self.PRODUCTS if r['name'] != self.PRODUCT['name']]
+        self.run_action()
+        self.action.api.update_products.assert_called_once_with(self.FILTER['id'],
+             self.DEFINITION['id'], self.ORG['name'], repos)

--- a/cli/test/katello/tests/core/filters/filter_add_remove_repo_test.py
+++ b/cli/test/katello/tests/core/filters/filter_add_remove_repo_test.py
@@ -1,0 +1,101 @@
+import unittest
+from mock import Mock
+import os
+from katello.tests.core.action_test_utils import CLIOptionTestCase,\
+        CLIActionTestCase
+from katello.tests.core.content_view_definition import content_view_definition_data
+from katello.tests.core.organization import organization_data
+from katello.tests.core.repo import repo_data
+from katello.tests.core.product import product_data
+import katello.client.core.filter
+from katello.client.core.filter import AddRemoveRepo
+from katello.client.api.utils import ApiDataError
+
+class RequiredCLIOptionsTest(object):
+
+    disallowed_options = [
+        ('--org=ACME', '--name=def1', '--repo=repo1', "--definition=foo"),
+        ('--org=ACME', '--repo=repo1', '--product=photoshop', "--definition=foo"),
+        ('--org=ACME', '--name=def1', '--product=photoshop', "--definition=foo"),
+        ('--namel=def1', '--repo=repo1', '--product=photoshop', "--definition=foo")
+    ]
+
+    allowed_options = [
+        ('--org=ACME', '--name=def1', '--repo=repo1', '--product=photoshop', "--definition=foo")
+    ]
+
+
+class AddRequiredCLIOptionsTest(RequiredCLIOptionsTest, CLIOptionTestCase):
+    action = AddRemoveRepo(True)
+
+class RemoveRequiredCLIOptionsTest(RequiredCLIOptionsTest, CLIOptionTestCase):
+    action = AddRemoveRepo(False)
+
+
+class FilterAddRemoveRepoTest(object):
+    ORG = organization_data.ORGS[0]
+    REPOS = repo_data.REPOS
+    REPO = REPOS[0]
+    PRODUCT = product_data.PRODUCTS[0]
+    DEFINITION = content_view_definition_data.DEFS[0]
+    FILTER = content_view_definition_data.FILTERS[0]
+
+    OPTIONS = {
+        'org': ORG['name'],
+        'label': DEFINITION['label'],
+        'repo': REPO['name'],
+        'product': PRODUCT['label'],
+        'definition': DEFINITION["name"],
+
+    }
+
+    addition = True
+
+    def setUp(self):
+        self.set_action(AddRemoveRepo(self.addition))
+        self.set_module(katello.client.core.filter)
+        self.mock_printer()
+
+        self.mock_options(self.OPTIONS)
+
+        self.mock(self.module, 'get_cv_definition', self.DEFINITION)
+        self.mock(self.module, 'get_filter', self.FILTER)
+        self.mock(self.module, 'get_repo', self.REPO)
+        self.mock(self.action.api, 'repos', self.REPOS)
+        self.mock(self.action.api, 'update_repos')
+
+    def test_it_returns_with_error_if_no_def_was_found(self):
+        self.mock(self.module, 'get_cv_definition').side_effect = ApiDataError()
+        self.run_action(os.EX_DATAERR)
+
+    def test_it_returns_with_error_if_no_filter_was_found(self):
+        self.mock(self.module, 'get_filter').side_effect = ApiDataError()
+        self.run_action(os.EX_DATAERR)
+
+    def test_it_returns_with_error_if_repo_was_not_found(self):
+        self.mock(self.module, 'get_repo').side_effect = ApiDataError()
+        self.run_action(os.EX_DATAERR)
+
+    def test_it_retrieves_all_definition_repos(self):
+        self.run_action()
+        self.action.api.repos.assert_called_once_with(self.FILTER['id'],
+                                 self.DEFINITION['id'], self.ORG['name'])
+        self.module.get_repo.assert_called_once_with(self.ORG['name'],
+                self.REPO['name'], self.PRODUCT['label'], None, None)
+
+class FilterAddRepoTest(FilterAddRemoveRepoTest, CLIActionTestCase):
+    addition = True
+    def test_it_calls_update_api(self):
+        repos = [r['id'] for r in self.REPOS + [self.REPO]]
+        self.run_action()
+        self.action.api.update_repos.assert_called_once_with(self.FILTER['id'],
+             self.DEFINITION['id'], self.ORG["name"], repos)
+
+class FilterRemoveRepoTest(FilterAddRemoveRepoTest, CLIActionTestCase):
+    addition = False
+
+    def test_it_calls_update_api(self):
+        repos = [r['id'] for r in self.REPOS if r['name'] != self.REPO['name']]
+        self.run_action()
+        self.action.api.update_repos.assert_called_once_with(self.FILTER['id'],
+             self.DEFINITION['id'], self.ORG['name'], repos)

--- a/cli/test/katello/tests/core/product/product_data.py
+++ b/cli/test/katello/tests/core/product/product_data.py
@@ -5,6 +5,7 @@ PRODUCTS = [
   {
     "last_sync": None,
     "name": "prod_a1",
+    "label": "prod_a1",
     "created_at": "2011-08-25T11:50:59Z",
     "productContent": [
       {
@@ -45,6 +46,7 @@ PRODUCTS = [
   {
     "last_sync": None,
     "name": "prod_a2",
+    "label": "prod_a2",
     "created_at": "2011-08-25T11:51:06Z",
     "productContent": [
       {

--- a/src/app/controllers/api/content_view_definitions_controller.rb
+++ b/src/app/controllers/api/content_view_definitions_controller.rb
@@ -44,6 +44,7 @@ class Api::ContentViewDefinitionsController < Api::ApiController
       :content_views => show_rule,
       :update_content_views => manage_rule,
       :list_products => show_rule,
+      :list_all_products => show_rule,
       :update_products => manage_rule,
       :list_repositories => show_rule,
       :update_repositories => manage_rule
@@ -221,6 +222,16 @@ class Api::ContentViewDefinitionsController < Api::ApiController
     @definition.save!
 
     render :json => @definition.products
+  end
+
+  api :GET, "/organizations/:organization_id/content_view_definitions/:id/products/all",
+      "Get a list of products belonging to the content view definition, even if one its repositories have been" +
+          " associated to this definition. Mainly used by filter api  "
+  param :organization_id, :identifier, :desc => "organization identifier", :required => true
+  param :id, :identifier, :required => true,
+        :desc => "content view definition identifier"
+  def list_all_products
+    render :json => @definition.resulting_products
   end
 
   private

--- a/src/app/controllers/api/filters_controller.rb
+++ b/src/app/controllers/api/filters_controller.rb
@@ -91,7 +91,7 @@ class Api::FiltersController < Api::ApiController
   param :content_view_definition_id, :identifier, :required => true,
         :desc => "content view definition identifier"
   param :id, String, :desc => "name of the filter", :required => true
-  param :repos, Array, :desc => "Updated list of repo ids", :required => true
+  param :products, Array, :desc => "Updated list of product ids", :required => true
   def update_products
     @products = Product.readable(@organization).where(:cp_id => params[:products],
                               "providers.organization_id" => @organization.id).joins(:provider)

--- a/src/app/models/content_view_definition_base.rb
+++ b/src/app/models/content_view_definition_base.rb
@@ -78,7 +78,9 @@ class ContentViewDefinitionBase < ActiveRecord::Base
 
   def remove_repository(repository)
     filters.each do |filter_item|
-      if filter_item.repositories.unscoped.include?(repository)
+      repo_exists = Repository.unscoped.joins(:filters).where(
+                      :filters => {:id => filter_item.id}, :id => repository.id).count
+      if repo_exists
         filter_item.repositories.delete(repository)
         filter_item.save!
       end

--- a/src/app/models/repository.rb
+++ b/src/app/models/repository.rb
@@ -29,6 +29,7 @@ class Repository < ActiveRecord::Base
   has_and_belongs_to_many :changesets
   has_many :content_view_definition_repositories
   has_many :content_view_definitions, :through => :content_view_definition_repositories
+  has_and_belongs_to_many :filters
   belongs_to :content_view_version, :inverse_of=>:repositories
 
   validates :environment_product, :presence => true
@@ -44,9 +45,12 @@ class Repository < ActiveRecord::Base
 
   default_scope order('repositories.name ASC')
   scope :enabled, where(:enabled => true)
-
   scope :in_default_view, joins(:content_view_version => :content_view).
     where("content_views.default" => true)
+
+  def self.ids_only
+    with_exclusive_scope{pluck(:id)}
+  end
 
   def product
     self.environment_product.product

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -637,6 +637,7 @@ Src::Application.routes.draw do
           collection do
             get :index, :action => :list_products
             put :index, :action => :update_products
+            get :all, :action => :list_all_products
           end
         end
         resources :repositories, :controller => :content_view_definitions, :only => [] do

--- a/src/test/controllers/api/content_view_definitions_controller_test.rb
+++ b/src/test/controllers/api/content_view_definitions_controller_test.rb
@@ -1,0 +1,87 @@
+# encoding: utf-8
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require "minitest_helper"
+
+class Api::ContentViewDefinitionsControllerTest < MiniTest::Rails::ActionController::TestCase
+  fixtures :all
+
+  def setup
+    models = ["Organization", "KTEnvironment", "User","ContentViewEnvironment",
+             "ContentViewDefinition", "Product", "EnvironmentProduct", "Repository"]
+    disable_glue_layers(["Candlepin", "Pulp", "ElasticSearch"], models)
+    login_user(User.find(users(:admin)))
+    Product.any_instance.stubs(:productContent).returns([])
+    Product.any_instance.stubs(:multiplier).returns(1)
+    Product.any_instance.stubs(:attrs).returns({})
+    Product.any_instance.stubs(:sync_state).returns(nil)
+    Product.any_instance.stubs(:last_sync).returns(nil)
+    Product.any_instance.stubs(:sync_plan).returns(nil)
+    @cvd = content_view_definition_bases(:populated_cvd)
+  end
+
+  test "should show products in the cvd" do
+    get :list_products, :organization_id => @cvd.organization.label,
+                        :content_view_definition_id=> @cvd.id
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_kind_of Array, body
+    assert_equal((body.collect{|item| item['id']}), @cvd.products.pluck(:cp_id))
+  end
+
+  test "should show all products in the cvd " do
+    cvd = content_view_definition_bases(:populated_with_repos_and_filters)
+    get :list_all_products, :organization_id => cvd.organization.label,
+        :content_view_definition_id=> cvd.id
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_kind_of Array, body
+    assert_includes((body.collect{|item| item['id']}), @cvd.repositories.first.product.cp_id)
+  end
+
+  test "should update product to the cvd" do
+    refute_empty(@cvd.products)
+    post :update_products, :organization_id => @cvd.organization.label,
+                    :content_view_definition_id=> @cvd.id,
+                    :products => []
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_kind_of Array, body
+    assert_empty(ContentViewDefinition.find(@cvd.id).products)
+  end
+
+  test "should show repos in the cvd" do
+    get :list_repositories, :organization_id => @cvd.organization.label,
+        :content_view_definition_id=> @cvd.id
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_kind_of Array, body
+    assert_equal(@cvd.repositories.collect(&:label), (body.collect{|item| item['label']}))
+  end
+
+
+  test "should update product to the cvd" do
+    refute_empty(@cvd.repositories)
+    post :update_repositories, :organization_id => @cvd.organization.label,
+         :content_view_definition_id=> @cvd.id,
+         :repos => []
+    assert_response :success
+    assert_kind_of Array, JSON.parse(response.body)
+    assert_empty(ContentViewDefinition.find(@cvd.id).repositories)
+  end
+
+end

--- a/src/test/fixtures/models/content_view_definition_bases.yml
+++ b/src/test/fixtures/models/content_view_definition_bases.yml
@@ -13,3 +13,11 @@ populated_cvd:
   description:  This CVD has products, repositories, filters and rules
   composite:    false
   type:         ContentViewDefinition
+
+populated_with_repos_and_filters:
+  name:         Populated CVD With Repos and Filters
+  organization: acme_corporation
+  label:        populated_with_repos_and_filters
+  description:  This CVD has repositories, filters and rules
+  composite:    false
+  type:         ContentViewDefinition

--- a/src/test/fixtures/models/content_view_definition_repositories.yml
+++ b/src/test/fixtures/models/content_view_definition_repositories.yml
@@ -1,3 +1,8 @@
 populated_cvd_repository_fedora_17_x86_64:
   content_view_definition: populated_cvd
   repository:              fedora_17_x86_64
+
+
+populated_cvd_repos_and_filters_fedora_17_x86_64:
+  content_view_definition: populated_with_repos_and_filters
+  repository:              fedora_17_x86_64

--- a/src/test/fixtures/models/filters.yml
+++ b/src/test/fixtures/models/filters.yml
@@ -5,3 +5,7 @@ simple_filter:
 populated_filter:
   name:                      Populated Filter
   content_view_definition:   populated_cvd
+
+populated_filter_with_repos_and_filters:
+  name:                      Populated Filter
+  content_view_definition:   populated_with_repos_and_filters


### PR DESCRIPTION
Previously filters cli due to a bug would not associate
partial products from CVD.
For example
CVD Foo, Repo: {repo3, repo4}, Prod:{prod1}, Filter: {f1}
now we want to be able to associate repo3.product and
repo4.product also to f1 in addition to prod1. This commit
enables that.
Other things in this commits
1) Unit tests for add products and add repos both cli and api
2) Couple of fixes for places where we accidentally used unscoped.
