### PR TITLE
splice-api-update - changes to fix/support distributors for use w/ splice

### DIFF
--- a/cli/src/katello/client/api/distributor.py
+++ b/cli/src/katello/client/api/distributor.py
@@ -37,6 +37,10 @@ class DistributorAPI(KatelloAPI):
         path = "/api/distributors/" + u_str(distributor_uuid)
         return self.server.DELETE(path)[1]
 
+    def export_manifest(self, distributor_uuid):
+        path = "/api/distributors/%s/export" % distributor_uuid
+        return self.server.GET(path)[1]
+
     def subscribe(self, distributor_id, pool, quantity):
         path = "/api/distributors/%s/subscriptions" % distributor_id
         data = {

--- a/cli/src/katello/client/api/system.py
+++ b/cli/src/katello/client/api/system.py
@@ -13,6 +13,8 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 
+import datetime
+
 from katello.client.api.base import KatelloAPI
 from katello.client.lib.utils.encoding import u_str
 from katello.client.lib.utils.data import update_dict_unless_none
@@ -50,6 +52,16 @@ class SystemAPI(KatelloAPI):
         path = "/api/systems/" + u_str(system_uuid)
         return self.server.DELETE(path)[1]
 
+    # checkin_time - datetime or None (default)
+    def checkin(self, system_uuid, checkin_time=None):
+        path = "/api/systems/%s/checkin" % u_str(system_uuid)
+        if not checkin_time:
+            checkin_time = datetime.datetime.now()
+        params = {
+            "date": checkin_time.isoformat()
+        }
+        return self.server.PUT(path, params)[1]
+
     def subscribe(self, system_id, pool, quantity):
         path = "/api/systems/%s/subscriptions" % system_id
         data = {
@@ -61,6 +73,10 @@ class SystemAPI(KatelloAPI):
     def subscriptions(self, system_id):
         path = "/api/systems/%s/subscriptions" % system_id
         return self.server.GET(path)[1]
+
+    def refresh_subscriptions(self, system_id):
+        path = "/api/systems/%s/refresh_subscriptions" % system_id
+        return self.server.POST(path, {})[1]
 
     def available_pools(self, system_id, match_system=False, match_installed=False, no_overlap=False):
         params = {}

--- a/src/app/assets/stylesheets/_menu.scss
+++ b/src/app/assets/stylesheets/_menu.scss
@@ -1,4 +1,4 @@
-$menu_width: 253px !default;
+$menu_width: 300px !default;
 
 @import "katello_base";
 

--- a/src/app/assets/stylesheets/katello.scss
+++ b/src/app/assets/stylesheets/katello.scss
@@ -30,6 +30,7 @@
 @import "jquery.tipsy";
 @import "jquery.multiselect";
 @import "jquery.multiselect.filter";
+@import "ui.spinner";
 
 body {
   min-width: $static_width;

--- a/src/app/controllers/api/distributors_controller.rb
+++ b/src/app/controllers/api/distributors_controller.rb
@@ -18,7 +18,7 @@ class Api::DistributorsController < Api::ApiController
   before_filter :find_only_environment, :only => [:create]
   before_filter :find_environment, :only => [:create, :index, :report, :tasks]
   before_filter :find_distributor, :only => [:destroy, :show, :update,
-                                        :subscribe, :unsubscribe, :subscriptions, :pools]
+                                        :subscribe, :unsubscribe, :subscriptions, :pools, :export]
   before_filter :find_task, :only => [:task_show]
   before_filter :authorize, :except => :activate
 
@@ -49,7 +49,8 @@ class Api::DistributorsController < Api::ApiController
       :pools => read_distributor,
       :activate => register_distributor,
       :tasks => index_distributors,
-      :task_show => read_distributor
+      :task_show => read_distributor,
+      :export => read_distributor
     }
   end
 
@@ -102,6 +103,18 @@ class Api::DistributorsController < Api::ApiController
   param :id, String, :desc => "UUID of the distributor", :required => true
   def show
     render :json => @distributor.to_json
+  end
+
+  api :GET, "/distributors/:id/export", "Export distributor's manifest"
+  param :id, String, :desc => "UUID of the distributor", :required => true
+  def export
+    filename = params[:filename]
+    filename = 'manifest.zip' if filename.nil? || filename == ''
+
+    data = @distributor.export
+    send_data data,
+              :filename => filename,
+              :type => 'application/xml'
   end
 
   api :DELETE, "/distributors/:id", "Unregister a distributor"

--- a/src/app/controllers/distributors_controller.rb
+++ b/src/app/controllers/distributors_controller.rb
@@ -379,13 +379,13 @@ class DistributorsController < ApplicationController
 
   def setup_options
     @panel_options = {
-      :title => _('Subscription Management Applications'),
+      :title => _('Distributors'),
       :col => ["name_sort", "lastCheckin"],
       :titles => [_("Name"), _("Created / Last Checked In")],
       :custom_rows => true,
-      :enable_create => Katello.config.katello? && Distributor.registerable?(@environment, current_organization),
+      :enable_create => Distributor.registerable?(@environment, current_organization),
       :create => _("Distributor"),
-      :create_label => _('+ New SMA'),
+      :create_label => _('+ New Distributor'),
       :enable_sort => true,
       :name => controller_display_name,
       :list_partial => 'distributors/list_distributors',

--- a/src/app/lib/resources/candlepin.rb
+++ b/src/app/lib/resources/candlepin.rb
@@ -130,6 +130,12 @@ module Resources
           self.delete(path(uuid), User.cp_oauth_header).code.to_i
         end
 
+        def checkin(uuid, checkin_date)
+          checkin_date ||= DateTime.now
+          uri = "%s?checkin_date=%s" % [join_path(path(uuid), 'checkin'), checkin_date]
+          self.put(uri, {}.to_json, self.default_headers).body
+        end
+
         def available_pools(uuid, listall=false)
           url = Pool.path() + "?consumer=#{uuid}&listall=#{listall}"
           response = Candlepin::CandlepinResource.get(url,self.default_headers).body
@@ -153,6 +159,10 @@ module Resources
         def entitlements uuid
           response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'entitlements'), self.default_headers).body
           Util::Data::array_with_indifferent_access JSON.parse(response)
+        end
+
+        def refresh_entitlements uuid
+          self.post(join_path(path(uuid), 'entitlements'), "", self.default_headers).body
         end
 
         def consume_entitlement uuid, pool, quantity = nil

--- a/src/app/models/distributor.rb
+++ b/src/app/models/distributor.rb
@@ -33,7 +33,7 @@ class Distributor < ActiveRecord::Base
   validates_with Validators::NonLibraryEnvironmentValidator, :attributes => :environment
   # multiple distributors with a single name are supported
   validates :name, :presence => true
-  #validates_uniqueness_of :name, :scope => {:environment => :organization_id}
+  validates_length_of :name, :maximum => 250
   validates_with Validators::UniqueFieldInOrg, :attributes => :name
   validates_with Validators::NoTrailingSpaceValidator, :attributes => :name
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description

--- a/src/app/models/glue/candlepin/consumer.rb
+++ b/src/app/models/glue/candlepin/consumer.rb
@@ -118,6 +118,22 @@ module Glue::Candlepin::Consumer
       raise e
     end
 
+    def checkin(checkin_time)
+      Rails.logger.debug "Updating consumer check-in time: #{name}"
+      Resources::Candlepin::Consumer.checkin(self.uuid, checkin_time)
+    rescue => e
+      Rails.logger.error "Failed to update consumer check-in time in candlepin for #{name}: #{e}, #{e.backtrace.join("\n")}"
+      raise e
+    end
+
+    def refresh_subscriptions
+      Rails.logger.debug "Refreshing consumer subscriptions in candlepin: #{name}"
+      Resources::Candlepin::Consumer.refresh_entitlements(self.uuid)
+    rescue => e
+      Rails.logger.error "Failed to refresh consumer subscriptions in candlepin for #{name}: #{e}, #{e.backtrace.join("\n")}"
+      raise e
+    end
+
     def del_candlepin_consumer
       Rails.logger.debug "Deleting consumer in candlepin: #{name}"
       Resources::Candlepin::Consumer.destroy(self.uuid)
@@ -187,7 +203,7 @@ module Glue::Candlepin::Consumer
     end
 
     def to_json
-      super(:methods => [:href, :facts, :idCert, :owner, :autoheal, :release, :releaseVer])
+      super(:methods => [:href, :facts, :idCert, :owner, :autoheal, :release, :releaseVer, :checkin_time, :installedProducts])
     end
 
     def convert_from_cp_fields(cp_json)

--- a/src/app/models/glue/provider.rb
+++ b/src/app/models/glue/provider.rb
@@ -53,7 +53,7 @@ module Glue::Provider
     end
 
     def refresh_manifest(upstream, options = {})
-      options = { :async => false, :notify => false }.merge options
+      options = { :async => true, :notify => false }.merge options
       options.assert_valid_keys(:async, :notify)
 
       self.task_status

--- a/src/app/views/subscriptions/_edit_manifest.html.haml
+++ b/src/app/views/subscriptions/_edit_manifest.html.haml
@@ -19,12 +19,6 @@
           #{_('No subscription manifest imported')}
       %fieldset
         .grid_3.ra.fieldset
-          %label #{_("Imported File Name")}
-        - if @upstream['fileName']
-          .grid_8.la.fl
-            #{@upstream['fileName']}
-      %fieldset
-        .grid_3.ra.fieldset
           %label #{_("Upstream Type")}
         - if @upstream['type']
           .grid_8.la.fl

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -520,6 +520,8 @@ Src::Application.routes.draw do
         put :enabled_repos
         post :system_groups, :action => :add_system_groups
         delete :system_groups, :action => :remove_system_groups
+        post :refresh_subscriptions
+        put :checkin
       end
       collection do
         match "/tasks/:id" => "systems#task_show", :via => :get
@@ -536,6 +538,7 @@ Src::Application.routes.draw do
     resources :distributors, :only => [:show, :destroy, :create, :index, :update] do
       member do
         get :pools
+        get :export
       end
       resources :subscriptions, :only => [:create, :index, :destroy] do
         collection do
@@ -812,6 +815,7 @@ Src::Application.routes.draw do
     match '/subscriptions' => 'candlepin_proxies#post', :via => :post, :as => :proxy_subscriptions_post_path
     match '/consumers/:id/profile/' => 'systems#upload_package_profile', :via => :put
     match '/consumers/:id/packages/' => 'systems#upload_package_profile', :via => :put
+    match '/consumers/:id/checkin/' => 'systems#checkin', :via => :put
 
     # development / debugging support
     if Rails.env == "development"


### PR DESCRIPTION
dist-fixes - allow create in headpin mode
dist-fixes - renamed SMA to distributor
splice-api-update - updates to api
splice-api-updates - download manifest api
splice-api-updates - export api
splice-api-updates - api for /consumers/<id>/checkin
