### PR TITLE
Worked on filter controller permissions tests

### DIFF
--- a/src/test/controllers/api/filters_controller_test.rb
+++ b/src/test/controllers/api/filters_controller_test.rb
@@ -22,6 +22,8 @@ class Api::FiltersControllerTest < MiniTest::Rails::ActionController::TestCase
     disable_glue_layers(["Candlepin", "Pulp", "ElasticSearch"], models)
     login_user(User.find(users(:admin)))
     @filter = filters(:simple_filter)
+    @cvd = @filter.content_view_definition
+    @organization = @cvd.organization
     Product.any_instance.stubs(:productContent).returns([])
     Product.any_instance.stubs(:multiplier).returns(1)
     Product.any_instance.stubs(:attrs).returns({})
@@ -29,16 +31,31 @@ class Api::FiltersControllerTest < MiniTest::Rails::ActionController::TestCase
     Product.any_instance.stubs(:last_sync).returns(nil)
     Product.any_instance.stubs(:sync_plan).returns(nil)
 
+    @readable_permission = lambda do |user|
+      user.can(:read, :content_view_definitions, [@cvd.id], @organization)
+    end
+    @editable_permission = lambda do |user|
+      user.can(:update, :content_view_definitions, [@cvd.id] , @organization)
+    end
   end
 
   test "should return a list of filters" do
-    get :index, :organization_id => @filter.content_view_definition.organization.label,
-                :content_view_definition_id=> @filter.content_view_definition.id
+    get :index, :organization_id => @organization.label,
+                :content_view_definition_id=> @cvd.id
     assert_response :success
 
     body = JSON.parse(response.body)
     assert_kind_of Array, body
     refute_empty body
+  end
+
+  test "index permissions" do
+    assert_authorized(
+        :permission => @readable_permission,
+        :action => :index,
+        :request => lambda { get :index, :organization_id => @organization.label,
+                                 :content_view_definition_id => @cvd.id}
+    )
   end
 
   test "should return a filter" do
@@ -50,6 +67,18 @@ class Api::FiltersControllerTest < MiniTest::Rails::ActionController::TestCase
     body = JSON.parse(response.body)
     assert_kind_of Hash, body
     assert_equal @filter.name, body["name"]
+  end
+
+  test "show permissions" do
+    assert_authorized(
+        :permission => @readable_permission,
+        :action => :show,
+        :request => lambda {
+          get :show, :organization_id => @filter.content_view_definition.organization.label,
+              :content_view_definition_id=> @filter.content_view_definition.id,
+              :id => @filter.id
+        }
+    )
   end
 
   test "should throw an 404 if definition is not found" do
@@ -75,6 +104,25 @@ class Api::FiltersControllerTest < MiniTest::Rails::ActionController::TestCase
     assert_nil Filter.find_by_name(@filter.name)
   end
 
+  test "delete permissions" do
+    action = :destroy
+    request = lambda do
+      delete action, :organization_id => @filter.content_view_definition.organization.label,
+             :content_view_definition_id=> @filter.content_view_definition.id,
+             :id => @filter.id
+    end
+
+    assert_authorized(:permission => @editable_permission,
+                      :action => action,
+                      :request => request
+                     )
+
+    refute_authorized(:permission => @readable_permission,
+                      :action => action,
+                      :request => request
+                     )
+  end
+
   test "should create a filter" do
     name = @filter.name + "Cool"
     post :create, :organization_id => @filter.content_view_definition.organization.label,
@@ -84,6 +132,19 @@ class Api::FiltersControllerTest < MiniTest::Rails::ActionController::TestCase
     assert_kind_of Hash, JSON.parse(response.body)
     assert_equal name, JSON.parse(response.body)["name"]
     refute_nil Filter.find_by_name(name)
+  end
+
+  test "create permissions" do
+    assert_authorized(
+        :permission => @editable_permission,
+        :action => :create,
+        :request => lambda {
+          name = @filter.name + "Cool"
+          post :create, :organization_id => @filter.content_view_definition.organization.label,
+               :content_view_definition_id=> @filter.content_view_definition.id,
+               :filter => name
+        }
+    )
   end
 
   test "should show products in the filter" do

--- a/src/test/factories/user_factory.rb
+++ b/src/test/factories/user_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     sequence(:username) { |n| "user#{n}" }
     sequence(:email) { |n| "user#{n}@katello.org" }
     password "password1"
-    remote_id "remote1"
+    sequence(:remote_id) { |n| "remote#{n}" }
 
     trait :batman do
       username  "batman"

--- a/src/test/minitest_helper.rb
+++ b/src/test/minitest_helper.rb
@@ -7,6 +7,7 @@ require 'simplecov'
 require 'json'
 require 'support/auth_support'
 require 'support/warden_support'
+require 'support/controller_support'
 require 'mocha/setup'
 
 class MiniTest::Rails::ActiveSupport::TestCase
@@ -46,6 +47,7 @@ end
 class Minitest::Rails::ActionController::TestCase
   include Warden::Test::Helpers
   include WardenSupport
+  include ControllerSupport
 end
 
 def configure_vcr

--- a/src/test/support/controller_support.rb
+++ b/src/test/support/controller_support.rb
@@ -1,0 +1,54 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+module ControllerSupport
+  def check_permission(params)
+    user = params[:user] || no_permission_user
+
+    params[:permission].call(::AuthorizationSupportMethods::UserPermissionsGenerator.new(user))
+
+    action = params[:action]
+    req = params[:request]
+    @controller.define_singleton_method(action) {render :nothing => true}
+
+    login_user(user)
+    req.call
+
+    if params[:authorized]
+      assert_response :success
+    else
+      assert_equal 403, response.status
+    end
+  end
+
+  def assert_authorized(params)
+    check_params = params.merge(authorized: true)
+    check_permission(check_params)
+  end
+
+  def refute_authorized(params)
+    check_params = params.merge(authorized: false)
+    check_permission(check_params)
+  end
+
+  def no_permission_user
+    begin
+      user = User.find(users(:no_perms_user))
+      user.own_role.permissions.delete_all
+      user
+    rescue
+      # fixtures not loaded
+      FactoryGirl.create(:user)
+    end
+  end
+end


### PR DESCRIPTION
I worked on #2052 addressing the feedback here. I also made some changes that include:
1. Broke `assert_permission` out into `assert_authorized` and `refute_authorized`.
2. Allowing `assert_authorized` and `refute_authorized` to be called multiple times in a test. Previously we could only call `assert_permission` once per test to check one authorized permission and one unauthorized permission. Now you can test as many permissions and combination of permissions as you like.
3. User can be passed into the assert to override the default no_perms_user.
4. Tests with fixtures and tests without fixtures are both supported. Previously, you always had to have `fixtures :all` in your test file. Now if fixtures aren't loaded, the code falls back to FactoryGirl.
5. Fixed places that said `test "index perms"` to say `test "index permissions"`.
6. Removed a few blank lines.
7. Variable names for single permissions are named permission and not permissions (e.g. `edit_permission` instead of `edit_permissions`)
