### PR TITLE
Fixing default route handler to not override engines

### DIFF
--- a/src/config/application.rb
+++ b/src/config/application.rb
@@ -122,8 +122,11 @@ module Src
             Katello.config.url_prefix].compact.join,
         :protocol => Katello.config.use_ssl ? 'https' : 'http' }
 
-    config.after_initialize do
+    config.after_initialize do |app|
       require 'string_to_bool'
+      #default all non-matched route to our special 404 page
+      # cannot be added to routes.rb due to conflicting with engines
+      app.routes.append{match '*a', :to => 'errors#routing'}
     end
 
     # set actions to profile (eg. %w(user_sessions#new))

--- a/src/config/routes.rb
+++ b/src/config/routes.rb
@@ -830,8 +830,4 @@ Src::Application.routes.draw do
   end
 
   match 'about', :to => "application_info#about", :as => "about"
-
-  #Last route in routes.rb - throws routing error for everything not handled
-  match '*a', :to => 'errors#routing'
-
 end


### PR DESCRIPTION
fix was pulled from: https://github.com/vidibus/vidibus-routing_error
