### PR TITLE
build katello-nightly-rhel6 into scl ruby193

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -5,6 +5,7 @@ default_tagger = tito.tagger.VersionTagger
 [katello-nightly-rhel6]
 disttag = .el6
 blacklist =
+scl = ruby193
 
 [katello-nightly-fedora18]
 disttag = .fc18


### PR DESCRIPTION
this will allow us to build package for el6 even without scl meta package on machine from which is task submited
