### PR TITLE
Errata list should require either repo_id or repo info

### DIFF
--- a/cli/src/katello/client/core/errata.py
+++ b/cli/src/katello/client/core/errata.py
@@ -60,8 +60,8 @@ class List(ErrataAction):
                       help=_("filter errata by severity"))
 
     def check_options(self, validator):
-        if not validator.exists('repo_id'):
-            validator.require('org')
+        validator.require_at_least_one_of(('repo', 'repo_id'))
+        validator.mutually_exclude('repo', 'repo_id')
         if validator.exists('repo'):
             validator.require('org')
             validator.require_at_least_one_of(('product', 'product_label', 'product_id'))

--- a/cli/test/katello/tests/core/errata/errata_list_test.py
+++ b/cli/test/katello/tests/core/errata/errata_list_test.py
@@ -22,6 +22,7 @@ class RequiredCLIOptionsTests(CLIOptionTestCase):
     disallowed_options = [
         ('--repo=repo-123', '--product=product-123'),
         ('--repo=repo-123', '--org=org-123'),
+        ('--repo=repo-123', '--repo_id=123'),
         ('--product=product-123', ),
         (),
     ]
@@ -29,11 +30,10 @@ class RequiredCLIOptionsTests(CLIOptionTestCase):
     allowed_options = [
         ('--repo=repo-123', '--product=product-123', '--org=org-123'),
         ('--repo_id=repo-123', ),
-        ('--org=org-123', ),
-        ('--org=org-123', '--environment=env-123', '--product=product-123'),
-        ('--org=org-123', '--environment=env-123', '--product=product-123', '--content_view=c1'),
-        ('--type=enhancements', '--org=org-123'),
-        ('--severity=critical', '--org=org-123'),
+        ('--org=org-123', '--environment=env-123', '--product=product-123', '--repo=repo-123'),
+        ('--org=org-123', '--environment=env-123', '--product=product-123', '--repo=repo-123', '--content_view=c1'),
+        ('--type=enhancements', '--repo_id=repo-123'),
+        ('--severity=critical', '--repo_id=repo-123'),
     ]
 
 


### PR DESCRIPTION
@bbuckingham  discovered that you could do `katello errata list --org=ACME --content_view=NoSQL` although it didn't work properly. However, the errata description says that it lists errata for a repo. Moreover, the package command that mirrors this requires repo info. Lastly, many of the commands don't work (such as `katello errata list --org=ACME --product_label=Mongo`) unless you specify repo info. I also talked to Garik and he confirmed that errata list is meant to list the errata for a single repo.
