### PR TITLE
Fixes #2077 - Since the JSRoutes paths mimic the rails path API

### DIFF
--- a/src/app/assets/javascripts/content_search/content_search.js
+++ b/src/app/assets/javascripts/content_search/content_search.js
@@ -110,7 +110,7 @@ KT.content_search = function(paths_in){
         paths = paths_in;
 
         if( KT.permissions.current_organization.editable ){
-            footer = $('<a/>', { "href" : KT.routes.organizations_path('#panel=organization_' + KT.permissions.current_organization['id'] + '&panelpage=edit')});
+            footer = $('<a/>', { "href" : KT.routes.organizations_path({ anchor : 'panel=organization_' + KT.permissions.current_organization['id'] + '&panelpage=edit' })});
             footer.append($('<i/>', { "class" : "gears_icon", "data-change_on_hover" : "dark" }));
             footer.append($('<span/>').html(i18n.manage_environments));
             footer = footer[0].outerHTML;


### PR DESCRIPTION
in order to put a hash parameter, the anchor option needs to be
used.
