### PR TITLE
workaround that "tito tag" does not create correct path in metadata file...

### DIFF
--- a/rel-eng/git-untagged-commits.pl
+++ b/rel-eng/git-untagged-commits.pl
@@ -34,6 +34,7 @@ for my $file (@files) {
 	close FILE;
 	my $name = File::Basename::basename($file);
 	my ($version, $dir) = split /\s/, $line;
+	$dir = './' if ($dir eq '/');
 	my @changes =
 		grep { not /^\S+\s([Bb]umping package versions for|All the NoTgzBuilders are now|%defattr is not needed since rpm 4\.4)/ }
 		`git log --pretty=format:'%h %s (%ae)' $name-$version..HEAD -- $cdup$dir`;


### PR DESCRIPTION
... if package is in git-root
