### PR TITLE
Double Render Error when accessing certain pages when logged out

### DIFF
--- a/app/controllers/api/ping_controller.rb
+++ b/app/controllers/api/ping_controller.rb
@@ -13,7 +13,7 @@
 class Api::PingController < Api::ApiController
 
   skip_before_filter :authorize # ok - anyone authenticated can ask for status
-  skip_before_filter :require_user, :only => [:status]
+  skip_before_filter :require_user, :only => [:system_status]
 
   api :GET, "/ping", "Shows status of system and it's subcomponents"
   description "This service is only available for authenticated users"
@@ -21,9 +21,9 @@ class Api::PingController < Api::ApiController
     render :json => Ping.ping().to_json and return
   end
 
-  api :GET, "/status", "Shows version information"
+  api :GET, "/system_status", "Shows version information"
   description "This service is also available for unauthenticated users"
-  def status
+  def system_status
     render :json => {:release => Katello.config.app_name,
         :version => Katello.config.katello_version,
         :standalone => true,

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -42,7 +42,7 @@ class ChangesetsController < ApplicationController
       :object => read_perm,
       :auto_complete_search => read_perm,
       :apply => apply_perm,
-      :status => read_perm
+      :changeset_status => read_perm
     }
   end
 
@@ -271,7 +271,7 @@ class ChangesetsController < ApplicationController
     render :text=>e.to_s, :status=>500
   end
 
-  def status
+  def changeset_status
     progress = @changeset.task_status.progress
     state = @changeset.state
     to_ret = {'id' => 'changeset_' + @changeset.id.to_s, 'state' => state, 'progress' => progress.to_i,

--- a/app/controllers/content_view_definitions_controller.rb
+++ b/app/controllers/content_view_definitions_controller.rb
@@ -17,7 +17,7 @@ class ContentViewDefinitionsController < ApplicationController
   before_filter :require_user
   before_filter :find_content_view_definition, :only => [:clone, :show, :edit, :update, :destroy, :views, :content,
                                                          :update_content, :update_component_views,
-                                                         :publish_setup, :publish, :status]
+                                                         :publish_setup, :publish, :definition_status]
   before_filter :authorize #after find_content_view_definition, since the definition is required for authorization
   before_filter :panel_options, :only => [:index, :items]
 
@@ -56,7 +56,7 @@ class ContentViewDefinitionsController < ApplicationController
       :destroy => delete_rule,
 
       :views => show_rule,
-      :status => publish_rule,
+      :definition_status => publish_rule,
 
       :content => show_rule,
       :update_content => manage_rule,
@@ -181,7 +181,7 @@ class ContentViewDefinitionsController < ApplicationController
                        :name => controller_display_name}
   end
 
-  def status
+  def definition_status
     # retrieve the status for publish & refresh tasks initiated by the client
     statuses = {:task_statuses => []}
 

--- a/app/controllers/distributor_events_controller.rb
+++ b/app/controllers/distributor_events_controller.rb
@@ -25,7 +25,7 @@ class DistributorEventsController < ApplicationController
       :index => read_distributor,
       :items => read_distributor,
       :show => read_distributor,
-      :status => read_distributor,
+      :distributor_status => read_distributor,
       :more_events => read_distributor
     }
   end
@@ -49,7 +49,7 @@ class DistributorEventsController < ApplicationController
   end
 
   # retrieve the status for the actions initiated by the client
-  def status
+  def distributor_status
     statuses = {:tasks => []}
     @distributor.tasks.where(:id => params[:task_id]).collect do |status|
       statuses[:tasks] << {

--- a/app/controllers/system_errata_controller.rb
+++ b/app/controllers/system_errata_controller.rb
@@ -12,7 +12,7 @@
 
 class SystemErrataController < ApplicationController
 
-  before_filter :find_system, :only =>[:install, :index, :items, :status]
+  before_filter :find_system, :only =>[:install, :index, :items, :errata_status]
   before_filter :authorize
 
   def section_id
@@ -27,7 +27,7 @@ class SystemErrataController < ApplicationController
       :index => read_system,
       :items => read_system,
       :install => edit_system,
-      :status => edit_system
+      :errata_status => edit_system
     }
   end
 
@@ -65,7 +65,7 @@ class SystemErrataController < ApplicationController
     render :text => task.id
   end
 
-  def status
+  def errata_status
     if params[:id]
       statuses = @system.tasks.where('task_statuses.id' => params[:id], :task_type => [:errata_install])
     else

--- a/app/controllers/system_events_controller.rb
+++ b/app/controllers/system_events_controller.rb
@@ -25,7 +25,7 @@ class SystemEventsController < ApplicationController
       :index => read_system,
       :items => read_system,
       :show => read_system,
-      :status => read_system,
+      :event_status => read_system,
       :more_events => read_system
     }
   end
@@ -49,7 +49,7 @@ class SystemEventsController < ApplicationController
   end
 
   # retrieve the status for the actions initiated by the client
-  def status
+  def event_status
     statuses = {:tasks => []}
     @system.tasks.where(:id => params[:task_id]).collect do |status|
       statuses[:tasks] << {

--- a/app/controllers/system_group_errata_controller.rb
+++ b/app/controllers/system_group_errata_controller.rb
@@ -14,7 +14,7 @@ class SystemGroupErrataController < ApplicationController
 
   helper SystemErrataHelper
 
-  before_filter :find_group, :only =>[:install, :index, :items, :status]
+  before_filter :find_group, :only =>[:install, :index, :items, :errata_status]
   before_filter :authorize
 
   def section_id
@@ -28,7 +28,7 @@ class SystemGroupErrataController < ApplicationController
       :index => read_group,
       :items => read_group,
       :install => edit_group,
-      :status => edit_group
+      :errata_status => edit_group
     }
   end
 
@@ -68,7 +68,7 @@ class SystemGroupErrataController < ApplicationController
     render :text => '' and return
   end
 
-  def status
+  def errata_status
     if params[:id]
       jobs = @group.refreshed_jobs.joins(:task_statuses).where(
           'jobs.id' => params[:id], 'task_statuses.task_type' => [:errata_install])

--- a/app/controllers/system_group_events_controller.rb
+++ b/app/controllers/system_group_events_controller.rb
@@ -25,7 +25,7 @@ class SystemGroupEventsController < ApplicationController
       :index => read_group,
       :items => read_group,
       :show => read_group,
-      :status => read_group,
+      :event_status => read_group,
       :more_items => read_group
     }
   end
@@ -44,7 +44,7 @@ class SystemGroupEventsController < ApplicationController
     end
   end
 
-  def status
+  def event_status
     # retrieve the status for the actions initiated by the client
     statuses = {:jobs => [], :tasks => []}
 

--- a/app/controllers/system_group_packages_controller.rb
+++ b/app/controllers/system_group_packages_controller.rb
@@ -31,7 +31,7 @@ class SystemGroupPackagesController < ApplicationController
       :add => edit_group,
       :remove => edit_group,
       :update => edit_group,
-      :status => edit_group
+      :package_status => edit_group
     }
   end
 
@@ -161,7 +161,7 @@ class SystemGroupPackagesController < ApplicationController
     render :text => '' and return
   end
 
-  def status
+  def package_status
     # retrieve the status for the actions initiated by the client
     response = []
     jobs = @group.refreshed_jobs.where('jobs.id' => params[:id])

--- a/app/controllers/system_packages_controller.rb
+++ b/app/controllers/system_packages_controller.rb
@@ -29,7 +29,7 @@ class SystemPackagesController < ApplicationController
       :add => edit_system,
       :remove => edit_system,
       :update => edit_system,
-      :status => edit_system
+      :package_status => edit_system
     }
   end
 
@@ -164,7 +164,7 @@ class SystemPackagesController < ApplicationController
                                                 :editable => @system.editable?}
   end
 
-  def status
+  def package_status
     # retrieve the status for the package actions initiated by the client
     statuses = @system.tasks.where(:id => params[:id],
                                    :task_type => [:package_install, :package_update, :package_remove,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Src::Application.routes.draw do
     end
     resources :events, :controller => "system_group_events", :only => [:index, :show] do
       collection do
-        get :status
+        get :status, action: :event_status
         get :more_items
         get :items
       end
@@ -29,14 +29,14 @@ Src::Application.routes.draw do
         put :add
         put :remove
         put :update
-        get :status
+        get :status, action: :package_status
       end
     end
     resources :errata, :controller => "system_group_errata", :only => [:index] do
       collection do
         get :items
         post :install
-        get :status
+        get :status, action: :errata_status
       end
     end
   end
@@ -71,7 +71,7 @@ Src::Application.routes.draw do
       get :views
       get :publish_setup
       post :publish
-      get :status
+      get :status, action: :definition_status
       get :content
       put :update_content
       put :update_component_views
@@ -200,7 +200,7 @@ Src::Application.routes.draw do
   resources :systems do
     resources :events, :only => [:index, :show], :controller => "system_events" do
       collection do
-        get :status
+        get :status, action: :event_status
         get :more_events
         get :items
       end
@@ -212,14 +212,14 @@ Src::Application.routes.draw do
         post :update
         get :packages
         get :more_packages
-        get :status
+        get :status, action: :package_status
       end
     end
     resources :errata, :controller => "system_errata", :only => [:index, :update] do
       collection do
         get :items
         post :install
-        get :status
+        get :status, action: :errata_status
       end
     end
 
@@ -275,7 +275,7 @@ Src::Application.routes.draw do
   resources :distributors do
     resources :events, :only => [:index, :show], :controller => "distributor_events" do
       collection do
-        get :status
+        get :status, action: :distributor_status
         get :more_events
         get :items
       end
@@ -429,7 +429,7 @@ Src::Application.routes.draw do
       put :name
       get :dependencies
       post :apply
-      get :status
+      get :status, action: :changeset_status
       get :object
     end
     collection do
@@ -780,7 +780,7 @@ Src::Application.routes.draw do
 
     resources :crls, :only => [:index]
 
-    match "/status"  => "ping#status", :via => :get
+    match "/status"  => "ping#system_status", :via => :get
     match "/version"  => "ping#version", :via => :get
     # some paths conflicts with rhsm
     scope 'katello' do

--- a/spec/controllers/api/ping_controller_spec.rb
+++ b/spec/controllers/api/ping_controller_spec.rb
@@ -56,12 +56,12 @@ describe Api::PingController do
     JSON.parse(response.body)
   end
 
-  context "status" do
+  context "system_status" do
 
     it "should reflect the correct information", :headpin => true do
       Katello.config.stub!(:app_name).and_return("Headpin")
       Katello.config.stub!(:katello_version).and_return("12")
-      get :status
+      get :system_status
       json(response).should include "release" => "Headpin"
       json(response).should include "version" => "12"
     end
@@ -69,7 +69,7 @@ describe Api::PingController do
     it "should reflect the correct information", :katello => true do
       Katello.config.stub!(:app_name).and_return("Katello")
       Katello.config.stub!(:katello_version).and_return("12")
-      get :status
+      get :system_status
       json(response).should include "release" => "Katello"
       json(response).should include "version" => "12"
     end

--- a/spec/controllers/changeset_controller_spec.rb
+++ b/spec/controllers/changeset_controller_spec.rb
@@ -86,7 +86,7 @@ describe ChangesetsController, :katello => true do
 
       @changeset.task_status = TaskStatus.create!(:organization_id =>@org.id, :uuid=>"FOO", :progress=>"0", :user=> new_user)
       @changeset.save!
-      get :status, :id=>@changeset.id
+      get :changeset_status, :id=>@changeset.id
       response.should be_success
       response.should contain('changeset_' + @changeset.id.to_s)
     end

--- a/spec/controllers/system_events_controller_spec.rb
+++ b/spec/controllers/system_events_controller_spec.rb
@@ -51,14 +51,14 @@ describe SystemEventsController do
         end
 
         specify "status call does the right thing" do
-          get :status, :system_id => @system.id, :task_id => @task.id
+          get :event_status, :system_id => @system.id, :task_id => @task.id
           response.should be_success
           JSON.parse(response.body)["tasks"].first["id"].should == @task.id
         end
 
         specify "status call does the right thing for multi tasks" do
           task1 = @system.install_packages(["baz"])
-          get :status, :system_id => @system.id, :task_id => [@task.id, task1.id]
+          get :event_status, :system_id => @system.id, :task_id => [@task.id, task1.id]
           response.should be_success
           JSON.parse(response.body)["tasks"].collect{|item| item['id']}.sort.should == [@task.id, task1.id].sort
         end

--- a/spec/controllers/system_group_events_controller_spec.rb
+++ b/spec/controllers/system_group_events_controller_spec.rb
@@ -79,7 +79,7 @@ describe SystemGroupEventsController do
         end
       end
 
-      describe 'status' do
+      describe 'event_status' do
         before (:each) do
           @job.stub!(:pending?).and_return(true)
         end
@@ -87,7 +87,7 @@ describe SystemGroupEventsController do
         it "should return a job" do
           @group.stub_chain(:refreshed_jobs, :where).and_return([@job])
 
-          get :status, :system_group_id => @group.id, :job_id => @job.id
+          get :event_status, :system_group_id => @group.id, :job_id => @job.id
           response.should be_success
           JSON.parse(response.body)["jobs"].first["id"].should == @job.id
         end
@@ -97,7 +97,7 @@ describe SystemGroupEventsController do
           job1.stub!(:pending?).and_return(true)
           @group.stub_chain(:refreshed_jobs, :where).and_return([@job, job1])
 
-          get :status, :system_group_id => @group.id, :job_id => [@job.id, job1.id]
+          get :event_status, :system_group_id => @group.id, :job_id => [@job.id, job1.id]
           response.should be_success
           JSON.parse(response.body)["jobs"].collect{|item| item['id']}.sort.should == [@job.id, job1.id].sort
         end
@@ -106,7 +106,7 @@ describe SystemGroupEventsController do
           @job.stub!(:pending?).and_return(true)
           @group.stub_chain(:refreshed_jobs, :where).and_return([@job])
 
-          get :status, :system_group_id => @group.id, :job_id => [@job.id]
+          get :event_status, :system_group_id => @group.id, :job_id => [@job.id]
           response.should be_success
         end
 


### PR DESCRIPTION
Steps to reproduce:
-  Log out of katello
-  Try to access  /katello/content_view_definitions

Expected to be redirected to login, instead get a double render error.  The cause seems to be that we define a 'status' method in ContentViewDefinitionController which is overriding some base 'status' method in the base controller class.  

/katello/changesets  is another UI page that does this.  There are other index-y pages:

[jlsherri@dhcp231-16 src]$ grep 'def status' app/controllers/ -R
app/controllers/api/ping_controller.rb:  def status
app/controllers/system_packages_controller.rb:  def status
app/controllers/system_group_events_controller.rb:  def status
app/controllers/distributor_events_controller.rb:  def status
app/controllers/system_group_packages_controller.rb:  def status
app/controllers/system_group_errata_controller.rb:  def status
app/controllers/system_events_controller.rb:  def status
app/controllers/content_view_definitions_controller.rb:  def status_foo
app/controllers/system_errata_controller.rb:  def status
app/controllers/changesets_controller.rb:  def status
