### PR TITLE
Speeding up rspec by deferring garbage collection

### DIFF
--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -304,6 +304,7 @@ development:
 # The following configuration values override ones from the common section
 #
 test:
+  rspec_gc_defer_time: <%= (ENV['DEFER_GC'] || 10).to_f %>
   database:
     database: katello-test<%= ENV['TEST_ENV_NUMBER'] %>
     min_messages: WARNING

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,14 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.include CustomMatchers
 
+  config.before(:suite) do
+    DeferredGarbageCollection.start
+  end
+
+  config.after(:each) do
+    DeferredGarbageCollection.reconsider
+  end
+
   config.after :all do
     Warden.test_reset!
   end

--- a/spec/support/deferred_garbage_collection.rb
+++ b/spec/support/deferred_garbage_collection.rb
@@ -1,0 +1,20 @@
+class DeferredGarbageCollection
+
+  DEFERRED_GC_THRESHOLD = Katello.config.rspec_gc_defer_time.to_f
+
+  @@last_gc_run = Time.now
+
+  def self.start
+    GC.disable if DEFERRED_GC_THRESHOLD > 0
+  end
+
+  def self.reconsider
+    if DEFERRED_GC_THRESHOLD > 0 && Time.now - @@last_gc_run >= DEFERRED_GC_THRESHOLD
+      GC.enable
+      GC.start
+      GC.disable
+      @@last_gc_run = Time.now
+    end
+  end
+
+end


### PR DESCRIPTION
This seemed to decrease the time it takes to run all our rspec tests from 14-18 minutes to 8-9 minutes.
