### PR TITLE
Fixing iconv deprecation warnings

### DIFF
--- a/app/lib/validators/content_validator.rb
+++ b/app/lib/validators/content_validator.rb
@@ -10,15 +10,12 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'iconv'
-
-
 module Validators
   class ContentValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       begin
-        Iconv.iconv("UTF8", "UTF8", value)
-      rescue
+        value.encode("UTF-8", 'binary') unless value.blank?
+      rescue Encoding::UndefinedConversionError
         record.errors[attribute] << (options[:message] || _("cannot be a binary file."))
       end
     end


### PR DESCRIPTION
Fixing these warnings:

```
activesupport-3.2.13/lib/active_support/dependencies.rb:252:in `block in require': iconv will be deprecated in the future, use String#encode instead.
```
