### PR TITLE
Experimental Menu - Fixes an issue where clicking the new button

### DIFF
--- a/app/assets/javascripts/common/katello.js
+++ b/app/assets/javascripts/common/katello.js
@@ -25,6 +25,10 @@ KT.widget = {};
 
 KT.utils = _.noConflict();
 
+// Must be at the top to prevent AngularJS unnecessary digest operations
+// And to handle the hashPrefix that AngularJS adds that confuses BBQ
+$.bbq.pushState('!', '');
+
 //i18n global variable
 var i18n = {};
 


### PR DESCRIPTION
on tupane wouldn't directly open the panel by injecting a root
hash on the end of the URL. This is needed because of angularjs
$locationProvider adding a hashPrefix.

Fixes #2087 
