### PR TITLE
Sync Plans - Sync plan name edits weren't updating

### DIFF
--- a/app/assets/javascripts/sync_plans/sync_plan_edit.js
+++ b/app/assets/javascripts/sync_plans/sync_plan_edit.js
@@ -93,7 +93,7 @@ $(document).ready(function() {
                     $("#current_plan").text(plan_name);
                 }
                 var id = $('#plan_id');
-                list.refresh(id.attr('name'), id.attr('data-ajax_url'));
+                list.refresh(id.attr('value'), id.attr('data-ajax_url'));
             },
             onerror     :  function(settings, original, xhr) {
             original.reset();


### PR DESCRIPTION
the tupane header or left hand list due to grabbing the wrong
property off of a DOM element.

Fixes #2142
