### PR TITLE
Fixed simplecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,10 +14,12 @@ $:.unshift(__FILE__, ".") #add  current path to the classpath
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test' # ok
+require 'simplecov'
+SimpleCov.start if ENV["COVERAGE"] # ok
+
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'webrat'
-require 'simplecov'
 require 'helpers/login_helper_methods'
 require 'helpers/authorization_helper_methods'
 require 'helpers/locale_helper_methods'

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,9 +1,10 @@
 ENV["RAILS_ENV"] = "test"
+require 'simplecov'
+SimpleCov.start if ENV["COVERAGE"] # ok
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'minitest/autorun'
 require 'minitest/rails'
-require 'simplecov'
 require 'json'
 require 'support/auth_support'
 require 'support/warden_support'


### PR DESCRIPTION
This should fix katello-coverage in Jenkins. I tried using Katello.config but ran into a problem in simplecov.rake where setting Katello.early_config.coverage_report did not persist into Rake::Task#execute calls.
