### PR TITLE
960145 -  publishing red hat content via http

### DIFF
--- a/app/models/candlepin/product_content.rb
+++ b/app/models/candlepin/product_content.rb
@@ -114,6 +114,7 @@ class Candlepin::ProductContent
                                     :content_type => self.content.type,
                                     :preserve_metadata => true, #preserve repo metadata when importing from cp
                                     :enabled =>false,
+                                    :unprotected => true,
                                     :content_view_version=>env_prod.environment.organization.library.default_content_view_version
                                    )
         end


### PR DESCRIPTION
allows foreman to point to katello for distributions. 
