### PR TITLE
delete-legacy-promotion - ui/model - make view required for system and akey

### DIFF
--- a/app/assets/javascripts/systems/index.js
+++ b/app/assets/javascripts/systems/index.js
@@ -18,6 +18,7 @@
 //= require "alchemy/jquery/plugins/chosen.jquery"
 //= require "alchemy/jquery/plugins/jquery.treeTable"
 //= require "widgets/auto_complete"
+//= require "widgets/env_content_view_selector"
 //= require "system_groups/system_groups_pane"
 //= require "systems/packages"
 //= require "systems/system_errata"

--- a/app/assets/javascripts/systems/system_edit.js
+++ b/app/assets/javascripts/systems/system_edit.js
@@ -11,21 +11,6 @@
  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 */
 
-update_content_views = function(env_id) {
-    // update content view options
-    $.ajax({  url: KT.routes.content_views_environment_path(env_id),
-              type: "GET",
-              success: (function(data) {
-                  options = {'': ''};
-                  $.each(data, function(key, value) {
-                       options[value.id] = value.name;
-                  });
-                  $("#system_content_view").data("options", options);
-                  $("#system_content_view").show();
-              })
-            });
-}
-
 $(document).ready(function() {
 
     var common_settings = {
@@ -76,56 +61,6 @@ $(document).ready(function() {
                 }
             };
         $(this).editable($(this).attr('data-url'), $.extend(common_settings, settings));
-    });
-
-    path_select = KT.path_select('environment_path_selector', 'edit_select_system_environment', KT.available_environments,
-        {select_mode:'single', submit_button_text: i18n.save, cancel_button_text: i18n.cancel, activate_on_click: true});
-
-    $(document).bind(path_select.get_submit_event(), function(event, environments) {
-        var selected_env_ids = KT.utils.values(path_select.get_selected())
-        if (selected_env_ids.length < 1) {
-            return;
-        }
-
-        var selector_element = $('#environment_path_selector');
-        selector_element.find(".KT_path_select_submit_button").attr('disabled', 'disabled');
-
-        var request = $.ajax({
-            url: selector_element.attr('data-url'),
-            type: 'PUT',
-            data: {'system[environment_id]': selected_env_ids[0]['id'], authenticity_token: AUTH_TOKEN}
-        });
-
-        // disable the field temporarily
-        $("#system_content_view").hide();
-
-        request.done(function(msg) {
-            selector_element.find('span:first').text(selected_env_ids[0]['name']);
-
-            panel_element = $('input[data-ajax_url="' + selector_element.attr('data-url') + '"]');
-            KT.panel.list.refresh(panel_element.attr('value'), panel_element.attr('data-ajax_url'));
-
-            path_select.hide();
-            selector_element.find(".KT_path_select_submit_button").removeAttr('disabled');
-
-            path_select.clear_selected();
-            notices.checkNotices();
-
-            update_content_views(selected_env_ids[0]['id']);
-            if($("#system_content_view").text() != i18n.clickToEdit) {
-                alert(i18n.contentViewReset);
-                $("#system_content_view").text(i18n.clickToEdit);
-            }
-        });
-
-        request.fail(function(jqXHR, textStatus) {
-            path_select.hide();
-            selector_element.find(".KT_path_select_submit_button").removeAttr('disabled');
-
-            path_select.clear_selected();
-            notices.checkNotices();
-            $("#system_content_view").show();
-        });
     });
 });
 

--- a/app/assets/javascripts/systems/systems.js
+++ b/app/assets/javascripts/systems/systems.js
@@ -60,6 +60,7 @@ KT.panel_search_autocomplete = KT.panel_search_autocomplete.concat(["distributio
 $(document).ready(function() {
 
     KT.panel.set_expand_cb(function() {
+        KT.systems_page.system_info_setup();
         KT.subs.initialize_edit();
     });
 
@@ -327,6 +328,20 @@ KT.systems_page = (function() {
             }
         );
     },
+    system_info_setup = function() {
+        var pane = $("#system");
+        if (pane.length === 0) {
+            return;
+        }
+
+//        KT.env_content_view_selector('edit_env_view',
+//            'environment_path_selector', KT.available_environments, KT.current_environment_id,
+//            'content_view_selector', KT.available_content_views, KT.current_content_view_id);
+
+        KT.env_content_view_selector.init('edit_env_view',
+            'environment_path_selector', KT.available_environments, KT.current_environment_id,
+            'content_view_selector', KT.available_content_views, KT.current_content_view_id);
+    },
     system_group_setup = function() {
         $('#create_system_group').live('click', create_system_group);
         $('#update_system_groups').live('submit', update_system_groups);
@@ -417,33 +432,36 @@ KT.systems_page = (function() {
                     var options = '';
                     var opt_template = KT.utils.template("<option value='<%= key %>'><%= text %></option>");
 
-                    // create an html option list using the response
-                    options += opt_template({key: "", text: i18n.no_content_view});
-                    $.each(response, function(key, item) {
-                        options += opt_template({key: item.id, text: item.name});
-                    });
-
-                    $("#system_content_view_id").html(options);
-
                     if (response.length > 0) {
-                        highlight_content_views(true);
+                        // create an html option list using the response
+                        $.each(response, function(key, item) {
+                            options += opt_template({key: item.id, text: item.name});
+                        });
+                        highlight_content_views(i18n.select_content_view);
+                    } else {
+                        // the user selected an environment that has not views, warn them
+                        highlight_content_views(i18n.no_content_views_available);
                     }
+                    $("#system_content_view_id").html(options);
                 }
             });
         }
     },
-    highlight_content_views = function(add_highlight){
-        var select_input = $("#system_content_view_id");
-        if (add_highlight) {
-            if( !select_input.next('span').hasClass('highlight_input_text')) {
-                select_input.addClass('highlight_input');
-                select_input.after('<span class ="highlight_input_text">' +
-                        i18n.select_content_view + '</span>');
-            }
+    highlight_content_views = function(text){
+        var select_input = $("#system_content_view_id"),
+            highlight_text = select_input.next('span.highlight_input_text');
+
+        select_input.addClass('highlight_input');
+        if (highlight_text.length > 0) {
+            highlight_text.html(text);
         } else {
-            select_input.removeClass('highlight_input');
-            $('.highlight_input_text').remove();
+            select_input.after('<span class ="highlight_input_text">' + text + '</span>');
         }
+    },
+    remove_content_view_highlight = function() {
+        var select_input = $("#system_content_view_id");
+        select_input.removeClass('highlight_input');
+        select_input.next('span.highlight_input_text').remove();
     };
 
   return {
@@ -452,6 +470,7 @@ KT.systems_page = (function() {
       registerActions : registerActions,
       update_content_views: update_content_views,
       highlight_content_views: highlight_content_views,
+      system_info_setup: system_info_setup,
       system_group_setup: system_group_setup
   }
 })();

--- a/app/assets/javascripts/widgets/env_content_view_selector.js
+++ b/app/assets/javascripts/widgets/env_content_view_selector.js
@@ -1,0 +1,186 @@
+/**
+ Copyright 2013 Red Hat, Inc.
+
+ This software is licensed to you under the GNU General Public
+ License as published by the Free Software Foundation; either version
+ 2 of the License (GPLv2) or (at your option) any later version.
+ There is NO WARRANTY for this software, express or implied,
+ including the implied warranties of MERCHANTABILITY,
+ NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ have received a copy of GPLv2 along with this software; if not, see
+ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+KT.env_content_view_selector = (function() {
+    var env_div,
+        content_view_div,
+        env_select,
+        content_view_select,
+        saved_env_id,
+        saved_content_view_id,
+        performing_cancel = false,
+
+        init = function(name, env_div_id, envs, current_env_id,
+                        content_view_div_id, content_views, current_content_view_id) {
+
+            // initialize the environment selector
+            env_div = $('#' + env_div_id);
+            content_view_div = $('#' + content_view_div_id);
+            saved_env_id = current_env_id;
+            saved_content_view_id = current_content_view_id;
+
+            env_select = KT.path_select(env_div_id, name, envs, {select_mode:'single', inline: true});
+            $(document).unbind(env_select.get_select_event());
+
+            // select the current environment
+            env_select.select(current_env_id);
+
+            // if the user changes the environment, update the available content views
+            $(document).bind(env_select.get_select_event(), function(event) {
+                update_content_views(KT.utils.keys(env_select.get_selected()));
+            });
+
+            // render the content view selector and the save/cancel buttons
+            render_selector(content_view_div, content_views, current_content_view_id);
+
+            register_cancel();
+            register_save();
+        },
+        register_cancel = function() {
+            var cancel_button = $('.cancel_env_content_view');
+            cancel_button.unbind('click').click(function(e) {
+               var current_env = KT.utils.values(env_select.get_selected());
+
+                if ((current_env.length === 0) || (current_env[0]['id'] !== saved_env_id)) {
+                    env_select.clear_selected();
+                    env_select.select(saved_env_id);
+                    performing_cancel = true;
+                } else {
+                    content_view_select.val(saved_content_view_id);
+                    remove_content_view_highlight();
+                }
+            });
+        },
+        register_save = function() {
+            var save_button = $('.save_env_content_view');
+            save_button.unbind('click').click(function(e) {
+                e.preventDefault();
+
+                var env_param = env_div.data('name'),
+                    view_param = content_view_div.data('name'),
+                    data = {};
+                data[env_param] = get_selected_env_id();
+                data[view_param] = get_selected_content_view_id();
+                data["authenticity_token"] = AUTH_TOKEN;
+                $.ajax({
+                    type: 'PUT',
+                    url: content_view_div.data('url'),
+                    data: data,
+                    cache: false,
+                    success: function(html) {
+                        remove_content_view_highlight();
+                        saved_env_id = get_selected_env_id();
+                        saved_content_view_id = get_selected_content_view_id();
+                    },
+                    error: function() {
+                    }
+                });
+            });
+
+        },
+        get_selected_content_view_id = function() {
+            return content_view_select.val();
+        },
+        get_selected_env_id = function() {
+            return KT.utils.values(env_select.get_selected())[0]['id'];
+        },
+        update_content_views = function(env_ids) {
+            if (env_ids.length === 0) {
+                clear_content_views();
+            } else {
+                // retrieve the list of views in this environment and update the options
+                $.ajax({
+                    url: KT.routes.content_views_environment_path(env_ids[0]),
+                    type: "GET",
+                    data: {'include_default': 'true'},
+                    success: (function(response) {
+                        var options = '', highlight_text;
+                        var opt_template = KT.utils.template("<option value='<%= key %>'><%= text %></option>");
+
+                        if (response.length > 0) {
+                            // create an html option list using the response
+                            $.each(response, function(key, item) {
+                                options += opt_template({key: item.id, text: item.name});
+                            });
+                            highlight_text = performing_cancel === true ? undefined : i18n.select_content_view;
+                        } else {
+                            // this environment doesn't have any views, warn the user
+                            highlight_text = i18n.no_content_views_available;
+                        }
+                        content_view_select.html(options);
+
+                        if (highlight_text !== undefined) {
+                            highlight_content_views(highlight_text);
+                        } else {
+                            content_view_select.val(saved_content_view_id);
+                            remove_content_view_highlight();
+                        }
+                        performing_cancel = false;
+                    })
+                });
+            }
+        },
+        clear_content_views = function() {
+            remove_content_view_highlight();
+            $("#content_view_select").html('');
+        },
+        highlight_content_views = function(text){
+            var highlight_text = content_view_select.next('span.highlight_input_text');
+
+            content_view_select.addClass('highlight_input');
+            if (highlight_text.length > 0) {
+                highlight_text.html(text);
+            } else {
+                content_view_select.after('<span class ="highlight_input_text">' + text + '</span>');
+            }
+        },
+        remove_content_view_highlight = function() {
+            content_view_select.removeClass('highlight_input');
+            content_view_select.next('span.highlight_input_text').remove();
+        },
+        render_selector = function(content_view_div, available_views, current_view) {
+            render_select(content_view_div, current_view, available_views);
+            render_buttons(content_view_div);
+            content_view_select = $('#content_view_select');
+        },
+        render_select = function(content_view_div, current_view, available_views) {
+            var opt_template = KT.utils.template("<option <%= selected %> value='<%= key %>'><%= text %></option>"),
+                name = content_view_div.data('name'),
+                html;
+
+            html = '<form><select id="content_view_select" name="' + name + '">';
+            $.each(available_views, function(key, item) {
+                if (item.id === current_view) {
+                    html += opt_template({key: item.id, text: item.name, selected: 'selected'});
+                } else {
+                    html += opt_template({key: item.id, text: item.name, selected: ''});
+                }
+            });
+            html += '</select></form>';
+            content_view_div.append(html);
+        },
+        render_buttons = function(content_view_div) {
+            var button_template = KT.utils.template("<input type='button' class='button <%= clazz %>' value='<%= text %>' > "),
+                html;
+
+            html = '<div class="fr">';
+            html += button_template({clazz: 'save_env_content_view', text: 'Save'});
+            html += button_template({clazz: 'cancel_env_content_view', text: 'Cancel'});
+            html += '</div>';
+            content_view_div.after(html);
+        };
+
+    return {
+        init : init
+    };
+}());

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -277,8 +277,8 @@ class SystemsController < ApplicationController
 
     # Stuff into var for use in spec tests
     @locals_hash = { :system => @system, :editable => @system.editable?,
-                    :releases => releases, :releases_error => releases_error, :name => controller_display_name,
-                    :environments => environment_paths(library_path_element, environment_path_element("systems_readable?")) }
+                     :releases => releases, :releases_error => releases_error, :name => controller_display_name,
+                     :environments => environment_paths(library_path_element, environment_path_element("systems_readable?")) }
     render :partial => "edit", :locals => @locals_hash
   end
 
@@ -302,7 +302,6 @@ class SystemsController < ApplicationController
         params[:system][:serviceLevel] = val[1..-1]
       end
     end
-    params[:system][:content_view_id] = nil if params[:system].has_key? :environment_id
 
     @system.update_attributes!(params[:system])
     notify.success _("System '%s' was updated.") % @system["name"]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -280,14 +280,17 @@ module ApplicationHelper
     form_for(object, options, &block)
   end
 
+  def select_content_view
+    _('Select Content View')
+  end
+
   def no_content_view
-    _("No Content View")
+    _('No Content View')
   end
 
   def content_view_select_labels(organization, environment)
-    labels = [[no_content_view, '']]
     if environment
-      labels += ContentView.readable(organization).non_default.
+      labels = ContentView.readable(organization).non_default.
           in_environment(environment).collect {|cv| [cv.name, cv.id]}
     else
       labels = []

--- a/app/helpers/systems_helper.rb
+++ b/app/helpers/systems_helper.rb
@@ -41,26 +41,19 @@ module SystemsHelper
 
   def architecture_select
     select(:arch, "arch_id", System.architectures.invert,
-             {:prompt => _('Select Architecture'), :id=>"arch_field"}, {:tabindex => 3})
+             {:prompt => _('Select Architecture'), :id => "arch_field"}, {:tabindex => 3})
   end
 
   def content_view_select(org, env)
     views = ContentView.readable(org).non_default.in_environment(env)
     choices = views.map {|v| [v.name, v.id]}
-    select(:system, "content_view_id", choices,
-             {:prompt => no_content_view, :id=>"content_view_field"},
-             {:tabindex => 2})
+    select(:system, "content_view_id", choices, {:id => "content_view_field"}, {:tabindex => 2})
   end
 
   def system_content_view_opts(system)
     keys = {}
-    if system.environment
-      content_views = system.environment.content_views.readable(current_organization)
-    else
-      content_views = ContentView.readable(current_organization)
-    end
-    content_views.non_default.each do |view|
-      keys[view.id] = view.name
+    system.environment.content_views.readable(current_organization).each do |view|
+      view.default? ? keys[view.id] = _('Default View') : keys[view.id] = view.name
     end
     keys[""] = ""
     keys["selected"] = system.content_view_id || ""

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -39,7 +39,9 @@ class System < ActiveRecord::Base
   has_many :custom_info, :as => :informable, :dependent => :destroy
   belongs_to :content_view
 
+  before_validation :set_default_content_view, :unless => Proc.new { |model| model.persisted? }
   validates :environment, :presence => true
+  validates :content_view, :presence => true, :allow_blank => false
   validates_with Validators::NonLibraryEnvironmentValidator, :attributes => :environment
   # multiple systems with a single name are supported
   validates :name, :presence => true
@@ -209,6 +211,10 @@ class System < ActiveRecord::Base
     def fill_defaults
       self.description = _("Initial Registration Params") unless self.description
       self.location = _("None") unless self.location
+    end
+
+    def set_default_content_view
+      self.content_view = self.environment.try(:default_content_view) unless self.content_view
     end
 
     def collect_installed_product_names

--- a/app/views/activation_keys/_new.html.haml
+++ b/app/views/activation_keys/_new.html.haml
@@ -24,7 +24,7 @@
       - if Katello.config.katello?
         = form.field :content_view_id, :label => _("Content View"), :wrapper => {:id => "content_views"}, :grid => [2,7] do
           = select_tag 'activation_key[content_view_id]',
-            options_for_select(content_view_select_labels(@organization, @environment), no_content_view),
+            options_for_select(content_view_select_labels(@organization, @environment)),
             :tabindex => auto_tab_index
 
       = form.field :usage_limit, :label => _("Usage Limit"), :grid => [2,7] do

--- a/app/views/common/_common_i18n.html.haml
+++ b/app/views/common/_common_i18n.html.haml
@@ -38,7 +38,8 @@
     "current_default_org" : '#{escape_javascript(_('This is your default organization.'))}',
     "make_default_org" : '#{escape_javascript(_('Make this your default organization.'))}',
     "no_content_view" : '#{no_content_view}',
-    "select_content_view": '#{escape_javascript(_('Select a View'))}',
+    "no_content_views_available" : '#{escape_javascript(_('No views available in selected environment.'))}',
+    "select_content_view": '#{escape_javascript(_('Select a view.'))}',
     "take_a_while_you_sure": '#{escape_javascript(_('This could take a while. Are you sure?'))}',
     "objects_affected_successfully": '#{escape_javascript(_('objects affected successfully'))}'
   });

--- a/app/views/systems/_edit.html.haml
+++ b/app/views/systems/_edit.html.haml
@@ -1,6 +1,10 @@
 = javascript do
   :plain
+    KT.current_environment_id = #{system.environment_id};
     KT.available_environments = $.parseJSON('#{escape_javascript(environments.to_json)}');
+    KT.current_content_view_id = #{system.content_view_id || -1};
+    KT.available_content_views = $.parseJSON('#{escape_javascript(system.environment.content_views.readable(current_organization).to_json)}');
+
     localize({
         "systemReleaseVerDefault": '#{escape_javascript(_("System Default"))}',
         "contentViewReset": 'The selected content view was unset. Please choose another one.'
@@ -12,29 +16,29 @@
 = content_for :content do
   #system
     %input#panel_element_id{:name => @system.id, :type => "hidden", :value => "#{name}_#{system.id.to_s}", "data-ajax_url"=>url_for(:action=> 'update')}
-    .grid_8
+    .grid_10
       %h5 #{_("System Info")}
-    .grid_8#system_info
+    .grid_10#system_info
       %fieldset
         .grid_2.ra.fieldset
           = label :id, :id, _("ID")
-        .grid_5.la #{system.id}
+        .grid_7.la #{system.id}
       %fieldset
         .grid_2.ra.fieldset
           = label :uuid, :uuid, _("UUID")
-        .grid_5.la #{system.uuid}
+        .grid_7.la #{system.uuid}
     .clear
-    .grid_8
+    .grid_10
       %h5 #{_("Networking")}
-    .grid_8#system_info
+    .grid_10#system_info
       %fieldset
         .grid_2.ra.fieldset
           = label :hostname, :hostname, _("Hostname")
-        .grid_5.la #{system.hostname}
+        .grid_7.la #{system.hostname}
       %fieldset
         .grid_2.ra.fieldset
           = label :interfaces, :interfaces, _("Interfaces")
-        .grid_5
+        .grid_7
           %table#interface_table
             - system.interfaces.each do |interface|
               %tr
@@ -43,95 +47,100 @@
                 %td.interface_addr
                   = interface[:addr]
     .clear
-    .grid_8
+    .grid_10
       %h5 #{_("System Properties")}
-    .grid_8#system_properties
+    .grid_10#system_properties
       %fieldset
         .grid_2.ra.fieldset
           = label :system, :name, _("Name")
-        .grid_5.la#system_name{'name' => 'system[name]', :class=>("editable edit_panel_element" if editable), 'data-url'=>system_path(system.id)} #{system[:name]}
+        .grid_7.la#system_name{'name' => 'system[name]', :class=>("editable edit_panel_element" if editable), 'data-url'=>system_path(system.id)} #{system[:name]}
       %fieldset
         .grid_2.ra.fieldset
           = label :system, :description, _("Description")
-        .grid_5.la#system_description{'name' => 'system[description]', :class=>("editable edit_textarea" if editable), 'data-url'=>system_path(system.id)} #{system[:description]}
+        .grid_7.la#system_description{'name' => 'system[description]', :class=>("editable edit_textarea" if editable), 'data-url'=>system_path(system.id)} #{system[:description]}
       %fieldset
         .grid_2.ra.fieldset
           = label :os, :os, _("OS")
-        .grid_5.la #{system.distribution_name}
+        .grid_7.la #{system.distribution_name}
       %fieldset
         .grid_2.ra.fieldset
           = label :release, :release, _("Release")
-        .grid_5.la #{system.kernel}
+        .grid_7.la #{system.kernel}
       %fieldset
         .grid_2.ra.fieldset
           - help_message = _("Setting the release version limits content to this version only, preventing newer packages from being available for installation.")
           %span.tipsify.details_icon-grey{:title => help_message}
           = label :releaseVer, :releaseVer, _("Release Version")
         - if !releases_error.nil?
-          .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever_message error_message" if editable), 'data-url'=>system_path(system.id), 'data-message'=>releases_error}
+          .grid_7.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever_message error_message" if editable), 'data-url'=>system_path(system.id), 'data-message'=>releases_error}
             = system.release == "" ? _("System Default") : system.release
         - elsif releases == []
           - if Katello.config.katello?
             - none_message = ("No alternate release version choices are available. These choices are based upon the repositories that have been enabled and promoted to this system's environment.")
           - else
             - none_message = _("No alternate release version choices are available. These choices are based upon the Red Hat manifest imported and the content available in the CDN.")
-          .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever_message" if editable), 'data-url'=>system_path(system.id), 'data-message'=>none_message}
+          .grid_7.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever_message" if editable), 'data-url'=>system_path(system.id), 'data-message'=>none_message}
             = system.release == "" ? _("System Default") : system.release
         - else
-          .grid_5.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever" if editable), 'data-url' => system_path(system.id), 'data-options' => system_releasevers_edit(system, releases)}
+          .grid_7.la{'name' => 'system[releaseVer]', 'class' => ("editable edit_select_system_releasever" if editable), 'data-url' => system_path(system.id), 'data-options' => system_releasevers_edit(system, releases)}
             = system.release
       %fieldset
         .grid_2.ra.fieldset
           = label :arch, :arch, _("Arch")
-        .grid_5.la #{System.architectures[system.arch]}
+        .grid_7.la #{System.architectures[system.arch]}
       %fieldset
         .grid_2.ra.fieldset
           = label :memory, :memory, _("RAM (MB)")
-        .grid_5.la #{system.memory}
+        .grid_7.la #{system.memory}
       %fieldset
         .grid_2.ra.fieldset
           = label :sockets, :sockets, _("Sockets")
-        .grid_5.la #{system.sockets}
+        .grid_7.la #{system.sockets}
       %fieldset
         .grid_2.ra.fieldset
           = label :location, :location, _("Location")
-        .grid_5.la#system_location{'name' => 'system[location]', :class=>("editable edit_textfield" if editable), 'data-url'=>system_path(system.id)} #{system[:location]}
+        .grid_7.la#system_location{'name' => 'system[location]', :class=>("editable edit_textfield" if editable), 'data-url'=>system_path(system.id)} #{system[:location]}
+
+
+      .clear
+      .grid_10
+        %h5 #{_('Content Available From')}
       %fieldset
         .grid_2.ra.fieldset
-          = label :arch, :arch, _("Environment")
-        .grid_5.la#environment_path_selector{'name'=> 'system[environment_id]', :class=>("editable" if editable), 'data-url'=>system_path(system.id)}
-          %span #{system_environment_name system}
+          = label :env, :env, _("Environment")
+        .grid_7.la#environment_path_selector{'data-name'=> 'system[environment_id]', 'data-url'=>system_path(system.id)}
       - if Katello.config.katello?
         %fieldset
           .grid_2.ra.fieldset
             = label :content_view, :content_view, _("Content View")
-          .grid_5.la#system_content_view{'name' => 'system[content_view_id]', :class=>("editable edit_select" if editable), 'data-url'=>system_path(system.id), 'data-options' => system_content_view_opts(system)} #{system.content_view}
+          .grid_7.la#content_view_selector{'data-name' => 'system[content_view_id]', 'data-url'=>system_path(system.id),
+            'data-options' => system_content_view_opts(system)}
 
     .clear
-    .grid_8
+    .grid_10
       %h5 #{_("System Events")}
-    .grid_8#system_events
+    .grid_10#system_events
       %fieldset
         .grid_2.ra.fieldset
           = label :checked_in, :checked_in, _("Checked In")
-        .grid_5.la
+        .grid_7.la
           = get_checkin(system)
       %fieldset
         .grid_2.ra.fieldset
           = label :registered_date, :registered_date, _("Registered")
-        .grid_5.la
+        .grid_7.la
           = convert_time(system.created)
       %fieldset
         .grid_2.ra.fieldset
           = label :last_booted, :last_booted, _("Last Booted")
-        .grid_5.la #{_("None")}
+        .grid_7.la #{_("None")}
       %fieldset
         .grid_2.ra.fieldset
           = label :host_guest, :activation_key, _("Activation Key")
         - if @system.activation_keys.blank?
-          .grid_5.la= _("None")
+          .grid_7.la= _("None")
         - else
-          .grid_5
+          .grid_7
             - @system.activation_keys.each do |key|
               %table#interface_table
                 %tr
@@ -141,30 +150,30 @@
                     - else
                       = key[:name]
     .clear
-    .grid_8
+    .grid_10
       %h5 #{_("Host & Guest Info")}
-    .grid_8#system_host_guest
+    .grid_10#system_host_guest
 
       %fieldset
         .grid_2.ra.fieldset
           = label :host_guest, :host_type, _("System Type")
-        .grid_5.la
+        .grid_7.la
           = system_type system
 
       %fieldset
         - if system.guest == 'true'
           .grid_2.ra.fieldset
             = label :host_guest, :host, _("Host")
-          .grid_5.la
+          .grid_7.la
             = system.host ? system.host.attributes['name'] : _("Unknown")
         -else
           .grid_2.ra.fieldset
             = label :host_guest, :guest, _("Guests")
           - if system.guests.length < 1
-            .grid_5.la
+            .grid_7.la
               = _("None")
           - else
-            .grid_5.la
+            .grid_7.la
               %ul
               - system.guests.each do |guest|
                 %li{:style=>'list-style: none;'}

--- a/app/views/systems/_new.html.haml
+++ b/app/views/systems/_new.html.haml
@@ -17,7 +17,7 @@
     .full
       = kt_form_for(System.new, :action => "create", :id => "new_system") do |form|
         = hidden_field_tag 'system[environment_id]', @environment.id
-        .grid_8#new_system
+        .grid_10#new_system
           = form.text_field :name, :label => _("Name of Your System:")
 
           = form.field :arch, :label => _("Architecture:") do
@@ -41,7 +41,7 @@
                   :url_content_views_proc => url_content_views_proc)
 
           - if Katello.config.katello?
-            = form.field :content_view_id, :label => _("Content View:") do
+            = form.field :content_view_id, :label => _("Content View:"), :grid => [2,7] do
               = content_view_select(current_organization, @environment)
 
 

--- a/spec/controllers/systems_controller_spec.rb
+++ b/spec/controllers/systems_controller_spec.rb
@@ -63,7 +63,7 @@ describe SystemsController do
         describe "GET index multiple orgs with #{perm} on #{resource}" do
           before do
             new_test_org
-            @environment = KTEnvironment.new(:name=>'test2', :label=> 'test2', :prior => @organization.library.id, :organization => @organization)
+            @environment = KTEnvironment.create!(:name=>'test2', :label=> 'test2', :prior => @organization.library.id, :organization => @organization)
             @system2 = System.create!(:name=>"bar2", :environment => @environment, :cp_type=>"system", :facts=>{"Test" => ""})
           end
           let(:action) {:items}

--- a/spec/models/system_spec.rb
+++ b/spec/models/system_spec.rb
@@ -70,7 +70,10 @@ describe System do
   end
 
   it "registers system in candlepin and pulp on create", :katello => true do #TODO headpin
-    Resources::Candlepin::Consumer.should_receive(:create).once.with(@environment.id, @organization.name, system_name, cp_type, facts, installed_products, nil, nil, nil).and_return({:uuid => uuid, :owner => {:key => uuid}})
+    Resources::Candlepin::Consumer.should_receive(:create).once.with(@environment.id.to_s, @organization.name,
+                                                                     system_name, cp_type, facts, installed_products,
+                                                                     nil, nil, nil).and_return({:uuid => uuid,
+                                                                                                :owner => {:key => uuid}})
     Runcible::Extensions::Consumer.should_receive(:create).once.with(uuid, {:display_name => system_name}).and_return({:id => uuid}) if Katello.config.katello?
     @system.save!
   end


### PR DESCRIPTION
This commit contains changes so that content view is required
for systems and activation keys.  Previously, the user could
assign systems/keys an environment, but omit the view.

Note; additional changes are needed to properly fence headpin
on the system edit; however, needed to make these changes 
available for others.
