### PR TITLE
949937-Modified the scope of queryable params with respect to permissions

### DIFF
--- a/app/controllers/api/v1/permissions_controller.rb
+++ b/app/controllers/api/v1/permissions_controller.rb
@@ -45,7 +45,8 @@ class Api::V1::PermissionsController < Api::V1::ApiController
   param :all_verbs, :bool, :desc => "filter by all_verbs flag"
   param :all_tags, :bool, :desc => "filter by all_flags flag"
   def index
-    respond :collection => @role.permissions.where(query_params)
+    queries = query_params.empty? ? {} : {:permissions => query_params}
+    respond :collection => @role.permissions.where(queries)
   end
 
   api :GET, "/roles/:role_id/permissions/:id", "Show a permission"


### PR DESCRIPTION
Basically  fixed the permissions index search calll, so that query params for permissions only look inside permissions table and NOT roles table.

Also look at
https://github.com/Katello/katello-cli/pull/20
https://bugzilla.redhat.com/show_bug.cgi?id=949937
