### PR TITLE
The favicon image is not showing up in Firefox

### DIFF
--- a/app/assets/javascripts/common/katello.js
+++ b/app/assets/javascripts/common/katello.js
@@ -30,6 +30,10 @@ var Katello = angular.module('Katello', ['alchemy', 'alch-templates', 'ngSanitiz
 
 // Must be at the top to prevent AngularJS unnecessary digest operations
 // And to handle the hashPrefix that AngularJS adds that confuses BBQ
+$(window).bind("hashchange", function(event) {
+// refresh the favicon to make sure it shows up
+    $('link[type*=icon]').detach().appendTo('head');
+});
 $.bbq.pushState('!', '');
 
 //i18n global variable
@@ -616,9 +620,4 @@ $(window).ready(function(){
     $.rails.confirm = function(message) {
         KT.common.customConfirm({message: message}); return false;
     };
-
-    $(window).bind("hashchange", function(event) {
-        // refresh the favicon to make sure it shows up
-        $('link[type*=icon]').detach().appendTo('head');
-    });
 });


### PR DESCRIPTION
The favicon in Firefox is not displaying, it just shows as an empty box.

Tested with FF 20 on linux and OSX.  It works in Chrome and Safari (didn't have IE available for testing).

Steps to Reproduce:
1. Go to katello
2. Notice missing favicon
