### PR TITLE
fixes 2232 - require custom create repo

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -250,6 +250,7 @@ Requires:        %{name}-common
 Requires:        pulp-server
 Requires:        pulp-rpm-plugins
 Requires:        pulp-selinux
+Requires:        createrepo = 0.9.9-18
 Requires:        %{?scl_prefix}rubygem(runcible) >= 0.4.4
 
 %description glue-pulp

--- a/rel-eng/comps/comps-katello-pulp-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-fedora18.xml
@@ -11,6 +11,7 @@
     <description>Pulp Server Packages</description>
     <uservisible>true</uservisible>
     <packagelist>
+       <packagereq type="default">createrepo</packagereq>
        <packagereq type="default">grinder</packagereq>
        <packagereq type="default">m2crypto</packagereq>
        <packagereq type="default">mod_wsgi</packagereq>

--- a/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
@@ -11,6 +11,7 @@
     <description>Pulp Server Packages</description>
     <uservisible>true</uservisible>
     <packagelist>
+       <packagereq type="default">createrepo</packagereq>
        <packagereq type="default">grinder</packagereq>
        <packagereq type="default">m2crypto</packagereq>
        <packagereq type="default">mod_wsgi</packagereq>


### PR DESCRIPTION
due to gziping of groups.xml, rhel6 cannot be kickstarted from our trees
this adds a custom version of createrepo assembled by the pulp team
