### PR TITLE
Bug 901657 - Adding check for HTML characters in the Role name validator

### DIFF
--- a/app/lib/validators/rolename_validator.rb
+++ b/app/lib/validators/rolename_validator.rb
@@ -16,6 +16,7 @@ module Validators
       if value
         #max length is 20 more than the usernam,e because we add 20 random characters
         #  on the end for the self role
+        record.errors[attribute] << N_("cannot contain characters >, <, or /") if value =~ %r{<|>|/}
         KatelloNameFormatValidator.validate_length(record, attribute, value, 148, 3)
       end
     end


### PR DESCRIPTION
to prevent cross-site scripting and meet naming requirements for other
entities.

Further re-factoring to follow to make this chunk of validation more re-usable.
