### PR TITLE
fixing createrepo requirement

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -250,7 +250,7 @@ Requires:        %{name}-common
 Requires:        pulp-server
 Requires:        pulp-rpm-plugins
 Requires:        pulp-selinux
-Requires:        createrepo = 0.9.9-18
+Requires:        createrepo = 0.9.9-18%{?dist}
 Requires:        %{?scl_prefix}rubygem(runcible) >= 0.4.4
 
 %description glue-pulp


### PR DESCRIPTION
apparently rpm requires the dist to be explicit when using = version requirement. Tested with a 1.3 build.
