### PR TITLE
Validators - Adding a set of unit tests targeted at validators that

### DIFF
--- a/test/lib/validators/katello_label_format_validator_test.rb
+++ b/test/lib/validators/katello_label_format_validator_test.rb
@@ -1,0 +1,55 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+require 'minitest_helper'
+
+class KatelloLabelFormatValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
+
+  def setup
+    @validator = Validators::KatelloLabelFormatValidator.new({:attributes => [:name]})
+    @model = OpenStruct.new(:errors => {:name => []})
+  end
+
+  def test_validate_each
+    @validator.validate_each(@model, :name, "Test2Name_underline-dash")
+
+    assert_empty @model.errors[:name]
+  end
+
+  test "fails with HTML tag" do
+    @validator.validate_each(@model, :name, '<a href="">Test Name</a>')
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails with more than 128 characters" do
+    cs = [*'0'..'9', *'a'..'z', *'A'..'Z']
+    random_string = 129.times.map { cs.sample }.join
+    @validator.validate_each(@model, :name, random_string)
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails if blank" do
+    @validator.validate_each(@model, :name, '')
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails with trailing white space" do
+    @validator.validate_each(@model, :name, "Trailing Whitespace   ")
+
+    refute_empty @model.errors[:name]
+  end
+
+end

--- a/test/lib/validators/katello_name_format_validator_test.rb
+++ b/test/lib/validators/katello_name_format_validator_test.rb
@@ -1,0 +1,55 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+require 'minitest_helper'
+
+class KatelloNameFormatValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
+
+  def setup
+    @validator = Validators::KatelloNameFormatValidator.new({:attributes => [:name]})
+    @model = OpenStruct.new(:errors => {:name => []})
+  end
+
+  def test_validate_each
+    @validator.validate_each(@model, :name, "Test2 Name_underline-dash")
+
+    assert_empty @model.errors[:name]
+  end
+
+  test "fails with HTML tag" do
+    @validator.validate_each(@model, :name, '<a href="">Test Name</a>')
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails with more than 128 characters" do
+    cs = [*'0'..'9', *'a'..'z', *'A'..'Z']
+    random_string = 129.times.map { cs.sample }.join
+    @validator.validate_each(@model, :name, random_string)
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails if blank" do
+    @validator.validate_each(@model, :name, '')
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails with trailing white space" do
+    @validator.validate_each(@model, :name, "Trailing Whitespace   ")
+
+    refute_empty @model.errors[:name]
+  end
+
+end

--- a/test/lib/validators/non_html_name_validator_test.rb
+++ b/test/lib/validators/non_html_name_validator_test.rb
@@ -1,0 +1,55 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+require 'minitest_helper'
+
+class NonHtmlNameValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
+
+  def setup
+    @validator = Validators::NonHtmlNameValidator.new({:attributes => [:name]})
+    @model = OpenStruct.new(:errors => {:name => []})
+  end
+
+  def test_validate_each
+    @validator.validate_each(@model, :name, "Test2 Name_underline-dash")
+
+    assert_empty @model.errors[:name]
+  end
+
+  test "fails with HTML tag" do
+    @validator.validate_each(@model, :name, '<a href="">Test Name</a>')
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails with more than 128 characters" do
+    cs = [*'0'..'9', *'a'..'z', *'A'..'Z']
+    random_string = 129.times.map { cs.sample }.join
+    @validator.validate_each(@model, :name, random_string)
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails if blank" do
+    @validator.validate_each(@model, :name, '')
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails with trailing white space" do
+    @validator.validate_each(@model, :name, "Trailing Whitespace   ")
+
+    refute_empty @model.errors[:name]
+  end
+
+end

--- a/test/lib/validators/rolename_validator_test.rb
+++ b/test/lib/validators/rolename_validator_test.rb
@@ -1,0 +1,43 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+require 'minitest_helper'
+
+class RolenameValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
+
+  def setup
+    @validator = Validators::RolenameValidator.new({:attributes => [:name]})
+    @model = OpenStruct.new(:errors => {:name => []})
+  end
+
+  def test_validate_each
+    @validator.validate_each(@model, :name, "Test2 Name_underline-dash")
+
+    assert_empty @model.errors[:name]
+  end
+
+  test "fails with more than 148 characters" do
+    cs = [*'0'..'9', *'a'..'z', *'A'..'Z']
+    random_string = 149.times.map { cs.sample }.join
+    @validator.validate_each(@model, :name, random_string)
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails if blank" do
+    @validator.validate_each(@model, :name, '')
+
+    refute_empty @model.errors[:name]
+  end
+
+end

--- a/test/lib/validators/username_validator_test.rb
+++ b/test/lib/validators/username_validator_test.rb
@@ -1,0 +1,49 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+require 'minitest_helper'
+
+class UsernameValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
+
+  def setup
+    @validator = Validators::UsernameValidator.new({:attributes => [:name]})
+    @model = OpenStruct.new(:errors => {:name => []})
+  end
+
+  def test_validate_each
+    @validator.validate_each(@model, :name, "Test2 Name_underline-dash")
+
+    assert_empty @model.errors[:name]
+  end
+
+  test "fails with HTML tag" do
+    @validator.validate_each(@model, :name, '<a href="">Test Name</a>')
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails with more than 128 characters" do
+    cs = [*'0'..'9', *'a'..'z', *'A'..'Z']
+    random_string = 129.times.map { cs.sample }.join
+    @validator.validate_each(@model, :name, random_string)
+
+    refute_empty @model.errors[:name]
+  end
+
+  test "fails if less than 3 characters" do
+    @validator.validate_each(@model, :name, 'ab')
+
+    refute_empty @model.errors[:name]
+  end
+
+end


### PR DESCRIPTION
use KatelloNameFormatValidator validate_length to facilitate future
re-factoring.
