### PR TITLE
Reenable chance to login for not existing users

### DIFF
--- a/app/controllers/failed_authentication_controller.rb
+++ b/app/controllers/failed_authentication_controller.rb
@@ -43,7 +43,13 @@ class FailedAuthenticationController < ActionController::Base
   end
 
   # In case Warden would fail this returns some reasonable output too
+  # warden stores it's options, for API request a scope is :api,
+  # when the scope is nil it's using a default one (currently :user that is used fo UI)
   def unauthenticated
-    unauthenticated_api
+    if request.env['warden.options'][:scope] == :api
+      unauthenticated_api
+    else
+      unauthenticated_ui
+    end
   end
 end


### PR DESCRIPTION
When you use LDAP and you try to login using Signo but the user does not
already exist in Katello database you should not end up in error page.
With this patch you are redirected to login page when you can enter
credentials again. Once you login using katello form you are able to use
Signo in future.
