### PR TITLE
add praise to be able to inspect exceptions before unwinding stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ vendor/ruby
 coverage
 public/assets
 bundler.d/local*.rb
+config/initializers/_local*.rb
+config/initializers/local*.rb
 lib/tasks/local*.rb
 doc/graphs/*.svg
 .ruby-version


### PR DESCRIPTION
Adding support for [praise](https://github.com/pitr-ch/praise) gem. 

Praise helps to inspect exceptions and current stack before stack is
unwounded. Follow instructions in `lib/development_tools/praise/load.rb`
to enable it.

See [documentation](http://blog.pitr.ch/praise/).
