### PR TITLE
959546 - publishing synced ISO-based repos by default in library

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -45,12 +45,17 @@ module ProductsHelper
 
   # Retrieve a hash of products that are accessible to the user.
   # This will be determined from the readable & editable products provided in the options.
+  # @param [Hash] options the options to construct the product hash with
+  # @option options [String] :readable_products List of readable products
+  # @option options [String] :editable_products List of editable products
+  # @option options [String] :content_types (Optional) Filter repos by listed types
   def get_products(options)
+    options[:content_types] ||= [Repository::TYPES]
     if @product_hash.nil?
       @product_hash = {}
       options[:readable_products].sort_by(&:name).each do |prod|
         repos = []
-        prod.repos(current_organization.library).sort{|a,b| a.name <=> b.name}.each{|repo|
+        prod.repos(current_organization.library).where(:content_type=>options[:content_types]).sort{|a,b| a.name <=> b.name}.each{|repo|
           repos << {:name=>repo.name, :id=>repo.id}
         }
         @product_hash[prod.id] = {:name=>prod.name, :repos=>repos, :id=>prod.id,

--- a/app/models/glue/pulp/repo.rb
+++ b/app/models/glue/pulp/repo.rb
@@ -145,9 +145,11 @@ module Glue::Pulp::Repo
         when Repository::YUM_TYPE
           Runcible::Extensions::YumDistributor.new(self.relative_path, (self.unprotected || false), true,
                   {:protected=>true, :id=>self.pulp_id,
-                      :auto_publish=>!self.environment.library?})
+                      :auto_publish=>true})
         when Repository::FILE_TYPE
-          Runcible::Extensions::IsoDistributor.new(true, true)
+          dist = Runcible::Extensions::IsoDistributor.new(true, true)
+          dist.auto_publish = true
+          dist
         else
           raise _("Unexpected repo type %s") % self.content_type
       end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -62,6 +62,9 @@ class Repository < ActiveRecord::Base
   scope :in_default_view, joins(:content_view_version => :content_view).
     where("content_views.default" => true)
 
+  scope :yum_type, where(:content_type=>YUM_TYPE)
+  scope :file_type, where(:content_type=>FILE_TYPE)
+
   def self.ids_only
     with_exclusive_scope{pluck(:id)}
   end

--- a/app/views/common/_common_product_repo_selector.html.haml
+++ b/app/views/common/_common_product_repo_selector.html.haml
@@ -1,5 +1,7 @@
+- content_types ||= nil
 = render :partial => "common/common_products",
          :locals => {:record => record,
+                     :content_types => content_types,
                      :readable_products => readable_products || nil,
                      :editable_products => editable_products || nil}
 

--- a/app/views/common/_common_products.html.haml
+++ b/app/views/common/_common_products.html.haml
@@ -1,10 +1,13 @@
+- content_types ||= nil
 = javascript do
   :plain
     KT.products = $.parseJSON('#{escape_javascript(get_products({:record => record,
+                                                                 :content_types => content_types,
                                                                  :readable_products => readable_products,
                                                                  :editable_products => editable_products}).to_json)}');
 
     KT.editable_products = $.parseJSON('#{escape_javascript(get_products({:record => record,
+                                                                          :content_types => content_types,
                                                                           :readable_products => readable_products,
                                                                           :editable_products => editable_products}).
                                                                         reject{|key,val|!val[:editable]}.to_json)}');


### PR DESCRIPTION
Also prevents users from publishing content views with repositories 
of type FILE.  There is no point in re-publishing these repos in different
content views across different environments. 
