### PR TITLE
Publish actions for repositories changes

### DIFF
--- a/app/models/deletion_changeset.rb
+++ b/app/models/deletion_changeset.rb
@@ -72,6 +72,9 @@ class DeletionChangeset < Changeset
 
     self.promotion_date = Time.now
     self.state          = Changeset::DELETED
+
+    Glue::Event.trigger(Katello::Actions::ChangesetPromote, self)
+
     self.save!
 
     index_repo_content from_env

--- a/app/models/promotion_changeset.rb
+++ b/app/models/promotion_changeset.rb
@@ -98,6 +98,9 @@ class PromotionChangeset < Changeset
 
     self.promotion_date = Time.now
     self.state          = Changeset::PROMOTED
+
+    Glue::Event.trigger(Katello::Actions::ChangesetPromote, self)
+
     self.save!
 
     index_repo_content to_env

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -19,6 +19,11 @@ class Repository < ActiveRecord::Base
   include Glue if (Katello.config.use_cp || Katello.config.use_pulp)
   include Authorization::Repository
 
+  include Glue::Event
+  def destroy_event
+    Katello::Actions::RepositoryDestroy
+  end
+
   include AsyncOrchestration
   include Ext::LabelFromName
   include Rails.application.routes.url_helpers

--- a/lib/katello/actions/changeset_promote.rb
+++ b/lib/katello/actions/changeset_promote.rb
@@ -1,0 +1,24 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Actions
+
+    class ChangesetPromote < Dynflow::Action
+
+      def plan(changeset)
+        # third party plugins can hook here to perform additional actions
+      end
+
+    end
+  end
+end

--- a/lib/katello/actions/repository_destroy.rb
+++ b/lib/katello/actions/repository_destroy.rb
@@ -1,0 +1,23 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Actions
+    class RepositoryDestroy < Dynflow::Action
+
+      def plan(repo)
+        # third party plugins can hook here to perform additional actions
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Thanks to this actions, we are able react to changes in repositories from
plugins. It's used by katello-foreman-engine to populate installation media
based on repo distribution.
