### PR TITLE
 #961122: fixes "Missing template users/destroy" error.

### DIFF
--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -110,8 +110,14 @@ class EnvironmentsController < ApplicationController
   # DELETE /environments/1
   def destroy
     @environment.destroy
-    notify.success _("Environment '%s' was deleted.") % @environment.name
-    render :partial => "common/post_delete_close_subpanel", :locals => {:path=>edit_organization_path(@organization.label)}
+    if @environment.destroyed?
+      notify.success _("Environment '%s' was deleted.") % @environment.name
+      render :partial => "common/post_delete_close_subpanel", :locals => {:path=>edit_organization_path(@organization.label)}
+    else
+      err_msg = N_("Removal of the environment failed. If you continue having trouble with this, please contact an Administrator.")
+      notify.error err_msg
+      render :nothing => true
+    end
   end
 
   # GET /environments/1/products

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -101,8 +101,14 @@ class RepositoriesController < ApplicationController
 
   def destroy
     @repository.destroy
-    notify.success _("Repository '%s' removed.") % @repository.name
-    render :partial => "common/post_delete_close_subpanel", :locals => {:path=>products_repos_provider_path(@provider.id)}
+    if @repository.destroyed?
+      notify.success _("Repository '%s' removed.") % @repository.name
+      render :partial => "common/post_delete_close_subpanel", :locals => {:path=>products_repos_provider_path(@provider.id)}
+    else
+      err_msg = N_("Removal of the repository failed. If you continue having trouble with this, please contact an Administrator.")
+      notify.error err_msg
+      render :nothing => true
+    end
   end
 
   def auto_complete_library

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -271,10 +271,15 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    if @user.destroy
+    @user.destroy
+    if @user.destroyed?
       notify.success _("User '%s' was deleted.") % @user[:username]
       #render and do the removal in one swoop!
       render :partial => "common/list_remove", :locals => { :id => params[:id], :name => controller_display_name }
+    else
+      err_msg = N_("Removal of the user failed. If you continue having trouble with this, please contact an Administrator.")
+      notify.error err_msg
+      render :nothing => true
     end
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -113,7 +113,6 @@ class Organization < ActiveRecord::Base
     self.providers << ::Provider.new(:name => "Red Hat", :provider_type => ::Provider::REDHAT, :organization => self)
   end
 
-  # TODO - this code seems to be dead
   def validate_destroy current_org
     def_error = _("Could not delete organization '%s'.")  % [self.name]
     if (current_org == self)

--- a/spec/controllers/environments_controller_spec.rb
+++ b/spec/controllers/environments_controller_spec.rb
@@ -210,18 +210,36 @@ describe EnvironmentsController do
         end
       end
     end
+
     describe "destroy an environment" do
-        before(:each) do
-          @env.stub(:destroy)
+      before(:each) { @env.stub(:destroy) }
+
+      describe "on success" do
+        before(:each) { @env.stub(:destroyed?).and_return(true) }
+
+        it "destroys the requested environment", :katello => true do #TODO headpin
+          @env.should_receive(:destroy)
+          @env.should_receive(:destroyed?)
+          delete :destroy, :id => @env.id, :organization_id => @org.label
         end
 
-      it "destroys the requested environment", :katello => true do #TODO headpin
-        @env.should_receive(:destroy)
-        delete :destroy, :id => @env.id, :organization_id => @org.label
+        it "redirects to the environments list", :katello => true do #TODO headpin
+          delete :destroy, :id => @env.id, :organization_id => @org.label
+        end
       end
 
-      it "redirects to the environments list", :katello => true do #TODO headpin
-        delete :destroy, :id => @env.id, :organization_id => @org.label
+      describe "on failure" do
+        before(:each) { @env.stub(:destroyed?).and_return(false) }
+
+        it "should produce an error notice on failure", :katello => true do
+          controller.should notify.error
+          delete :destroy, :id => @env.id, :organization_id => @org.label
+        end
+
+        it "shouldn't render anything on failure", :katello => true do
+          delete :destroy, :id => @env.id, :organization_id => @org.label
+          response.body.should be_blank
+        end
       end
     end
   end

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -69,6 +69,49 @@ describe RepositoriesController, :katello => true do
     end
   end
 
+  describe "destroy a repository" do
+     before(:each) do
+       login_user
+
+       Provider.stub(:find).and_return(mock_model(Repository))
+       Product.stub(:find).and_return(@product = mock_model(Product))
+       @product.stub(:editable?).and_return(true)
+
+       @repository = mock_model(Repository, :name=>"deleted", :id => 123456).as_null_object
+       Repository.stub(:find).and_return(@repository)
+       @repository.stub(:destroy)
+     end
+
+     describe "on success" do
+       before(:each) { @repository.stub(:destroyed?).and_return(true) }
+
+       it "destroys the requested repository" do
+         @repository.should_receive(:destroy)
+         @repository.should_receive(:destroyed?)
+         delete :destroy, :id => "123456", :provider_id => "123", :product_id => "123"
+       end
+
+        it "updates the view" do
+          delete :destroy, :id => "123456", :provider_id => "123", :product_id => "123", :format => :js
+          response.should render_template(:partial => 'common/_post_delete_close_subpanel')
+        end
+     end
+
+     describe "on failure" do
+       before(:each) { @repository.stub(:destroyed?).and_return(false) }
+
+       it "should produce an error notice on failure" do
+         controller.should notify.error
+         delete :destroy, :id => "123456", :provider_id => "123", :product_id => "123"
+       end
+
+       it "shouldn't render anything on failure" do
+         delete :destroy, :id => "123456", :provider_id => "123", :product_id => "123"
+         response.body.should be_blank
+       end
+     end
+   end
+
   describe "other-tests" do
     before (:each) do
       login_user

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -136,6 +136,45 @@ describe UsersController do
 
   end
 
+  describe "destroy a user" do
+    before(:each) do
+      User.any_instance.stub(:deletable?).and_return(true)
+
+      @to_delete = mock_model(User, :username=>"deleted", :password=>"deleted", :email=>"delete@test").as_null_object
+      User.stub(:find).and_return(@to_delete)
+      @to_delete.stub(:destroy)
+    end
+
+    describe "on success" do
+      before(:each) { @to_delete.stub(:destroyed?).and_return(true) }
+
+      it "destroys the requested user", :katello => true do
+        @to_delete.should_receive(:destroy)
+        @to_delete.should_receive(:destroyed?)
+        delete :destroy, :id => "123456"
+      end
+
+      it "updates the user list", :katello => true do
+        delete :destroy, :id => "123456", :format => :js
+        response.should render_template(:partial => 'common/_list_remove')
+      end
+    end
+
+    describe "on failure" do
+      before(:each) { @to_delete.stub(:destroyed?).and_return(false) }
+
+      it "should produce an error notice on failure", :katello => true do
+        controller.should notify.error
+        delete :destroy, :id => "123456"
+      end
+
+      it "shouldn't render anything on failure", :katello => true do
+        delete :destroy, :id => "123456"
+        response.body.should be_blank
+      end
+    end
+  end
+
   describe "set helptips" do
 
     before(:each) do


### PR DESCRIPTION
Since user.destroy may fail (if any of the callbacks fail, for example), we need to handle this case as well.
