### PR TITLE
BZ 961836: Fixes broken user deletion.

### DIFF
--- a/app/lib/glue/event.rb
+++ b/app/lib/glue/event.rb
@@ -24,10 +24,12 @@ module Glue
 
     def trigger_create_event
       Glue::Event.trigger(create_event, self) if create_event
+      return true
     end
 
     def trigger_destroy_event
       Glue::Event.trigger(destroy_event, self) if destroy_event
+      return true
     end
 
     # define the Dynflow action to be triggered after create


### PR DESCRIPTION
For new orchestration events, if there is no create or destroy event
the functions would return the default nil and cause orchestration
to fail. This manifested itself by preventing user deletion in the
database but leaving the user deleted in Pulp.
