### PR TITLE
893596 - fixing repobinding to be specific to a single repo

### DIFF
--- a/spec/controllers/api/v1/systems_controller_spec.rb
+++ b/spec/controllers/api/v1/systems_controller_spec.rb
@@ -615,17 +615,17 @@ describe Api::V1::SystemsController do
       User.stub(:consumer? => true)
       @system = System.create(:name => 'test', :environment => @environment_1, :cp_type => 'system', :facts => facts, :uuid => uuid)
       System.stub!(:first).and_return(@system)
-      Repository.stub!(:find_by_cp_label).with('a').and_return(OpenStruct.new({ :pulp_id => 'a' }))
-      Repository.stub!(:find_by_cp_label).with('b').and_return(OpenStruct.new({ :pulp_id => 'b' }))
+      Repository.stub!(:where).with(:relative_path=>'foo').and_return([OpenStruct.new({ :pulp_id => 'a' })])
+      Repository.stub!(:where).with(:relative_path=>'bar').and_return([OpenStruct.new({ :pulp_id => 'b' })])
     end
     let(:enabled_repos) {
       {
           "repos" => [
               {
-                  "repositoryid" => "a",
+                  "baseurl" => ["https://hostname/pulp/repos/foo"],
               },
               {
-                  "repositoryid" => "b",
+                  "baseurl" => ["https://hostname/pulp/repos/bar"],
               },
           ]
       }


### PR DESCRIPTION
Previously katello-agent sent up the repo_id from the redhat.repos
file.  This however was the cp_id of the content and in no way 
uniquely identified the repo.  Now katello-agent sends up the baseurl:

https://github.com/Katello/katello-agent/pull/2

which we can use to uniquely identify the repo.
