### PR TITLE
959895 - Handling nil for products

### DIFF
--- a/app/controllers/content_view_definitions_controller.rb
+++ b/app/controllers/content_view_definitions_controller.rb
@@ -220,8 +220,8 @@ class ContentViewDefinitionsController < ApplicationController
   end
 
   def update_content
-    if params[:products]
-      products_ids = params[:products].empty? ? [] : Product.readable(current_organization).
+    if params.has_key?(:products)
+      products_ids = params[:products].blank? ? [] : Product.readable(current_organization).
           where(:id => params[:products]).pluck("products.id")
 
       @view_definition.product_ids = products_ids

--- a/spec/controllers/content_view_definitions_controller_spec.rb
+++ b/spec/controllers/content_view_definitions_controller_spec.rb
@@ -318,6 +318,20 @@ describe ContentViewDefinitionsController, :katello => true do
         ContentViewDefinition.where(:id=>@definition.id).first.products.first.should == @product
       end
 
+      it "should unset products if products param is nil" do
+        @definition.products = [@product]
+        @definition.save!
+        @definition.products.reload.length.should eql(1)
+
+        post :update_content, :id=>@definition.id
+        response.should be_success
+        @definition.products.reload.length.should eql(1)
+
+        post :update_content, :id=>@definition.id, :products => nil
+        response.should be_success
+        @definition.products.reload.length.should eql(0)
+      end
+
       it "should successfully update repositories" do
         assert @definition.repositories.size == 0
 


### PR DESCRIPTION
Probably due to https://github.com/rails/rails/pull/8862. It appears that Rails is converting [] to nil for JSON calls. Thus, we need to check if params has products as a key instead of just checking that it's truthy.
