### PR TITLE
Runcible: Overriding the default config error message

### DIFF
--- a/config/initializers/runcible.rb
+++ b/config/initializers/runcible.rb
@@ -1,0 +1,12 @@
+if Katello.config.use_pulp
+
+  # override Runcible's default configuration error message
+  module Runcible
+    class ConfigurationUndefinedError
+      def self.message
+        "Runcible configuration not defined. Is User.current set?"
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This is part of Katello/runcible#64. This won't pass until after the new release of runcible which has Katello/runcible#64.
