### PR TITLE
952728 - fixing sync status reporting issue

### DIFF
--- a/app/models/glue/pulp/repo.rb
+++ b/app/models/glue/pulp/repo.rb
@@ -561,10 +561,10 @@ module Glue::Pulp::Repo
         history = Runcible::Extensions::Repository.sync_status(pulp_id)
 
         if history.nil? or history.empty?
-          history = Runcible::Extensions::Repository.sync_history(pulp_id)
+          history = PulpSyncStatus.convert_history(Runcible::Extensions::Repository.sync_history(pulp_id))
         end
       rescue => e
-          history = Runcible::Extensions::Repository.sync_history(pulp_id)
+          history = PulpSyncStatus.convert_history(Runcible::Extensions::Repository.sync_history(pulp_id))
       end
 
       if history.nil? or history.empty?

--- a/test/models/pulp_sync_status_test.rb
+++ b/test/models/pulp_sync_status_test.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'minitest_helper'
+
+class PulpSyncStatusTest < MiniTest::Rails::ActiveSupport::TestCase
+
+  def test_convert_history
+    item = [{
+        'started' => Time.now.to_s,
+        'completed' => Time.now.to_s,
+        'result' => 'failed'
+    }]
+    returned = PulpSyncStatus.convert_history(item).first
+    assert_equal item.first['started'], returned['start_time']
+    assert_equal item.first['completed'], returned['finish_time']
+    assert_equal 'error', returned['state']
+  end
+
+end


### PR DESCRIPTION
if a sync task had been moved from the task
queue to the sync history queue, the structure
and status codes are different.  So let us
convert one to the other since we treat them the same
anyways.
