### PR TITLE
fix log correlation by request uuid

### DIFF
--- a/app/lib/util/thread_session.rb
+++ b/app/lib/util/thread_session.rb
@@ -82,6 +82,7 @@ module Util
             self.current = User.find_by_username(username)
             raise(ArgumentError, "Cannot find user '%s'" % username) if self.current.nil?
             do_block.call
+          ensure
             self.current = old_user
           end
         end
@@ -97,22 +98,10 @@ module Util
       end
 
       def thread_locals
-        # store request uuid (for Rails 3.2+ we can use Request.uuid) and process pid
-        uuid = request.respond_to?(:uuid) ? request.uuid : SecureRandom.hex(16)
-        ::Logging.mdc['uuid'] = Thread.current[:request_uuid] = uuid
-
-        # store user
-        u = current_user
-        User.current = u
-
+        User.current = current_user
         yield
-
-        # reset the current user (for security reasons)
+      ensure
         User.current = nil
-      rescue => exception
-        # reset the current user (for security reasons)
-        User.current = nil
-        raise
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,6 +71,9 @@ LdapFluff::CONFIG = config_file_path unless LdapFluff::CONFIG == config_file_pat
 module Src
   class Application < Rails::Application
 
+    require 'katello/middleware/log_request_uuid'
+    config.middleware.insert_after ActionDispatch::RequestId, Katello::Middleware::LogRequestUUID
+
     # use dabase configuration form katello.yml instead database.yml
     config.class_eval do
       def database_configuration

--- a/lib/katello/middleware/log_request_uuid.rb
+++ b/lib/katello/middleware/log_request_uuid.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Middleware
+    class LogRequestUUID
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        ::Logging.mdc['uuid'] = env['action_dispatch.request_id']
+        @app.call(env)
+      ensure
+        ::Logging.mdc.delete 'uuid'
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Uuid correlation was set too late. It was showing wrong uuid for log
messages when uuid is being logged and level is set to :debug.

Uuid is now set in middleware right after request uuid determination
before any logging occurs.

It changed uuid in the middle of logging

```
[ INFO 2013-05-21 10:12:30 app f8a67bdf7d72191540b8cc8feff34f8d #77151] Started GET "/katello//api/repositories/157/distributions" for 127.0.0.1 at 2013-05-21 10:12:30 +0200
[ INFO 2013-05-21 10:12:30 app f8a67bdf7d72191540b8cc8feff34f8d #77151] Processing by Api::V1::DistributionsController#index as JSON
[ INFO 2013-05-21 10:12:30 app f8a67bdf7d72191540b8cc8feff34f8d #77151]   Parameters: {"repository_id"=>"157"}
[DEBUG 2013-05-21 10:12:30 app f8a67bdf7d72191540b8cc8feff34f8d #77151] Setting locale: en
[DEBUG 2013-05-21 10:12:30 app f8a67bdf7d72191540b8cc8feff34f8d #77151] Warden is authenticating admin against database
[DEBUG 2013-05-21 10:12:30 app f8a67bdf7d72191540b8cc8feff34f8d #77151] User admin authenticated: database
[DEBUG 2013-05-21 10:12:30 app 2626589640febaac7390e9ba596f3b07 #77151] Setting current user thread-local variable to admin
[DEBUG 2013-05-21 10:12:30 app 2626589640febaac7390e9ba596f3b07 #77151] Checking  params  for api/v1/distributions/index
[DEBUG 2013-05-21 10:12:30 app 2626589640febaac7390e9ba596f3b07 #77151] Authorizing admin for api/v1/distributions/index
[DEBUG 2013-05-21 10:12:30 pulp_rest 2626589640febaac7390e9ba596f3b07 #77151] RestClient.post "https://192.168.25.100/pulp/api/v2/repositories/org_label_H3klffMCivk7-fewups_product_H3klffMCivk7-repo_H3klffMCivk7/search/units/", "{\"criteria\":{\"type_ids\":[\"distribution\"]}}", "Accept"=>"application/json", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"OAuth oauth_body_hash=\"2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D\", oauth_consumer_key=\"katello\", oauth_nonce=\"sCSXzWWfPklS8QkBwT2j5h5xYYLizseWMFW3lGXos\", oauth_signature=\"HAVKsAOz%2FPP8aVLKFQ1pHK2WKYU%3D\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1369123950\", oauth_version=\"1.0\"", "Content-Length"=>"42", "Content-Type"=>"application/json", "pulp-user"=>"admin"
 | \n# => 200 OK | application/json 2735 bytes
```
