### PR TITLE
965776 - allow library to be selectable

### DIFF
--- a/app/assets/javascripts/widgets/path_selector.js
+++ b/app/assets/javascripts/widgets/path_selector.js
@@ -41,7 +41,6 @@ KT.path_select = function(div_id, name, environments, options_in){
         init = function(){
             div = $('#' + KT.common.escapeId(div_id));
             paths_id = "path_select_" + name;
-            options.library_select = default_opt(options_in.library_select, true);
             options.inline = default_opt(options_in.inline, false);
             options.activate_on_click = default_opt(options_in.activate_on_click, false);
             options.select_mode = default_opt(options_in.select_mode, 'none');

--- a/app/controllers/distributors_controller.rb
+++ b/app/controllers/distributors_controller.rb
@@ -253,7 +253,8 @@ class DistributorsController < ApplicationController
     # Stuff into var for use in spec tests
     @locals_hash = { :distributor => @distributor, :editable => @distributor.editable?,
                     :releases => releases, :releases_error => releases_error, :name => controller_display_name,
-                    :environments => environment_paths(library_path_element, environment_path_element("distributors_readable?")) }
+                    :environments => environment_paths(library_path_element("distributors_readable?"),
+                                                       environment_path_element("distributors_readable?")) }
     render :partial => "edit", :locals => @locals_hash
   end
 

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -318,7 +318,8 @@ class SystemsController < ApplicationController
     # Stuff into var for use in spec tests
     @locals_hash = { :system => @system, :editable => @system.editable?,
                     :releases => releases, :releases_error => releases_error, :name => controller_display_name,
-                    :environments => environment_paths(library_path_element, environment_path_element("systems_readable?")) }
+                    :environments => environment_paths(library_path_element("systems_readable?"),
+                                                       environment_path_element("systems_readable?")) }
     render :partial => "edit", :locals => @locals_hash
   end
 
@@ -385,7 +386,8 @@ class SystemsController < ApplicationController
       # Stuff into var for use in spec tests
       @locals_hash = { :system => @system, :editable => @system.editable?,
                       :releases => releases, :releases_error => releases_error, :name => controller_display_name,
-                      :environments => environment_paths(library_path_element, environment_path_element("systems_readable?"))}
+                      :environments => environment_paths(library_path_element("systems_readable?"),
+                                                         environment_path_element("systems_readable?"))}
 
       if request.xhr?
         render :show_nutupane, :leyout => false, :locals => @locals_hash


### PR DESCRIPTION
This commit contains a minor change to the environment selector
used on system and distributor edit to allow library to be a
'selectable' environment.  Without this change, library is
listed but cannot be chosen.
