### PR TITLE
Fixes login issues with JS

### DIFF
--- a/app/assets/javascripts/user_sessions/user_sessions.controller.js
+++ b/app/assets/javascripts/user_sessions/user_sessions.controller.js
@@ -12,7 +12,15 @@
  **/
 
 Katello.controller('UserSessionsController', ['$scope', function($scope) {
-    $('#login_form').bind('ajax:complete', function() {
-        $scope.orgSwitcher.refresh();
+    $('#login_form').bind('ajax:complete', function(event, request) {
+        var status = request.status;
+
+        // 40x error means that user was not authenticated, for such case we don't want
+        // to trigger orgSwitcher refresh
+        if (status >= 400 && status < 500) {
+            notices.displayNotice("error", request.responseText);
+        } else {
+            $scope.orgSwitcher.refresh();
+        }
     });
 }]);

--- a/app/assets/stylesheets/loginpage.css.scss
+++ b/app/assets/stylesheets/loginpage.css.scss
@@ -1,6 +1,5 @@
 @import "compass/reset";
 @import "overrides";
-
 $login_background_top_color: lighten($primary_color, 10%) !default;
 $login_background_bottom-color: darken($primary_color, 10%) !default;
 
@@ -13,6 +12,7 @@ $switcherformwidth: 300px;
 @import "katello_base";
 
 @import "jquery.jscrollpane";
+@import "jquery.jnotify";
 
 //interstitial container
 #interstitial {


### PR DESCRIPTION
When user entered wrong credentials a login screen still tried to fetch
allowed organizations. Also an error notification was not displayed.
