### PR TITLE
Do not log to /var/log/katello by default

### DIFF
--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -261,8 +261,6 @@ production:
     database: katello
   logging:
     loggers:
-      root:
-        path: /var/log/katello
       sql:
         level: fatal
 


### PR DESCRIPTION
Log by default to ./log not to /var/log/katello. Otherwise it
tries to write to /var/log/katello on developer's machine. It
is handled by a symlink (part of RPM)

```
`/usr/share/katello/log -> /var/log/katello`
```

in deployment.
