### PR TITLE
Nutupane: ensure bulk actions pane opens if details are visible.

### DIFF
--- a/app/assets/javascripts/systems/systems.controller.js
+++ b/app/assets/javascripts/systems/systems.controller.js
@@ -145,6 +145,7 @@ angular.module('Katello').controller('SystemsController',
          * @param state the state to fill the right pane with.
          */
         $scope.fillActionPaneWithState = function(state) {
+            $scope.table.setDetailsVisibility(false);
             $scope.table.openActionPane();
             $state.transitionTo(state);
         };


### PR DESCRIPTION
This fixes an issue where the actions pane wouldn't open with the bulk actions if the details were already open.
