### PR TITLE
[FEEDBACK_PLEASE] Adds success notifs for creating and removing custom information keynames.

### DIFF
--- a/app/assets/javascripts/organizations/default_info.js
+++ b/app/assets/javascripts/organizations/default_info.js
@@ -118,6 +118,7 @@ KT.default_info = (function() {
             data    : { "keyname" : keyname },
             success : function(data) {
                 add_default_info_row(data);
+                notices.displayNotice("success", window.JSON.stringify({ "notices": [i18n.default_info_create_success] }));
             },
             error   : function(data) {
                 notices.displayNotice("error", window.JSON.stringify({ "notices": [$.parseJSON(data.responseText)["displayMessage"]] }));
@@ -131,6 +132,7 @@ KT.default_info = (function() {
             type   : $button.data("method"),
             success: function(data) {
                 remove_default_info_row($button.data("id"));
+                notices.displayNotice("success", window.JSON.stringify({ "notices": [i18n.default_info_delete_success] }));
             }
         });
     };

--- a/app/views/organizations/_default_info.html.haml
+++ b/app/views/organizations/_default_info.html.haml
@@ -4,7 +4,9 @@
 = javascript do
   :plain
     localize({
-       "default_info_apply_error": '#{escape_javascript(_("An error has occurred while applying default info. Please contact your administrator"))}'
+       "default_info_apply_error": '#{escape_javascript(_("An error has occurred while applying default info. Please contact your administrator"))}',
+       "default_info_create_success": '#{escape_javascript(_("Successfully created default information keyname"))}',
+       "default_info_delete_success": '#{escape_javascript(_("Successfully deleted default information keyname"))}'
     });
 
 = content_for :title do


### PR DESCRIPTION
QE really needs to see notifications (success/failures when creating and removing custom information keynames. I'd love to get some feedback on this.
