### PR TITLE
967103 - RAM and Cores limit displayed wrong

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -312,7 +312,7 @@ module ApplicationHelper
     lim = []
     lim << _("Sockets: %s") % sub.sockets if sub.sockets > 0
     lim << _("Cores: %s") % sub.cores if sub.cores > 0
-    lim << _("RAM: %s") % sub.ram if sub.ram > 0
+    lim << _("RAM: %s GB") % sub.ram if sub.ram > 0
     lim.join(", ")
   end
 end

--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -335,7 +335,7 @@ module Glue::Candlepin::Consumer
       else
         mem = '0'
       end
-      memory_in_megabytes(mem)
+      memory_in_gigabytes(mem)
     end
 
     def memory=(mem)
@@ -371,19 +371,19 @@ module Glue::Candlepin::Consumer
       end
     end
 
-    def memory_in_megabytes(mem_str)
-      # convert total memory into megabytes
+    def memory_in_gigabytes(mem_str)
+      # convert total memory into gigabytes
       return 0 if mem_str.nil?
       mem,unit = mem_str.split
       total_mem = mem.to_f
       case unit
         when 'B'  then total_mem = 0
-        when 'kB' then total_mem = (total_mem / 1024)
-        when 'MB' then total_mem *= 1
-        when 'GB' then total_mem *= (1024)
-        when 'TB' then total_mem *= (1024*1024)
+        when 'kB' then total_mem = 0
+        when 'MB' then total_mem /= 1024
+        when 'GB' then total_mem *= 1
+        when 'TB' then total_mem *= 1024
         # default memtotal is in kB
-        else total_mem = (total_mem / 1024)
+        else total_mem = (total_mem / (1024*1024))
       end
       total_mem.to_i
     end

--- a/app/views/distributors/_subs.html.haml
+++ b/app/views/distributors/_subs.html.haml
@@ -113,8 +113,7 @@
                       #{sub.support_level}
                   %td{:style => "padding-top:9px;"}
                     - if sub.provider_id == current_organization.redhat_provider.id
-                      = _("Sockets: %s") % sub.sockets
-                      = _(", RAM: %s") % sub.ram if sub.ram != 0
+                      = subscription_limits_helper(sub)
                   %td
                     - if sub.quantity < 0
                       = text_field_tag "spinner[#{sub.cp_id}]", nil, :min => 0, :max => 99999, :step=>1, :value=>0, :class=>"ui-spinner"

--- a/app/views/systems/_edit.html.haml
+++ b/app/views/systems/_edit.html.haml
@@ -117,7 +117,7 @@
               = System.architectures[system.arch]
         .control-group
           .label
-            = label :memory, :memory, _("RAM (MB)")
+            = label :memory, :memory, _("RAM (GB)")
           .input
             %span.value
               = system.memory

--- a/app/views/systems/_new.html.haml
+++ b/app/views/systems/_new.html.haml
@@ -7,7 +7,7 @@
 
 :ruby
   sockets_help = _("The number of CPU Sockets or LPARs which this system uses")
-  memory_help = _("The amount of RAM memory, in megabytes (MB), which this system has")
+  memory_help = _("The amount of RAM memory, in gigabytes (GB), which this system has")
 
 
 - if @environment
@@ -25,7 +25,7 @@
 
           = form.text_field :sockets, :label => _("Number of Sockets or LPARs:"), :help => sockets_help, :value => 1
 
-          = form.text_field :memory, :label => _("Amount of RAM (MB):"), :help => memory_help, :value => ''
+          = form.text_field :memory, :label => _("Amount of RAM (GB):"), :help => memory_help, :value => ''
 
           = form.field :virtual, :label => _("System Type:") do
             = virtual_buttons

--- a/app/views/systems/new_nutupane.html.haml
+++ b/app/views/systems/new_nutupane.html.haml
@@ -6,7 +6,7 @@
 
 :ruby
   sockets_help = _("The number of CPU Sockets or LPARs which this system uses")
-  memory_help = _("The amount of RAM memory, in megabytes (MB), which this system has")
+  memory_help = _("The amount of RAM memory, in gigabytes (GB), which this system has")
 
 
 - if @environment
@@ -24,7 +24,7 @@
 
           = form.text_field :sockets, :label => _("Number of Sockets or LPARs:"), :note => sockets_help, :value => 1
 
-          = form.text_field :memory, :label => _("Amount of RAM (MB):"), :note => memory_help, :value => ''
+          = form.text_field :memory, :label => _("Amount of RAM (GB):"), :note => memory_help, :value => ''
 
           = form.field :virtual, :label => _("System Type:") do
             = virtual_buttons

--- a/app/views/systems/show_nutupane.html.haml
+++ b/app/views/systems/show_nutupane.html.haml
@@ -103,7 +103,7 @@
             = System.architectures[system.arch]
       .control-group
         .label
-          = label :memory, :memory, _("RAM (MB)")
+          = label :memory, :memory, _("RAM (GB)")
         .input
           %span.value
             = system.memory

--- a/test/glue/candlepin/consumer_test.rb
+++ b/test/glue/candlepin/consumer_test.rb
@@ -99,13 +99,13 @@ class GlueCandlepinConsumerTestSystem < GlueCandlepinConsumerTestBase
 
   # Memory values
   def test_memory_candlepin_consumer
-    assert_equal 256, @@sys.memory
+    assert_equal (256 / 1024), @@sys.memory
 
     @@sys.facts['memory.memtotal'] = '2 GB'
     @@sys.facts['dmi.memory.size'] = '4 GB'
-    assert_equal 2048, @@sys.memory
+    assert_equal 2, @@sys.memory
     @@sys.facts['memory.memtotal'] = nil
-    assert_equal 4096, @@sys.memory
+    assert_equal 4, @@sys.memory
 
     @@sys.memory = 'abc'
     assert_equal 0, @@sys.memory


### PR DESCRIPTION
katello displayed RAM in megabytes in some places and gigabytes in some
other places. Making it consistent throughout the application.
