### PR TITLE
Nutupane - Allowing customization of shown columns in details mode.

### DIFF
--- a/app/assets/javascripts/systems/systems.controller.js
+++ b/app/assets/javascripts/systems/systems.controller.js
@@ -101,7 +101,7 @@ angular.module('Katello').controller('SystemsController',
         $scope.table.data.columns   = columns;
         $scope.table.active_item    = {};
 
-        Nutupane.set_columns();
+        Nutupane.setColumns([columns[0]]);
 
         $scope.createNewSystem = function () {
             var createSuccess = function (data) {

--- a/app/assets/javascripts/widgets/nutupane.js
+++ b/app/assets/javascripts/widgets/nutupane.js
@@ -47,7 +47,7 @@ Katello.config(['$locationProvider', function($locationProvider){
  *   $scope.table.data.columns   = columns;
  *   $scope.table.active_item    = {};
  *
- *   Nutupane.set_columns();
+ *   Nutupane.setColumns();
  *
  *   Nutupane.default_item_url = function(id) {
  *       return KT.routes.edit_system_path(id);
@@ -73,11 +73,18 @@ angular.module('Katello').factory('Nutupane', ['$location', '$http', 'current_or
             },
             sort : sort
         },
-        allColumns, nameColumn;
+        allColumns, shownColums;
 
-    Nutupane.set_columns = function() {
+    /**
+     * @ngdoc function
+     * @name Katello.factory:Nutupane#setColumns
+     *
+     * @param {Array} columnsToShow list of column objects that will be shown when
+     *                              the details pane is made visible
+     */
+    Nutupane.setColumns = function(columnsToShow) {
         allColumns = Nutupane.table.data.columns.slice(0);
-        nameColumn = Nutupane.table.data.columns.slice(0).splice(0, 1);
+        shownColums = columnsToShow;
     };
 
     Nutupane.get = function(callback) {
@@ -174,7 +181,7 @@ angular.module('Katello').factory('Nutupane', ['$location', '$http', 'current_or
 
         if (visibility) {
             // Remove all columns except name and replace them with the details pane
-            table.data.columns = nameColumn;
+            table.data.columns = shownColums;
         } else {
             // Restore the former columns
             table.data.columns = allColumns;
@@ -228,7 +235,7 @@ angular.module('Katello').factory('Nutupane', ['$location', '$http', 'current_or
             // Only reset the active_item if an ID is provided
             if (id) {
                 // Remove all columns except name and replace them with the details pane
-                table.data.columns = nameColumn;
+                table.data.columns = shownColums;
                 table.select_all(false);
                 table.active_item = item;
                 table.active_item.selected  = true;


### PR DESCRIPTION
The previous assumption was that the first column would always be
the column shown when viewing the details of an item. To allow this
to be more flexible, a controller can now specify which columns
specifically that are shown when details are open.
