### PR TITLE
966256 - Fixes for new ldap_fluff API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'rails_warden', '>= 0.5.2'
 gem 'rack-openid'
 gem 'net-ldap'
 gem 'oauth'
-gem 'ldap_fluff', '~> 0.1.7'
+gem 'ldap_fluff', '>= 0.2.2'
 
 if defined? JRUBY_VERSION
   gem 'jruby-openssl'

--- a/app/lib/ldap.rb
+++ b/app/lib/ldap.rb
@@ -14,28 +14,27 @@ require 'ldap_fluff'
 
 class Ldap
 
+  def self.ldap
+    LdapFluff.new(Katello.config.ldap_fluff_config)
+  end
+
   def self.valid_ldap_authentication?(uid, password)
-    ldap = LdapFluff.new
     ldap.authenticate? uid, password
   end
 
   def self.ldap_groups(uid)
-    ldap = LdapFluff.new
     ldap.group_list(uid)
   end
 
   def self.is_in_groups(uid, grouplist)
-    ldap = LdapFluff.new
     ldap.is_in_groups?(uid, grouplist)
   end
 
   def self.valid_user?(uid)
-    ldap = LdapFluff.new
     ldap.valid_user?(uid)
   end
 
   def self.valid_group?(gid)
-    ldap = LdapFluff.new
     ldap.valid_group?(gid)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,18 +56,6 @@ else
   end
 end
 
-# TODO to be removed after config path is made configurable in LdapFluff
-candidates       = [
-    # production environment
-    LdapFluff::CONFIG,
-    # rpm build environment
-    '/opt/rh/ruby193/root' + LdapFluff::CONFIG,
-    # on travis and in development environment
-    File.join(Gem.loaded_specs['ldap_fluff'].full_gem_path, 'etc', 'ldap_fluff.yml')]
-config_file_path = candidates.find { |path| File.exist? path }
-raise "missing LdapFluff config file, candidates: #{candidates.join(' ')}" if config_file_path.nil?
-LdapFluff::CONFIG = config_file_path unless LdapFluff::CONFIG == config_file_path
-
 module Src
   class Application < Rails::Application
 

--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -87,6 +87,18 @@ common:
   notification:
     polling_seconds: 120
 
+  ldap_fluff_config:
+    host: ## ip address or hostname
+    port: 389 ## ip address or hostname
+    encryption: ## blank or :start_tls
+    base_dn: dc=redhat,dc=com ## baseDN for ldap auth, eg dc=redhat,dc=com
+    group_base: dc=redhat,dc=com ##baseDN for your ldap groups, eg ou=Groups,dc=redhat,dc=com
+    server_type: posix ## type of server. default == posix. :active_directory, :posix, :free_ipa
+    ad_domain: ## domain for your users if using active directory, eg redhat.com
+    service_user: ## service account for authenticating ldap calls in active directory or ipa
+    service_pass: ## service password for authenticating ldap calls in active directory or ipa
+    anon_queries: ## allow anonymous queries for AD or FreeIPA
+
   # authentication
   sso:
     enable: true

--- a/katello.spec
+++ b/katello.spec
@@ -106,7 +106,7 @@ Requires:       %{?scl_prefix}rubygem(ui_alchemy-rails) >= 1.0.0
 Requires:       %{?scl_prefix}rubygem(chunky_png)
 Requires:       %{?scl_prefix}rubygem(tire) >= 0.3.0
 Requires:       %{?scl_prefix}rubygem(tire) < 0.4
-Requires:       %{?scl_prefix}rubygem(ldap_fluff)
+Requires:       %{?scl_prefix}rubygem(ldap_fluff) >= 0.2.1
 Requires:       %{?scl_prefix}rubygem(anemone)
 Requires:       %{?scl_prefix}rubygem(apipie-rails) >= 0.0.18
 Requires:       %{?scl_prefix}rubygem(logging) >= 1.8.0


### PR DESCRIPTION
Ldap configuration is now merged to katello.yml. /etc/ldap_fluff.yml
is not used anymore.
