### PR TITLE
Style - Adding min-widths on the body in regular and experimental views.

### DIFF
--- a/app/assets/stylesheets/katello.scss
+++ b/app/assets/stylesheets/katello.scss
@@ -39,6 +39,7 @@
 
 body {
   background-color: white;
+  min-width: $static_width;
 }
 
 pre  { text-indent: 18px; }

--- a/app/assets/stylesheets/katello_experimental.scss
+++ b/app/assets/stylesheets/katello_experimental.scss
@@ -6,6 +6,7 @@
 
 body {
   background: white;
+  min-width: 800px;
 }
 
 ul {


### PR DESCRIPTION
The UI breaksdown at small browser sizes due to element squashing.
The min-widths added here match the size of the content elements
found throughout the UI to the extent of preventing the user from
getting themselves into a poor user experience state.
