### PR TITLE
default_info - converting apply to sync

### DIFF
--- a/app/assets/javascripts/organizations/default_info.js
+++ b/app/assets/javascripts/organizations/default_info.js
@@ -59,10 +59,12 @@ KT.default_info = (function() {
                 $("#apply_default_info_button").removeClass("processing");
                 allow_default_info_manipulation(true);
                 task_status_updater.stop();
+                if (data['result'].length > 0) {
+                    notices.displayNotice("success", window.JSON.stringify({ "notices": [i18n.default_info_apply_success] }));
+                }
             }
         }
     };
-
 
     var check_for_apply_button_enable = function() {
         if ($("#default_info_table tr").length > 1) {
@@ -177,7 +179,7 @@ KT.default_info = (function() {
         var button = $(this);
         e.preventDefault();
         KT.common.customConfirm({
-            message     : i18n.take_a_while_you_sure,
+            message     : i18n.default_info_warning,
             yes_callback: function() {
                 apply_default_info(button);
             }

--- a/app/controllers/api/v1/organization_default_info_controller.rb
+++ b/app/controllers/api/v1/organization_default_info_controller.rb
@@ -83,9 +83,9 @@ class Api::V1::OrganizationDefaultInfoController < Api::V1::ApiController
     # retval will either be the Task, or an array of system names, based on whether the call is asynchronous or not
     retval = @organization.apply_default_info(params[:informable_type], to_apply, :async => params[:async])
 
-    response = {:systems => [], :task => nil}
+    response = {:informables => [], :task => nil}
     if params[:async] == false
-      response[:systems] = retval
+      response[:informables] = retval
     else
       response[:task] = retval
     end

--- a/app/views/common/_common_i18n.html.haml
+++ b/app/views/common/_common_i18n.html.haml
@@ -38,7 +38,5 @@
     "current_default_org" : '#{escape_javascript(_('This is your default organization.'))}',
     "make_default_org" : '#{escape_javascript(_('Make this your default organization.'))}',
     "no_content_view" : '#{no_content_view}',
-    "select_content_view": '#{escape_javascript(_('Select a View'))}',
-    "take_a_while_you_sure": '#{escape_javascript(_('This could take a while. Are you sure?'))}',
-    "objects_affected_successfully": '#{escape_javascript(_('objects affected successfully'))}'
+    "select_content_view": '#{escape_javascript(_('Select a View'))}'
   });

--- a/app/views/organizations/_default_info.html.haml
+++ b/app/views/organizations/_default_info.html.haml
@@ -4,9 +4,11 @@
 = javascript do
   :plain
     localize({
-       "default_info_apply_error": '#{escape_javascript(_("An error has occurred while applying default info. Please contact your administrator"))}',
-       "default_info_create_success": '#{escape_javascript(_("Successfully created default information keyname"))}',
-       "default_info_delete_success": '#{escape_javascript(_("Successfully deleted default information keyname"))}'
+      "default_info_apply_success": '#{escape_javascript(_("Successfully synced default info"))}',
+      "default_info_apply_error": '#{escape_javascript(_("An error has occurred while syncing default info. Please contact your administrator"))}',
+      "default_info_create_success": '#{escape_javascript(_("Successfully created default information keyname"))}',
+      "default_info_delete_success": '#{escape_javascript(_("Successfully deleted default information keyname"))}',
+      "default_info_warning": '#{escape_javascript(_("Caution: this action will remove default custom info, even those containing values"))}'
     });
 
 = content_for :title do
@@ -22,7 +24,7 @@
         = _('%s Default Custom Info') % informable_type.capitalize
     .grid_4
       #apply_default_info_button_container
-        %input.btn.fullwidth#apply_default_info_button{ :value => _("Apply default info to all %s") % informable_type.pluralize, :type => "button", "data-url" => api_organization_apply_default_info_path(org.label, informable_type), "data-method" => "post", :disabled => org.default_info[informable_type].empty?, "data-taskstate" => task_state, "data-taskuuid" => task_uuid }
+        %input.btn.fullwidth#apply_default_info_button{ :value => _("Sync default info to all %s") % informable_type.pluralize, :type => "button", "data-url" => api_organization_apply_default_info_path(org.label, informable_type), "data-method" => "post", :disabled => org.default_info[informable_type].empty?, "data-taskstate" => task_state, "data-taskuuid" => task_uuid }
       %table#default_info_table.default_info
         %tbody
           %tr#new_default_info_row

--- a/db/migrate/20130520172232_custom_info_add_default_column.rb
+++ b/db/migrate/20130520172232_custom_info_add_default_column.rb
@@ -1,0 +1,9 @@
+class CustomInfoAddDefaultColumn < ActiveRecord::Migration
+  def up
+    add_column :custom_info, :org_default, :boolean, :default => false
+  end
+
+  def down
+    remove_column :custom_info, :org_default
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -225,8 +225,9 @@ ActiveRecord::Schema.define(:version => 20130529211902) do
     t.string   "value",           :default => ""
     t.integer  "informable_id"
     t.string   "informable_type"
-    t.datetime "created_at",                      :null => false
-    t.datetime "updated_at",                      :null => false
+    t.datetime "created_at",                         :null => false
+    t.datetime "updated_at",                         :null => false
+    t.boolean  "org_default",     :default => false
   end
 
   add_index "custom_info", ["informable_type", "informable_id", "keyname"], :name => "index_custom_info_on_type_id_keyname"

--- a/spec/controllers/api/v1/organization_default_info_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_default_info_controller_spec.rb
@@ -123,8 +123,8 @@ describe Api::V1::OrganizationDefaultInfoController do
 
       get :apply_to_all, :organization_id => @org.label, :informable_type => "system", :async => false
       response.code.should == "200"
-      JSON.parse(response.body)["systems"].nil?.should == false
-      JSON.parse(response.body)["task"].nil?.should == true
+      JSON.parse(response.body)["informables"].should_not be_nil
+      JSON.parse(response.body)["task"].should be_nil
 
       @org.systems.each do |s|
         s.custom_info.size.should == @org.default_info["system"].size
@@ -140,8 +140,8 @@ describe Api::V1::OrganizationDefaultInfoController do
 
       get :apply_to_all, :organization_id => @org.label, :informable_type => "system", :async => true
       response.code.should == "200"
-      JSON.parse(response.body)['systems'].empty?.should == true
-      JSON.parse(response.body)['task'].nil?.should == false
+      JSON.parse(response.body)["informables"].should be_empty
+      JSON.parse(response.body)["task"].should_not be_nil
     end
   end
 end


### PR DESCRIPTION
- db migration adding a new 'default' column for custom_info
- updating the schema
- re-wording from 'apply' to 'sync'

default_info "apply" takes the default_info keys that are specified on an org,
and syncs them with all the systems (or distributors) under that org. this
includes adding custom_info but also removing custom_info
(that may have values attached to it).
