### PR TITLE
969229 - require minitest for installation to support rails console

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -115,6 +115,7 @@ Requires:       %{?scl_prefix}rubygem(rack-openid) >= 1.3.1
 Requires:       %{?scl_prefix}rubygem(ruby-openid) >= 2.2.3
 Requires:       %{?scl_prefix}rubygem(rabl)
 Requires:       %{?scl_prefix}rubygem(dynflow)
+Requires:       %{?scl_prefix}rubygem(minitest)
 Requires:       signo >= 0.0.5
 Requires:       signo-katello >= 0.0.5
 Requires:       lsof


### PR DESCRIPTION
due to rails issue 6907 running rails console in production
requires minitest to be installed.  Since this is a highly
valuable debugging tool, we should allow rails console to be
run without additional packages to be installed
