### PR TITLE
967467 - search for env by label when not found by name only for rhsm

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -57,7 +57,20 @@ class Api::ApiController < ActionController::Base
   end
 
   def request_from_katello_cli?
-    request.headers['User-Agent'].to_s =~ /^katello-cli/
+    request.user_agent.to_s =~ /^katello-cli/
+  end
+
+  # For situations where rhsm/subscirption-manager expect a bit
+  # different behaviour.
+  def request_from_rhsm?
+    # We should rather use "x-python-rhsm-version" that are sent in
+    # headers from subcription-manager, but this was added quite
+    # recently: https://bugzilla.redhat.com/show_bug.cgi?id=790481.
+    # For compatibility reasons we use the checking for katello_cli
+    # instead for now. Therefore this method should be used only
+    # rarely in cases where the expected behaviour differs between
+    # this two agents, without large impact on other possible clients.
+    !request_from_katello_cli?
   end
 
   def process_action(method_name, *args)

--- a/app/controllers/api/v1/environments_controller.rb
+++ b/app/controllers/api/v1/environments_controller.rb
@@ -100,7 +100,7 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
 
     # The following is a workaround to handle the fact that rhsm currently requests the
     # environment using the 'name' parameter; however, the value is actually the environment label.
-    if @environments.empty?
+    if request_from_rhsm? && @environments.empty?
       if query_params.has_key?(:name)
         query_params[:label] = query_params[:name]
         query_params.delete(:name)

--- a/spec/controllers/api/v1/environments_controller_spec.rb
+++ b/spec/controllers/api/v1/environments_controller_spec.rb
@@ -75,6 +75,35 @@ describe Api::V1::EnvironmentsController do
       KTEnvironment.should_receive(:where).once
       req
     end
+
+    context 'from katello cli' do
+      before do
+        request.stub(:user_agent).and_return('katello-cli')
+      end
+
+      it 'should return empty set when not found by name' do
+        KTEnvironment.stub(:where => [])
+        KTEnvironment.should_receive(:where).once
+        req
+      end
+    end
+
+    context 'from subscription-manager' do
+      before do
+        request.stub(:user_agent).and_return(nil)
+      end
+
+      it ' should try again with label when not found by name' do
+        KTEnvironment.should_receive(:where).with do |search_query|
+          search_query['name'] == 'foo'
+        end.once.and_return([])
+        KTEnvironment.should_receive(:where).with do |search_query|
+          search_query['label'] == 'foo'
+        end.once
+        req
+      end
+    end
+
   end
 
 


### PR DESCRIPTION
Otherwise, katello-cli behaves strangely when addressing environment by name,
and it uses the label instead.
