### PR TITLE
969216 - retrieve org by label when org identified in pool details

### DIFF
--- a/app/models/glue/candlepin/pool.rb
+++ b/app/models/glue/candlepin/pool.rb
@@ -53,7 +53,7 @@ module Glue::Candlepin::Pool
     end
 
     def organization
-      Organization.find_by_name(self.owner["key"])
+      Organization.find_by_label(self.owner["key"])
     end
 
     # if defined +load_remote_data+ will be used by +lazy_accessors+


### PR DESCRIPTION
When katello gets a pool from candlepin, the 'owner key' is
equivalent to the organization label.  This change is to
properly retrieve org by label vs name.
