### PR TITLE
969001 - requiring org when calling Product.find_by_cp_id

### DIFF
--- a/app/controllers/api/v1/changesets_content_controller.rb
+++ b/app/controllers/api/v1/changesets_content_controller.rb
@@ -12,9 +12,9 @@
 
 class Api::V1::ChangesetsContentController < Api::V1::ApiController
 
+  before_filter :find_changeset!
   before_filter :find_product, :only => [:add_product, :remove_product, :add_package, :remove_package, :add_erratum,
                                          :remove_erratum, :add_distribution, :remove_distribution]
-  before_filter :find_changeset!
   before_filter :find_content_view!, :only => [:add_content_view, :remove_content_view]
   before_filter :authorize
 
@@ -152,13 +152,8 @@ class Api::V1::ChangesetsContentController < Api::V1::ApiController
   end
 
   def find_product
-    product_id = nil
-    if params[:product_id]
-      product_id = params[:product_id]
-    elsif params[:id]
-      product_id = params[:id]
-    end
-    @product = Product.find_by_cp_id(product_id.to_s) unless product_id.nil?
+    product_id = params[:product_id] || params[:id]
+    @product = Product.find_by_cp_id(product_id.to_s, @changeset.environment.organization) if product_id
     raise HttpErrors::NotFound, _("Couldn't find product with id '%s'") % product_id if @product.nil?
   end
 end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -135,9 +135,9 @@ class Api::V1::ProductsController < Api::V1::ApiController
   private
 
   def find_product
-    @product = Product.find_by_cp_id(params[:id].to_s)
+    raise _("Neither organization nor environment has been provided.") if @organization.nil?
+    @product = Product.find_by_cp_id(params[:id], @organization)
     raise HttpErrors::NotFound, _("Couldn't find product with id '%s'") % params[:id] if @product.nil?
-    @organization ||= @product.organization
   end
 
   def find_environment

--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -187,7 +187,7 @@ Pulp doesn't send correct headers."
   end
 
   def find_product
-    @product = Product.find_by_cp_id params[:product_id]
+    @product = Product.find_by_cp_id(params[:product_id])
     raise HttpErrors::NotFound, _("Couldn't find product with id '%s'") % params[:product_id] if @product.nil?
     @organization ||= @product.organization
   end

--- a/app/controllers/api/v1/repository_sets_controller.rb
+++ b/app/controllers/api/v1/repository_sets_controller.rb
@@ -13,9 +13,9 @@
 class Api::V1::RepositorySetsController < Api::V1::ApiController
   respond_to :json
 
+  before_filter :find_organization
   before_filter :find_product, :only => [:enable, :disable, :index]
   before_filter :find_product_content, :only => [:enable, :disable]
-
   before_filter :authorize
 
 
@@ -30,7 +30,7 @@ class Api::V1::RepositorySetsController < Api::V1::ApiController
   end
 
 
-  api :POST, "/product/:product_id/repository_sets/:id/enable", "Enable a repository set for a product."
+  api :POST, "/organizations/:organization_id/product/:product_id/repository_sets/:id/enable", "Enable a repository set for a product."
   param :organization_id, :identifier, :required => true, :desc => "id of an organization the repository will be contained in"
   param :product_id, :number, :required => true, :desc => "id of a product the repository will be contained in"
   param :id, :number, :required => true, :desc => "id or name of the repository set to enable"
@@ -39,7 +39,7 @@ class Api::V1::RepositorySetsController < Api::V1::ApiController
     respond_for_async :resource => @product.async(:organization => @organization).refresh_content(@product_content.content.id)
   end
 
-  api :POST, "/product/:product_id/repository_sets/:id/disable", "Enable a repository set for a product."
+  api :POST, "/organizations/:organization_id/product/:product_id/repository_sets/:id/disable", "Enable a repository set for a product."
   param :organization_id, :identifier, :required => true, :desc => "id of an organization the repository will be contained in"
   param :product_id, :number, :required => true, :desc => "id of a product the repository will be contained in"
   param :id, :number, :required => true, :desc => "id of the repository set to disable"
@@ -48,7 +48,7 @@ class Api::V1::RepositorySetsController < Api::V1::ApiController
     respond_for_async :resource => @product.async(:organization => @organization).disable_content(@product_content.content.id)
   end
 
-  api :GET, "/product/:product_id/repository_sets/", "List repository sets for a product."
+  api :GET, "/organizations/:organization_id/product/:product_id/repository_sets/", "List repository sets for a product."
   param :product_id, :number, :required => true, :desc => "id of a product to list repository sets for"
   def index
     raise _('Repository sets are not available for custom products.') if @product.custom?
@@ -69,7 +69,7 @@ class Api::V1::RepositorySetsController < Api::V1::ApiController
   end
 
   def find_product
-    @product = Product.find_by_cp_id(params[:product_id])
+    @product = Product.find_by_cp_id(params[:product_id], @organization)
     raise HttpErrors::NotFound, _("Couldn't find product with id '%s'") % params[:product_id] if @product.nil?
     @organization = @product.organization
   end

--- a/app/controllers/api/v1/sync_controller.rb
+++ b/app/controllers/api/v1/sync_controller.rb
@@ -27,6 +27,7 @@ class Api::V1::SyncController < Api::V1::ApiController
     api_version 'v2'
   end
 
+  before_filter :find_optional_organization, :only => [:index, :create, :cancel]
   before_filter :find_object, :only => [:index, :create, :cancel]
   before_filter :ensure_library, :only => [:create]
   respond_to :json
@@ -92,7 +93,8 @@ class Api::V1::SyncController < Api::V1::ApiController
   end
 
   def find_product
-    @product = Product.find_by_cp_id(params[:product_id])
+    raise _("Organization required") if @organization.nil?
+    @product = Product.find_by_cp_id(params[:product_id], @organization)
     raise HttpErrors::NotFound, _("Couldn't find product with id '%s'") % params[:product_id] if @product.nil?
     @product
   end

--- a/app/controllers/api/v2/changesets_content_controller.rb
+++ b/app/controllers/api/v2/changesets_content_controller.rb
@@ -168,7 +168,7 @@ class Api::V2::ChangesetsContentController < Api::V2::ApiController
   end
 
   def find_product(product_id)
-    product = Product.find_by_cp_id(product_id.to_s)
+    product = Product.find_by_cp_id(product_id.to_s, @changeset.environment.organization)
     raise HttpErrors::NotFound, _("Couldn't find product with id '%s'") % product_id if product.nil?
     return product
   end

--- a/app/models/activation_key.rb
+++ b/app/models/activation_key.rb
@@ -120,7 +120,7 @@ class ActivationKey < ActiveRecord::Base
 
       # we sort just to make the order deterministig.
       self.pools.group_by(&:product_id).sort_by(&:first).each do |product_id, pools|
-        product = Product.find_by_cp_id(product_id)
+        product = Product.find_by_cp_id(product_id, self.organization)
         consumption = calculate_consumption(product, pools, allocate)
 
         Rails.logger.debug "Autosubscribing pools: #{consumption.map { |pool, amount| "#{pool.cp_id} => #{amount}"}.join(", ")}"

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -381,7 +381,7 @@ class Changeset < ActiveRecord::Base
     products_ids += self.errata.map { |e| e.product.cp_id }
     products_ids -= self.products.collect { |p| p.cp_id }
     products_ids.uniq.collect do |product_cp_id|
-      Product.find_by_cp_id(product_cp_id)
+      Product.find_by_cp_id(product_cp_id, self.environment.organization)
     end
   end
 

--- a/app/models/glue/provider.rb
+++ b/app/models/glue/provider.rb
@@ -367,7 +367,7 @@ module Glue::Provider
 
 
       product_to_remove_ids = (product_in_katello_ids - products_in_candlepin_ids).uniq
-      product_to_remove_ids.each { |cp_id| Product.find_by_cp_id(cp_id).destroy }
+      product_to_remove_ids.each { |cp_id| Product.find_by_cp_id(cp_id, self.organization).destroy }
 
       self.index_subscriptions
       true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -58,6 +58,14 @@ class Product < ActiveRecord::Base
         with_repos(env, true)
   }
 
+  def self.find_by_cp_id(cp_id, organization)
+    self.where(:cp_id=>cp_id).in_org(organization).first
+  end
+
+  def self.in_org(organization)
+    self.joins(:provider).where('providers.organization_id' => organization.id)
+  end
+
   scope :engineering, where(:type => "Product")
 
   before_save :assign_unique_label

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -289,13 +289,6 @@ Src::Application.routes.draw do
 
       match "/status" => "ping#server_status", :via => :get
       match "/version" => "ping#version", :via => :get
-      # some paths conflicts with rhsm
-      scope 'katello' do
-
-        # routes for non-ActiveRecord-based resources
-        match '/products/:id/repositories' => 'products#repo_create', :via => :post, :constraints => { :id => /[0-9\.]*/ }
-
-      end
 
       # subscription-manager support
       match '/consumers' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -278,14 +278,6 @@ Src::Application.routes.draw do
 
       api_resources :crls, :only => [:index]
 
-      # some paths conflicts with rhsm
-      scope 'katello' do
-
-        # routes for non-ActiveRecord-based resources
-        match '/products/:id/repositories' => 'products#repo_create', :via => :post, :constraints => { :id => /[0-9\.]*/ }
-
-      end
-
       # subscription-manager support
       match '/consumers' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
       match '/hypervisors' => 'systems#hypervisors_update', :via => :post

--- a/spec/controllers/api/v1/changesets_content_controller_spec.rb
+++ b/spec/controllers/api/v1/changesets_content_controller_spec.rb
@@ -41,8 +41,10 @@ describe Api::V1::ChangesetsContentController, :katello => true do
     @library    = KTEnvironment.new(:name => 'Library', :label => 'Library', :library => true)
     @library.id = 2
     @library.stub(:library?).and_return(true)
-    @environment    = KTEnvironment.new(:name => 'environment', :label => 'environment', :library => false)
+    @org = Organization.new(:name=>"blahorg")
+    @environment    = KTEnvironment.new(:name => 'environment', :label => 'environment', :library => false, :organization=>@org)
     @environment.id = 1
+
     @environment.stub(:library?).and_return(false)
     @environment.stub(:prior).and_return(@library)
     @library.stub(:successor).and_return(@environment)
@@ -66,7 +68,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "products" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
     end
 
     let(:action) { :add_product }
@@ -82,7 +84,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "products" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
     end
 
     let(:action) { :remove_product }
@@ -98,7 +100,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "packages" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
     end
 
     let(:action) { :add_package }
@@ -114,7 +116,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "packages" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
     end
 
     let(:action) { :remove_package }
@@ -130,7 +132,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "erratum" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id, @org).and_return(@product)
       @errata = Errata.new({ :id => erratum_unit_id, :errata_id => erratum_id })
       Errata.stub(:find_by_errata_id).and_return(@errata)
     end
@@ -148,7 +150,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "erratum" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id, @org).and_return(@product)
       @errata = Errata.new({ :id => erratum_unit_id, :errata_id => erratum_id })
       Errata.stub(:find_by_errata_id).and_return(@errata)
     end
@@ -192,7 +194,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "distributions" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
     end
 
     let(:action) { :add_distribution }
@@ -208,7 +210,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
 
   describe "distributions" do
     before(:each) do
-      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s).and_return(@product)
+      Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
     end
 
     let(:action) { :remove_distribution }

--- a/spec/controllers/api/v1/products_controller_spec.rb
+++ b/spec/controllers/api/v1/products_controller_spec.rb
@@ -214,7 +214,7 @@ describe Api::V1::ProductsController, :katello => true do
     end
 
     it "should find product" do
-      Product.should_receive(:find_by_cp_id).once.with(@product.id.to_s).and_return(@products[0])
+      Product.should_receive(:find_by_cp_id).once.with(@product.id.to_s, @organization).and_return(@products[0])
       get 'repositories', :organization_id => @organization.label, :environment_id => @environment.id, :id => @product.id
     end
 

--- a/spec/controllers/api/v1/sync_controller_spec.rb
+++ b/spec/controllers/api/v1/sync_controller_spec.rb
@@ -154,7 +154,7 @@ describe Api::V1::SyncController, :katello => true do
       it "should find product if :product_id is specified" do
         stub_product_with_repo
         controller.stub!(:params).and_return({ :organization_id => @organization.label, :product_id => @product.id })
-
+        controller.send(:find_optional_organization)
         subject.should == @product
       end
 

--- a/spec/models/activation_key_spec.rb
+++ b/spec/models/activation_key_spec.rb
@@ -208,7 +208,7 @@ describe ActivationKey do
       @system = System.new(:name => "test", :cp_type => "system", :facts => {"distribution.name"=>"Fedora"}, :uuid => "uuid-uuid")
       @system.should_receive(:sockets).and_return(sockets)
       dates.each do |k,v|
-        unless Product.find_by_cp_id(v[:productId])
+        unless Product.find_by_cp_id(v[:productId], @organization)
           product = @organization.redhat_provider.products.create!(:label =>"blah", :cp_id => v[:productId], :name => "Blah Server OS #{v[:productId]}") do |p|
             p.environments = [@organization.library,
                               @environment_1,


### PR DESCRIPTION
Products do not have a unique cp_id, as redhat products are
singular within candlepin.  As a result calls to Product.find_by_cp_id
may return the wrong katello product.
