### PR TITLE
966027 - hiding ability to refresh a manifest if its not supported

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -123,7 +123,9 @@ class SubscriptionsController < ApplicationController
 
   def new
     get_manifest_details
-    render :partial=>"new", :locals=>{:provider=>@provider, :statuses=>@statuses, :details=>@details, :upstream=>@upstream, :name => controller_display_name}
+    can_refresh = @upstream['idCert'] && @upstream['idCert']['cert']
+    render :partial=>"new", :locals=>{:provider=>@provider, :statuses=>@statuses, :details=>@details, :upstream=>@upstream,
+                                      :name => controller_display_name, :can_refresh=>can_refresh}
   end
 
   def edit_manifest

--- a/app/views/subscriptions/_new.html.haml
+++ b/app/views/subscriptions/_new.html.haml
@@ -35,9 +35,13 @@
           - if !@provider.manifest_task || @provider.manifest_task.finished?
             .grid_3.ra.fieldset
               &nbsp;
-            = form_for @provider, :html => {:method => :post, :id => :refresh_manifest}, :remote => true, :url => refresh_manifest_subscriptions_path do |f|
-              .grid_2.la#refresh_button
-                = f.submit _("Refresh Manifest"), :id => :refresh_form_button
+            - if can_refresh
+              = form_for @provider, :html => {:method => :post, :id => :refresh_manifest}, :remote => true, :url => refresh_manifest_subscriptions_path do |f|
+                .grid_2.la#refresh_button
+                  = f.submit _("Refresh Manifest"), :id => :refresh_form_button
+            -else
+              .grid_6.la
+                = _("Refreshing manifest not supported by this manifest.")
             - if Katello.config.headpin?
               = form_for @provider, :html => {:method => :post, :id => :delete_manifest}, :remote => true, :url => delete_manifest_subscriptions_path do |f|
                 .grid_4.la#delete_button


### PR DESCRIPTION
Newer versions of candlepin produce manifests that contain an idCert field
with the key and cert of the distributor.  This allows manifests to be refreshed.
The current version of candlepin within Red Hat has not be upgraded to support this however
so some manifests (even ones generated today), will error with a nasty traceback if the
refresh button is clicked.  Here we check if the idCert is present within the candlepin
owner's upstream hash.
