### PR TITLE
956308 - Some models no longer accept names with i18n characters

### DIFF
--- a/app/lib/validators/katello_name_format_validator.rb
+++ b/app/lib/validators/katello_name_format_validator.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 #
 # Copyright 2013 Red Hat, Inc.
 #
@@ -14,7 +15,7 @@ module Validators
   class KatelloNameFormatValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       if value
-        record.errors[attribute] << N_("cannot contain characters other than alpha numerals, space, '_', '-'") unless value =~ /\A[\w| |_|-]*\Z/
+        record.errors[attribute] << N_("cannot contain characters other than alpha numerals, space, '_', '-'") unless value =~ /\A[\w\P{ASCII}| |_|-]*\Z/
         NoTrailingSpaceValidator.validate_trailing_space(record, attribute, value)
         KatelloNameFormatValidator.validate_length(record, attribute, value)
       else

--- a/test/lib/validators/katello_name_format_validator_test.rb
+++ b/test/lib/validators/katello_name_format_validator_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 #
 # Copyright 2013 Red Hat, Inc.
 #
@@ -21,7 +22,7 @@ class KatelloNameFormatValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
   end
 
   def test_validate_each
-    @validator.validate_each(@model, :name, "Test2 Name_underline-dash")
+    @validator.validate_each(@model, :name, "Test2 Name_underline-dash í18n_chäřs")
 
     assert_empty @model.errors[:name]
   end


### PR DESCRIPTION
Models like:
- gpg_key
- envitonment
- product
- provider
- sync_plan
- system_group
- content view

couldn't be created with i18n characters and special characters. Now they can contain i18n chars.
