### PR TITLE
970644 - Allows passing organization name with a dot in the path

### DIFF
--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -54,7 +54,7 @@ Src::Application.routes.draw do
         end
         resources :sync_plans
         resources :tasks, :only => [:index]
-        resources :providers, :only => [:index]
+        resources :providers, :only => [:index], :constraints => { :organization_id => /[^\/]*/ }
         match '/systems' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
         resources :systems, :only => [:index, :create] do
           get :report, :on => :collection

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -27,7 +27,7 @@ Src::Application.routes.draw do
         api_resources :environments
         api_resources :sync_plans, :only => [:index, :create]
         api_resources :tasks, :only => [:index]
-        api_resources :providers, :only => [:index]
+        api_resources :providers, :only => [:index], :constraints => { :organization_id => /[^\/]*/ }
         match '/systems' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
         api_resources :systems, :only => [:index, :create] do
           get :report, :on => :collection


### PR DESCRIPTION
to providers API.

The default Rails routing returns 404s when dynamic URL segements
contain a dot. This fix adds a constraint to the providers list route
to allow Rails to pass through the organization_id and allow the
controller to handle processing. This is required if an organization
with a dot in the name is created and a user wants to list the providers
from that organization.
