### PR TITLE
969603 - changesets - list views based on environment

### DIFF
--- a/app/controllers/promotions_controller.rb
+++ b/app/controllers/promotions_controller.rb
@@ -249,7 +249,8 @@ class PromotionsController < ApplicationController
 
   def content_views
     # render the list of content views
-    view_versions = ContentViewVersion.non_default_view.promotable(@environment.organization) || []
+    view_versions = ContentViewVersion.non_default_view.promotable(@environment.organization).
+        in_environment(@environment) || []
 
     next_env_view_version_ids = @next_environment.nil? ? [].to_set :
                                 @next_environment.content_view_versions.non_default_view.


### PR DESCRIPTION
This commit fixes a regression on the changesets page where
the content views listed for an environment would actually
include all views regardless of environment.  This could include
listing multiple views (if multiple versions were available
in different environments).
