### PR TITLE
970617 - fix content promotion/deletion of packages and errata

### DIFF
--- a/app/models/deletion_changeset.rb
+++ b/app/models/deletion_changeset.rb
@@ -133,14 +133,13 @@ class DeletionChangeset < Changeset
         end
       end
     end
-    total_pkg_ids = []
 
-    pkgs_delete.each_pair do |repo, pkg_ids|
-      total_pkg_ids  += pkg_ids
-      repo.delete_packages(pkg_ids)
+    pkg_ids = []
+    pkgs_delete.each_pair do |repo, pkgs|
+      PulpTaskStatus::wait_for_tasks [repo.delete_packages(pkgs)]
+      pkg_ids.concat(pkgs)
     end
-
-    Package.index_packages(total_pkg_ids)
+    Package.index_packages(pkg_ids)
   end
 
 
@@ -151,7 +150,7 @@ class DeletionChangeset < Changeset
     not_included_errata.each do |errata|
        product = errata.product
        product.repos(from_env).each do |repo|
-         if repo.has_erratum? errata.errata_id
+         if repo.has_erratum? errata.display_name
            @affected_repos << repo
            errata_delete[repo] ||= []
            errata_delete[repo] << errata.errata_id
@@ -159,10 +158,12 @@ class DeletionChangeset < Changeset
        end
     end
 
+    errata_ids = []
     errata_delete.each_pair do |repo, errata|
-       repo.delete_errata(errata)
-       Errata.index_errata(errata)
+      PulpTaskStatus::wait_for_tasks [repo.delete_errata(errata)]
+      errata_ids.concat(errata)
     end
+    Errata.index_errata(errata_ids)
   end
 
 
@@ -181,7 +182,7 @@ class DeletionChangeset < Changeset
     end
 
     distribution_delete.each_pair do |repo, distro|
-       repo.delete_distribution(distro)
+      PulpTaskStatus::wait_for_tasks [repo.delete_distribution(distro)]
     end
   end
 

--- a/app/models/glue/pulp/repo.rb
+++ b/app/models/glue/pulp/repo.rb
@@ -479,11 +479,11 @@ module Glue::Pulp::Repo
     end
 
     def delete_packages package_id_list
-      Runcible::Extensions::Rpm.unassociate_unit_ids_from_repo(self.pulp_id,  package_id_list)
+      Runcible::Extensions::Rpm.unassociate_unit_ids_from_repo(self.pulp_id, package_id_list)
     end
 
     def delete_errata errata_id_list
-      Runcible::Extensions::Errata.unassociate_ids_from_repo(self.pulp_id,  errata_id_list)
+      Runcible::Extensions::Errata.unassociate_unit_ids_from_repo(self.pulp_id, errata_id_list)
     end
 
     def delete_distribution distribution_id

--- a/app/models/promotion_changeset.rb
+++ b/app/models/promotion_changeset.rb
@@ -175,10 +175,10 @@ class PromotionChangeset < Changeset
         end
       end
     end
-    pkg_ids = []
 
+    pkg_ids = []
     pkgs_promote.each_pair do |repo, pkgs|
-      repo.add_packages(pkgs)
+      PulpTaskStatus::wait_for_tasks [repo.add_packages(pkgs)]
       pkg_ids.concat(pkgs)
     end
     Package.index_packages(pkg_ids)
@@ -196,8 +196,7 @@ class PromotionChangeset < Changeset
         if repo.is_cloned_in? to_env
           clone             = repo.get_clone to_env
 
-
-          if repo.has_erratum? err.errata_id and !clone.has_erratum? err.errata_id
+          if repo.has_erratum? err.display_name and !clone.has_erratum? err.display_name
             errata_promote[clone] ||= []
             errata_promote[clone] << err.errata_id
           end
@@ -207,7 +206,7 @@ class PromotionChangeset < Changeset
 
     errata_ids = []
     errata_promote.each_pair do |repo, errata|
-      repo.add_errata(errata)
+      PulpTaskStatus::wait_for_tasks [repo.add_errata(errata)]
       errata_ids.concat(errata)
     end
     Errata.index_errata(errata_ids)
@@ -236,7 +235,7 @@ class PromotionChangeset < Changeset
     end
 
     distribution_promote.each_pair do |repo, distro|
-      repo.add_distribution(distro)
+      PulpTaskStatus::wait_for_tasks [repo.add_distribution(distro)]
     end
   end
 


### PR DESCRIPTION
This commit contains a couple of changes to fix the
promotion and deletion of packages and errata:
- whenever performing a promote/delete of a list of
  packages or errata, 'wait' for the pulp task to complete
  before updating the elastic search index.  If this is not
  done, there is a race condition in which we could update
  the search index before the operation is complete, resulting
  in incorrect data (e.g. repoids)
- when deleting errata, use the 'unit_id' in the request
  to pulp to perform the unassociate; otherwise, the errata
  will not get removed from the repo.
