### PR TITLE
TDD - Do not hide exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'gettext_i18n_rails'
 gem 'i18n_data', '>= 0.2.6', :require => 'i18n_data'
 
 # Reports - TODO this is hack that needs to be removed once ruport is officially released
-if (`rpm -q rubygem-ruport` rescue "") =~ /^rubygem-ruport-1.7.0\S+/ && ! defined? JRUBY_VERSION
+if (`rpm -q rubygem-ruport` rescue "") =~ /^rubygem-ruport-1.7.0\S+/ && ! defined?(JRUBY_VERSION)
   gem 'ruport', '>=1.7.0'
 else
   gem 'ruport', '>=1.7.0', :git => 'git://github.com/ruport/ruport.git'
@@ -76,3 +76,4 @@ Dir[File.expand_path('bundler.d/*.rb', File.dirname(__FILE__))].each do |bundle|
 end
 
 gem 'dynflow', '>= 0.1.0'
+gem 'justified', :require => 'justified/standard_error'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,23 +44,24 @@ class ApplicationController < ActionController::Base
   # order of these are important.
   rescue_from Exception do |exception|
     paranoia = Katello.config.exception_paranoia
+    hide     = Katello.config.hide_exceptions
 
     to_do = case exception
               when StandardError
-                :handle
+              hide ? :handle : :raise
               when ScriptError
                 paranoia ? :handle : :raise
               when SignalException, SystemExit, NoMemoryError
                 :raise
               else
-                Rails.logger.error "Uknown child of Exception instead of StandardError detected: " +
+              Rails.logger.error 'Unknown child of Exception instead of StandardError detected: ' +
                                        "#{exception.message} (#{exception.class})"
                 paranoia ? :handle : :raise
             end
 
     case to_do
       when :handle
-        execute_rescue exception, lambda { |exception| render_error(exception) }
+      execute_rescue(exception) { |exception| render_error(exception) }
       when :raise
         raise exception
     end
@@ -85,24 +86,20 @@ class ApplicationController < ActionController::Base
     render :nothing => true, :status => :not_found
   end
 
-  rescue_from ActionController::RoutingError do |exception|
-    execute_rescue(exception, lambda{|exception| render_404})
+  if Katello.config.hide_exceptions
+    rescue_from ActionController::RoutingError,
+                ActionController::UnknownController,
+                AbstractController::ActionNotFound do |exception|
+      execute_rescue(exception) { |exception| render_404 }
   end
-
-  rescue_from ActionController::UnknownController do |exception|
-    execute_rescue(exception, lambda{|exception| render_404})
-  end
-
-  rescue_from AbstractController::ActionNotFound do |exception|
-    execute_rescue(exception, lambda{|exception| render_404})
   end
 
   rescue_from Errors::SecurityViolation do |exception|
-    execute_rescue(exception, lambda{|exception| render_403})
+    execute_rescue(exception) { |exception| render_403 }
   end
 
   rescue_from HttpErrors::UnprocessableEntity do |exception|
-    execute_rescue(exception, lambda{|exception| render_bad_parameters(exception)})
+    execute_rescue(exception) { |exception| render_bad_parameters(exception) }
   end
   # support for session (thread-local) variables must be the last filter (except authorize)in this class
   include Util::ThreadSession::Controller
@@ -237,16 +234,11 @@ class ApplicationController < ActionController::Base
   def parse_calendar_date(date_str, time_str = "")
     return nil if date_str.blank?
 
-    event = date_str
-    unless time_str.blank?
-      event = event + ' ' + time_str
-    else
-      event = event + ' ' + "12:00 am"
-    end
-    event = event + ' '  + DateTime.now.zone
-    DateTime.strptime(event, "%m/%d/%Y %I:%M %P %:z")
-  rescue ArgumentError
-    raise _("Invalid date or time format")
+    datetime_str = [date_str,
+                    time_str.blank? ? '12:00 am' : time_str,
+                    DateTime.now.zone].join ' '
+
+    DateTime.strptime(datetime_str, '%m/%d/%Y %I:%M %P %:z') rescue false
   end
 
 
@@ -365,16 +357,46 @@ class ApplicationController < ActionController::Base
     User.current = nil
   end
 
-  # render bad params
-  def render_bad_parameters(exception)
+  # render bad params to user
+  # @overload render_bad_parameters()
+  #   render bad_parameters with `default_message` and status `400`
+  # @overload render_bad_parameters(message)
+  #   render bad_parameters with `message` and status `400`
+  #   @param [String] message
+  # @overload render_bad_parameters(error)
+  #   render bad_parameters with `error.message` and `error.status_code` if present
+  #   @param [Exception] error
+  # @overload render_bad_parameters(error, message)
+  #   add `message` to overload `exception.message`
+  #   @param [String] message
+  #   @param [Exception] error
+  def render_bad_parameters(*args)
+    default_message = if request.xhr?
+                        _('Invalid parameters sent in the request for this operation. Please contact a system administrator.')
+                      else
+                        _('Invalid parameters sent. You may have mistyped the address. If you continue having trouble with this, please contact an Administrator.')
+                      end
+
+    exception = args.find { |o| o.kind_of? Exception }
+    message   = args.find { |o| o.kind_of? String } || exception.try(:message) || default_message
+
+    status = if exception && exception.respond_to?(:status_code)
+               exception.status_code
+             else
+               400
+             end
+
     if exception
-        logger.error _("Rendering 422:") + " #{exception.message}"
-        notify.exception(
-            _("Invalid parameters sent in the request for this operation. Please contact a system administrator."),
-            exception)
+      log_exception exception
+      notify.exception(message, exception)
+    else
+      notify.error message
+      log.warn message
     end
+
     respond_to do |format|
-      format.html { render :template => "common/400", :layout => !request.xhr?, :status => exception.status_code }
+      format.html { render :template => 'common/400', :layout => !request.xhr?, :status => status,
+                           :locals   => { :message => message } }
       format.atom { head exception.status_code }
       format.xml  { head exception.status_code }
       format.json { head exception.status_code }
@@ -647,7 +669,7 @@ class ApplicationController < ActionController::Base
     nil
   end
 
-  def execute_rescue exception, renderer
+  def execute_rescue(exception, &renderer)
     log_exception exception
     if current_user
       User.current = current_user
@@ -662,8 +684,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def org_not_found_error exception
-    logger.error exception.message
+  def org_not_found_error
     execute_after_filters
     logout
     message = _("Your current organization is no longer valid. It is possible that either the organization has been deleted or your permissions revoked, please log back in to continue.")

--- a/app/controllers/content_view_definitions_controller.rb
+++ b/app/controllers/content_view_definitions_controller.rb
@@ -159,14 +159,16 @@ class ContentViewDefinitionsController < ApplicationController
 
   def publish
     # perform the publish
-    @view_definition.publish(params[:content_view][:name], params[:content_view][:description],
-                             params[:content_view][:label], {:notify => true}) if params.has_key?(:content_view)
+    if params.has_key?(:content_view)
+      @view_definition.publish(params[:content_view][:name], params[:content_view][:description],
+                               params[:content_view][:label], {:notify => true})
+      notify.success(_("Started publish of content view '%{view_name}' from definition '%{definition_name}'.") %
+                         {:view_name => params[:content_view][:name], :definition_name => @view_definition.name})
 
-    notify.success(_("Started publish of content view '%{view_name}' from definition '%{definition_name}'.") %
-                       {:view_name => params[:content_view][:name], :definition_name => @view_definition.name})
-
-    render :nothing => true
-
+      render :nothing => true
+    else
+      render_bad_parameters
+    end
   rescue => e
     notify.exception(_("Failed to publish content view '%{view_name}' from definition '%{definition_name}'.") %
                          {:view_name => params[:content_view][:name], :definition_name => @view_definition.name}, e)

--- a/app/controllers/filter_rules_controller.rb
+++ b/app/controllers/filter_rules_controller.rb
@@ -134,11 +134,11 @@ class FilterRulesController < ApplicationController
         if params[:parameter][:date_range]
           @rule.parameters[:date_range] ||= {}
           if params[:parameter][:date_range][:start]
-            result = params[:parameter][:date_range][:start]
-            @rule.start_date = parse_calendar_date(result)
+            (@rule.start_date = parse_calendar_date params[:parameter][:date_range][:start]) or
+                return render_bad_parameters(_('Invalid date or time format'))
           elsif params[:parameter][:date_range][:end]
-            result = params[:parameter][:date_range][:end]
-            @rule.end_date = parse_calendar_date(result)
+            (@rule.end_date = parse_calendar_date params[:parameter][:date_range][:end]) or
+                return render_bad_parameters(_('Invalid date or time format'))
           end
         elsif params[:parameter][:errata_type]
           @rule.parameters[:errata_type] ||= []
@@ -156,7 +156,7 @@ class FilterRulesController < ApplicationController
                            {:type => FilterRule::CONTENT_OPTIONS.key(@rule.content_type),
                             :filter => @filter.name})
 
-        render :text => escape_html(result) and return
+        render :text => escape_html(result.to_s) and return
       end
     end
     render :nothing => true

--- a/app/controllers/gpg_keys_controller.rb
+++ b/app/controllers/gpg_keys_controller.rb
@@ -87,9 +87,10 @@ class GpgKeysController < ApplicationController
   end
 
   def create
-    gpg_key_params = params[:gpg_key]
-
+    (gpg_key_params = params[:gpg_key]) or
+        return render_bad_parameters
     file_uploaded = gpg_key_params.has_key?("content_upload") && !gpg_key_params.has_key?("content")
+
     if file_uploaded
       gpg_key_params['content'] = params[:gpg_key][:content_upload].read
       gpg_key_params.delete('content_upload')

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -87,7 +87,8 @@ class OrganizationsController < ApplicationController
 
   def create
     org_label_assigned = ""
-    org_params = params[:organization]
+    org_params = params[:organization] or
+        return render_bad_parameters
     org_params[:label], org_label_assigned = generate_label(org_params[:name], 'organization') if org_params[:label].blank?
     @organization = Organization.new(:name => org_params[:name], :label => org_params[:label], :description => org_params[:description])
     @organization.save!
@@ -145,6 +146,7 @@ class OrganizationsController < ApplicationController
   end
 
   def update
+    return render_bad_parameters unless params[:organization]
     result = params[:organization].values.first
 
     @organization.name = params[:organization][:name] unless params[:organization][:name].nil?

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -69,15 +69,20 @@ class ProductsController < ApplicationController
   end
 
   def refresh_content
-    raise _('Repository sets are enabled by default for custom products.') if @product.custom?
-    pc = @product.refresh_content(params[:content_id])
-    render :partial=>'providers/redhat/repos', :locals=>{:product_content=>pc}
+    if @product.custom?
+      render_bad_parameters _('Repository sets are enabled by default for custom products.')
+    else
+      pc = @product.refresh_content(params[:content_id])
+      render :partial => 'providers/redhat/repos', :locals => { :product_content => pc }
+    end
   end
 
   def disable_content
-    raise _('Repository sets cannot be disabled for custom products.') if @product.custom?
-    pc = @product.disable_content(params[:content_id])
-    render :json=>pc
+    if @product.custom?
+      render_bad_parameters _('Repository sets cannot be disabled for custom products.')
+    else
+      render :json => @product.disable_content(params[:content_id])
+    end
   end
 
   def update

--- a/app/controllers/sync_plans_controller.rb
+++ b/app/controllers/sync_plans_controller.rb
@@ -73,11 +73,13 @@ class SyncPlansController < ApplicationController
     end
 
     if params[:sync_plan][:time]
-      updated_plan.sync_date = convert_date_time(updated_plan.plan_date, params[:sync_plan][:time].strip)
+      (updated_plan.sync_date = convert_date_time(updated_plan.plan_date, params[:sync_plan][:time].strip)) or
+          return render_bad_parameters(_('Invalid date or time format'))
     end
 
     if params[:sync_plan][:date]
-      updated_plan.sync_date = convert_date_time(params[:sync_plan][:date].strip, updated_plan.plan_time)
+      (updated_plan.sync_date = convert_date_time(params[:sync_plan][:date].strip, updated_plan.plan_time)) or
+          return render_bad_parameters(_('Invalid date or time format'))
     end
 
     updated_plan.save!
@@ -124,7 +126,8 @@ class SyncPlansController < ApplicationController
   def create
     sdate = params[:sync_plan].delete :plan_date
     stime = params[:sync_plan].delete :plan_time
-    params[:sync_plan][:sync_date] = convert_date_time(sdate, stime)
+    (params[:sync_plan][:sync_date] = convert_date_time(sdate, stime)) or
+        return render_bad_parameters(_('Invalid date or time format'))
 
     @plan = SyncPlan.create! params[:sync_plan].merge({:organization => current_organization})
     notify.success N_("Sync Plan '%s' was created.") % @plan['name']

--- a/app/controllers/system_errata_controller.rb
+++ b/app/controllers/system_errata_controller.rb
@@ -51,6 +51,9 @@ class SystemErrataController < ApplicationController
     errata_state = params[:errata_state] if params[:errata_state]
     chunk_size = current_user.page_size
     errata, total_count, results_count = get_errata(offset.to_i, offset.to_i+chunk_size, filter_type, errata_state)
+
+    return render_bad_parameters unless errata
+
     rendered_html = render_to_string(:partial=>"systems/errata/items", :locals => { :errata => errata, :editable => @system.editable? })
     render :json => {:html => rendered_html,
                       :results_count => results_count,

--- a/app/controllers/system_group_errata_controller.rb
+++ b/app/controllers/system_group_errata_controller.rb
@@ -45,6 +45,8 @@ class SystemGroupErrataController < ApplicationController
     chunk_size = current_user.page_size
     errata, errata_systems, total_count, results_count = get_errata(offset.to_i, offset.to_i+chunk_size, filter_type, errata_state)
 
+    return render_bad_parameters unless errata
+
     rendered_html = render_to_string(:partial=>"systems/errata/items", :locals => { :errata => errata,
                                                                                     :errata_systems => errata_systems,
                                                                                     :editable => @group.systems_editable? })

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -400,9 +400,9 @@ class SystemsController < ApplicationController
         end
       end
       if !invalid_perms.empty?
-        raise _("System Group membership modification not allowed for group(s): %s") % invalid_perms.join(', ')
+        return render_bad_parameters _("System Group membership modification not allowed for group(s): %s") % invalid_perms.join(', ')
       elsif !max_systems_exceeded.empty?
-        raise _("System Group maximum number of systems exceeded for group(s): %s") % max_systems_exceeded.join(', ')
+        return render_bad_parameters _("System Group maximum number of systems exceeded for group(s): %s") % max_systems_exceeded.join(', ')
       end
 
       @systems.each do |system|
@@ -596,6 +596,7 @@ class SystemsController < ApplicationController
 
   def system_groups
     # retrieve the available groups that aren't currently assigned to the system and that haven't reached their max
+    # TODO move the sql to the model
     @system_groups = SystemGroup.where(:organization_id=>current_organization).
         select("system_groups.id, system_groups.name").
         joins("LEFT OUTER JOIN system_system_groups ON system_system_groups.system_group_id = system_groups.id").

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,8 +64,8 @@ class User < ActiveRecord::Base
   # validate the password length before hashing
   validates_each :password do |model, attr, value|
     if Katello.config.warden != 'ldap'
-      if model.password_changed?
-        model.errors.add(attr, _("must be at least 5 characters.")) if value.length < 5
+      if model.password_changed? || model.new_record?
+        model.errors.add(attr, _('must be at least 5 characters.')) if value.nil? || value.length < 5
       end
     end
   end
@@ -78,7 +78,7 @@ class User < ActiveRecord::Base
   # hash the password before creating or updateing the record
   def hash_password
     if Katello.config.warden != 'ldap'
-      self.password = Password::update(self.password) if self.password.length != 192
+      self.password = Password::update(self.password) if self.password && self.password.length != 192
     end
   end
 

--- a/app/views/common/400.html.haml
+++ b/app/views/common/400.html.haml
@@ -1,5 +1,5 @@
 .grid_16
   %h1 #{_("400 - Invalid Parameters")}
-  %p #{_("Invalid parameters sent. You may have mistyped the address. If you continue having trouble with this, please contact an Administrator.")}
+  %p #{message}
   %p
     = link_to _("Back"), root_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,6 +68,7 @@ module Src
         Katello.database_configs
       end
     end
+
     # Setup additional routes by loading all routes file from routes directory
     config.paths["config/routes"] += Dir[Rails.root.join("config/routes/**/*.rb")]
 

--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -75,6 +75,8 @@ common:
 
   # if paranoia is set to true even children of Exception will be rescued
   exception_paranoia: false
+  # set true to hide exceptions from user
+  hide_exceptions: false
 
   # run yard server inside katello server
   embed_yard_documentation: false
@@ -271,6 +273,7 @@ common:
 #
 production:
   exception_paranoia: true
+  hide_exceptions: true
   database:
     database: katello
   logging:

--- a/config/routes/test.rb
+++ b/config/routes/test.rb
@@ -1,0 +1,7 @@
+if Rails.env.test?
+  Src::Application.routes.draw do
+
+    match 'a_test/a_controller/failing_action' => 'a_controller_test/a#failing_action', :via => :get
+
+  end
+end

--- a/lib/katello/load_configuration.rb
+++ b/lib/katello/load_configuration.rb
@@ -33,7 +33,8 @@ module Katello
                     search use_foreman password_reset_expiration redhat_repository_url port
                     elastic_url rest_client_timeout elastic_index
                     katello_version pulp email_reply_address
-                    embed_yard_documentation logging system_lang profiling)
+                    embed_yard_documentation logging system_lang profiling
+                    exception_paranoia hide_exceptions)
 
           has_values :app_mode, %w(katello headpin)
           has_values :url_prefix, %w(/headpin /sam /katello)
@@ -59,7 +60,8 @@ module Katello
             is_not_empty :thumbslug_url
           end
 
-          are_booleans :use_cp, :use_foreman, :use_pulp, :use_elasticsearch, :use_ssl, :ldap_roles, :validate_ldap, :gravatar
+          are_booleans :use_cp, :use_foreman, :use_pulp, :use_elasticsearch, :use_ssl, :ldap_roles,
+                       :validate_ldap, :gravatar, :exception_paranoia, :hide_exceptions
 
           if !early? && environment != :build
             validate :database do

--- a/spec/controllers/activation_keys_controller_spec.rb
+++ b/spec/controllers/activation_keys_controller_spec.rb
@@ -315,7 +315,10 @@ describe ActivationKeysController do
     end
 
     it "retrieves the system groups to display", :katello => true do #TODO headpin
-      SystemGroup.should_receive(:where).with(:organization_id => @organization)
+      SystemGroup.
+          should_receive(:where).
+          with(:organization_id => @organization).
+          and_return(mock(:order => []))
       get :system_groups, :id => @a_key.id
     end
 

--- a/spec/controllers/content_view_definitions_controller_spec.rb
+++ b/spec/controllers/content_view_definitions_controller_spec.rb
@@ -259,9 +259,8 @@ describe ContentViewDefinitionsController, :katello => true do
       end
 
       it "should fail if content view not provided" do
-        controller.should notify.exception
         post :publish, :id=>@definition.id
-        response.should_not be_success
+        response.should be_bad_request
       end
 
     end

--- a/spec/controllers/environments_controller_spec.rb
+++ b/spec/controllers/environments_controller_spec.rb
@@ -220,11 +220,11 @@ describe EnvironmentsController do
         it "destroys the requested environment", :katello => true do #TODO headpin
           @env.should_receive(:destroy)
           @env.should_receive(:destroyed?)
-          delete :destroy, :id => @env.id, :organization_id => @org.label
+          delete :destroy, :id => @env.id, :organization_id => @org.label, :format => :js
         end
 
         it "redirects to the environments list", :katello => true do #TODO headpin
-          delete :destroy, :id => @env.id, :organization_id => @org.label
+          delete :destroy, :id => @env.id, :organization_id => @org.label, :format => :js
         end
       end
 

--- a/spec/controllers/gpg_keys_controller_spec.rb
+++ b/spec/controllers/gpg_keys_controller_spec.rb
@@ -186,7 +186,7 @@ describe GpgKeysController, :katello => true do
 
     describe "with invalid params" do
       it "should generate an error notice" do
-        controller.should notify.exception
+        controller.should notify.error
         post :create, GPGKeyControllerTest::GPGKEY_INVALID
       end
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -114,7 +114,7 @@ describe OrganizationsController do
 
     describe 'with invalid paramaters' do
       it 'should generate an error notice' do
-        controller.should notify.exception
+        controller.should notify.error
         post 'create', { :name => "", :description => "" }
         response.should_not be_success
       end
@@ -275,7 +275,7 @@ describe OrganizationsController do
       end
 
       it "should generate an error notice" do
-        controller.should notify.exception
+        controller.should notify.error
         put 'update', :id => OrgControllerTest::ORG_ID
       end
 

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -88,7 +88,7 @@ describe RepositoriesController, :katello => true do
        it "destroys the requested repository" do
          @repository.should_receive(:destroy)
          @repository.should_receive(:destroyed?)
-         delete :destroy, :id => "123456", :provider_id => "123", :product_id => "123"
+         delete :destroy, :id => "123456", :provider_id => "123", :product_id => "123", :format => :js
        end
 
         it "updates the view" do

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -125,7 +125,7 @@ describe RolesController do
     end
 
     it 'should successfully delete', :katello => true do #TODO headpin
-      delete 'destroy', { :id => @role.id }
+      delete 'destroy', :id => @role.id, :format => :js
       Role.exists?(@role.id).should be_false
     end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -73,15 +73,6 @@ describe SearchController do
       response.should be_success
     end
 
-    it "generates an error notification, if exception raised" do
-      mock = mock("search", :where => [])
-      mock.stub(:create!).with({:path=>"/resource", :params=>"provider.name => theBest"}).and_raise(StandardError)
-      controller.stub_chain(:current_user, :search_favorites).and_return(mock)
-
-      controller.should notify.exception
-      post :create_favorite, {:favorite => @favoriteText}
-    end
-
     it "renders search partial" do
       post :create_favorite, {:favorite => @favoriteText}
       response.should render_template("common/_search")

--- a/spec/controllers/sync_plans_controller_spec.rb
+++ b/spec/controllers/sync_plans_controller_spec.rb
@@ -90,7 +90,7 @@ describe SyncPlansController, :katello => true do
       end
 
       it "should have a valid date" do
-        controller.should notify.exception
+        controller.should notify.error
         plan_create[:sync_plan].should_not be_nil
         data = plan_create
         data[:sync_plan][:plan_date] = '01/101/11'
@@ -184,14 +184,14 @@ describe SyncPlansController, :katello => true do
 
       it "should not update bad sync dates" do
         SyncPlan.first.should_not be_nil
-        controller.should notify.exception
+        controller.should notify.error
         put :update, :id => @plan.id, :sync_plan => {:date => '11/111111/11'}
         response.should_not be_success
       end
 
       it "should not update bad sync time" do
         SyncPlan.first.should_not be_nil
-        controller.should notify.exception
+        controller.should notify.error
         put :update, :id => @plan.id, :sync_plan => {:time => '30:00 pmm'}
         response.should_not be_success
       end

--- a/spec/controllers/systems_controller_spec.rb
+++ b/spec/controllers/systems_controller_spec.rb
@@ -182,12 +182,6 @@ describe SystemsController do
         end
       end
 
-      it "should throw an exception when the search parameters are invalid" do
-        controller.should notify.exception
-        get :items, :search => 1
-        response.should_not be_success
-      end
-
       describe 'and requesting individual data' do
         before (:each) do
           @system = System.create!(:name=>"verbose", :environment => @environment, :cp_type=>"system", :facts=>{"Test1"=>1, "verbose_facts" => "Test facts"})
@@ -298,13 +292,6 @@ describe SystemsController do
         assigns[:system].releaseVer.should == "6Server"
       end
 
-      # The params to #update_subscriptions are entirely wrong here. The only reason the test
-      # used to pass was because the error handler was not passing back an error status
-      it "should not update a subscription", :katello => true do #TODO headpin
-        put :update_subscriptions, { :id => @system.id, :system => { :name=> "foo" }}
-        response.should_not be_success
-      end
-
       it "should throw an error with bad parameters", :katello => true do #TODO headpin
         invalid_name = " Foo   "
         put :update, { :id => @system.id, :system => { :name=> invalid_name }}
@@ -363,7 +350,14 @@ describe SystemsController do
 
       describe "listing/viewing" do
         it "retrieves the system groups to display", :katello => true do #TODO headpin
-          SystemGroup.should_receive(:where).with(:organization_id => @organization).and_return([@group1, @group2])
+          System.any_instance.tap do |any|
+            any.stub(:editable?).and_return true
+            any.stub(:readable?).and_return true
+          end
+          SystemGroup.
+              should_receive(:where).
+              with(:organization_id => @organization).
+              and_return mock.tap { |m| m.stub_chain(:select, :joins, :group, :order).and_return([@group1, @group2]) }
           get :system_groups, :id => @system.id
         end
 
@@ -463,7 +457,7 @@ describe SystemsController do
           @group1.max_systems = 1
           @group1.systems << @system1
           @group1.save!
-          controller.should notify.exception
+          controller.should notify.error
           put :bulk_add_system_group, {:ids => [@system2.id], :group_ids => [@group1.id]}
           response.should_not be_success
         end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -50,10 +50,12 @@ describe UsersController do
       response.should_not be_success
     end
 
-    it "should error if no password", :katello => true do #TODO headpin
+    it 'should error if blank password', :katello => true do #TODO headpin
       post 'create', {:user => {:username=>"testuser", :password=>"", :email=> "user@somewhere.com", :env_id => @environment.id}}
       response.should_not be_success
+    end
 
+    it 'should error if no password', :katello => true do #TODO headpin
       post 'create', {:user => {:username=>"testuser", :email=> "user@somewhere.com", :env_id => @environment.id}}
       response.should_not be_success
     end
@@ -151,7 +153,7 @@ describe UsersController do
       it "destroys the requested user", :katello => true do
         @to_delete.should_receive(:destroy)
         @to_delete.should_receive(:destroyed?)
-        delete :destroy, :id => "123456"
+        delete :destroy, :id => '123456', :format => :js
       end
 
       it "updates the user list", :katello => true do

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,47 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'minitest_helper'
+
+class AControllerTest < MiniTest::Rails::ActionController::TestCase
+  ERROR_MESSAGE = 'user should not see this'
+
+  class AController < ApplicationController
+    def rules
+      { failing_action: -> { true } }
+    end
+
+    def failing_action
+      raise ERROR_MESSAGE
+    end
+  end
+
+  self.controller_class = AController
+
+  fixtures :all
+
+  def setup
+    @org = organizations :acme_corporation
+    login_user users(:admin), @org
+
+    Katello.config.stubs(hide_exceptions: true)
+  end
+
+  test 'any action test shows error notification for any error' do
+    assert @controller.is_a? AController
+    notify = stub exception: -> e, *_ { e.message == ERROR_MESSAGE }
+    @controller.expects(:notify).returns(notify)
+    get :failing_action
+    assert response.body =~ /#{ERROR_MESSAGE}/
+  end
+end
+

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -52,7 +52,7 @@ class ProductsControllerTest < MiniTest::Rails::ActionController::TestCase
     @redhat_product.stubs(:refresh_content).with('3').returns(@pc)
 
     put :refresh_content, {:id => @custom_product.id,  :content_id=>'3'}
-    assert_response :error
+    assert_response :bad_request
   end
 
 
@@ -61,7 +61,7 @@ class ProductsControllerTest < MiniTest::Rails::ActionController::TestCase
     @redhat_product.stubs(:disable_content).with('3').returns(@pc)
 
     put :disable_content, {:id => @custom_product.id,  :content_id=>'3'}
-    assert_response :error
+    assert_response :bad_request
   end
 
 

--- a/test/fixtures/vcr_cassettes/glue_pulp_consumer.yml
+++ b/test/fixtures/vcr_cassettes/glue_pulp_consumer.yml
@@ -117,7 +117,7 @@ http_interactions:
     body: 
       encoding: US-ASCII
       string: "{\"repo_id\":\"1\",\"distributor_id\":\"1\",\"notify_agent\":false}"
-    headers: 
+    headers:
       Accept: 
       - application/json
       Accept-Encoding: 

--- a/test/glue/pulp/consumer_test.rb
+++ b/test/glue/pulp/consumer_test.rb
@@ -107,9 +107,9 @@ class GluePulpConsumerBindTest < GluePulpConsumerTestBase
   end
 
   def test_enable_repos
-    ids = @@simple_server.enable_repos([RepositorySupport.repo.pulp_id])
-    assert_includes ids.first, RepositorySupport.repo.pulp_id
-    refute_includes ids.last, RepositorySupport.repo.pulp_id
+    processed_ids, error_ids = @@simple_server.enable_repos([RepositorySupport.repo.pulp_id])
+    assert_includes processed_ids, RepositorySupport.repo.pulp_id
+    refute_includes error_ids, RepositorySupport.repo.pulp_id
   end
 
 end

--- a/test/lib/navigation/navigation_items_test.rb
+++ b/test/lib/navigation/navigation_items_test.rb
@@ -23,6 +23,7 @@ class NavigationItemsTest < MiniTest::Rails::ActiveSupport::TestCase
     @admin = User.find(users(:admin).id)
     User.current = @admin
     @acme_corporation = Organization.find(organizations(:acme_corporation).id)
+    Katello.config.stubs(hide_exceptions: true)
   end
 
   def test_dashboard_item


### PR DESCRIPTION
This pull-request does two things:
- [x] package justified
## Adds gem `justified`

_taken from readme_

A mini-gem to add missing **causes** to exception `backtrace`-s like Java has. This gem will add following at the bottom of a `backtrace`:

```
    from caused by: (AnError) an ugly bug
    from justified.rb:83:in `bad_code'
    from     ... skipped 4 lines
```

Exception cause can be also accessed with `#cause` method which returns `nil` or an `Exception`.
### Example

``` ruby
require 'justified/standard_error'

begin 
  raise 'a cause'
rescue
  raise 'an exception'
end
```

will print 

```
file.rb:6:in `rescue in <main>': an exception (RuntimeError)
          from file.rb:3:in `<main>'
          from caused by: (RuntimeError) a cause
          from file.rb:4:in `<main>'
          from     ... skipped 0 lines
```
-   Documentation: http://blog.pitr.ch/justified
-   Source: https://github.com/pitr-ch/justified
-   Blog: http://blog.pitr.ch/blog/categories/justified/
### Why am I adding this?

It allows to raise new exceptions from current layer/abstraction without dropping the original cause for the new exception. Good example what it helps to do is in [`http_resource.rb`](https://github.com/Katello/katello/blob/dbc46dcb8fbb0e61ce4704379ac3467d6a43180e/app/lib/http_resource.rb#L114-L117).
## Disables hiding of exceptions

I've disabled exception hiding in `application_controller.rb` for development and testing environment. I had time only to disable it in UI controllers for now. I'll do the same for API controllers next TDD.

I think that hiding an exception is relevant only in production mode where the exception needs to be hidden form an user. On the other hand it should not be hidden In development and testing from a developer. Exceptions should be allowed to bubble up and be seen and fixed. By disabling the hiding it showed about 30 false positive tests which I've fixed in this PR.

There is a common anti-pattern I've seen in controller actions. An action tries to do its job without any testing of parameters. If parameters are wrong (which is not an exceptional state) the action with fail with an exception which is handled by `rescue_from` and by returning state 500. This is problematic for several reasons:
- user sees 500 (server error) and an ugly exception instead of correct 400 (bad request)
- relying on exceptions to handle bad parameters, an expected error cannot be distinguished from an actual bug/error in code
- using exceptions to control program flow

Where I needed to fix action to detect bad parameters I've started using method `return render_bad_parameters`. If you detect bad parameters please consider using same method.
