### PR TITLE
allow to be task_statuses.organization_id null

### DIFF
--- a/app/models/async_orchestration.rb
+++ b/app/models/async_orchestration.rb
@@ -16,7 +16,6 @@ module AsyncOrchestration
     def initialize(target, options)
       @target = target
 
-      raise ArgumentError, "Please pass in organization to which the sync job belongs to" unless options.has_key?(:organization)
       @organization = options.delete(:organization)
 
       @task_type = options.delete(:task_type)

--- a/app/models/organization_destroyer.rb
+++ b/app/models/organization_destroyer.rb
@@ -28,7 +28,7 @@ class OrganizationDestroyer
   def setup(organization)
     raise NotImplementedError unless options[:async]
 
-    task = self.async(:organization => organization).run
+    task = self.async.run
     organization.deletion_task_id = task.id
     organization.save!
     return task

--- a/db/migrate/20130604124100_task_statuses.rb
+++ b/db/migrate/20130604124100_task_statuses.rb
@@ -1,0 +1,9 @@
+class TaskStatuses < ActiveRecord::Migration
+  def self.up
+    change_column :task_statuses, :organization_id, :integer, :null => true
+  end
+
+  def self.down
+    change_column :task_statuses, :organization_id, :integer, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130529211902) do
+ActiveRecord::Schema.define(:version => 20130604124100) do
 
   create_table "activation_keys", :force => true do |t|
     t.string   "name"
@@ -663,7 +663,7 @@ ActiveRecord::Schema.define(:version => 20130529211902) do
 
   create_table "task_statuses", :force => true do |t|
     t.string   "type"
-    t.integer  "organization_id",                :null => false
+    t.integer  "organization_id",                :null => true
     t.string   "uuid",                           :null => false
     t.string   "state"
     t.text     "result"


### PR DESCRIPTION
When organization is going to be deleted, the org record is deleted from db,
and is created async task, which belongs to org which just have been deleted.

Task which is deleting organization will have organization_id set to null.

addressing:

```
[ERROR 2013-06-04 05:15:04 app  #5643] <ActiveRecord::InvalidForeignKey> PGError: ERROR:  update or delete on table "organizations" violates foreign key constraint "task_statuses_organization_id_fk" on table "task_statuses"
DETAIL:  Key (id)=(5) is still referenced from table "task_statuses".
: COMMIT
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/postgresql_adapter.rb:654:in `async_exec'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/postgresql_adapter.rb:654:in `block in execute'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
        /opt/rh/ruby193/root/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/postgresql_adapter.rb:653:in `execute'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/postgresql_adapter.rb:708:in `commit_db_transaction'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/abstract/database_statements.rb:217:in `transaction'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/transactions.rb:208:in `transaction'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/transactions.rb:293:in `with_transaction_returning_status'
        /opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/transactions.rb:236:in `destroy'
        /usr/share/katello/app/models/glue.rb:92:in `destroy'
        /usr/share/katello/app/models/organization_destroyer.rb:39:in `run'
        /usr/share/katello/app/models/async_operation.rb:58:in `perform'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/backend/base.rb:94:in `block in invoke_job'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `block in initialize'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `execute'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:38:in `run_callbacks'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/backend/base.rb:91:in `invoke_job'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:178:in `block (2 levels) in run'
        /opt/rh/ruby193/root/usr/share/ruby/timeout.rb:68:in `timeout'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:178:in `block in run'
        /opt/rh/ruby193/root/usr/share/ruby/benchmark.rb:295:in `realtime'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:177:in `run'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:234:in `block in reserve_and_run_one_job'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `block in initialize'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `execute'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:38:in `run_callbacks'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:234:in `reserve_and_run_one_job'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:162:in `block in work_off'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:161:in `times'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:161:in `work_off'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:133:in `block (4 levels) in start'
        /opt/rh/ruby193/root/usr/share/ruby/benchmark.rb:295:in `realtime'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:132:in `block (3 levels) in start'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `block in initialize'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `execute'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:38:in `run_callbacks'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:129:in `block (2 levels) in start'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:128:in `loop'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:128:in `block in start'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/plugins/clear_locks.rb:7:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/plugins/clear_locks.rb:7:in `block (2 levels) in <class:ClearLocks>'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:78:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:78:in `block (2 levels) in add'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:60:in `block in initialize'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:78:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:78:in `block in add'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:65:in `execute'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/lifecycle.rb:38:in `run_callbacks'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/worker.rb:127:in `start'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:101:in `run'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:89:in `block in run_process'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/application.rb:249:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/application.rb:249:in `block in start_proc'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/daemonize.rb:197:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/daemonize.rb:197:in `call_as_daemon'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/application.rb:253:in `start_proc'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/application.rb:293:in `start'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/controller.rb:70:in `run'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons.rb:195:in `block in run_proc'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/cmdline.rb:109:in `call'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons/cmdline.rb:109:in `catch_exceptions'
        /opt/rh/ruby193/root/usr/share/gems/gems/daemons-1.1.4/lib/daemons.rb:194:in `run_proc'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:87:in `run_process'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:80:in `block in daemonize'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:78:in `times'
        /opt/rh/ruby193/root/usr/share/gems/gems/delayed_job-3.0.2/lib/delayed/command.rb:78:in `daemonize'
        script/delayed_job:5:in `<main>'
```
