### PR TITLE
fixing broken instance of find_by_cp_id

### DIFF
--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -187,7 +187,8 @@ Pulp doesn't send correct headers."
   end
 
   def find_product
-    @product = Product.find_by_cp_id(params[:product_id])
+    #since this is only used for create, it isn't supported for rhel products, so cp_id is unique
+    @product = Product.where(:cp_id=>params[:product_id]).first
     raise HttpErrors::NotFound, _("Couldn't find product with id '%s'") % params[:product_id] if @product.nil?
     @organization ||= @product.organization
   end

--- a/spec/controllers/api/v1/repositories_controller_spec.rb
+++ b/spec/controllers/api/v1/repositories_controller_spec.rb
@@ -46,7 +46,7 @@ describe Api::V1::RepositoriesController, :katello => true do
       @product.stub(:arch).and_return('noarch')
       @product.save!
       Product.stub!(:find).and_return(@product)
-      Product.stub!(:find_by_cp_id).and_return(@product)
+      Product.stub!(:where).and_return([@product])
       ep          = EnvironmentProduct.find_or_create(@organization.library, @product)
       @repository = new_test_repo(ep, "repo_1", "#{@organization.name}/Library/prod/repo")
       Repository.stub(:find).and_return(@repository)
@@ -171,12 +171,12 @@ describe Api::V1::RepositoriesController, :katello => true do
 
     describe "create a repository" do
       before do
-        Product.stub(:find_by_cp_id => @product)
+        Product.stub(:where => [@product])
         @product.stub!(:custom?).and_return(true)
       end
 
       it 'should call pulp and candlepin layer' do
-        Product.should_receive(:find_by_cp_id).with('product_1').and_return(@product)
+        Product.should_receive(:where).with(:cp_id=>'product_1').and_return([@product])
         @product.should_receive(:add_repo).and_return({})
 
         post 'create', :name => 'repo_1', :label => 'repo_1', :url => 'http://www.repo.org', :product_id => 'product_1', :organization_id => @organization.label
@@ -313,7 +313,7 @@ describe Api::V1::RepositoriesController, :katello => true do
 
       context 'there is already a repo for the product with the same name' do
         before do
-          Product.stub(:find_by_cp_id => @product)
+          Product.stub(:where => [@product])
           @product.stub(:add_repo).and_return { raise Errors::ConflictException }
           @product.stub!(:custom?).and_return(true)
         end


### PR DESCRIPTION
Previous commit changed Product.find_by_cp_id to take an organization in addition
to cp_id, since cp_id isn't unique.  Here the organization isn't present as its not passed by the user.  Since this is only used for a create call, which only works for custom content, cp_id is unique and we do not really need the organization.
