### PR TITLE
970684 - changesets - fix deletion/promotion of distributions

### DIFF
--- a/app/controllers/api/v1/changesets_content_controller.rb
+++ b/app/controllers/api/v1/changesets_content_controller.rb
@@ -119,15 +119,17 @@ class Api::V1::ChangesetsContentController < Api::V1::ApiController
   param :distribution_id, :number, :desc => "The id of the distribution to add"
   param :product_id, :number, :desc => "The product which contains the distribution"
   def add_distribution
-    @changeset.add_distribution!(params[:distribution_id], @product)
+    distribution = Distribution.find(params[:distribution_id])
+    @changeset.add_distribution!(distribution, @product)
     render :text => _("Added distribution '%s'") % params[:distribution_id]
   end
 
   api :DELETE, "/changesets/:changeset_id/distributions/:id", "Remove a distribution from a changeset"
   def remove_distribution
-    render_after_removal @changeset.remove_distribution!(params[:id], @product),
-                         :success   => _("Removed distribution '%s'") % params[:id],
-                         :not_found => _("Distribution '%s' not found in the changeset") % params[:id]
+    distribution = Distribution.find(params[:content_id])
+    render_after_removal @changeset.remove_distribution!(distribution, @product),
+                         :success   => _("Removed distribution '%s'") % params[:content_id],
+                         :not_found => _("Distribution '%s' not found in the changeset") % params[:content_id]
   end
 
   private

--- a/app/controllers/api/v2/changesets_content_controller.rb
+++ b/app/controllers/api/v2/changesets_content_controller.rb
@@ -142,7 +142,8 @@ class Api::V2::ChangesetsContentController < Api::V2::ApiController
   end
   def add_distribution
     product = find_product(params[:distribution][:product_id])
-    @changeset.add_distribution!(params[:distribution][:distribution_id], product)
+    distribution = Distribution.find(params[:distribution][:distribution_id])
+    @changeset.add_distribution!(distribution, product)
     respond_for_create :resource => @changeset, :template => :show
   end
 
@@ -150,7 +151,9 @@ class Api::V2::ChangesetsContentController < Api::V2::ApiController
   param :changeset_id, :number
   param :distribution_id, :number, :desc => "id of the distribution to remove"
   def remove_distribution
-    ChangesetErratum.find(params[:id]).destroy
+    product = find_product(params[:distribution][:product_id])
+    distribution = Distribution.find(params[:distribution][:distribution_id])
+    @changeset.remove_distribution!(distribution, product)
     respond_for_show :resource => @changeset, :template => :show
   end
 

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -212,8 +212,8 @@ class ChangesetsController < ApplicationController
 
           when "distribution"
             product = Product.find pid
-            @changeset.add_distribution! id, product if adding
-            @changeset.remove_distribution! id, product if !adding
+            @changeset.add_distribution! Distribution.find(id), product if adding
+            @changeset.remove_distribution! Distribution.find(id), product if !adding
         end
       end
       @changeset.updated_at = Time.now

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -39,6 +39,6 @@ class DistributionsController < ApplicationController
   end
 
   def find_distribution
-    @distribution = Glue::Pulp::Distribution.find params[:id]
+    @distribution = Distribution.find(params[:id])
   end
 end

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -191,15 +191,15 @@ class Changeset < ActiveRecord::Base
      return repository
    end
 
-   def add_distribution! distribution_id, product
-     env_to_verify_on_add_content.repositories.any? { |repo| repo.has_distribution? distribution_id } or
+   def add_distribution! distribution, product
+     env_to_verify_on_add_content.repositories.any? { |repo| repo.has_distribution? distribution.id } or
          raise Errors::ChangesetContentException.new(
                    "Distribution not found within this environment you want to promote from.")
 
-     distro = ChangesetDistribution.create!(:distribution_id => distribution_id,
-                                       :display_name    => distribution_id,
-                                       :product_id      => product.id,
-                                       :changeset       => self)
+     distro = ChangesetDistribution.create!(:distribution_id => distribution._id,
+                                            :display_name    => distribution.id,
+                                            :product_id      => product.id,
+                                            :changeset       => self)
      self.distributions << distro
      save!
      distro
@@ -257,8 +257,8 @@ class Changeset < ActiveRecord::Base
     return deleted
   end
 
-  def remove_distribution! distribution_id, product
-    deleted = ChangesetDistribution.destroy_all(:distribution_id => distribution_id,
+  def remove_distribution! distribution, product
+    deleted = ChangesetDistribution.destroy_all(:distribution_id => distribution._id,
                                                 :changeset_id    => self.id, :product_id => product.id)
     save!
     return deleted

--- a/app/models/changeset_distribution.rb
+++ b/app/models/changeset_distribution.rb
@@ -25,7 +25,7 @@ class ChangesetDistribution < ActiveRecord::Base
     @repos   = []
 
     self.product.repos(from_env).each do |repo|
-      @repos << repo if repo.has_distribution? self.distribution_id
+      @repos << repo if repo.has_distribution? self.display_name
     end
     @repos
   end

--- a/app/models/deletion_changeset.rb
+++ b/app/models/deletion_changeset.rb
@@ -174,7 +174,7 @@ class DeletionChangeset < Changeset
     not_included_distribution.each do |distro|
       product = distro.product
       product.repos(from_env).each do |repo|
-        if repo.has_distribution? distro.distribution_id
+        if repo.has_distribution? distro.display_name
           @affected_repos << repo
           distribution_delete[repo] = distro.distribution_id
         end

--- a/app/models/glue/pulp/distribution.rb
+++ b/app/models/glue/pulp/distribution.rb
@@ -16,7 +16,7 @@ module Glue::Pulp::Distribution
     base.send :include, InstanceMethods
 
     base.class_eval do
-      attr_accessor :id, :description, :files, :family, :variant, :version, :url, :arch
+      attr_accessor :_id, :id, :description, :files, :family, :variant, :version, :url, :arch
 
       def self.find(id)
         ::Distribution.new(Runcible::Extensions::Distribution.find(id))
@@ -36,6 +36,14 @@ module Glue::Pulp::Distribution
           instance_variable_set("@#{k}", v)
         end
       end
+    end
+
+    def as_json(*args)
+      result = super(*args)
+      result['files'] = result['files'].inject([]) do |paths, file|
+        paths << file['relativepath']
+      end
+      result
     end
 
   end

--- a/app/models/glue/pulp/repo.rb
+++ b/app/models/glue/pulp/repo.rb
@@ -483,11 +483,11 @@ module Glue::Pulp::Repo
     end
 
     def delete_errata errata_id_list
-      Runcible::Extensions::Errata.unassociate_unit_ids_from_repo(self.pulp_id, errata_id_list)
+      Runcible::Extensions::Errata.unassociate_ids_from_repo(self.pulp_id, errata_id_list)
     end
 
     def delete_distribution distribution_id
-      Runcible::Extensions::Distribution.unassociate_ids_from_repo(self.pulp_id, [distribution_id])
+      Runcible::Extensions::Distribution.unassociate_unit_ids_from_repo(self.pulp_id, [distribution_id])
     end
 
     def cancel_sync

--- a/app/models/promotion_changeset.rb
+++ b/app/models/promotion_changeset.rb
@@ -227,8 +227,8 @@ class PromotionChangeset < Changeset
         clone = repo.get_clone to_env
         next if clone.nil?
 
-        if repo.has_distribution? distro.distribution_id and
-            !clone.has_distribution? distro.distribution_id
+        if repo.has_distribution? distro.display_name and
+            !clone.has_distribution? distro.display_name
           distribution_promote[clone] = distro.distribution_id
         end
       end

--- a/app/views/distributions/_filelist.html.haml
+++ b/app/views/distributions/_filelist.html.haml
@@ -16,6 +16,6 @@
       -@distribution.files.each do |file|
         %tr
           %td{:class=>'distribution'}
-            #{file}
+            #{file[:relativepath]}
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/promotions/_distributions.html.haml
+++ b/app/views/promotions/_distributions.html.haml
@@ -9,7 +9,7 @@
     %li.no_slide.block{:id => distribution.id, "data-ajax_url" => repository_distribution_path(repo.id, URI::escape(distribution.id))}
 
       - promoted = @next_env_distros.include? distribution.id
-      - promotable = !promoted and (@next_environment && !(@next_env_repos & repo.clone_ids).empty?)
+      - promotable = !promoted and (@next_environment && !(@next_env_repos).empty?)
 
       .fr
         %span.added.tipsify.hidden #{_("Added")}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,7 +372,7 @@ Src::Application.routes.draw do
       get :auto_complete_library
     end
 
-    resources :distributions, :only => [:show], :constraints => { :id => /[0-9a-zA-Z\-\+%_.]+/ } do
+    resources :distributions, :only => [:show], :constraints => { :id => /[0-9a-zA-Z \-\+%_.]+/ } do
       member do
         get :filelist
       end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -228,7 +228,7 @@ Src::Application.routes.draw do
           get :search, :on => :collection
         end
         resources :errata, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z\-\+%_.:]+/ }
-        resources :distributions, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z\-\+%_.]+/ }
+        resources :distributions, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z \-\+%_.]+/ }
         member do
           get :package_groups
           get :package_group_categories

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -182,7 +182,7 @@ Src::Application.routes.draw do
           get :search, :on => :collection
         end
         api_resources :errata, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z\-\+%_.:]+/ }
-        api_resources :distributions, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z\-\+%_.]+/ }
+        api_resources :distributions, :only => [:index, :show], :constraints => { :id => /[0-9a-zA-Z \-\+%_.]+/ }
         member do
           get :package_groups
           get :package_group_categories

--- a/spec/controllers/api/v1/changesets_content_controller_spec.rb
+++ b/spec/controllers/api/v1/changesets_content_controller_spec.rb
@@ -195,6 +195,10 @@ describe Api::V1::ChangesetsContentController, :katello => true do
   describe "distributions" do
     before(:each) do
       Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
+
+      @distribution = mock(Distribution, { "id" => "ks-Red Hat Enterprise Linux-Server-6.4-x86_64",
+                                           '_id' => "0b74d908-5b95-4315-a925-d3e97fd058f2" })
+      Distribution.stub(:find).and_return(@distribution)
     end
 
     let(:action) { :add_distribution }
@@ -202,7 +206,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
     it_should_behave_like "protected action"
 
     it "should add a distribution" do
-      @cs.should_receive(:add_distribution!).with(distribution_id.to_s, @product).and_return(@product)
+      @cs.should_receive(:add_distribution!).with(@distribution, @product).and_return(@product)
       req
       response.should be_success
     end
@@ -211,6 +215,10 @@ describe Api::V1::ChangesetsContentController, :katello => true do
   describe "distributions" do
     before(:each) do
       Product.should_receive(:find_by_cp_id).with(product_cp_id.to_s, @org).and_return(@product)
+
+      @distribution = mock(Distribution, { "id" => "ks-Red Hat Enterprise Linux-Server-6.4-x86_64",
+                                           '_id' => "0b74d908-5b95-4315-a925-d3e97fd058f2" })
+      Distribution.stub(:find).and_return(@distribution)
     end
 
     let(:action) { :remove_distribution }
@@ -218,7 +226,7 @@ describe Api::V1::ChangesetsContentController, :katello => true do
     it_should_behave_like "protected action"
 
     it "should remove a distribution" do
-      @cs.should_receive(:remove_distribution!).with(distribution_id.to_s, @product).and_return(@product)
+      @cs.should_receive(:remove_distribution!).with(@distribution, @product).and_return(@product)
       req
       response.should be_success
     end

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -36,7 +36,10 @@ describe DistributionsController, :katello => true do
     ep_library = EnvironmentProduct.find_or_create(@organization.library, @product)
     @repo = new_test_repo(ep_library, "repo", "#{@organization.name}/Library/prod/repo")
     Repository.stub(:find).and_return(@repo)
-    Glue::Pulp::Distribution.stub(:find).and_return([])
+
+    @distribution = mock(Distribution, { "id" => "ks-Red Hat Enterprise Linux-Server-6.4-x86_64",
+                                         '_id' => "0b74d908-5b95-4315-a925-d3e97fd058f2" })
+    Distribution.stub(:find).and_return(@distribution)
   end
 
   let(:authorized_user) do
@@ -51,23 +54,21 @@ describe DistributionsController, :katello => true do
 
   describe "GET show" do
     let(:action) {:show}
-    let(:req) { get :show, :repository_id => @repo.id, :id => distribution_id }
+    let(:req) { get :show, :repository_id => @repo.id, :id => @distribution.id }
 
     it_should_behave_like "protected action"
 
     it "should lookup the distribution" do
-      Glue::Pulp::Distribution.should_receive(:find).once.with(distribution_id).and_return(distribution)
+      Distribution.should_receive(:find).once.with(@distribution.id).and_return(@distribution)
       req
     end
 
     it "renders show partial" do
-      Glue::Pulp::Distribution.should_receive(:find).once.with(distribution_id).and_return(distribution)
       req
       response.should render_template(:partial => "_show")
     end
 
     it "should be successful" do
-      Glue::Pulp::Distribution.should_receive(:find).once.with(distribution_id).and_return(distribution)
       req
       response.should be_success
     end
@@ -75,23 +76,21 @@ describe DistributionsController, :katello => true do
 
   describe "GET filelist" do
     let(:action) {:filelist}
-    let(:req) { get :filelist, :repository_id => @repo.id, :id => distribution_id }
+    let(:req) { get :filelist, :repository_id => @repo.id, :id => @distribution.id }
 
     it_should_behave_like "protected action"
 
     it "should lookup the distribution" do
-      Glue::Pulp::Distribution.should_receive(:find).once.with(distribution_id).and_return(distribution)
+      Distribution.should_receive(:find).once.with(@distribution.id).and_return(@distribution)
       req
     end
 
     it "renders the file list partial" do
-      Glue::Pulp::Distribution.should_receive(:find).once.with(distribution_id).and_return(distribution)
       req
       response.should render_template(:partial => "_filelist")
     end
 
     it "should be successful" do
-      Glue::Pulp::Distribution.should_receive(:find).once.with(distribution_id).and_return(distribution)
       req
       response.should be_success
     end

--- a/spec/models/changeset_spec.rb
+++ b/spec/models/changeset_spec.rb
@@ -198,14 +198,15 @@ describe Changeset, :katello => true do
                                  :content_view_version=>ep.environment.default_content_view_version,
                                  :feed => 'https://localhost')
 
-        @distribution = mock('Distribution', { :id => 'some-distro-id' })
+        @distribution = mock(Distribution, { "id" => "ks-Red Hat Enterprise Linux-Server-6.4-x86_64",
+                                             '_id' => "0b74d908-5b95-4315-a925-d3e97fd058f2" })
         @repo.stub(:distributions).and_return([@distribution])
         @repo.stub_chain(:distributions, :index).and_return([@distribution])
         @repo.stub(:packages).and_return([@pack])
         @repo.stub(:errata).and_return([@err])
         @repo.stub(:has_package?).with(1).and_return(true)
         @repo.stub(:has_erratum?).with('err').and_return(true)
-        @repo.stub(:has_distribution?).with('some-distro-id').and_return(true)
+        @repo.stub(:has_distribution?).with('ks-Red Hat Enterprise Linux-Server-6.4-x86_64').and_return(true)
         @repo.stub(:clone_ids).and_return([])
         Product.stub(:find).and_return(@prod)
         @changeset.stub(:find_package_data).and_return(@pack)
@@ -270,7 +271,7 @@ describe Changeset, :katello => true do
 
         it "should fail on add distribution" do
           @changeset.stub_chain(:environment, :prior, :repositories, :any?).and_return { true }
-          lambda { @changeset.add_distribution!("some-distro-id", @prod) }.
+          lambda { @changeset.add_distribution!(@distribution, @prod) }.
               should raise_error(ActiveRecord::RecordInvalid, /has not been promoted/)
         end
       end
@@ -317,9 +318,9 @@ describe Changeset, :katello => true do
 
         it "should add distribution" do
           @changeset.environment.stub_chain(:prior, :repositories, :any?).and_return { true }
-          @changeset.add_distribution!("some-distro-id", @prod)
+          @changeset.add_distribution!(@distribution, @prod)
           @changeset.distributions.length.should == 1
-          lambda { @changeset.add_distribution!("some-distro-id", @prod) }.
+          lambda { @changeset.add_distribution!(@distribution, @prod) }.
               should raise_error(ActiveRecord::RecordInvalid, /already been taken/)
         end
 
@@ -353,7 +354,8 @@ describe Changeset, :katello => true do
                                    :feed=>"http://localhost.com/foo/")
         @repo.stub(:create_pulp_repo).and_return([])
         @repo.save!
-        @distribution = mock('Distribution', { :id => 'some-distro-id' })
+        @distribution = mock(Distribution, { "id" => "ks-Red Hat Enterprise Linux-Server-6.4-x86_64",
+                                             '_id' => "0b74d908-5b95-4315-a925-d3e97fd058f2" })
         @repo.stub(:distributions).and_return([@distribution])
         @repo.stub(:packages).and_return([@pack])
         @repo.stub(:errata).and_return([@err])
@@ -396,9 +398,9 @@ describe Changeset, :katello => true do
 
       it "should remove distribution" do
         ChangesetDistribution.should_receive(:destroy_all).
-            with(:distribution_id => 'some-distro-id', :changeset_id => @changeset.id, :product_id => @prod.id).
+            with(:distribution_id => @distribution._id, :changeset_id => @changeset.id, :product_id => @prod.id).
             and_return(true)
-        @changeset.remove_distribution!('some-distro-id', @prod)
+        @changeset.remove_distribution!(@distribution, @prod)
       end
     end
 
@@ -418,7 +420,8 @@ describe Changeset, :katello => true do
 
         @pack         = mock('Pack', { :id => 1, :name => 'pack' })
         @err          = mock('Err', { :id => 'asdfasdf', :name => 'err' , :errata_id=>'err'})
-        @distribution = mock('Distribution', { :id => 'some-distro-id' })
+        @distribution = mock(Distribution, { "id" => "ks-Red Hat Enterprise Linux-Server-6.4-x86_64",
+                                             '_id' => "0b74d908-5b95-4315-a925-d3e97fd058f2" })
         ep            = EnvironmentProduct.find_or_create(@organization.library, @prod)
         @repo         = Repository.new(:environment_product => ep, :name => 'repo', :label => 'repo_label',
                                            :pulp_id => "test_pulp_id", :relative_path=>"/foo/", :content_id=>'aasfd',
@@ -436,7 +439,7 @@ describe Changeset, :katello => true do
         @repo.stub(:sync).and_return([])
         @repo.stub(:has_package?).and_return(true)
         @repo.stub(:has_erratum?).and_return(true)
-        @repo.stub(:has_distribution?).with('some-distro-id').and_return(true)
+        @repo.stub(:has_distribution?).with('ks-Red Hat Enterprise Linux-Server-6.4-x86_64').and_return(true)
 
         @repo.stub(:is_cloned_in?).and_return(true)
         @repo.stub(:clone_ids).and_return([])

--- a/spec/views/distributions/_filelist.html.haml_spec.rb
+++ b/spec/views/distributions/_filelist.html.haml_spec.rb
@@ -16,9 +16,12 @@ describe "distributions/_filelist.html.haml", :katello => true do
   before(:each) do
     view.stub(:render_menu)
     view.stub(:promotion_distribution_navigation).and_return([])
-    @filename = "/path/to/file/in/distribution"
+    @files = [ { 'relativepath' => "/path/to/file/in/distribution" } ]
     @distribution = Distribution.new()
-    @distribution.stub!(:files).and_return([@filename])
+    @distribution = mock(Distribution, { "id" => "ks-Red Hat Enterprise Linux-Server-6.4-x86_64",
+                                         '_id' => "0b74d908-5b95-4315-a925-d3e97fd058f2" })
+
+    @distribution.stub!(:files).and_return(@files)
   end
 
   it "content_for :title is included" do


### PR DESCRIPTION
The following is a summary of the changes:
- fix ability to delete distributions (UI/CLI/API)
- fix ability to promote distributions (UI/CLI/API)
- fix the ability to view distributions (UI/CLI/API)
- fix the ability to view distribution file list (UI/CLI/API)
