### PR TITLE
960695 - Fixes alignment issue with the attach and remove buttons.

### DIFF
--- a/app/assets/javascripts/activation_keys/activation_key.js
+++ b/app/assets/javascripts/activation_keys/activation_key.js
@@ -91,25 +91,20 @@ KT.activation_key = (function($) {
         var fakesubbutton = $('#fake_subscription_submit_button');
         var subcheckboxes = $('#subscription_form input[type="checkbox"]');
         var checked = 0;
-        subbutton.hide();
 
         subcheckboxes.each(function(){
             $(this).change(function(){
                 if($(this).is(":checked")){
                     checked += 1;
-                    if(!(subbutton.is(":visible"))){
-                        fakesubbutton.fadeOut("fast", function(){subbutton.fadeIn()});
-                    }
-                }else{
+                    subbutton.removeAttr('disabled');
+                } else {
                     checked -= 1;
-                    if((subbutton.is(":visible")) && checked === 0){
-                        subbutton.fadeOut("fast", function(){fakesubbutton.fadeIn()});
+                    if (checked === 0) {
+                        subbutton.attr('disabled', 'disabled');
                     }
                 }
             });
         });
-
-        //subbutton.unbind('click').click(disable_submit);
     },
     initialize_new = function() {
         $('#usage_limit_checkbox').live('click', function() {

--- a/app/views/activation_keys/_applied_subscriptions.html.haml
+++ b/app/views/activation_keys/_applied_subscriptions.html.haml
@@ -20,20 +20,19 @@
           - else
             %strong #{env.display_name}
             - break
-      .fr
-        = render :partial => "common/filter_table"
 
     .full.lower_content.clear
+      .fl
+        = render :partial => "common/filter_table"
       = form_tag remove_subscriptions_activation_key_path(@activation_key), :id=>"subscription_form", :method=>"post", :remote=>true do
+
+        - if applied_subs.length > 0 && editable
+          = submit_tag _('Remove'), :class => 'submit button fr', :id=>"subscription_submit_button", :disabled=>"disabled"
 
         = render :partial => "subscriptions", :locals => {:product_families => applied_subs}
 
         - if editable
           .actions.panel_link
             = link_to(_("Add Subscriptions ▸"), available_subscriptions_activation_key_path(@activation_key))
-
-            - if applied_subs.length > 0
-              = submit_tag _('Remove'), :class => 'submit dialogbutton', :id=>"subscription_submit_button", :style => 'display:none;'
-              %a{:class=>'dialogbutton button disabled', :id=>"fake_subscription_submit_button"} #{_('Remove')}
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/activation_keys/_available_subscriptions.html.haml
+++ b/app/views/activation_keys/_available_subscriptions.html.haml
@@ -22,14 +22,12 @@
             - break
 
     .full.lower_content.clear
-      .fr
+      .fl
         = render :partial => "common/filter_table"
       = form_tag add_subscriptions_activation_key_path(@activation_key), :id=>"subscription_form", :method=>"post", :remote=>true do
 
         - if editable && available_subs.length > 0
-          .actions.fl
-            = submit_tag _('Attach to Key'), :class => 'submit dialogbutton', :id=>"subscription_submit_button", :style => 'display:none;'
-            %a{:class=>'dialogbutton button disabled', :id=>"fake_subscription_submit_button"} #{_('Attach to Key')}
+          = submit_tag _('Attach to Key'), :class => 'submit button fr', :id=>"subscription_submit_button", :disabled=>"disabled"
 
         = render :partial => "subscriptions", :locals => {:product_families => available_subs}
 


### PR DESCRIPTION
The attach key and remove key button from the available and attached
subscriptions tabs were in different places. This fix standardizes
the actions to the upper right hand corner and the filter box to the
upper left hand corner of the table. Moving the actions to the upper
right is to account for potentially long lists that could hide the
actions from the users view.
