### PR TITLE
971142 - Fixed spelling error "Defintions" -> "Definitions"

### DIFF
--- a/app/models/authorization/content_view_definition.rb
+++ b/app/models/authorization/content_view_definition.rb
@@ -56,7 +56,7 @@ module Authorization::ContentViewDefinition
       {
         :create  => _("Administer Content View Definitions"),
         :read    => _("Read Content View Definitions"),
-        :update  => _("Modify Content View Defintions"),
+        :update  => _("Modify Content View Definitions"),
         :delete  => _("Delete Content View Definitions"),
         :publish => _("Publish Content View Definitions")
       }.with_indifferent_access

--- a/app/models/resource_type.rb
+++ b/app/models/resource_type.rb
@@ -110,7 +110,7 @@ class ResourceType < ActiveRecord::Base
         :users => { :model => User, :name => _("Users"), :global=>true},
         :roles => { :model => Role, :name => _("Roles"), :global=>true},
         :content_view_definitions => { :model => ContentViewDefinition,
-          :name => _("Content View Defintions"), :global => false},
+          :name => _("Content View Definitions"), :global => false},
         :content_views => { :model => ContentView, :name => _("Content View"), :global => false},
         :all => { :model => DefaultModel, :name => _("All"), :global => false}
      }.with_indifferent_access

--- a/doc/apipie_examples.yml
+++ b/doc/apipie_examples.yml
@@ -14128,7 +14128,7 @@ roles#available_verbs:
       - name: delete
         display_name: Delete Content View Definitions
       - name: update
-        display_name: Modify Content View Defintions
+        display_name: Modify Content View Definitions
       - name: publish
         display_name: Publish Content View Definitions
       - name: read
@@ -14138,7 +14138,7 @@ roles#available_verbs:
       no_tag_verbs: 
       - create
       global: false
-      name: Content View Defintions
+      name: Content View Definitions
     content_views: 
       verbs: 
       - name: promote
@@ -14328,7 +14328,7 @@ roles#available_verbs:
       - name: delete
         display_name: Delete Content View Definitions
       - name: update
-        display_name: Modify Content View Defintions
+        display_name: Modify Content View Definitions
       - name: publish
         display_name: Publish Content View Definitions
       - name: read
@@ -14338,7 +14338,7 @@ roles#available_verbs:
       no_tag_verbs: 
       - create
       global: false
-      name: Content View Defintions
+      name: Content View Definitions
     content_views: 
       verbs: 
       - name: promote
@@ -14534,7 +14534,7 @@ roles#available_verbs:
       - name: delete
         display_name: Delete Content View Definitions
       - name: update
-        display_name: Modify Content View Defintions
+        display_name: Modify Content View Definitions
       - name: publish
         display_name: Publish Content View Definitions
       - name: read
@@ -14544,7 +14544,7 @@ roles#available_verbs:
       no_tag_verbs: 
       - create
       global: false
-      name: Content View Defintions
+      name: Content View Definitions
     content_views: 
       verbs: 
       - name: promote
@@ -14739,7 +14739,7 @@ roles#available_verbs:
       - name: delete
         display_name: Delete Content View Definitions
       - name: update
-        display_name: Modify Content View Defintions
+        display_name: Modify Content View Definitions
       - name: publish
         display_name: Publish Content View Definitions
       - name: read
@@ -14749,7 +14749,7 @@ roles#available_verbs:
       no_tag_verbs: 
       - create
       global: false
-      name: Content View Defintions
+      name: Content View Definitions
     content_views: 
       verbs: 
       - name: promote
@@ -14945,7 +14945,7 @@ roles#available_verbs:
       - name: delete
         display_name: Delete Content View Definitions
       - name: update
-        display_name: Modify Content View Defintions
+        display_name: Modify Content View Definitions
       - name: publish
         display_name: Publish Content View Definitions
       - name: read
@@ -14955,7 +14955,7 @@ roles#available_verbs:
       no_tag_verbs: 
       - create
       global: false
-      name: Content View Defintions
+      name: Content View Definitions
     content_views: 
       verbs: 
       - name: promote


### PR DESCRIPTION
Fixed all occurrences of the typo "Defintions" 
