### PR TITLE
register system - doing away with the "New System" pane

### DIFF
--- a/app/assets/stylesheets/katello.scss
+++ b/app/assets/stylesheets/katello.scss
@@ -1429,3 +1429,40 @@ tr.no_sort.not_filtered {
     vertical-align: middle;
   }
 }
+
+// stoled from github
+code {
+  margin: 0 2px;
+  padding: 0 5px;
+  white-space: nowrap;
+  border: 1px solid #eaeaea;
+  background-color: #f8f8f8;
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: Consolas, "Liberation Mono", Courier, monospace;
+}
+
+pre code {
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  border: none;
+  background: transparent;
+  background-color: transparent;
+  border: none;
+}
+
+pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px;
+  margin: 15px 5px;
+}
+
+.instruction-page {
+  padding: 10px 20px;
+}

--- a/app/views/systems/_new.html.haml
+++ b/app/views/systems/_new.html.haml
@@ -1,55 +1,20 @@
-
-= javascript do
-  :plain
-    localize({
-      "edit_environment": '#{escape_javascript(_('Edit Environment'))}'
-    });
-
-:ruby
-  sockets_help = _("The number of CPU Sockets or LPARs which this system uses")
-  memory_help = _("The amount of RAM memory, in gigabytes (GB), which this system has")
-
-
-- if @environment
-  = content_for :title do
-    #{_("New system")}
-  = content_for :content do
-    .full
-      = kt_form_for(System.new, :action => "create", :id => "new_system") do |form|
-        = hidden_field_tag 'system[environment_id]', @environment.id
-        .grid_8#new_system
-          = form.text_field :name, :label => _("Name of Your System:")
-
-          = form.field :arch, :label => _("Architecture:") do
-            = architecture_select
-
-          = form.text_field :sockets, :label => _("Number of Sockets or LPARs:"), :help => sockets_help, :value => 1
-
-          = form.text_field :memory, :label => _("Amount of RAM (GB):"), :help => memory_help, :value => ''
-
-          = form.field :virtual, :label => _("System Type:") do
-            = virtual_buttons
-
-          = form.field :environment, :label => envsys ? _("Environment:") : _("Choose Environment:") do
-            - if envsys
-              = @environment.name
-            - else
-              = environment_selector(:path_widget_class => "grid_10",
-                  :path_entries_class => "grid_10", :library_clickable => true,
-                  :accessible_envs => accessible_envs,
-                  :url_products_proc => url_products_proc,
-                  :url_content_views_proc => url_content_views_proc)
-
-          - if Katello.config.katello?
-            = form.field :content_view_id, :label => _("Content View:") do
-              = content_view_select(current_organization, @environment)
-
-
-          = form.submit _("Save")
-- else
-  = content_for :title do
-    #{_("New system")}
-    = content_for :content do
-      #{_("You need to create an environment for this org before you can create a system.")}
+= content_for :title do
+  #{_("Register System")}
+= content_for :content do
+  %section.instruction-page
+    %p
+      #{_("To register a system to this server, run the following commands within a console on the client system.")}
+    .clear
+      &nbsp
+    %p
+      #{_("Install the pre-built bootstrap RPM. This will configure the system to use this server.")}
+    %pre
+      %code
+        = install_cert_command
+    %p
+      #{_("Use Subscription Manager to register.")}
+    %pre
+      %code
+        = register_command
 
 = render :template => "layouts/tupane_layout"

--- a/spec/controllers/systems_controller_spec.rb
+++ b/spec/controllers/systems_controller_spec.rb
@@ -352,67 +352,6 @@ describe SystemsController do
       end
     end
 
-    describe 'creating a system' do
-      render_views
-
-      before (:each) do
-        System.stub!(:save!).and_return true
-        login_user({ :mock => false })
-
-        # Stub out System.where().search_for()
-        @system = System.create!(:name=>"bar", :environment => @environment, :cp_type=>"system", :facts=>{"Test" => ""})
-        System.stub!(:where).and_return @system
-        @system.stub!(:search_for).and_return [@system]
-      end
-
-      # GET :index should not render an env_select until the :new is called
-      it "should create a system in env", :katello => true do #TODO headpin
-        get :index
-        response.should_not render_template(:partial=>"_env_select")
-
-        get :new
-        response.should render_template(:partial=>"_new")
-        response.should render_template(:partial=>"_env_select")
-
-        controller.should notify(:success, :message)
-        post :create, {:system=>{:name=>"sys1", :environment_id=>@env1.id, :sockets=>2},
-                       :arch=>{:arch_id=>1},
-                       :system_type=>{:virtualized=>'virtual'}}
-        response.should be_success
-      end
-
-      # GET :index should render an env_select but not on the :new response
-      it "should create a system in env", :katello => true do #TODO headpin
-        get :environments, :env_id=>@env2.id
-        response.should render_template(:partial=>"_env_select")
-
-        # The link to :new should include env_id
-        # NOTE: This can't be tested since the url is modified by javascript
-        #response.should have_selector("a", :id=>'new', :href=>"#", 'data-ajax_url'=>"/headpin/systems/new?env_id=#{@env2.id}")
-
-        get :new, {:env_id=>@env2.id}
-        response.should render_template(:partial=>"_new")
-        response.should_not render_template(:partial=>"_env_select")
-
-        # The hidden env_id form field should have correct id
-        response.should have_selector("input", :id=>'system_environment_id', :value=>"#{@env2.id}")
-
-        controller.should notify(:success, :message)
-        post :create, {:system=>{:name=>"sys1", :environment_id=>@env2.id, :sockets=>2},
-                       :arch=>{:arch_id=>1},
-                       :system_type=>{:virtualized=>'virtual'}}
-        response.should be_success
-        response.should contain '{"no_match":true}'
-      end
-      it_should_behave_like "bad request"  do
-        let(:req) do
-          post :create, {:system=>{:bad_foo=> true,:name=>"sys1", :environment_id=>@env2.id, :sockets=>2},
-                         :arch=>{:arch_id=>1},
-                         :system_type=>{:virtualized=>'virtual'}}
-        end
-      end
-    end
-
     describe "system groups" do
       before (:each) do
         @system = System.create!(:name=>"bar1", :environment => @environment, :cp_type=>"system", :facts=>{"Test" => ""})

--- a/test/controllers/systems_controller_test.rb
+++ b/test/controllers/systems_controller_test.rb
@@ -26,36 +26,6 @@ describe SystemsController do
     login_user(User.find(users(:admin)), @org)
   end
 
-  describe "create"  do
-    before do
-      @content_view = content_views(:library_dev_view)
-      @cv_id = @content_view.id
-      @env_id = @system.environment.id
-      @subscribe_permission = UserPermission.new(:subscribe, :content_views, @cv_id, @content_view.organization)
-      @register_system_perm = UserPermission.new(:register_systems, :environments, @env_id, @system.environment.organization)
-      @req = lambda do
-        post :create, :system => {:environment_id => @env_id,
-                        :content_view_id => @cv_id,
-                        :name => @system.name + "-foo#{rand 10**6}"}
-      end
-    end
-
-    it "permission" do
-      master_perm = @subscribe_permission + @register_system_perm
-      action = :create
-      assert_authorized(
-                :permission => master_perm,
-                :action => action,
-                :request => @req
-      )
-      refute_authorized(
-          :permission => [@register_system_perm, @subscribe_permission, NO_PERMISSION],
-          :action => action,
-          :request => @req
-      )
-    end
-  end
-
   describe "update"  do
     before do
       @content_view = content_views(:library_dev_view)


### PR DESCRIPTION
Doing away with the "New System" pane in favor of a "Register System"
pane. This pane is much simpler because it only contains two commands to
run on the client system that you want to register.

``` bash
rpm -Uvh http://hostname/pub/candlepin-cert-consumer-latest.noarch.rpm
subscription-manager register --org="org_name"
```
