### PR TITLE
971468 - fixing high memory usage during unit unassociate calls

### DIFF
--- a/app/models/content_view_version.rb
+++ b/app/models/content_view_version.rb
@@ -117,7 +117,7 @@ class ContentViewVersion < ActiveRecord::Base
         # this repo is in both the definition and in the previous library version,
         # so clear it and later we'll regenerate the content... this is more
         # efficient than deleting the repo and recreating it...
-        async_tasks << repo.clear_contents
+        async_tasks +=  repo.clear_contents
       else
         # this repo no longer exists in the definition, so destroy it
         repo.destroy

--- a/app/models/glue/pulp/package.rb
+++ b/app/models/glue/pulp/package.rb
@@ -11,6 +11,10 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Glue::Pulp::Package
+
+  #fields we use to trim down our unit association calls to pulp
+  PULP_SELECT_FIELDS = ['name', 'epoch', 'version', 'release', 'arch', 'checksumtype', 'checksum']
+
   def self.included(base)
     base.send :include, InstanceMethods
 

--- a/test/glue/pulp/package_test.rb
+++ b/test/glue/pulp/package_test.rb
@@ -60,4 +60,10 @@ class GluePulpPackageTest < GluePulpPackageTestBase
     refute_nil package.nvrea
   end
 
+  def test_ignored_fields
+    refute_includes Package::PULP_SELECT_FIELDS, 'changelog'
+    refute_includes Package::PULP_SELECT_FIELDS, 'repodata'
+    refute_includes Package::PULP_SELECT_FIELDS, 'filelist'
+  end
+
 end


### PR DESCRIPTION
limiting the set of fields when we do an unassociate call reduces the
memory footprint of pulp greatly when those operations are done
