### PR TITLE
Dashboard: setting dashhead height to align widgets

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -46,6 +46,7 @@ $forty: $static_width - $sixty;
     }
     .dashhead {
         position: relative;
+        height: 34px;
     }
 
     #dashboard_subscriptions {


### PR DESCRIPTION
Setting the height of dashhead element since it seemed to vary from widget to widget and thus changed the heights of the widgets.
