### PR TITLE
KatelloNameFormatValidator - shortening up the regex

### DIFF
--- a/app/lib/validators/katello_name_format_validator.rb
+++ b/app/lib/validators/katello_name_format_validator.rb
@@ -15,7 +15,9 @@ module Validators
   class KatelloNameFormatValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       if value
-        record.errors[attribute] << N_("cannot contain characters other than alpha numerals, space, '_', '-'") unless value =~ /\A[\w\P{ASCII}| |_|-]*\Z/
+        unless value =~ /\A[[:alnum:] _-]*\z/
+          record.errors[attribute] << N_("cannot contain characters other than alpha numerals, space, '_', '-'")
+        end
         NoTrailingSpaceValidator.validate_trailing_space(record, attribute, value)
         KatelloNameFormatValidator.validate_length(record, attribute, value)
       else


### PR DESCRIPTION
- `[:alnum:]-_` catches the same as `\w\P{ASCII} -`
- changing `\Z` to `\z`
