### PR TITLE
970617 - errata deletion - update to use unit_id vs id

### DIFF
--- a/app/models/glue/pulp/repo.rb
+++ b/app/models/glue/pulp/repo.rb
@@ -488,7 +488,7 @@ module Glue::Pulp::Repo
     end
 
     def delete_errata errata_id_list
-      Runcible::Extensions::Errata.unassociate_ids_from_repo(self.pulp_id, errata_id_list)
+      Runcible::Extensions::Errata.unassociate_unit_ids_from_repo(self.pulp_id, errata_id_list)
     end
 
     def delete_distribution distribution_id


### PR DESCRIPTION
Without this change, the erratum is not being properly
unassociated (deleted) from the repo.
