### PR TITLE
[Do Not Merge] 973834 - telling runcible to use our rest timeout values

### DIFF
--- a/app/lib/util/thread_session.rb
+++ b/app/lib/util/thread_session.rb
@@ -57,6 +57,8 @@ module Util
                 :url      => "#{uri.scheme}://#{uri.host.downcase}",
                 :api_path => uri.path,
                 :user     => user_id,
+                :timeout      => Katello.config.rest_client_timeout,
+                :open_timeout => Katello.config.rest_client_timeout,
                 :oauth    => {:oauth_secret => Katello.config.pulp.oauth_secret,
                               :oauth_key    => Katello.config.pulp.oauth_key },
                 :logging  => {:logger     => ::Logging.logger['pulp_rest'],


### PR DESCRIPTION
requires a new runcible, but due to other changes that also require it, not includes
a requirement bump here, wanted to open the PR though.
