### PR TITLE
add ruby193-rubygem-po_to_json to comps-katello-foreman-server-rhel6

### DIFF
--- a/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
@@ -97,6 +97,7 @@
        <packagereq type="default">ruby193-rubygem-net-scp</packagereq>
        <packagereq type="default">ruby193-rubygem-net-ssh</packagereq>
        <packagereq type="default">ruby193-rubygem-nokogiri</packagereq>
+       <packagereq type="default">ruby193-rubygem-po_to_json</packagereq>
        <packagereq type="default">ruby193-rubygem-quiet_assets</packagereq>
        <packagereq type="default">ruby193-rubygem-rabl</packagereq>
        <packagereq type="default">ruby193-rubygem-rbovirt</packagereq>


### PR DESCRIPTION
addressing:

```
Error: Package: ruby193-rubygem-gettext_i18n_rails_js-0.0.8-1.el6.noarch (katello-foreman)
           Requires: ruby193-rubygem(po_to_json) >= 0.0.7
```
