### PR TITLE
GPG Keys: Limiting the length of content

### DIFF
--- a/app/assets/javascripts/gpg_keys/gpg_key_edit.js
+++ b/app/assets/javascripts/gpg_keys/gpg_key_edit.js
@@ -50,8 +50,9 @@ $(document).ready(function(){
         var settings = {
                 type            :  'textarea',
                 name            :  $(this).attr('name'),
-                height            :  '300',
-                width            :  $(this).width() - 20
+                height          :  '300',
+                width           :  $(this).width() - 20,
+                maxlength       :  $(this).data('maxlength')
         };
         $(this).editable($(this).attr('data-url'), $.extend(common_settings, settings));
     });

--- a/app/helpers/gpg_keys_helper.rb
+++ b/app/helpers/gpg_keys_helper.rb
@@ -12,4 +12,8 @@
 
 module GpgKeysHelper
 
+  def gpg_content_limit
+    GpgKey::MAX_CONTENT_LENGTH
+  end
+
 end

--- a/app/models/gpg_key.rb
+++ b/app/models/gpg_key.rb
@@ -15,6 +15,7 @@ class GpgKey < ActiveRecord::Base
 
   include Glue::ElasticSearch::GpgKey if Katello.config.use_elasticsearch
   include Authorization::GpgKey
+  MAX_CONTENT_LENGTH = 100000
 
   has_many :repositories, :inverse_of => :gpg_key
   has_many :products, :inverse_of => :gpg_key
@@ -25,6 +26,7 @@ class GpgKey < ActiveRecord::Base
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates :content, :presence => true
   validates_with Validators::ContentValidator, :attributes => :content
+  validates_length_of :content, :maximum => MAX_CONTENT_LENGTH
   validates_presence_of :organization
   validates_uniqueness_of :name, :scope => :organization_id, :message => N_("Label has already been taken")
 

--- a/app/views/gpg_keys/_edit.html.haml
+++ b/app/views/gpg_keys/_edit.html.haml
@@ -40,6 +40,6 @@
         .grid_1.ra
           %label #{_("Key")}:
         .grid_8.la
-          .grid_8.la.multiline#gpg_key_content{'name' => 'gpg_key[content]', :class => ("editable edit_textarea" if editable), 'data-url' => gpg_key_path(@gpg_key.id)} #{@gpg_key[:content]}
+          .grid_8.la.multiline#gpg_key_content{'name' => 'gpg_key[content]', :class => ("editable edit_textarea" if editable), 'data-maxlength' => gpg_content_limit, 'data-url' => gpg_key_path(@gpg_key.id)} #{@gpg_key[:content]}
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/gpg_keys/_new.html.haml
+++ b/app/views/gpg_keys/_new.html.haml
@@ -19,7 +19,7 @@
 
     = kt_form_for GpgKey.new, :html => {:id => "new_gpg_key"}, :tabindex => 5 do |form|
 
-      = form.text_area :content, :id=> "gpg_key_content", :size => "40x15", :label => _("Paste GPG Key"), :class => "grid_6"
+      = form.text_area :content, :id=> "gpg_key_content", :size => "40x15", :label => _("Paste GPG Key"), :class => "grid_6", :maxlength => gpg_content_limit
 
       %fieldset
         .grid_2.la.push_2

--- a/spec/models/gpg_key_spec.rb
+++ b/spec/models/gpg_key_spec.rb
@@ -81,6 +81,11 @@ describe GpgKey, :katello => true do
       gpg_key = GpgKey.new(:name => "Gpg Key 1", :content =>"\231\001\r\004\026\001\b\000\276", :organization => @organization)
       gpg_key.should_not be_valid
     end
+
+    it "should be unsuccessful with a key longer than #{GpgKey::MAX_CONTENT_LENGTH} characters" do
+      gpg_key = GpgKey.new(:name => "Gpg Key 8", :content => ("abc123" * GpgKey::MAX_CONTENT_LENGTH), :organization => @organization)
+      gpg_key.should_not be_valid
+    end
   end
 
 end


### PR DESCRIPTION
Limiting the length of gpg keys to 100,000 characters (100 KB).
