### PR TITLE
Gravatar Image - Adding gravatar image to the Katello User Page

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,12 +1,6 @@
 @import "ui_alchemy/alchemy/alchemy";
 @import "alchemy-header/header";
 
-.logo-header {
-  .menu-item {
-    a { color: white; }
-  }
-}
-
 .fade-in-down, .fade-in-bottom{
 -webkit-animation: fade-in-down .9s ease 0;
    -moz-animation: fade-in-down .9s ease 0;
@@ -37,4 +31,15 @@
 
 .dropdown-menu-item-link, .flyout li a {
   font-family: "Liberation Sans", sans-serif;
+}
+
+.gravatar {
+  height: 25px;
+  width:  30px;
+  float: left;
+}
+
+.gravatar-span {
+  line-height: 1;
+  vertical-align: bottom;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -150,6 +150,15 @@ module ApplicationHelper
     render :partial=>"/common/env_select", :locals => options
   end
 
+  def gravatar_image_tag(email)
+    image_url = gravatar_url(email)
+    return "<img src=\"#{image_url}\" class=\"gravatar\"><span class=\"gravatar-span\">"
+  end
+
+  def gravatar_url(email)
+    "https:///secure.gravatar.com/avatar/#{Digest::MD5.hexdigest(email)}?d=mm&s=25"
+  end
+
   def env_select_class curr_env, selected_env, curr_path, selected_path, accessible_envs, library_clickable
     classes = []
     if (library_clickable or !curr_env.library?) and accessible_envs.member?(curr_env)
@@ -320,3 +329,5 @@ module ApplicationHelper
     return Validators::KatelloDescriptionFormatValidator::MAX_LENGTH
   end
 end
+
+

--- a/app/lib/navigation/menus/user.rb
+++ b/app/lib/navigation/menus/user.rb
@@ -10,14 +10,16 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-
 module Navigation
   module Menus
+
     class User < Navigation::Menu
+
+      include ApplicationHelper
 
       def initialize(user)
         @key           = :user
-        @display       = user.username
+        @display       = Katello.config[:gravatar] ? "#{gravatar_image_tag(user.email)}#{user.username}" : user.username
         @authorization = true
         @type          = 'dropdown'
         @items         = [

--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -21,7 +21,7 @@ common:
   use_foreman: # set to true/false if you want to override default
   use_elasticsearch: # set to true/false if you want to override default
   app_name: # set a name if you want to override default
-
+  gravatar: true # set to true/false for enabling disabling gravatar
   warden: database
   ldap_roles: false
   validate_ldap: false

--- a/lib/katello/load_configuration.rb
+++ b/lib/katello/load_configuration.rb
@@ -59,7 +59,7 @@ module Katello
             is_not_empty :thumbslug_url
           end
 
-          are_booleans :use_cp, :use_foreman, :use_pulp, :use_elasticsearch, :use_ssl, :ldap_roles, :validate_ldap
+          are_booleans :use_cp, :use_foreman, :use_pulp, :use_elasticsearch, :use_ssl, :ldap_roles, :validate_ldap, :gravatar
 
           if !early? && environment != :build
             validate :database do

--- a/test/lib/navigation/navigation_headpin_menus_test.rb
+++ b/test/lib/navigation/navigation_headpin_menus_test.rb
@@ -91,10 +91,17 @@ class NavigationMenusTest < MiniTest::Rails::ActiveSupport::TestCase
   def test_user_menu
     menu = Navigation::Menus::User.new(@admin)
 
-    assert_equal  @admin.username, menu.display
     assert_equal  2, menu.items.length
     assert_equal  'dropdown', menu.type
     assert        menu.accessible?
   end
+
+  def test_gravatar
+    menu = Navigation::Menus::User.new(@admin)
+
+    Katello.config[:gravatar] ? assert_equal("<img src=\"https:///secure.gravatar.com/avatar/985b643b38ac0b1589b212197e27a143?d=mm&s=25\" class=\"gravatar\"><span class=\"gravatar-span\">admin", menu.display) : assert_equal(@admin.user, menu.display)
+    assert        menu.accessible?
+  end
+
 
 end

--- a/test/lib/navigation/navigation_menus_test.rb
+++ b/test/lib/navigation/navigation_menus_test.rb
@@ -109,10 +109,18 @@ class NavigationMenusTest < MiniTest::Rails::ActiveSupport::TestCase
   def test_user_menu
     menu = Navigation::Menus::User.new(@admin)
 
-    assert_equal  @admin.username, menu.display
     assert_equal  2, menu.items.length
     assert_equal  'dropdown', menu.type
     assert        menu.accessible?
   end
+
+  def test_gravatar
+    menu = Navigation::Menus::User.new(@admin)
+
+    Katello.config[:gravatar] ? assert_equal("<img src=\"https:///secure.gravatar.com/avatar/985b643b38ac0b1589b212197e27a143?d=mm&s=25\" class=\"gravatar\"><span class=\"gravatar-span\">admin", menu.display) : assert_equal(@admin.user, menu.display)
+    assert        menu.accessible?
+  end
+
+
 
 end


### PR DESCRIPTION
We defined some methods for pulling gravatar image for the signed in user and
displayed it on the Katello User Page and modified the header css.
