### PR TITLE
973811: Small vms show ram as 0.

### DIFF
--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -385,7 +385,7 @@ module Glue::Candlepin::Consumer
         # default memtotal is in kB
         else total_mem = (total_mem / (1024*1024))
       end
-      total_mem.to_i
+      total_mem.round(2)
     end
 
     def available_pools_full listall=false


### PR DESCRIPTION
This is due to rounding the memory to the nearest integer. This change makes it a float which is rounded to  spaces.
