### PR TITLE
Use katello-configure-foreman-proxy instead of foreman-proxy-installer

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -228,7 +228,7 @@ BuildArch:      noarch
 Summary:        A meta-package to pull in all components for Katello and Foreman
 Requires:       %{name}-all
 Requires:       %{name}-configure-foreman
-Requires:       foreman-proxy-installer
+Requires:       %{name}-configure-foreman-proxy
 
 %description foreman-all
 

--- a/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora18.xml
@@ -24,17 +24,6 @@
        <packagereq type="default">foreman-proxy</packagereq>
 
        <packagereq type="default">foreman-installer</packagereq>
-       <packagereq type="default">foreman-proxy-installer</packagereq>
-       <packagereq type="default">foreman-installer-puppet-apache</packagereq>
-       <packagereq type="default">foreman-installer-puppet-concat</packagereq>
-       <packagereq type="default">foreman-installer-puppet-dhcp</packagereq>
-       <packagereq type="default">foreman-installer-puppet-dns</packagereq>
-       <packagereq type="default">foreman-installer-puppet-foreman</packagereq>
-       <packagereq type="default">foreman-installer-puppet-foreman_proxy</packagereq>
-       <packagereq type="default">foreman-installer-puppet-passenger</packagereq>
-       <packagereq type="default">foreman-installer-puppet-puppet</packagereq>
-       <packagereq type="default">foreman-installer-puppet-tftp</packagereq>
-       <packagereq type="default">foreman-installer-puppet-xinetd</packagereq>
 
        <packagereq type="default">rubygem-ancestry</packagereq>
        <packagereq type="default">rubygem-awesome_print</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora19.xml
@@ -24,17 +24,6 @@
        <packagereq type="default">foreman-proxy</packagereq>
 
        <packagereq type="default">foreman-installer</packagereq>
-       <packagereq type="default">foreman-proxy-installer</packagereq>
-       <packagereq type="default">foreman-installer-puppet-apache</packagereq>
-       <packagereq type="default">foreman-installer-puppet-concat</packagereq>
-       <packagereq type="default">foreman-installer-puppet-dhcp</packagereq>
-       <packagereq type="default">foreman-installer-puppet-dns</packagereq>
-       <packagereq type="default">foreman-installer-puppet-foreman</packagereq>
-       <packagereq type="default">foreman-installer-puppet-foreman_proxy</packagereq>
-       <packagereq type="default">foreman-installer-puppet-passenger</packagereq>
-       <packagereq type="default">foreman-installer-puppet-puppet</packagereq>
-       <packagereq type="default">foreman-installer-puppet-tftp</packagereq>
-       <packagereq type="default">foreman-installer-puppet-xinetd</packagereq>
 
        <packagereq type="default">rubygem-ancestry</packagereq>
        <packagereq type="default">rubygem-excon</packagereq>

--- a/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-rhel6.xml
@@ -23,17 +23,6 @@
        <packagereq type="default">foreman-proxy</packagereq>
 
        <packagereq type="default">foreman-installer</packagereq>
-       <packagereq type="default">foreman-proxy-installer</packagereq>
-       <packagereq type="default">foreman-installer-puppet-apache</packagereq>
-       <packagereq type="default">foreman-installer-puppet-concat</packagereq>
-       <packagereq type="default">foreman-installer-puppet-dhcp</packagereq>
-       <packagereq type="default">foreman-installer-puppet-dns</packagereq>
-       <packagereq type="default">foreman-installer-puppet-foreman</packagereq>
-       <packagereq type="default">foreman-installer-puppet-foreman_proxy</packagereq>
-       <packagereq type="default">foreman-installer-puppet-passenger</packagereq>
-       <packagereq type="default">foreman-installer-puppet-puppet</packagereq>
-       <packagereq type="default">foreman-installer-puppet-tftp</packagereq>
-       <packagereq type="default">foreman-installer-puppet-xinetd</packagereq>
 
        <packagereq type="default">rubygem-ancestry</packagereq>
        <packagereq type="default">rubygem-audited</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -24,6 +24,7 @@
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-configure</packagereq>
        <packagereq type="default">katello-configure-foreman</packagereq>
+       <packagereq type="default">katello-configure-foreman-proxy</packagereq>
        <packagereq type="default">katello-foreman-all</packagereq>
        <packagereq type="default">katello-glue-candlepin</packagereq>
        <packagereq type="default">katello-glue-elasticsearch</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -24,6 +24,7 @@
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-configure</packagereq>
        <packagereq type="default">katello-configure-foreman</packagereq>
+       <packagereq type="default">katello-configure-foreman-proxy</packagereq>
        <packagereq type="default">katello-foreman-all</packagereq>
        <packagereq type="default">katello-glue-candlepin</packagereq>
        <packagereq type="default">katello-glue-elasticsearch</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -24,6 +24,7 @@
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-configure</packagereq>
        <packagereq type="default">katello-configure-foreman</packagereq>
+       <packagereq type="default">katello-configure-foreman-proxy</packagereq>
        <packagereq type="default">katello-foreman-all</packagereq>
        <packagereq type="default">katello-glue-candlepin</packagereq>
        <packagereq type="default">katello-glue-elasticsearch</packagereq>


### PR DESCRIPTION
Foreman-proxy-installer package is deprecated. Instead, foreman upstream
pupped modules in combination with katello-configure script is used.

Reflect the change made here

https://github.com/Katello/katello-installer/pull/35
