### PR TITLE
consumer glue - ignore deleted consumers that were already deleted

### DIFF
--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -137,6 +137,9 @@ module Glue::Candlepin::Consumer
     def del_candlepin_consumer
       Rails.logger.debug "Deleting consumer in candlepin: #{name}"
       Resources::Candlepin::Consumer.destroy(self.uuid)
+    rescue RestClient::Gone => e
+      #ignore already deleted system
+      true
     rescue => e
       Rails.logger.error "Failed to delete candlepin consumer #{name}: #{e}, #{e.backtrace.join("\n")}"
       raise e

--- a/test/glue/candlepin/consumer_test.rb
+++ b/test/glue/candlepin/consumer_test.rb
@@ -151,9 +151,7 @@ class GlueCandlepinConsumerTestSecondDelete < GlueCandlepinConsumerTestBase
     # First delete
     CandlepinConsumerSupport.destroy_system(@sys.id)
     # Second delete
-    assert_raises(RestClient::Gone) do
-      CandlepinConsumerSupport.destroy_system(@sys.id, 'support/candlepin/system_delete')
-    end
+    assert_equal true, CandlepinConsumerSupport.destroy_system(@sys.id, 'support/candlepin/system_delete')
   end
 
   def test_candlepin_distributor_second_delete
@@ -161,9 +159,7 @@ class GlueCandlepinConsumerTestSecondDelete < GlueCandlepinConsumerTestBase
     # First delete
     CandlepinConsumerSupport.destroy_distributor(@dist.id)
     # Second delete
-    assert_raises(RestClient::Gone) do
-      CandlepinConsumerSupport.destroy_distributor(@dist.id, 'support/candlepin/distributor_delete')
-    end
+    assert_equal true, CandlepinConsumerSupport.destroy_distributor(@dist.id, 'support/candlepin/distributor_delete')
   end
 
 end


### PR DESCRIPTION
This makes cleaning up systems who's record was deleted
in candlepin much much easier.
