### PR TITLE
975061 - prevent deletion of CV from environment with systems

### DIFF
--- a/app/assets/javascripts/promotions/promotion.js
+++ b/app/assets/javascripts/promotions/promotion.js
@@ -1093,7 +1093,7 @@ var promotion_page = (function($){
                     });
                     if (current_changeset.type() === "deletion") {
                         // show all add/remove links
-                        buttons.show();
+                        buttons.not('[data-block_delete="true"]').show();
 
                     } else { // promotion changeset
                         // show add/remove links for only promotable objects

--- a/app/views/promotions/_content_views.html.haml
+++ b/app/views/promotions/_content_views.html.haml
@@ -10,12 +10,13 @@
 
         - view = view_version.content_view
         - promoted = next_env_view_version_ids.include?(view_version.id)
+        - current_env_version = view.version(@environment)
 
         .fr
           %span.added.tipsify.hidden #{_("Added")}
           %a{:class => "fr content_add_remove remove_content_view st_button hidden","data-display_name"=> view.name,
              "data-id" => view.id, "data-type" => "content_view", "data-promotable" => "#{!promoted}",
-             :id => "add_remove_content_view_#{view.id}"}
+             :id => "add_remove_content_view_#{view.id}", "data-block_delete" => "#{!current_env_version.deletable?(@environment)}"}
 
         - if promoted
           .fr.promoted


### PR DESCRIPTION
If we delete a content view from an environment the candlepin
environment gets deleted.  This results in all the candlepin consumers
being deleted.   Prevent this from happening.  While this is not the ideal
way, the promotion of content views should be changed soon and we can
address this better there.
