### PR TITLE
do not list files twice

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -655,13 +655,7 @@ usermod -a -G katello-shared tomcat
 %{homedir}/app/models/ext
 %{homedir}/app/models/roles_permissions
 %{homedir}/app/assets/
-%{homedir}/app/assets/stylesheets
-%{homedir}/app/assets/javascripts
-%{homedir}/app/assets/images
 %{homedir}/vendor
-%{homedir}/vendor/assets
-%{homedir}/vendor/assets/stylesheets
-%{homedir}/vendor/assets/images
 %{homedir}/app/views
 %{homedir}/autotest
 %{homedir}/ca
@@ -781,13 +775,7 @@ usermod -a -G katello-shared tomcat
 %exclude %{homedir}/lib/tasks/test.rake
 %exclude %{homedir}/lib/tasks/simplecov.rake
 %{homedir}/app/assets/
-%{homedir}/app/assets/stylesheets
-%{homedir}/app/assets/javascripts
-%{homedir}/app/assets/images
 %{homedir}/vendor
-%{homedir}/vendor/assets
-%{homedir}/vendor/assets/stylesheets
-%{homedir}/vendor/assets/images
 %{homedir}/app/views
 %{homedir}/autotest
 %{homedir}/ca


### PR DESCRIPTION
addressing:

```
Processing files: katello-1.4.2-1.git.678.21d7a4c.el6.noarch
warning: File listed twice: /usr/share/katello/app/assets/images
warning: File listed twice: /usr/share/katello/app/assets/images/3rd-level-bg.png
...
```
