### PR TITLE
System subscription status graph intermittently appears misaligned 

### DIFF
--- a/app/views/dashboard/_subscriptions.haml
+++ b/app/views/dashboard/_subscriptions.haml
@@ -7,6 +7,10 @@
                             {data:#{escape_javascript(owner_info.total_valid_compliance_consumers + owner_info.total_partial_compliance_consumers + owner_info.total_invalid_compliance_consumers == 0 ? "100" : owner_info.total_valid_compliance_consumers.to_s)}, color:"#9ccc50"}]; //green   valid
 
 #dashboard_subscriptions.widget
+  .right_side
+    #overlay
+    #sub_graph
+
   .left_side
     .line
     .stats
@@ -39,8 +43,3 @@
 
         %h4.fr
           #{_("Total Systems")}
-
-
-  .right_side
-    #overlay
-    #sub_graph


### PR DESCRIPTION
See screenshot:

![screenshot from 2013-06-06 10 38 55](https://f.cloud.github.com/assets/4116405/618548/14a40334-ceb7-11e2-8554-8958a5a8fb8d.png)

I was able to reproduce this in Chrome pretty reliably doing the following.

Tentative Steps to Reproduce:
1. Login to Katello
2. Go to the dashboard page
3. Copy the link in the location bar
4. Open a new tab, paste the link, and visit the page
5. Note misplaced graph
