### PR TITLE
subscriptions - suggested_quantity and instance_multiplier

### DIFF
--- a/app/assets/javascripts/systems/systems.js
+++ b/app/assets/javascripts/systems/systems.js
@@ -527,21 +527,21 @@ KT.subs = (function() {
                     value,
                     of_string;
 
-                if($(this).is(":checked")) {
+                spinner = $("#spinner_" + id);
+                if ($(this).is(":checked")) {
                     _checked += 1;
                     direction = "increment";
-                    value = 1;
+                    value = spinner.data("suggested");
                 } else {
                     _checked -= 1;
                     direction = "decrement";
                     value = 0;
                 }
-                spinner = $("#spinner_" + id);
-                if(spinner.length > 0) {
+                if (spinner.length > 0) {
                     if (spinner.attr("class") === "ui-spinner") {
-                        if((spinner.spinner("value") === 0 && direction === "increment") ||
-                           (spinner.spinner("value") !== 0 && direction === "decrement")) {
-                            spinner.spinner(direction);
+                        if ((spinner.spinner("value") === 0 && value > 0) ||
+                           (spinner.spinner("value") !== 0 && value === 0)) {
+                            spinner.spinner("value", value);
                         }
                     } else if (spinner.attr("class") === "ui-nonspinner") {
                         spinner.val(value);

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -227,10 +227,15 @@ class SystemsController < ApplicationController
     end
     consumed_entitlements = @system.consumed_entitlements
     avail_pools = @system.available_pools_full
-    render :partial=>"subs_update", :locals=>{:system=>@system, :avail_subs => avail_pools,
-                                              :consumed_subs => consumed_entitlements,
-                                              :editable=>@system.editable?}
+    render :partial => "subs_update",
+           :locals => { :system => @system,
+                        :avail_subs => avail_pools,
+                        :consumed_subs => consumed_entitlements,
+                        :editable => @system.editable? }
     notify.success _("System subscriptions updated.")
+  rescue RestClient::Exception => e
+    notify.error(JSON.parse(e.response)["displayMessage"])
+    render :text => "", :status => 500
   end
 
   def products

--- a/app/models/glue/candlepin/pool.rb
+++ b/app/models/glue/candlepin/pool.rb
@@ -133,10 +133,9 @@ module Glue::Candlepin::Pool
 
       @suggested_quantity = 1
       attrs['calculatedAttributes'].each_key do |key|
-        calc_attrs = attrs['calculatedAttributes']
         case key
           when 'suggested_quantity'
-            @suggested_quantity = calc_attrs['suggested_quantity'].to_i
+            @suggested_quantity = attrs['calculatedAttributes']['suggested_quantity'].to_i
         end
       end if attrs['calculatedAttributes']
     end

--- a/app/views/systems/_subs.html.haml
+++ b/app/views/systems/_subs.html.haml
@@ -116,7 +116,7 @@
                     = subscription_limits_helper(sub)
                   - if sub.multi_entitlement
                     %td
-                      = text_field_tag "spinner[#{sub.cp_id}]", nil, :min => 0, :max => (sub.quantity-sub.consumed), :step=>1, :value=>0, :class=>"ui-spinner"
+                      = text_field_tag "spinner[#{sub.cp_id}]", nil, :min => 0, :max => (sub.quantity - sub.consumed), :step => (sub.instance_multiplier ? sub.instance_multiplier : 1), :value => 0, :class => "ui-spinner", 'data-suggested' => sub.suggested_quantity
                       %span{:style => "padding-top:9px;"}
                         = "of #{sub.quantity - sub.consumed}"
                   - else
@@ -124,8 +124,8 @@
                       - if sub.quantity < 0
                         = _("Unlimited")
                       -else
-                        %div{:id=>"spinner_label_#{sub.cp_id}", :class=>"ui-nonspinner-label"} 0 of #{sub.quantity - sub.consumed}
-                      = hidden_field_tag "spinner[#{sub.cp_id}]", 0, :class => "ui-nonspinner"
+                        %div{:id => "spinner_label_#{sub.cp_id}", :class => "ui-nonspinner-label"} 0 of #{sub.quantity - sub.consumed}
+                      = hidden_field_tag "spinner[#{sub.cp_id}]", 0, :class => "ui-nonspinner", 'data-suggested' => sub.suggested_quantity
                   %td{:style => "padding-top:9px;"} #{format_time sub.start_date}
                   %td{:style => "padding-top:9px;"} #{format_time sub.end_date}
                 - sub.provided_products.each do |product|


### PR DESCRIPTION
including suggested_quantity and instance_multiplier into the "Available
Subscriptions" section for Systems.

If a subscription has an instance_multiplier > 1, then the  spinner's step
is set to that. The suggested_quantity is set into a spinner when a user
clicks that subscription's checkbox.
