### PR TITLE
issue 2513 - fix activation key subscriptions format issues

### DIFF
--- a/app/assets/javascripts/activation_keys/activation_key.js
+++ b/app/assets/javascripts/activation_keys/activation_key.js
@@ -167,9 +167,9 @@ KT.activation_key = (function($) {
         // toggle the expand/collapse arrow
         var arrow = data.find('img');
         if(arrow.attr("src").indexOf("collapsed") === -1){
-            arrow.attr("src", "icons/expander-collapsed.png");
+            arrow.attr("src", "assets/icons/expander-collapsed.png");
         } else {
-            arrow.attr("src", "icons/expander-expanded.png");
+            arrow.attr("src", "assets/icons/expander-expanded.png");
         }
     },
     toggle_usage_limit = function(checkbox) {

--- a/app/views/activation_keys/_subscriptions.html.haml
+++ b/app/views/activation_keys/_subscriptions.html.haml
@@ -1,4 +1,4 @@
-%table.filter_table
+%table.filter_table.clear
   %thead
     %tr
       %th #{_("Subscription")}


### PR DESCRIPTION
This commit addresses github issue #2513 where, activation keys subscriptions
tabs had the following issues:
1. format in firefox is bad, compared to chrome
2. the icon for the expander/collapser was not rendered properly
