### PR TITLE
978001 - add 'display_name' to rhsm environment listing

### DIFF
--- a/app/controllers/api/v1/environments_controller.rb
+++ b/app/controllers/api/v1/environments_controller.rb
@@ -119,16 +119,12 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
   api :GET, "/owners/:organization_id/environments", "List environments for RHSM"
   param_group :search_params
   def rhsm_index
-    if query_params.has_key?(:name)
-      # retrieve the requested environment
-      @all_environments = get_content_view_environments(query_params[:name]).
-          collect { |env| { :id          => env.cp_id, :name => env.label,
-                            :description => env.content_view.description } }
-    else
-      # retrieve the list of all environments
-      @all_environments = get_content_view_environments.collect { |env| { :id          => env.cp_id, :name => env.label,
-                                                                          :description => env.content_view.description } }
-    end
+    @all_environments = get_content_view_environments(query_params[:name]).
+        collect { |env| { :id  => env.cp_id,
+                          :name => env.label,
+                          :display_name => env.name,
+                          :description => env.content_view.description } }
+
     respond_for_index :collection => @all_environments
   end
 


### PR DESCRIPTION
When a system registers to katello using subscription manager,
the environment 'label' is used.  This is also what is shown
if a user lists the environments.

There are, however, cases where rhsm tools desire access
to the environment name.  Since we need to support the
existing interface where name=env.label, this commit will
add display_name=env.name to the rhsm api for environments.
