### PR TITLE
Use db:reset instead of db:migrate:reset to load db

### DIFF
--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -27,6 +27,6 @@ task :seed_with_logging => ["db:seed"] do
 end
 
 desc "task to perform steps required for katello to work"
-task :setup => ['environment', "clear_search_indices", "db:migrate:reset", "seed_with_logging"] do
+task :setup => ['environment', "clear_search_indices", "db:reset"] do
   puts "Database sucessfully recreated in #{Rails.env}"
 end

--- a/script/katello-reset-dbs
+++ b/script/katello-reset-dbs
@@ -150,7 +150,7 @@ echo "Initializing Katello database"
 # cannot use initdb for this (BZ 745542)
 pushd $KATELLO_HOME >/dev/null
 
-RAKE_TASKS=( 'clear_search_indices' 'db:migrate:reset' 'seed_with_logging' )
+RAKE_TASKS=( 'clear_search_indices' 'db:reset' )
 for i in ${RAKE_TASKS[@]};  do 
   RAILS_ENV=$KATELLO_ENV RAILS_RELATIVE_URL_ROOT=$KATELLO_PREFIX rake $i --trace  2>&1
 done


### PR DESCRIPTION
This is a change to use `db:reset` instead of `db:migrate:reset` to load db in katello-reset-dbs and setup.rake. It's a bit faster, simpler, and [it's the Rails recommended way of setting up your database from scratch](http://guides.rubyonrails.org/migrations.html#schema-dumping-and-you).

You'll notice that this is just seeding (`db:reset` calls `db:seed`) instead of running `seed_with_logging`. Looking at setup_sql.log, it doesn't look like anything is getting logged anyway with `seed_with_logging`. I think something is busted there. Regardless though, I'm thinking we probably don't need to log seeding in development environments but this can be changed back to using `seed_with_logging` if need be.

My next goal will be to move katello-configure over to this method (while still keeping katello-upgrade on migrate). This will be a sort of test ground for that. I think using this method will be better long term as creating a new database with migrations is a [Rube Goldberg machine](https://en.wikipedia.org/wiki/Rube_Goldberg_machine).
