### PR TITLE
runcible - increase to 0.4.11

### DIFF
--- a/bundler.d/pulp.rb
+++ b/bundler.d/pulp.rb
@@ -3,7 +3,7 @@
 if Katello.early_config.katello?
   group :pulp do
     # Pulp API bindings
-    gem 'runcible', '~> 0.4.10'
+    gem 'runcible', '~> 0.4.11'
     gem 'anemone'
   end
 end

--- a/katello.spec
+++ b/katello.spec
@@ -254,7 +254,7 @@ Requires:        pulp-server
 Requires:        pulp-rpm-plugins
 Requires:        pulp-selinux
 Requires:        createrepo = 0.9.9-18%{?dist}
-Requires:        %{?scl_prefix}rubygem(runcible) >= 0.4.10
+Requires:        %{?scl_prefix}rubygem(runcible) >= 0.4.11
 
 %description glue-pulp
 Katello connection classes for the Pulp backend


### PR DESCRIPTION
The new runcible provides support needed for 'update all' of
packages for a system or system group.
