### PR TITLE
Add katello-cli-tests-fakecert to comps

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -21,6 +21,7 @@
        <packagereq type="default">katello-cli-common</packagereq>
        <packagereq type="default">katello-cli-headpin</packagereq>
        <packagereq type="default">katello-cli-tests</packagereq>
+       <packagereq type="default">katello-cli-tests-fakecert</packagereq>
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-configure</packagereq>
        <packagereq type="default">katello-configure-foreman</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -21,6 +21,7 @@
        <packagereq type="default">katello-cli-common</packagereq>
        <packagereq type="default">katello-cli-headpin</packagereq>
        <packagereq type="default">katello-cli-tests</packagereq>
+       <packagereq type="default">katello-cli-tests-fakecert</packagereq>
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-configure</packagereq>
        <packagereq type="default">katello-configure-foreman</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -21,6 +21,7 @@
        <packagereq type="default">katello-cli-common</packagereq>
        <packagereq type="default">katello-cli-headpin</packagereq>
        <packagereq type="default">katello-cli-tests</packagereq>
+       <packagereq type="default">katello-cli-tests-fakecert</packagereq>
        <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-configure</packagereq>
        <packagereq type="default">katello-configure-foreman</packagereq>


### PR DESCRIPTION
This package makes it possible to import fake manifests with recent candlepin
versions, where the signature is required.

The subpackage was introduced here:

https://github.com/Katello/katello-cli/pull/46
