### PR TITLE
980523-user-env - always save user object in api update

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -107,9 +107,9 @@ class Api::V1::UsersController < Api::V1::ApiController
       #TODO: this should be placed in model validations
       if Katello.config.available_locales.include? user_params[:default_locale]
         @user.default_locale = user_params[:default_locale]
-        @user.save!
       end
     end
+    @user.save!
     respond
   end
 


### PR DESCRIPTION
Only user locale was ever saved previously via API
