### PR TITLE
Refresh systems index after modification through API

### DIFF
--- a/app/controllers/api/v1/system_groups_controller.rb
+++ b/app/controllers/api/v1/system_groups_controller.rb
@@ -277,7 +277,7 @@ class Api::V1::SystemGroupsController < Api::V1::ApiController
   # to make sure that the changes are reflected to elasticsearch immediately
   # otherwise the index action doesn't have to know about the changes
   def refresh_index
-    SystemGroup.index.refresh
+    SystemGroup.index.refresh if Katello.config.use_elasticsearch
   end
 
 end

--- a/app/controllers/api/v1/systems_controller.rb
+++ b/app/controllers/api/v1/systems_controller.rb
@@ -591,7 +591,7 @@ This information is then used for computing the errata available for the system.
   # to make sure that the changes are reflected to elasticsearch immediately
   # otherwise the index action doesn't have to know about the changes
   def refresh_index
-    System.index.refresh
+    System.index.refresh if Katello.config.use_elasticsearch
   end
 
 end

--- a/spec/controllers/api/v1/system_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/system_groups_controller_spec.rb
@@ -25,6 +25,8 @@ describe Api::V1::SystemGroupsController, :katello => true do
     disable_org_orchestration
     disable_consumer_group_orchestration
 
+    SystemGroup.stub(:index).and_return(stub.as_null_object)
+
     @org         = Organization.create!(:name => 'test_org', :label => 'test_org')
     @environment = KTEnvironment.create!(:name => 'test_1', :label => 'test_1', :prior => @org.library.id, :organization => @org)
 
@@ -114,6 +116,11 @@ describe Api::V1::SystemGroupsController, :katello => true do
         user_without_permissions
       end
       it_should_behave_like "protected action"
+
+      it "should refresh ES index" do
+        SystemGroup.index.should_receive(:refresh)
+        post :create, :organization_id => @org.label, :system_group => { :name => "foo", :description => "describe", :max_systems => 5 }
+      end
 
       it "should create a group correctly" do
         post :create, :organization_id => @org.label, :system_group => { :name => "foo", :description => "describe", :max_systems => 5 }
@@ -215,6 +222,11 @@ describe Api::V1::SystemGroupsController, :katello => true do
         user_without_permissions
       end
       it_should_behave_like "protected action"
+
+      it "should refresh ES index" do
+        SystemGroup.index.should_receive(:refresh)
+        put :update, :organization_id => @org.label, :id => @group.id, :system_group => { :name => "rocky" }
+      end
 
       it "should allow name to be changed" do
         old_name = @group.name

--- a/spec/controllers/api/v1/systems_controller_spec.rb
+++ b/spec/controllers/api/v1/systems_controller_spec.rb
@@ -50,6 +50,8 @@ describe Api::V1::SystemsController do
     disable_consumer_group_orchestration
     disable_system_orchestration
 
+    System.stub(:index).and_return(stub.as_null_object)
+
     Resources::Candlepin::Consumer.stub!(:create).and_return({ :uuid => uuid, :owner => { :key => uuid } })
     Resources::Candlepin::Consumer.stub!(:update).and_return(true)
     Resources::Candlepin::Consumer.stub!(:available_pools).and_return([])
@@ -92,6 +94,12 @@ describe Api::V1::SystemsController do
       System.should_receive(:create!).with(hash_including(content_view: view, environment: @environment_1, cp_type: "system", name: "test"))
       post :create, :organization_id => @organization.name, :environment_id => @environment_1.id, :name => 'test', :cp_type => 'system',
         :content_view_id => view.id
+    end
+
+    it "should refresh ES index" do
+      System.index.should_receive(:refresh)
+      System.stub(:create!).and_return({})
+      post :create, :organization_id => @organization.name, :environment_id => @environment_1.id, :name => 'test', :cp_type => 'system', :installedProducts => installed_products
     end
 
     context "in organization with one environment" do
@@ -213,6 +221,10 @@ describe Api::V1::SystemsController do
           System.last.content_view_id.should eql(content_view.id)
         end
 
+        it "should refresh ES index" do
+          System.index.should_receive(:refresh)
+          post :activate, @system_data
+        end
       end
 
       context "and they are not in the system" do
@@ -487,6 +499,11 @@ describe Api::V1::SystemsController do
       put :update, :id => uuid, :environment_id => @environment_2.id
       response.body.should == @sys.to_json
       response.should be_success
+    end
+
+    it "should refresh ES index" do
+      System.index.should_receive(:refresh)
+      put :update, :id => uuid, :name => "foo_name"
     end
 
   end


### PR DESCRIPTION
Addresses:

```
katello system register --name system --org=org --environment env
katello system info --name=system --org=org
Could not find System [ system ] in Org [ org ]
```

The problem was the elastic search was not updated before searching for the
newly created system.
