### PR TITLE
switch to a greater than or equals for createrepo.

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -255,7 +255,7 @@ Requires:        %{name}-common
 Requires:        pulp-server
 Requires:        pulp-rpm-plugins
 Requires:        pulp-selinux
-Requires:        createrepo = 0.9.9-18%{?dist}
+Requires:        createrepo >= 0.9.9-18%{?dist}
 Requires:        %{?scl_prefix}rubygem(runcible) >= 0.4.11
 
 %description glue-pulp


### PR DESCRIPTION
hard version requirements are horrible in that they often will break
yum updates since newer versions are available
