### PR TITLE
981311 - fix nested constraints with match routes

### DIFF
--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -56,7 +56,9 @@ Src::Application.routes.draw do
         resources :tasks, :only => [:index]
         resources :providers, :only => [:index], :constraints => { :organization_id => /[^\/]*/ }
 
-        match '/systems' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
+        scope :constraints => RegisterWithActivationKeyContraint.new do
+          match '/systems' => 'systems#activate', :via => :post
+        end
         resources :systems, :only => [:index, :create] do
           get :report, :on => :collection
 
@@ -248,7 +250,9 @@ Src::Application.routes.draw do
       end
 
       resources :environments, :only => [:show, :update, :destroy] do
-        match '/systems' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
+        scope :constraints => RegisterWithActivationKeyContraint.new do
+          match '/systems' => 'systems#activate', :via => :post
+        end
         resources :systems, :only => [:create, :index] do
           get :report, :on => :collection
         end
@@ -298,7 +302,9 @@ Src::Application.routes.draw do
       match "/version" => "ping#version", :via => :get
 
       # subscription-manager support
-      match '/consumers' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
+      scope :constraints => RegisterWithActivationKeyContraint.new do
+        match '/consumers' => 'systems#activate', :via => :post
+      end
       match '/hypervisors' => 'systems#hypervisors_update', :via => :post
       resources :consumers, :controller => 'systems'
       match '/owners/:organization_id/environments' => 'environments#rhsm_index', :via => :get

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -28,7 +28,9 @@ Src::Application.routes.draw do
         api_resources :sync_plans, :only => [:index, :create]
         api_resources :tasks, :only => [:index]
         api_resources :providers, :only => [:index], :constraints => { :organization_id => /[^\/]*/ }
-        match '/systems' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
+        scope :constraints => RegisterWithActivationKeyContraint.new do
+          match '/systems' => 'systems#activate', :via => :post
+        end
         api_resources :systems, :only => [:index, :create] do
           get :report, :on => :collection
 
@@ -194,7 +196,9 @@ Src::Application.routes.draw do
       end
 
       api_resources :environments, :only => [:show, :update, :destroy] do
-        match '/systems' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
+        scope :constraints => RegisterWithActivationKeyContraint.new do
+          match '/systems' => 'systems#activate', :via => :post
+        end
         api_resources :systems, :only => [:create, :index] do
           get :report, :on => :collection
         end
@@ -279,7 +283,9 @@ Src::Application.routes.draw do
       api_resources :crls, :only => [:index]
 
       # subscription-manager support
-      match '/consumers' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
+      scope :constraints => RegisterWithActivationKeyContraint.new do
+        match '/consumers' => 'systems#activate', :via => :post
+      end
       match '/hypervisors' => 'systems#hypervisors_update', :via => :post
       api_resources :consumers, :controller => 'systems'
       match '/owners/:organization_id/environments' => 'environments#rhsm_index', :via => :get


### PR DESCRIPTION
Due to bug in Rails, this code:

```
scope :module => :v2, :constraints => ApiVersionConstraint.new(:version => 2) do
  match '/systems' => 'systems#activate', :via => :post, :constraints => RegisterWithActivationKeyContraint.new
end
```

causes the version 2 of systems#activate to be used, even the version 2 is no
specified in headers (the nested constraints are not combined when using with
match.

This code works as expected:

```
scope :module => :v2, :constraints => ApiVersionConstraint.new(:version => 2) do
  scope :constraints => RegisterWithActivationKeyContraint.new do
    match '/systems' => 'systems#activate', :via => :post
  end
end
```
