### PR TITLE
Rspec: Setting the version of rspec to 2.13.0 to eliminate deprecation

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,6 +1,6 @@
 group :development do
   # <test gems> that are here to make things (rake) easier
-    gem 'rspec-rails', '>= 2.0.0'
+    gem 'rspec-rails', '~> 2.13.2'
     gem "parallel_tests"
   # </test gems>
 

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,6 +1,6 @@
 group :test do
   # (also appears in development group)
-  gem 'rspec-rails', '>= 2.0.0'
+  gem 'rspec-rails', '~> 2.13.2'
 
   gem 'webrat', '>=0.7.3'
   gem 'nokogiri', '>= 1.5.0'


### PR DESCRIPTION
warnings and allow Travis to complete.

This is a stop gap. If we wish to upgrade our version of Rspec we will need to cleanup all the deprecation messages.
