### PR TITLE
allow "." in org names

### DIFF
--- a/app/lib/validators/katello_name_format_validator.rb
+++ b/app/lib/validators/katello_name_format_validator.rb
@@ -15,8 +15,8 @@ module Validators
   class KatelloNameFormatValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       if value
-        unless value =~ /\A[[:alnum:] _-]*\z/
-          record.errors[attribute] << N_("cannot contain characters other than alpha numerals, space, '_', '-'")
+        unless value =~ /\A[[:alnum:] ._-]*\z/
+          record.errors[attribute] << N_("cannot contain characters other than alpha numerals, space, '_', '-', '.'")
         end
         NoTrailingSpaceValidator.validate_trailing_space(record, attribute, value)
         KatelloNameFormatValidator.validate_length(record, attribute, value)

--- a/test/lib/validators/katello_name_format_validator_test.rb
+++ b/test/lib/validators/katello_name_format_validator_test.rb
@@ -53,4 +53,10 @@ class KatelloNameFormatValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
     refute_empty @model.errors[:name]
   end
 
+  test "succeeds with dot" do
+    @validator.validate_each(@model, :name, "Weightlifting Dept.")
+
+    assert_empty @model.errors[:name]
+  end
+
 end


### PR DESCRIPTION
Previous versions of katello allowed "." in org names, but the validator was
changed to not accept this char.

This commit adds "." back in as a valid char, and alters the error message.
