### PR TITLE
975593 - Make name field validation consistent across entities, and use ...

### DIFF
--- a/app/lib/validators/katello_name_format_validator.rb
+++ b/app/lib/validators/katello_name_format_validator.rb
@@ -15,9 +15,6 @@ module Validators
   class KatelloNameFormatValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       if value
-        unless value =~ /\A[[:alnum:] ._-]*\z/
-          record.errors[attribute] << N_("cannot contain characters other than alpha numerals, space, '_', '-', '.'")
-        end
         NoTrailingSpaceValidator.validate_trailing_space(record, attribute, value)
         KatelloNameFormatValidator.validate_length(record, attribute, value)
       else
@@ -25,7 +22,7 @@ module Validators
       end
     end
 
-    def self.validate_length(record, attribute, value, max_length = 128, min_length = 1)
+    def self.validate_length(record, attribute, value, max_length = 255, min_length = 1)
       if value
         record.errors[attribute] << _("cannot contain more than %s characters") % max_length unless value.length <= max_length
         record.errors[attribute] << _("must contain at least %s character") % min_length unless value.length >= min_length

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -34,12 +34,12 @@ class Changeset < ActiveRecord::Base
                          :allow_blank => false,
                          :message     => "A changeset must have one of the following states: #{STATES.join(', ')}."
 
-  validates :name, :presence => true, :allow_blank => false, :length => { :maximum => 255 }
+  validates :name, :presence => true, :allow_blank => false
   validates_uniqueness_of :name, :scope => :environment_id, :message => N_("Label has already been taken")
   validates :environment, :presence => true
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_with Validators::NotInLibraryValidator
-
+  validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   has_and_belongs_to_many :products, :uniq => true
   has_many :packages, :class_name => "ChangesetPackage", :inverse_of => :changeset
   has_many :users, :class_name => "ChangesetUser", :inverse_of => :changeset

--- a/app/models/distributor.rb
+++ b/app/models/distributor.rb
@@ -38,6 +38,7 @@ class Distributor < ActiveRecord::Base
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_length_of :location, :maximum => 255
   validates_with Validators::ContentViewEnvironmentValidator
+  validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
   before_create  :fill_defaults
 

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -18,8 +18,8 @@ class Filter < ActiveRecord::Base
 
   validate :validate_products_and_repos
   validates :name, :presence => true, :allow_blank => false,
-              :length => { :maximum => 255 },
               :uniqueness => {:scope => :content_view_definition_id}
+  validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
   def self.applicable(repo)
     query = %{filters.id in (select filter_id from  filters_repositories where repository_id = #{repo.id})

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -48,6 +48,7 @@ class Repository < ActiveRecord::Base
   validates :label, :presence => true
   validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
   validates_with Validators::RepoDisablementValidator, :attributes => :enabled, :on => :update
+  validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
   validates_inclusion_of :content_type,
       :in => TYPES,

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -30,7 +30,7 @@ class Role < ActiveRecord::Base
 
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_with Validators::LockValidator, :on => :update
-
+  validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   #validates_associated :permissions
   accepts_nested_attributes_for :permissions, :allow_destroy => true
 

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -47,9 +47,9 @@ class System < ActiveRecord::Base
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_length_of :location, :maximum => 255
   validates_with Validators::ContentViewEnvironmentValidator
+  validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
   before_create  :fill_defaults
-
   after_create :init_default_custom_info
 
   scope :by_env, lambda { |env| where('environment_id = ?', env) unless env.nil?}

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -140,8 +140,8 @@ describe Product, :katello => true do
       disable_product_orchestration
     end
 
-    specify { Product.new(:label=> "goo", :name => 'contains /', :environments => [@organization.library], :provider => @provider).should_not be_valid }
-    specify { Product.new(:label=>"boo", :name => 'contains #', :environments => [@organization.library], :provider => @provider).should_not be_valid }
+    specify { Product.new(:label=> "goo", :name => 'contains /', :environments => [@organization.library], :provider => @provider).should be_valid }
+    specify { Product.new(:label=>"boo", :name => 'contains #', :environments => [@organization.library], :provider => @provider).should be_valid }
     specify { Product.new(:label=> "shoo", :name => 'contains space', :environments => [@organization.library], :provider => @provider).should be_valid }
     specify { Product.new(:label => "bar foo", :name=> "foo", :environments => [@organization.library], :provider => @provider).should_not be_valid}
 

--- a/test/lib/validators/katello_name_format_validator_test.rb
+++ b/test/lib/validators/katello_name_format_validator_test.rb
@@ -27,19 +27,41 @@ class KatelloNameFormatValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
     assert_empty @model.errors[:name]
   end
 
-  test "fails with HTML tag" do
+  test "succeeds with HTML tag" do
     @validator.validate_each(@model, :name, '<a href="">Test Name</a>')
 
-    refute_empty @model.errors[:name]
+    assert_empty @model.errors[:name]
   end
 
-  test "fails with more than 128 characters" do
+  test "fails with more than 255 characters" do
     cs = [*'0'..'9', *'a'..'z', *'A'..'Z']
-    random_string = 129.times.map { cs.sample }.join
+    random_string = 256.times.map { cs.sample }.join
     @validator.validate_each(@model, :name, random_string)
 
     refute_empty @model.errors[:name]
   end
+
+  test "succeeds with 255 characters" do
+    cs = [*'0'..'9', *'a'..'z', *'A'..'Z']
+    random_string = 255.times.map { cs.sample }.join
+    @validator.validate_each(@model, :name, random_string)
+
+    assert_empty @model.errors[:name]
+  end
+
+
+  test "succeeds with special characters" do
+    @validator.validate_each(@model, :name, '@!#$%^&*()')
+
+    assert_empty @model.errors[:name]
+  end
+
+  test "succeeds with special characters and html tag" do
+    @validator.validate_each(@model, :name, 'bar_+{}|"?<blink>hi</blink>')
+
+    assert_empty @model.errors[:name]
+  end
+
 
   test "fails if blank" do
     @validator.validate_each(@model, :name, '')


### PR DESCRIPTION
...the non-html validator

Removed all the constraints on name field to allow all characters.Added test cases to test
all the scenarios and modified existing testcases as per requirement.
