### PR TITLE
Renamed the migration class TaskStatus to not mix with model

### DIFF
--- a/db/migrate/20110711195621_create_task_status.rb
+++ b/db/migrate/20110711195621_create_task_status.rb
@@ -1,4 +1,4 @@
-class TaskStatus < ActiveRecord::Migration
+class CreateTaskStatus < ActiveRecord::Migration
   def self.up
     create_table :task_statuses do |t|
       t.string :type

--- a/db/migrate/20130604124100_update_task_statuses.rb
+++ b/db/migrate/20130604124100_update_task_statuses.rb
@@ -1,4 +1,4 @@
-class TaskStatuses < ActiveRecord::Migration
+class UpdateTaskStatuses < ActiveRecord::Migration
   def self.up
     change_column :task_statuses, :organization_id, :integer, :null => true
   end


### PR DESCRIPTION
Renamed the migration class TaskStatus to not mix with model
