### PR TITLE
adding new signal trap that allows a sysadmin to dump threads

### DIFF
--- a/config/initializers/sig_ttin_trap.rb
+++ b/config/initializers/sig_ttin_trap.rb
@@ -1,6 +1,6 @@
 # This initalizer overrides the TTIN signal:
 #   http://www.gnu.org/software/coreutils/manual/html_node/Signal-specifications.html
-#   TTIN - Background process attempting read. 
+#   TTIN - Background process attempting read.
 # This signal is not used with the thin server so we can override and add our additional
 # behavior.  if/when we switch to Passenger we can use their existing ABRT (SIGABRT) trap
 # which prints a threaddump and backtrace


### PR DESCRIPTION
Dumps the threads to the thin log file with a:

kill -TTIN <thin pid>
