### PR TITLE
Content Search: expanding the row header column

### DIFF
--- a/app/assets/stylesheets/content_search.scss
+++ b/app/assets/stylesheets/content_search.scss
@@ -13,7 +13,7 @@ $comparison_grid_header_h2-height:  45px;
 $comparison_grid_column_header-height:  35px;
 $comparison_grid_header-height: $comparison_grid_header_h2-height + $comparison_grid_column_header-height + 20;
 $comparison_grid-height: 350px;
-$comparison_grid_filter-width: 190px - 2px;
+$comparison_grid_filter-width: 192px - 2px;
 $comparison_grid_column_1-width: 100px - 10px - 1px;
 $comparison_grid_column_2-width: 200px - 10px - 1px;
 $comparison_grid_column_3-width: 300px - 10px - 1px;


### PR DESCRIPTION
This is for Chrome. This makes the comparison grid 2 pixels wider but the width of their container div remains the same (at 1152px).

**Before**
![image](https://f.cloud.github.com/assets/86290/812211/20557866-eeec-11e2-8ec2-f9b1180107f3.png)

**After**
![image](https://f.cloud.github.com/assets/86290/812205/0dee71be-eeec-11e2-918c-5e95d90a2dc7.png)
