### PR TITLE
985444-clean-cp-json - remove hibernate fields from candlepin json

### DIFF
--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -214,7 +214,19 @@ module Glue::Candlepin::Consumer
 
     def convert_from_cp_fields(cp_json)
       cp_json.merge(:cp_type => cp_json.delete(:type)) if cp_json.has_key?(:type)
-      reject_db_columns(cp_json)
+      cp_json = reject_db_columns(cp_json)
+
+      cp_json[:guestIds] = remove_hibernate_fields(cp_json[:guestIds]) if cp_json.has_key?(:guestIds)
+      cp_json[:installedProducts] = remove_hibernate_fields(cp_json[:installedProducts]) if cp_json.has_key?(:installedProducts)
+
+      cp_json
+    end
+
+    # Candlepin sends back its internal hibernate fields in the json. However it does not accept them in return
+    # when updating (PUT) objects.
+    def remove_hibernate_fields(elements)
+      return nil if !elements
+      elements.collect{ |e| e.except(:id, :created, :updated)}
     end
 
     def reject_db_columns(cp_json)

--- a/app/models/glue/candlepin/product.rb
+++ b/app/models/glue/candlepin/product.rb
@@ -136,8 +136,16 @@ module Glue::Candlepin::Product
     def convert_from_cp_fields(cp_json)
       ar_safe_json = cp_json.has_key?(:attributes) ? cp_json.merge(:attrs => cp_json.delete(:attributes)) : cp_json
       ar_safe_json[:productContent] = ar_safe_json[:productContent].collect { |pc| ::Candlepin::ProductContent.new(pc, self.id) }
-      ar_safe_json[:attrs] ||=[]
+      ar_safe_json[:attrs] = remove_hibernate_fields(cp_json[:attrs]) if ar_safe_json.has_key?(:attrs)
+      ar_safe_json[:attrs] ||= []
       ar_safe_json.except('id')
+    end
+
+    # Candlepin sends back its internal hibernate fields in the json. However it does not accept them in return
+    # when updating (PUT) objects.
+    def remove_hibernate_fields(elements)
+      return nil if !elements
+      elements.collect{ |e| e.except(:id, :created, :updated)}
     end
 
     def add_content content

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -119,7 +119,7 @@ describe Product, :katello => true do
       end
 
       it "should have the value of 'arch' attribute" do
-        Resources::Candlepin::Product.stub!(:get).and_return([ProductTestData::SIMPLE_PRODUCT.merge(:attributes => [{:name => 'arch', :value => 'i386'}])])
+        Resources::Candlepin::Product.stub!(:get).and_return([ProductTestData::SIMPLE_PRODUCT.merge(:attrs => [{:name => 'arch', :value => 'i386'}])])
         Product.find(@p.id).arch.should == 'i386'
       end
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=985444

Candlepin sends back its internal hibernate fields in the json. However it does not accept them in return
when updating (PUT) objects.
