### PR TITLE
Fixed sys controller to work with content view id

### DIFF
--- a/app/controllers/api/v1/systems_controller.rb
+++ b/app/controllers/api/v1/systems_controller.rb
@@ -541,6 +541,7 @@ This information is then used for computing the errata available for the system.
       else
         # assumption here is :content_view_id is passed as a separate attrib
         @environment = KTEnvironment.find(params[:environment_id])
+        @organization = @environment.organization
         raise HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
       end
       return @environment, @content_view
@@ -603,6 +604,7 @@ This information is then used for computing the errata available for the system.
     return if @content_view
     organization = @organization
     organization ||= @system.organization if @system
+    organization ||= @environment.organization if @environment
     if cv_id && organization
       @content_view = ContentView.readable(organization).find_by_id(cv_id)
       raise HttpErrors::NotFound, _("Couldn't find content view '%s'") % cv_id if @content_view.nil?


### PR DESCRIPTION
One of the ways to register a system is to directly send
it a content view as a separate param. There was a
minor bug in the system controller that didnot handle that aspect
correctly. So fixed that.
