### PR TITLE
Added elastic search if to help with migration

### DIFF
--- a/app/models/content_view_definition.rb
+++ b/app/models/content_view_definition.rb
@@ -161,7 +161,7 @@ class ContentViewDefinition < ContentViewDefinitionBase
     repos.each do |repo|
       repo.purge_empty_groups_errata
       # update search indices for package and errata
-      repo.index_content
+      repo.index_content if Katello.config.use_elasticsearch
     end
   end
 

--- a/app/models/pulp_task_status.rb
+++ b/app/models/pulp_task_status.rb
@@ -13,7 +13,7 @@
 
 
 class PulpTaskStatus < TaskStatus
-  use_index_of TaskStatus
+  use_index_of TaskStatus if Katello.config.use_elasticsearch
 
   def refresh
     PulpTaskStatus.refresh(self)


### PR DESCRIPTION
During a katello-upgrade we turn off elastic search
before we run a db:migrate. This implies that all the
migration scripts should be able to run without elastic search
support. However the legacy promotion migration does things like
publish content view definitions which run calls on elastic.
So needed to add if Katello.config.use_elasticsearch lines
in the model to make sure that code is only executed when
elastic search is turned on. The upgrade script automatically
runs a reindex operation after completing the db migration in any case.
