### PR TITLE
allow system updates to handle lastCheckin

### DIFF
--- a/app/controllers/api/v1/systems_controller.rb
+++ b/app/controllers/api/v1/systems_controller.rb
@@ -166,7 +166,7 @@ Schedules the consumer identity certificate regeneration
     attrs = params.clone
     slice_attrs = [:name, :description, :location,
                    :facts, :guestIds, :installedProducts,
-                   :releaseVer, :serviceLevel
+                   :releaseVer, :serviceLevel, :lastCheckin
                    ]
     unless User.consumer?
       slice_attrs =  slice_attrs + [:environment_id, :content_view_id]

--- a/app/lib/resources/candlepin.rb
+++ b/app/lib/resources/candlepin.rb
@@ -112,7 +112,7 @@ module Resources
         end
 
         def update(uuid, facts, guest_ids = nil, installed_products = nil, autoheal = nil, release_ver = nil,
-                   service_level=nil, environment_id=nil, capabilities=nil)
+                   service_level=nil, environment_id=nil, capabilities=nil, last_checkin = nil)
           attrs = {:facts => facts,
                    :guestIds => guest_ids,
                    :releaseVer => release_ver,
@@ -120,7 +120,8 @@ module Resources
                    :autoheal => autoheal,
                    :serviceLevel => service_level,
                    :environment => environment_id.nil? ? nil : {:id => environment_id},
-                   :capabilities => capabilities
+                   :capabilities => capabilities,
+                   :lastCheckin => last_checkin
                   }.delete_if { |k,v| v.nil? }
           unless attrs.empty?
             response = self.put(path(uuid), attrs.to_json, self.default_headers).body

--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -114,7 +114,7 @@ module Glue::Candlepin::Consumer
     def update_candlepin_consumer
       Rails.logger.debug "Updating consumer in candlepin: #{name}"
       Resources::Candlepin::Consumer.update(self.uuid, @facts, @guestIds, @installedProducts, @autoheal,
-                                            @releaseVer, self.serviceLevel, self.cp_environment_id, @capabilities)
+                                            @releaseVer, self.serviceLevel, self.cp_environment_id, @capabilities, @lastCheckin)
     rescue => e
       Rails.logger.error "Failed to update candlepin consumer #{name}: #{e}, #{e.backtrace.join("\n")}"
       raise e

--- a/spec/controllers/api/v1/systems_controller_spec.rb
+++ b/spec/controllers/api/v1/systems_controller_spec.rb
@@ -463,7 +463,7 @@ describe Api::V1::SystemsController do
     it "should update installed products" do
       @sys.facts = {}
       @sys.stub(:guest => 'false', :guests => [])
-      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, installed_products, nil, nil, nil, anything, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, installed_products, nil, nil, nil, anything, nil, nil).and_return(true)
       put :update, :id => uuid, :installedProducts => installed_products
       response.body.should == @sys.to_json
       response.should be_success
@@ -472,16 +472,26 @@ describe Api::V1::SystemsController do
     it "should update releaseVer" do
       @sys.facts = {}
       @sys.stub(:guest => 'false', :guests => [])
-      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, nil, nil, "1.1", nil, anything, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, nil, nil, "1.1", nil, anything, nil, nil).and_return(true)
       put :update, :id => uuid, :releaseVer => "1.1"
       response.body.should == @sys.to_json
       response.should be_success
     end
 
+    it "should update lastCheckin" do
+        @sys.facts = {}
+        @sys.stub(:guest => 'false', :guests => [])
+        timestamp = 3.days.ago
+        Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, nil, nil, nil, nil, anything, nil, timestamp.strftime('%F %T')).and_return(true)
+        put :update, :id => uuid, :lastCheckin => timestamp
+        response.body.should == @sys.to_json
+        response.should be_success
+    end
+
     it "should update service level agreement" do
       @sys.facts = {}
       @sys.stub(:guest => 'false', :guests => [])
-      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, nil, nil, nil, "SLA", anything, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, nil, nil, nil, "SLA", anything, nil, nil).and_return(true)
       put :update, :id => uuid, :serviceLevel => "SLA"
       response.body.should == @sys.to_json
       response.should be_success
@@ -492,7 +502,7 @@ describe Api::V1::SystemsController do
       @sys.facts = {}
       @sys.stub(:guest => 'false', :guests => [], :environment => @environment_2)
       Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {}, nil, nil, nil, nil, nil,
-                                                            "#{@environment_2.id}-#{@sys.content_view.id}", nil).and_return(true)
+                                                            "#{@environment_2.id}-#{@sys.content_view.id}", nil, nil).and_return(true)
       put :update, :id => uuid, :environment_id => @environment_2.id
       response.body.should == @sys.to_json
       response.should be_success
@@ -502,7 +512,7 @@ describe Api::V1::SystemsController do
       promote_content_view(@sys.content_view, @environment_1, @environment_2)
       @sys.capabilities = {:name => 'cores'}
       @sys.stub(:guest => 'false', :guests => [])
-      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {"sockets" => 0}, nil, nil, nil, nil, nil, anything, {:name => "cores"}).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {"sockets" => 0}, nil, nil, nil, nil, nil, anything, {:name => "cores"}, nil).and_return(true)
       put :update, :id => uuid, :environment_id => @environment_2.id
       response.body.should == @sys.to_json
       response.should be_success

--- a/spec/models/system_spec.rb
+++ b/spec/models/system_spec.rb
@@ -174,14 +174,14 @@ describe System do
     it "should give facts to Resources::Candlepin::Consumer" do
       @system.facts = facts
       @system.installedProducts = nil # simulate it's not loaded in memory
-      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, facts, nil, nil, nil, nil, nil, anything, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, facts, nil, nil, nil, nil, nil, anything, nil, nil).and_return(true)
       @system.save!
     end
 
     it "should give installeProducts to Resources::Candlepin::Consumer" do
       @system.installedProducts = installed_products
       @system.facts = nil # simulate it's not loaded in memory
-      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, installed_products, nil, nil, nil, anything, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, nil, nil, installed_products, nil, nil, nil, anything, nil, nil).and_return(true)
       @system.save!
     end
 


### PR DESCRIPTION
Candlepin now allows an optional arbitrary last checkin time to be set on the
consumer json. This change allows the lastCheckin attribute to pass through to
cp.

Also thanks to @daviddavis for helping me with the spec test! :icecream: 
