### PR TITLE
convert memory totals to strings before parsing

### DIFF
--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -353,7 +353,7 @@ module Glue::Candlepin::Consumer
       else
         mem = '0'
       end
-      memory_in_gigabytes(mem)
+      memory_in_gigabytes(mem.to_s)
     end
 
     def memory=(mem)

--- a/spec/controllers/api/v1/systems_controller_spec.rb
+++ b/spec/controllers/api/v1/systems_controller_spec.rb
@@ -498,6 +498,15 @@ describe Api::V1::SystemsController do
       response.should be_success
     end
 
+    it "handle memory as int" do
+      @sys.facts = {'memory.memtotal' => 20000}
+      @sys.stub(:guest => 'false', :guests => [])
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {'memory.memtotal' => 20000}, nil, nil, nil, nil, nil, anything, nil).and_return(true)
+      put :update, :id => uuid
+      response.body.should == @sys.to_json
+      response.should be_success
+    end
+
     it "should update capabilities", :katello => true  do
       promote_content_view(@sys.content_view, @environment_1, @environment_2)
       @sys.capabilities = {:name => 'cores'}

--- a/test/glue/candlepin/consumer_test.rb
+++ b/test/glue/candlepin/consumer_test.rb
@@ -109,6 +109,8 @@ class GlueCandlepinConsumerTestSystem < GlueCandlepinConsumerTestBase
 
     @@sys.memory = 'abc'
     assert_equal 0, @@sys.memory
+    @@sys.facts['memory.memtotal'] = 3145728 # 3MB
+    assert_equal 3, @@sys.memory
   end
 
   def test_candlepin_system_export


### PR DESCRIPTION
Previously, the memory.memtotal fact was assumed to be a string, and was being
parsed as such. However, there are cases when the fact will be a number, which
would break memory_in_gigabytes().

Instead, convert the argument to memory_in_gigabytes() to a string before parsing.
