### PR TITLE
fix spec test that expects wrong number of args

### DIFF
--- a/spec/controllers/api/v1/systems_controller_spec.rb
+++ b/spec/controllers/api/v1/systems_controller_spec.rb
@@ -511,7 +511,8 @@ describe Api::V1::SystemsController do
     it "handle memory as int" do
       @sys.facts = {'memory.memtotal' => 20000}
       @sys.stub(:guest => 'false', :guests => [])
-      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {'memory.memtotal' => 20000}, nil, nil, nil, nil, nil, anything, nil).and_return(true)
+      Resources::Candlepin::Consumer.should_receive(:update).once.with(uuid, {'memory.memtotal' => 20000}, nil,
+                                                                            nil, nil, nil, nil, anything, nil, nil).and_return(true)
       put :update, :id => uuid
       response.body.should == @sys.to_json
       response.should be_success


### PR DESCRIPTION
https://github.com/Katello/katello/pull/2662 worked against master, but expected the wrong # of args after 2661 was merged. Fixing the expected arg count.
