### PR TITLE
system-crosslink - host and guest systems now pulled from katello db

### DIFF
--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -34,13 +34,15 @@ module Glue::Candlepin::Consumer
       lazy_accessor :pools, :initializer => lambda {|s| entitlements.collect { |ent| Resources::Candlepin::Pool.find ent["pool"]["id"]} }
       lazy_accessor :available_pools, :initializer => lambda {|s| Resources::Candlepin::Consumer.available_pools(uuid, false) }
       lazy_accessor :all_available_pools, :initializer => lambda {|s| Resources::Candlepin::Consumer.available_pools(uuid, true) }
-      lazy_accessor :host, :initializer => lambda {|s|
+      lazy_accessor :host, :initializer => lambda { |s|
         host_attributes = Resources::Candlepin::Consumer.host(self.uuid)
-        System.new(host_attributes) if host_attributes
+        (System.find_by_uuid(host_attributes['uuid']) || System.new(host_attributes)) if host_attributes
       }
-      lazy_accessor :guests, :initializer => lambda {|s|
+      lazy_accessor :guests, :initializer => lambda { |s|
         guests_attributes = Resources::Candlepin::Consumer.guests(self.uuid)
-        guests_attributes.map { |attr| System.new(attr) }
+        guests_attributes.map do |attr|
+          System.find_by_uuid(attr['uuid']) || System.new(attr)
+        end
       }
       lazy_accessor :compliance, :initializer => lambda {|s| Resources::Candlepin::Consumer.compliance(uuid) }
       lazy_accessor :events, :initializer => lambda {|s| Resources::Candlepin::Consumer.events(uuid) }

--- a/app/views/systems/_edit.html.haml
+++ b/app/views/systems/_edit.html.haml
@@ -201,7 +201,14 @@
               = label :host_guest, :host, _("Host")
             .input
               %span.value
-                = system.host ? system.host.attributes['name'] : _("Unknown")
+                - if system.host
+                  - if system.host.id
+                    = link_to(system.host.attributes['name'],
+                                        systems_path(:anchor => "/!=&panel=system_#{system.host.id}"))
+                  - else
+                    = system.host.attributes['name']
+                - else
+                  = _("Unknown")
           -else
             .label
               = label :host_guest, :guest, _("Guests")
@@ -213,6 +220,10 @@
                   %ul
                   - system.guests.each do |guest|
                     %li{:style=>'list-style: none;'}
-                      = guest.attributes['name']
+                      - if guest.id
+                        = link_to(guest.attributes['name'],
+                                  systems_path(:anchor => "/!=&panel=system_#{guest.id}"))
+                      - else
+                        = guest.attributes['name']
 
 = render :template => "layouts/tupane_layout"


### PR DESCRIPTION
In order to correctly crosslink host/guest, the katello ID must be available. 
