### PR TITLE
Setting Rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ require 'katello/load_configuration'
 # With a pull request, send also link to our (or Fedora) koji with RPMs.
 source 'http://rubygems.org'
 
-gem 'rails', '~> 3.2.8'
+gem 'rails', '~> 3.2.8', "< 3.2.14"
 gem 'json'
 gem 'rabl'
 gem 'rest-client', :require => 'rest_client'


### PR DESCRIPTION
Setting the Rails version in Gemfile. Our code seems to hit errors when running against Rails 3.2.14.

```
    ActiveRecord::ConfigurationError:
       Association named 'provider' was not found on Provider; perhaps you misspelled it?
     # ./app/models/authorization/product.rb:22:in `block (2 levels) in <module:Product>'
     # ./app/models/authorization/repository.rb:43:in `content_readable'
     # ./app/models/authorization/repository.rb:36:in `libraries_content_readable'
     # ./app/controllers/content_search_controller.rb:577:in `process_repos'
     # ./app/controllers/content_search_controller.rb:100:in `packages'
     # ./app/lib/util/thread_session.rb:104:in `thread_locals'
     # ./spec/controllers/content_search_controller_spec.rb:81:in `block (6 levels) in <top (required)>'
```
