### PR TITLE
975593(username) -  Make name field validation consistent across entities, and use the non-html validator

### DIFF
--- a/app/lib/validators/username_validator.rb
+++ b/app/lib/validators/username_validator.rb
@@ -14,7 +14,6 @@ module Validators
   class UsernameValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       if value
-        record.errors[attribute] << N_("cannot contain characters >, <, or /") if value =~ %r{<|>|/}
         KatelloNameFormatValidator.validate_length(record, attribute, value, 128, 3)
       end
     end

--- a/test/lib/validators/username_validator_test.rb
+++ b/test/lib/validators/username_validator_test.rb
@@ -26,10 +26,10 @@ class UsernameValidatorTest < MiniTest::Rails::ActiveSupport::TestCase
     assert_empty @model.errors[:name]
   end
 
-  test "fails with HTML tag" do
+  test "succeeds with HTML tag" do
     @validator.validate_each(@model, :name, '<a href="">Test Name</a>')
 
-    refute_empty @model.errors[:name]
+    assert_empty @model.errors[:name]
   end
 
   test "fails with more than 128 characters" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -75,10 +75,10 @@ class UserCreateTest < UserTestBase
     assert_includes @user.errors, :password
   end
 
-  def test_create_with_bad_username
-    @user.username = 'bad_<blink>hacker</blink>'
-    assert !@user.save
-    assert_includes @user.errors, :username
+  def test_create_with_htmlchars_username
+    @user.username = 'html_char_<blink>hacker</blink>'
+    assert @user.save
+    refute_includes @user.errors, :username
   end
 
   def test_create_with_long_username


### PR DESCRIPTION
Removed the constraint from username_validator for < > /.Altered existing test cases for the same.
