### PR TITLE
987909 - Org names rendered as HTML

### DIFF
--- a/app/assets/javascripts/common/jquery.jeditable.custominputs.js
+++ b/app/assets/javascripts/common/jquery.jeditable.custominputs.js
@@ -13,6 +13,11 @@
 
 $(document).ready(function() {
 
+    // override textfield
+    $.editable.types.text.content = function(string, settings, original) {
+        $(':input:first', this).val($("<div/>").html(string).text());
+    };
+
     // override textarea
     $.editable.types.textarea.content = function(string, settings, original) {
         $(':input:first', this).val($("<div/>").html(string).text());

--- a/app/assets/javascripts/widgets/jquery.jeditable.helpers.js
+++ b/app/assets/javascripts/widgets/jquery.jeditable.helpers.js
@@ -99,7 +99,13 @@ KT.editable = (function(){
                     type        :  'text',
                     data        :  null,
                     width       :  270,
-                    name        :  $(this).attr('name')
+                    name        :  $(this).attr('name'),
+                    onsuccess   : function(result, status, xhr) {
+                        element.text(KT.utils.unescape(result)); // hax
+                    },
+                    onerror     : function(settings, original, xhr) {
+                        original.reset();
+                    }
                 };
                 $(this).editable($(this).attr('data-url'), $.extend(common_settings, settings));
             });

--- a/app/lib/notifications/notifier.rb
+++ b/app/lib/notifications/notifier.rb
@@ -122,6 +122,7 @@ class Notifications::Notifier
   def notice(notices, options = { })
     options = process_options options
     notices = [*notices].compact
+    notices.collect! { |n| n.gsub(/[\<\>]/, '<' => '&lt;', '>' => '&gt;') }
 
     unless options[:asynchronous]
       # On a sync request, the client should expect to receive a notification


### PR DESCRIPTION
making sure ORG name is escaped if it has HTML characters in its name.

this includes changes to jeditable's default text.content function and a quick
substitution of characters in displayed notices
