### PR TITLE
Nutupane: fix alignment of details panel to table header.

### DIFF
--- a/app/assets/stylesheets/widgets/nutupane.scss
+++ b/app/assets/stylesheets/widgets/nutupane.scss
@@ -15,7 +15,6 @@ tbody {
 }
 
 table.details-visible {
-  display: block;
   width: 20%;
   float: left;
 }
@@ -118,8 +117,7 @@ input {
 .nutupane-details-open {
   @include transition(background-color 1.25s ease-in-out);
   display: block;
-  float: left;
-  width: 79.8%;
+  width: inherit;
   opacity: 1;
   border-radius: 0;
 }


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/4116405/863504/c622fa96-f60a-11e2-8d42-705e66908e70.png)

Notice the right side of the 

After:
![after](https://f.cloud.github.com/assets/4116405/863508/cdbaef84-f60a-11e2-857b-2829759e208a.png)
