### PR TITLE
distributor-ui - fix distributor UI and version

### DIFF
--- a/app/assets/javascripts/distributors/distributor_edit.js
+++ b/app/assets/javascripts/distributors/distributor_edit.js
@@ -11,79 +11,8 @@
  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 */
 
-update_content_views = function(env_id) {
-    // update content view options
-    $.ajax({  url: KT.routes.content_views_environment_path(env_id),
-              type: "GET",
-              success: function(data) {
-                  options = {'': ''};
-                  $.each(data, function(key, value) {
-                       options[value.id] = value.name;
-                  });
-                  $("#distributor_content_view").data("options", options);
-              }
-            });
-};
-
-
 $(document).ready(function() {
 
-    var select_settings = {
-        select_mode:'single',
-        submit_button_text: i18n.save,
-        cancel_button_text: i18n.cancel,
-        activate_on_click: true,
-        library_select: true
-    };
-    path_select = KT.path_select('environment_path_selector', 'edit_select_distributor_environment', KT.available_environments,
-        select_settings);
-
-    $(document).bind(path_select.get_submit_event(), function(event, environments) {
-        var selected_env_ids = KT.utils.values(path_select.get_selected());
-        if (selected_env_ids.length < 1) {
-            return;
-        }
-
-        var selector_element = $('#environment_path_selector');
-        selector_element.find(".KT_path_select_submit_button").attr('disabled', 'disabled');
-
-        var request = $.ajax({
-            url: selector_element.attr('data-url'),
-            type: 'PUT',
-            data: {'distributor[environment_id]': selected_env_ids[0]['id'], authenticity_token: AUTH_TOKEN}
-        });
-
-        // disable the field temporarily
-        $("#distributor_content_view").hide();
-
-        request.done(function(msg) {
-            selector_element.find('span:first').text(selected_env_ids[0]['name']);
-
-            panel_element = $('input[data-ajax_url="' + selector_element.attr('data-url') + '"]');
-            KT.panel.list.refresh(panel_element.attr('value'), panel_element.attr('data-ajax_url'));
-
-            path_select.hide();
-            selector_element.find(".KT_path_select_submit_button").removeAttr('disabled');
-
-            path_select.clear_selected();
-            notices.checkNotices();
-
-            update_content_views(selected_env_ids[0]['id']);
-            if($("#distributor_content_view").text() !== i18n.clickToEdit) {
-                alert(i18n.contentViewReset);
-                $("#distributor_content_view").text(i18n.clickToEdit);
-            }
-        });
-
-        request.fail(function(jqXHR, textStatus) {
-            path_select.hide();
-            selector_element.find(".KT_path_select_submit_button").removeAttr('disabled');
-
-            path_select.clear_selected();
-            notices.checkNotices();
-            $("#distributor_content_view").show();
-        });
-    });
 });
 
 

--- a/app/assets/javascripts/distributors/index.js
+++ b/app/assets/javascripts/distributors/index.js
@@ -17,5 +17,7 @@
 //= require "alchemy/jquery/plugins/chosen.jquery"
 //= require "alchemy/jquery/plugins/jquery.treeTable"
 //= require "widgets/auto_complete"
+//= require "widgets/env_content_view_selector"
+//= require "widgets/jquery.jeditable.helpers"
 //= require "distributors/distributors"
 //= require "systems/custom_info"

--- a/app/assets/javascripts/widgets/path_selector.js
+++ b/app/assets/javascripts/widgets/path_selector.js
@@ -99,12 +99,6 @@ KT.path_select = function(div_id, name, environments, options_in){
                 }
             }
 
-            $(document).mouseup(function(e){
-                if(path_selector.has(e.target).length === 0){
-                    path_selector.hide();
-                }
-            });
-
             scroll_obj = KT.env_select_scroll({});
             recalc_scroll();
         },

--- a/app/assets/stylesheets/distributors.scss
+++ b/app/assets/stylesheets/distributors.scss
@@ -2,11 +2,11 @@
 
 #distributors {
   .path_selector {
+    @include border-radius(4px);
     top: auto;
   }
   table {
     margin-bottom: 4px;
-    width: 100%;
     td {
       &.package_select {
           width: 29px;

--- a/app/helpers/distributors_helper.rb
+++ b/app/helpers/distributors_helper.rb
@@ -51,22 +51,17 @@ module DistributorsHelper
     views = ContentView.readable(org).non_default.in_environment(env)
     choices = views.map {|v| [v.name, v.id]}
     select(:distributor, "content_view_id", choices,
-             {:prompt => no_content_view, :id=>"content_view_field"},
+             {:id=>"content_view_field"},
              {:tabindex => 2})
   end
 
   def distributor_content_view_opts(distributor)
     keys = {}
-    if distributor.environment
-      content_views = distributor.environment.content_views.subscribable(current_organization)
-    else
-      content_views = ContentView.subscribable(current_organization)
-    end
-    content_views.non_default.each do |view|
-      keys[view.id] = view.name
+    distributor.environment.content_views.subscribable(current_organization).each do |view|
+      keys[view.id] = view.default? ? _('Default View') : view.name
     end
     keys[""] = ""
-    keys["selected"] = @distributor.content_view_id || ""
+    keys["selected"] = distributor.content_view_id || ""
 
     keys.to_json
   end

--- a/app/models/authorization/distributor.rb
+++ b/app/models/authorization/distributor.rb
@@ -44,12 +44,10 @@ module Authorization::Distributor
       end
     end
 
-    def registerable?(env, org)
-      if env
-        env.distributors_registerable?
-      else
-        org.distributors_registerable?
-      end
+    def registerable?(env, org, content_view=nil)
+      subscribable = content_view ? content_view.subscribable? : true
+      registerable = (env || org).distributors_registerable?
+      subscribable && registerable
     end
   end
 

--- a/app/views/distributors/_edit.html.haml
+++ b/app/views/distributors/_edit.html.haml
@@ -1,6 +1,9 @@
 = javascript do
   :plain
+    KT.current_environment_id = #{distributor.environment_id};
     KT.available_environments = $.parseJSON('#{escape_javascript(environments.to_json)}');
+    KT.current_content_view_id = #{distributor.content_view_id || -1};
+    KT.available_content_views = $.parseJSON('#{escape_javascript(distributor.environment.content_views.readable(current_organization).to_json)}');
     localize({
         "contentViewReset": 'The selected content view was unset. Please choose another one.'
     });
@@ -35,18 +38,18 @@
             .value
               #distributor_description{'name' => 'distributor[description]', :class=>("editable edit_textarea" if editable), 'data-maxlength' => default_description_limit, 'data-url'=>distributor_path(distributor.id)} #{distributor[:description]}
         - if Katello.config.katello?
+          %h5 #{_("Content Available From")}
           .control-group
             .label
               = label :env, :env, _("Environment")
             .input
-              %span.value#environment_path_selector{'name'=> 'distributor[environment_id]', :class=>("editable" if editable && Katello.config.katello?), 'data-url'=>distributor_path(distributor.id)}
-                #{distributor_environment_name distributor}
+              %span.value#environment_path_selector{'data-name'=> 'distributor[environment_id]'}
           .control_group
             .label
               = label :content_view, :content_view, _("Content View")
             .input
-              %span.value{'name' => 'distributor[content_view_id]', :class=>("editable edit_select" if editable), 'data-url'=>distributor_path(distributor.id), 'data-options' => distributor_content_view_opts(distributor)}
-                = distributor.content_view
+              %span.value#content_view_selector{'data-name' => 'distributor[content_view_id]', 'data-options' => distributor_content_view_opts(distributor)}
+          .control-group#env_content_view_selector_buttons{'data-url'=>distributor_path(distributor.id)}
 
         %h5 #{_("Distributor Events")}
         .control-group


### PR DESCRIPTION
distributor-ui - fixed disappearing environments

Notes:
- The 'mouseup' binding was causing the environment selector to disappear. This was added as part of BZ 859106 fix. I tested without this code and that BZ remains working without it.
- The hardcode of distributor version to 3.2 is required for now. Future feature will (possibly?) allow setting it based upon what type of downstream tool the distributor is exporting a manifest for.
- In general, the changes in this pull-request are to bring distributors inline w/ recent changes made to systems.
