### PR TITLE
headpin-envcv - always allow cv access in headpin mode

### DIFF
--- a/app/models/authorization/content_view.rb
+++ b/app/models/authorization/content_view.rb
@@ -22,6 +22,7 @@ module Authorization::ContentView
   end
 
   def readable?
+    return true if !Katello.config.katello?
     User.allowed_to?(READ_PERM_VERBS, :content_views, self.id, self.organization)
   end
 
@@ -30,6 +31,7 @@ module Authorization::ContentView
   end
 
   def subscribable?
+    return true if !Katello.config.katello?
     User.allowed_to?([:subscribe], :content_views, self.id, self.organization)
   end
 

--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -323,7 +323,9 @@ module Glue::Candlepin::Consumer
     end
 
     def guest
-      facts["virt.is_guest"]
+      v = facts["virt.is_guest"]
+      return false if (v == false || v.nil?)
+      return(v == true || v.to_bool)
     end
 
     def guest=(val)

--- a/app/models/glue/elastic_search/system.rb
+++ b/app/models/glue/elastic_search/system.rb
@@ -127,7 +127,7 @@ module Glue::ElasticSearch::System
       :content_view => self.content_view.try(:name),
       :status => self.compliance_color
     }
-    if self.guest.to_bool
+    if self.guest
       attrs[:host] = self.host ? self.host.name : ''
     else
       attrs[:guests] = self.guests.map(&:name)


### PR DESCRIPTION
- since there is only ever one CV (Library/Default_Content_View) in headpin, force 'true'
- better handling of guest fact
