### PR TITLE
Fixing 20121112144229_repository_add_content_view.rb

### DIFF
--- a/db/migrate/20121112144229_repository_add_content_view.rb
+++ b/db/migrate/20121112144229_repository_add_content_view.rb
@@ -1,4 +1,34 @@
 class RepositoryAddContentView < ActiveRecord::Migration
+  class Organization < ActiveRecord::Base
+    has_many :environments, :class_name => "KTEnvironment", :dependent => :destroy, :inverse_of => :organization
+  end
+  class KTEnvironment < ActiveRecord::Base
+    self.table_name = "environments"
+    has_many :repositories, :through => :environment_products
+    belongs_to :organization, :inverse_of => :environments
+    has_many :environment_products, :foreign_key => "environment_id"
+
+    def default_content_view
+      ContentView.find_find_by_id(default_content_view_id)
+    end
+  end
+  class EnvironmentProduct < ActiveRecord::Base
+    has_many :repositories
+    belongs_to :environment, :class_name => "KTEnvironment"
+  end
+  class Repository < ActiveRecord::Base
+    belongs_to :environment_product
+    belongs_to :content_view_version
+  end
+  class ContentViewVersion < ActiveRecord::Base
+    has_many :repositories, :dependent => :destroy
+    belongs_to :content_view
+  end
+  class ContentView < ActiveRecord::Base
+    include Ext::LabelFromName
+    has_many :content_view_versions, :dependent => :destroy
+  end
+
   def self.up
     add_column :repositories, :content_view_version_id, :integer, :null=>true
     add_index :repositories, :content_view_version_id
@@ -9,7 +39,7 @@ class RepositoryAddContentView < ActiveRecord::Migration
     User.current = User.hidden.first
     KTEnvironment.all.each do |env|
      view = ContentView.create!(:name=>"Default View for #{env.name}",
-                         :organization=>env.organization, :default=>true)
+                         :organization_id=>env.organization_id, :default=>true)
      env.default_content_view_id = view.id
      env.save!
      version = ContentViewVersion.create!(:version=>1, :content_view=>view)


### PR DESCRIPTION
Fixing the following:
1. Organization has an initialize_default_info callback which writes to a field which does not exist
2. The repositories relationship for KTEnvironment still depends on the table environment_products but the code has a direct relationship (Repository belongs_to KTEnvironment)
3. The default_content_view relationship of KTEnvironment no longer exists
