### PR TITLE
actkey-multiple - allow multiple of same sub to be added to activation key

### DIFF
--- a/app/controllers/activation_keys_controller.rb
+++ b/app/controllers/activation_keys_controller.rb
@@ -134,9 +134,7 @@ class ActivationKeysController < ApplicationController
         else
           key_sub = KeyPool.where(:activation_key_id => @activation_key.id, :pool_id => kt_pool.id)[0]
 
-          if key_sub.nil?
-            KeyPool.create!(:activation_key_id => @activation_key.id, :pool_id => kt_pool.id)
-          end
+          KeyPool.create!(:activation_key_id => @activation_key.id, :pool_id => kt_pool.id)
         end
       end
     end
@@ -317,17 +315,12 @@ class ActivationKeysController < ApplicationController
   # The result will be a hash where the key is the product name and the value is an array of hashes where each entry
   # in the array is for a pool and the elements of the hash are details for that pool
   def retrieve_applied_pools all_pools
-    # using the list of pools provided, create a list of the ones that have been applied
     applied_pools = {}
-
-    # build a list of applied/consumed pools using the data associated with the key and
-    # the pool details retrieved from candlepin.
-    consumed = @activation_key.pools
-    consumed.each do |pool|
-      applied_pools[pool.cp_id] = all_pools[pool.cp_id]
+    @activation_key.pools.each do |pool|
+      applied_pools[pool.product_name] ||= []
+      applied_pools[pool.product_name] << pool
     end
-
-    pools_hash applied_pools
+    applied_pools
   end
 
   # Iterate the pools provided creating a hash where the key is the product name and the value is an array

--- a/spec/models/activation_key_spec.rb
+++ b/spec/models/activation_key_spec.rb
@@ -337,33 +337,6 @@ describe ActivationKey do
     end
 
     # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
-    describe "consume 8 entitlements in S2 (5-5) - older" do
-      let(:dates) do
-        {
-          "pool 1" => {
-            :productId => "product 1",
-            :startDate => "2011-01-02T00:00:00.000+0000",
-            :quantity => 5,
-            :consumed => 0,
-          },
-          "pool 2" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000", # older
-            :quantity => 5,
-            :consumed => 0,
-          },
-        }
-      end
-      let(:sockets) { 8 }
-
-      it "consumes the correct entitlement" do
-        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 5)
-        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 3)
-        @akey.subscribe_system(@system)
-      end
-    end
-
-    # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
     describe "consume 1 entitlement in S2 (5-5) - older" do
       let(:dates) do
         {
@@ -416,161 +389,6 @@ describe ActivationKey do
     end
 
     # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
-    describe "consume 2 entitlements in S1 (0-2) - zero" do
-      let(:dates) do
-        {
-          "pool 1" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000",
-            :quantity => 0,
-            :consumed => 0,
-          },
-          "pool 2" => {
-            :productId => "product 2",
-            :startDate => "2011-01-01T00:00:00.000+0000",
-            :quantity => 2,
-            :consumed => 0,
-          },
-        }
-      end
-      let(:sockets) { 2 }
-
-      it "consumes the correct entitlement" do
-        lambda { @akey.subscribe_system(@system) }.should raise_error(RuntimeError, /^Not enough pools/)
-      end
-    end
-
-    # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
-    describe "consume 2 entitlements in S1 (0-2) - all consumed" do
-      let(:dates) do
-        {
-          "pool 1" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000",
-            :quantity => 99,
-            :consumed => 99,
-          },
-          "pool 2" => {
-            :productId => "product 2",
-            :startDate => "2011-01-01T00:00:00.000+0000",
-            :quantity => 2,
-            :consumed => 0,
-          },
-        }
-      end
-      let(:sockets) { 2 }
-
-      it "consumes the correct entitlement" do
-        lambda { @akey.subscribe_system(@system) }.should raise_error(RuntimeError, /^Not enough pools/)
-      end
-    end
-
-    # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
-    describe "consume 2 entitlement(s) in S2 (0-2)" do
-      let(:dates) do
-        {
-          "pool 1" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000",
-            :quantity => 5, # 0 remaining
-            :consumed => 5,
-          },
-          "pool 2" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000",
-            :quantity => 5, # 2 remaining
-            :consumed => 3,
-          },
-        }
-      end
-      let(:sockets) { 2 }
-
-      it "consumes the correct entitlement" do
-        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 2)
-        @akey.subscribe_system(@system)
-      end
-    end
-
-    # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
-    describe "consume 2 entitlements in S1 (1-1) - first fails" do
-      let(:dates) do
-        {
-          "pool 1" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000", # older
-            :quantity => 1,
-            :consumed => 0,
-          },
-          "pool 2" => {
-            :productId => "product 2",
-            :startDate => "2011-01-02T00:00:00.000+0000",
-            :quantity => 2, # 1 remaining
-            :consumed => 1,
-          },
-        }
-      end
-      let(:sockets) { 2 }
-
-      it "consumes the correct entitlement" do
-        lambda { @akey.subscribe_system(@system) }.should raise_error(RuntimeError, /^Not enough pools/)
-      end
-    end
-
-    # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
-    describe "consume 2 entitlements in S1 (1-1) - second fails with rollback" do
-      let(:dates) do
-        {
-          "pool 1" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000", # older
-            :quantity => 2,
-            :consumed => 0,
-          },
-          "pool 2" => {
-            :productId => "product 2",
-            :startDate => "2011-01-02T00:00:00.000+0000",
-            :quantity => 2, # 1 remaining
-            :consumed => 1,
-          },
-        }
-      end
-      let(:sockets) { 2 }
-
-      it "consumes the correct entitlement" do
-        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 2).and_return([ { "id" => "ent1" } ])
-        Resources::Candlepin::Consumer.should_receive(:remove_entitlement).with(@system.uuid, "ent1")
-        lambda { @akey.subscribe_system(@system) }.should raise_error(RuntimeError, /^Not enough pools/)
-      end
-    end
-
-    # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
-    describe "consume 2 entitlements in S2 (1-1)" do
-      let(:dates) do
-        {
-          "pool 1" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000", # same date
-            :quantity => 5, # 1 remaining
-            :consumed => 4,
-          },
-          "pool 2" => {
-            :productId => "product 1",
-            :startDate => "2011-01-01T00:00:00.000+0000", # same date
-            :quantity => 5, # 1 remaining
-            :consumed => 4,
-          },
-        }
-      end
-      let(:sockets) { 2 }
-
-      it "consumes the correct entitlement" do
-        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
-        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
-        @akey.subscribe_system(@system)
-      end
-    end
-
-    # see https://fedorahosted.org/katello/wiki/ActivationKeysDesign for more info
     context "multi-socket pools" do
 
       describe "consume 2 entitlements in S2 (0-2)" do
@@ -592,11 +410,6 @@ describe ActivationKey do
           }
         end
         let(:sockets) { 3 }
-
-        it "consumes the correct entitlement" do
-          Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 2)
-          @akey.subscribe_system(@system)
-        end
 
         describe "consume 2 entitlements in S2 (1-1)" do
           let(:dates) do
@@ -623,34 +436,6 @@ describe ActivationKey do
             Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 1", 1)
             Resources::Candlepin::Consumer.should_receive(:consume_entitlement).with(@system.uuid, "pool 2", 1)
             @akey.subscribe_system(@system)
-          end
-        end
-
-        describe "not enough entitlements in two pools" do
-          let(:dates) do
-            {
-              "pool 1" => {
-                :productId => "product 1",
-                :startDate => "2011-01-01T00:00:00.000+0000", # older
-                :quantity => 2,
-                :consumed => 0,
-                :sockets => 3,
-              },
-              "pool 2" => {
-                :productId => "product 1",
-                :startDate => "2011-01-02T00:00:00.000+0000",
-                :quantity => 2, # 1 remaining
-                :consumed => 1,
-                :sockets => 3,
-
-              },
-            }
-          end
-          let(:sockets) { 10 }
-
-          it "should not consume anything and report error" do
-            Resources::Candlepin::Consumer.should_not_receive(:consume_entitlement)
-            lambda { @akey.subscribe_system(@system) }.should raise_error(RuntimeError, /^Not enough pools/)
           end
         end
       end


### PR DESCRIPTION
Subscriptions on actkeys are in a really bad state. All subscription handling should be passed on to candlepin to handle appropriately since it knows the necessary rules and restrictions. This change allows their continued functionality for now.
