### PR TITLE
Bastion: make nutupane use $resource and convert system subscriptions.

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -43,7 +43,14 @@ class Api::V1::SubscriptionsController < Api::V1::ApiController
   api :GET, "/systems/:system_id/subscriptions", "List subscriptions"
   param_group :system
   def index
-    respond :collection => { :entitlements => @system.consumed_entitlements }
+    response = { :entitlements => @system.consumed_entitlements }
+    if params[:paged]
+      response = {
+        :results  => @system.consumed_entitlements,
+        :subtotal => @system.consumed_entitlements.length
+      }
+    end
+    respond :collection => response
   end
 
   api :GET, "/subscriptions", "List subscriptions"
@@ -82,9 +89,13 @@ class Api::V1::SubscriptionsController < Api::V1::ApiController
 
     if params[:paged]
       subscriptions = {
-        :subscriptions => subscriptions.results,
+        :results  => subscriptions.results,
+        :offset   => params[:offset],
+        :limit    => options[:page_size],
+        :search   => params[:search],
+        :sort     => { :by => params[:sort_by], :order => params[:sort_order] },
         :subtotal => total_count,
-        :total => items.total_items
+        :total    => items.total_items
       }
     end
 

--- a/app/controllers/api/v1/systems_controller.rb
+++ b/app/controllers/api/v1/systems_controller.rb
@@ -222,7 +222,11 @@ Schedules the consumer identity certificate regeneration
 
     if params[:paged]
       systems = {
-        :records  => systems,
+        :results  => systems,
+        :offset   => params[:offset],
+        :limit    => options[:page_size],
+        :search   => params[:search],
+        :sort     => { :by => params[:sort_by], :order => params[:sort_order] },
         :subtotal => total_count,
         :total    => items.total_items
       }

--- a/engines/bastion/app/assets/bastion/incubator/alch-table.directive.js
+++ b/engines/bastion/app/assets/bastion/incubator/alch-table.directive.js
@@ -148,7 +148,7 @@ angular.module('alchemy')
     }])
     .directive('alchTableColumn', ['$compile', function($compile) {
         var sortIconTemplate = '<th ng-click="table.sortBy(column)">' +
-                                  '<i class="sort-icon" ng-show="table.sort.by == column.id" ng-class="{\'icon-sort-down\': column.sortOrder == \'DESC\', \'icon-sort-up\': column.sortOrder == \'ASC\'}"></i>' +
+                                  '<i class="sort-icon" ng-show="table.resource.sort.by == column.id" ng-class="{\'icon-sort-down\': column.sortOrder == \'DESC\', \'icon-sort-up\': column.sortOrder == \'ASC\'}"></i>' +
                                '</th>';
         return {
             require: '^alchTableHead',

--- a/engines/bastion/app/assets/bastion/stylesheets/nutupane.scss
+++ b/engines/bastion/app/assets/bastion/stylesheets/nutupane.scss
@@ -365,5 +365,6 @@ table.details-visible {
 }
 
 .nutupane-sub-section {
+  height: 250px;
   padding-top: 20px;
 }

--- a/engines/bastion/app/assets/bastion/subscriptions/subscriptions.factory.js
+++ b/engines/bastion/app/assets/bastion/subscriptions/subscriptions.factory.js
@@ -24,6 +24,8 @@
  */
 angular.module('Bastion.subscriptions').factory('Subscriptions', ['$resource', 'Routes', 'CurrentOrganization',
     function($resource, Routes, CurrentOrganization) {
-        return $resource(Routes.apiSubscriptionsPath(), {'organization_id': CurrentOrganization});
+        return $resource(Routes.apiSubscriptionsPath(), {'organization_id': CurrentOrganization}, {
+            query: {method: 'GET', isArray: false}
+        });
     }]
 );

--- a/engines/bastion/app/assets/bastion/systems/details/system-subscriptions.controller.js
+++ b/engines/bastion/app/assets/bastion/systems/details/system-subscriptions.controller.js
@@ -18,13 +18,18 @@
  * @requires $scope
  * @requires System
  * @requires Subscriptions
+ * @requires Nutupane
  *
  * @description
  *   Provides the functionality for the system details action pane.
  */
-angular.module('Bastion.systems').controller('SystemSubscriptionsController', ['$scope', 'System', 'Subscriptions',
-    function($scope, System, Subscriptions) {
-        $scope.systemSubscriptions = System.subscriptions({id: $scope.$stateParams.systemId});
-        $scope.availableSubscriptions = Subscriptions.query();
+angular.module('Bastion.systems').controller('SystemSubscriptionsController',
+    ['$scope', 'SystemSubscriptions', 'Subscriptions', 'Nutupane',
+    function($scope, SystemSubscriptions, Subscriptions, Nutupane) {
+        var currentSubscriptionsNutupane = new Nutupane(SystemSubscriptions, {id: $scope.$stateParams.systemId});
+        $scope.currentSubscriptionsTable = currentSubscriptionsNutupane.table;
+
+        var availableSubscriptionsNutupane = new Nutupane(Subscriptions, {paged: true});
+        $scope.availableSubscriptionsTable = availableSubscriptionsNutupane.table;
     }
 ]);

--- a/engines/bastion/app/assets/bastion/systems/details/views/system-info.html
+++ b/engines/bastion/app/assets/bastion/systems/details/views/system-info.html
@@ -36,7 +36,7 @@
     <div class="detail">
       <span class="info-label">{{ "Release Version" | i18n }}</span>
         <span class="info-value" alch-edit-select="system.releaseVer.releaseVer"
-              options="releaseVersions" on-save="system.$update()"></span>
+              options="releaseVersions.releases" on-save="system.$update()"></span>
     </div>
 
     <div class="detail">

--- a/engines/bastion/app/assets/bastion/systems/details/views/system-subscriptions.html
+++ b/engines/bastion/app/assets/bastion/systems/details/views/system-subscriptions.html
@@ -1,84 +1,103 @@
 <section class="nutupane-sub-section">
   <div class="nutupane-titlebar">
-    <h3 class="nutupane-title">{{ "Current Subscription(s)" | i18n }}</h3>
+    <h1 class="nutupane-title">{{ "Current Subscription(s)" | i18n }}</h1>
   </div>
   <div class="nutupane-actionbar">
     <div class="form">
       <input type="text"
              class="input input-search"
              placeholder="{{ 'Filter' | i18n }}"
-             ng-model="systemSearch">
+             ng-model="currentSubscriptionsTable.filter">
+      <span class="result-count">Showing {{ currentSubscriptionsTable.rows.length }} of {{ currentSubscriptionsTable.resource.subtotal }} ({{ currentSubscriptionsTable.resource.total }} Total) Subscriptions</span>
+    </div>
+    <div class="fr select-action">
+      <span>{{ currentSubscriptionsTable.numSelected }} Selected</span>
+      <span>|</span>
+      <a class="deselect-action"
+         ng-class="{ 'disabled-link' : currentSubscriptionsTable.numSelected == 0 }"
+         ng-click="currentSubscriptionsTable.selectAll(false)">
+        Deselect All
+      </a>
     </div>
   </div>
 
-  <p ng-show="systemSubscriptions.length == 0">
-    {{ "You have no current subscriptions" | i18n }}
-  </p>
+  <div alch-table="currentSubscriptionsTable">
+    <div alch-container-scroll control-width="table" alch-infinite-scroll="table.nextPage()">
+      <table ng-class="{'table-mask': table.working}" class="table table-full table-striped">
+        <thead>
+        <tr alch-table-head row-select>
+          <th alch-table-column="name">{{ "Name" | i18n }}</th>
+          <th alch-table-column="sla">{{ "SLA" | i18n }}</th>
+          <th alch-table-column="contract">{{ "Contract" | i18n }}</th>
+          <th alch-table-column="quantity">{{ "Quantity" | i18n }}</th>
+          <th alch-table-column="startDate">{{ "Start Date" | i18n }}</th>
+          <th alch-table-column="endDate">{{ "End Date" | i18n }}</th>
+        </tr>
+        </thead>
 
-  <table ng-show="systemSubscriptions.length > 0" class="table table-striped">
-    <thead>
-      <tr>
-        <th>{{ "Name" | i18n }}</th>
-        <th>{{ "SLA" | i18n }}</th>
-        <th>{{ "Contract" | i18n }}</th>
-        <th>{{ "Quantity" | i18n }}</th>
-        <th>{{ "Start Date" | i18n }}</th>
-        <th>{{ "End Date" | i18n }}</th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <tr ng-repeat="subscription in systemSubscriptions | filter:systemSearch" row-select>
-        <td>{{ subscription.poolName }}</td>
-        <td>{{ subscription.sla }}</td>
-        <td>{{ subscription.contractNumber }}</td>
-        <td>{{ subscription.quantity }}</td>
-        <td>{{ subscription.startDate }}</td>
-        <td>{{ subscription.endDate }}</td>
-      </tr>
-    </tbody>
-  </table>
+        <tbody>
+          <tr alch-table-row ng-repeat="subscription in table.rows | filter:table.filter" row-select>
+            <td alch-table-cell>{{ subscription.poolName }}</td>
+            <td alch-table-cell>{{ subscription.sla }}</td>
+            <td alch-table-cell>{{ subscription.contractNumber }}</td>
+            <td alch-table-cell>{{ subscription.quantity }}</td>
+            <td alch-table-cell>{{ subscription.startDate | date:"short" }}</td>
+            <td alch-table-cell>{{ subscription.endDate | date:"short"}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </section>
-
 
 <section class="nutupane-sub-section">
   <div class="nutupane-titlebar">
-    <h3 class="nutupane-title">{{ "Available Subscription(s)" | i18n }}</h3>
+    <h1 class="nutupane-title">{{ "Available Subscription(s)" | i18n }}</h1>
   </div>
   <div class="nutupane-actionbar">
     <div class="form">
       <input type="text"
              class="input input-search"
              placeholder="{{ 'Filter' | i18n }}"
-             ng-model="availableSearch">
+             ng-model="availableSubscriptionsTable.filter">
+      <span class="result-count">Showing {{ availableSubscriptionsTable.rows.length }} of {{ availableSubscriptionsTable.resource.subtotal }} ({{ availableSubscriptionsTable.resource.total }} Total) Subscriptions</span>
+    </div>
+    <div class="fr select-action">
+      <span>{{ availableSubscriptionsTable.numSelected }} Selected</span>
+      <span>|</span>
+      <a class="deselect-action"
+         ng-class="{ 'disabled-link' : availableSubscriptionsTable.numSelected == 0 }"
+         ng-click="availableSubscriptionsTable.selectAll(false)">
+        Deselect All
+      </a>
     </div>
   </div>
 
-  <p ng-show="availableSubscriptions.length == 0">
-    {{ "You have no available subscriptions" | i18n }}
-  </p>
+  <div alch-table="availableSubscriptionsTable">
+    <div alch-container-scroll control-width="table" alch-infinite-scroll="table.nextPage()">
+      <table ng-class="{'table-mask': table.working}" class="table table-full table-striped">
+        <thead>
+          <tr alch-table-head row-select>
+            <th alch-table-column="name">{{ "Name" | i18n }}</th>
+            <th alch-table-column="sla">{{ "SLA" | i18n }}</th>
+            <th alch-table-column="contract">{{ "Contract" | i18n }}</th>
+            <th alch-table-column="quantity">{{ "Quantity" | i18n }}</th>
+            <th alch-table-column="startDate">{{ "Start Date" | i18n }}</th>
+            <th alch-table-column="endDate">{{ "End Date" | i18n }}</th>
+          </tr>
+        </thead>
 
-  <table ng-show="availableSubscriptions.length > 0" class="table table-striped">
-    <thead>
-      <tr>
-        <th>{{ "Name" | i18n }}</th>
-        <th>{{ "SLA" | i18n }}</th>
-        <th>{{ "Contract" | i18n }}</th>
-        <th>{{ "Quantity" | i18n }}</th>
-        <th>{{ "Start Date" | i18n }}</th>
-        <th>{{ "End Date" | i18n }}</th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <tr ng-repeat="subscription in availableSubscriptions | filter:availableSearch" row-select>
-        <td>{{ subscription.name }}</td>
-        <td>{{ subscription.sla }}</td>
-        <td>{{ subscription.contractNumber }}</td>
-        <td>{{ subscription.quantity }}</td>
-        <td>{{ subscription.startDate | date:"short" }}</td>
-        <td>{{ subscription.endDate | date:"short"}}</td>
-      </tr>
-    </tbody>
-  </table>
+        <tbody>
+          <tr alch-table-row ng-repeat="subscription in table.rows | filter:table.filter" row-select>
+            <td alch-table-cell>{{ subscription.name }}</td>
+            <td alch-table-cell>{{ subscription.sla }}</td>
+            <td alch-table-cell>{{ subscription.contractNumber }}</td>
+            <td alch-table-cell>{{ subscription.quantity }}</td>
+            <td alch-table-cell>{{ subscription.startDate | date:"short" }}</td>
+            <td alch-table-cell>{{ subscription.endDate | date:"short"}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </section>

--- a/engines/bastion/app/assets/bastion/systems/system.factory.js
+++ b/engines/bastion/app/assets/bastion/systems/system.factory.js
@@ -22,111 +22,31 @@
  *   Provides a $resource for system or list of systems.
  */
 angular.module('Bastion.systems').factory('System',
-    ['$resource', '$q', 'Routes',
-    function($resource, $q, Routes) {
-        var Collection = {},
-            resource,
-            updateCounts,
-            findIndex,
-            replaceInCollection;
-
-        resource = $resource(Routes.apiSystemsPath() + '/:id/:action', {id: '@uuid'}, {
-            update: { method: 'PUT'},
-            query: { method: 'GET'},
-            releaseVersions: { method: 'GET', params: {action: 'releases'}},
-            subscriptions: { method: 'GET', params: {action: 'subscriptions'}}
+    ['$resource', 'Routes',
+    function($resource, Routes) {
+        return $resource(Routes.apiSystemsPath() + '/:id/:action', {id: '@uuid'}, {
+            update: {method: 'PUT'},
+            query: {method: 'GET', isArray: false},
+            releaseVersions: {method: 'GET', params: {action: 'releases'}}
         });
-
-        findIndex = function(record) {
-            var index;
-
-            angular.forEach(Collection.records, function(item, itemIndex) {
-                if (item.id === record.id) {
-                    index = itemIndex;
-                }
-            });
-
-            return index;
-        };
-
-        replaceInCollection = function(record) {
-            var index = findIndex(record);
-
-            if (index) {
-                Collection.records[index] = record;
-            } else {
-                Collection.records.push(record);
-                updateCounts(1);
-            }
-        };
-
-        updateCounts = function(count) {
-            Collection.offset += count;
-            Collection.total  += count;
-            Collection.subtotal += count;
-        };
-
-        Collection.records  = [];
-        Collection.offset   = 0;
-        Collection.total    = 0;
-        Collection.subtotal = 0;
-        Collection.resource = resource;
-
-        Collection.get = function(args, callback) {
-            args = args || {};
-            callback = callback || function() {};
-
-            if (args['id']) {
-                return resource.get(args, function(record) {
-                    replaceInCollection(record);
-                    callback();
-                });
-            }
-        };
-
-        Collection.query = function(args, callback) {
-            args = args || {};
-            callback = callback || function() {};
-
-            if (args['offset'] === 0) {
-                Collection.offset = 0;
-            } else {
-                Collection.offset = args['offset'];
-            }
-
-            resource.query(args, function(data) {
-                if (Collection.offset === 0) {
-                    Collection.records = data.records;
-                } else {
-                    Collection.records = Collection.records.concat(data.records);
-                }
-
-                Collection.offset = Collection.records.length;
-                Collection.total = data.total;
-                Collection.subtotal = data.subtotal;
-                callback();
-            });
-        };
-
-        Collection.releaseVersions = function(args) {
-            var deferred = $q.defer();
-
-            resource.releaseVersions(args, function(data) {
-                deferred.resolve(data.releases);
-            });
-
-            return deferred.promise;
-        };
-
-        Collection.subscriptions = function(args) {
-            var deferred = $q.defer();
-
-            resource.subscriptions(args, function(data) {
-                deferred.resolve(data.entitlements);
-            });
-
-            return deferred.promise;
-        };
-        return Collection;
     }]
+);
+
+/**
+ * @ngdoc service
+ * @name  Katello.systems.factory:SystemSubscriptions
+ *
+ * @requires $resource
+ * @requires Routes
+ *
+ * @description
+ *   Provides a $resource for system subscriptions.
+ */
+angular.module('Bastion.systems').factory('SystemSubscriptions',
+    ['$resource', 'Routes',
+        function($resource, Routes) {
+            return $resource(Routes.apiSystemsPath() + '/:id/subscriptions', {id: '@uuid'}, {
+                query: {method: 'GET', isArray: false, params: {paged: true}}
+            });
+        }]
 );

--- a/engines/bastion/app/assets/bastion/systems/systems.controller.js
+++ b/engines/bastion/app/assets/bastion/systems/systems.controller.js
@@ -26,10 +26,19 @@
  *   within the table.
  */
 angular.module('Bastion.systems').controller('SystemsController',
-    ['$scope', '$state', 'Nutupane', 'System',
-    function($scope, $state, Nutupane, System) {
+    ['$scope', '$state', '$location', 'Nutupane', 'System', 'CurrentOrganization',
+    function($scope, $state, $location, Nutupane, System, CurrentOrganization) {
 
-        var nutupane = new Nutupane(System);
+        var params = {
+            'organization_id':  CurrentOrganization,
+            'search':           $location.search().search || "",
+            'offset':           0,
+            'sort_by':          'name',
+            'sort_order':       'ASC',
+            'paged':            true
+        };
+
+        var nutupane = new Nutupane(System, params);
         $scope.table = nutupane.table;
 
         $scope.getStatusColor = function(status) {

--- a/engines/bastion/app/assets/bastion/systems/views/systems-table-collapsed.html
+++ b/engines/bastion/app/assets/bastion/systems/views/systems-table-collapsed.html
@@ -6,7 +6,7 @@
   </thead>
 
   <tbody>
-    <tr alch-table-row ng-repeat="system in table.resource.records" row-select>
+    <tr alch-table-row ng-repeat="system in table.rows" row-select>
       <td alch-table-cell>
         <a class="clickable" ng-click="table.openDetails(system)">{{ system.name }}</a>
         <i class="icon-chevron-right selected-icon" ng-show="system.selected"></i>

--- a/engines/bastion/app/assets/bastion/systems/views/systems-table-full.html
+++ b/engines/bastion/app/assets/bastion/systems/views/systems-table-full.html
@@ -12,19 +12,19 @@
   </thead>
 
   <tbody>
-  <tr alch-table-row ng-repeat="system in table.resource.records" row-select>
-    <td alch-table-cell>
-      <a class="clickable" ng-click="table.openDetails(system)">{{ system.name }}</a>
-      <i class="icon-chevron-right selected-icon" ng-show="system.selected"></i>
-    </td>
-    <td alch-table-cell>
-      <span class="status_icon" ng-class="getStatusColor(system.compliance.status)"></span>
-    </td>
-    <td alch-table-cell>{{ system.distribution }}</td>
-    <td alch-table-cell>{{ system.environment.name }}</td>
-    <td alch-table-cell>{{ system.content_view.name || "" }}</td>
-    <td alch-table-cell>{{ system.registered | date:'short' }}</td>
-    <td alch-table-cell>{{ system.checkin_time || 'Never checked in' | date:'short' }}</td>
-  </tr>
+    <tr alch-table-row ng-repeat="system in table.rows" row-select>
+      <td alch-table-cell>
+        <a class="clickable" ng-click="table.openDetails(system)">{{ system.name }}</a>
+        <i class="icon-chevron-right selected-icon" ng-show="system.selected"></i>
+      </td>
+      <td alch-table-cell>
+        <span class="status_icon" ng-class="getStatusColor(system.compliance.status)"></span>
+      </td>
+      <td alch-table-cell>{{ system.distribution }}</td>
+      <td alch-table-cell>{{ system.environment.name }}</td>
+      <td alch-table-cell>{{ system.content_view.name || "" }}</td>
+      <td alch-table-cell>{{ system.registered | date:'short' }}</td>
+      <td alch-table-cell>{{ system.checkin_time || 'Never checked in' | date:'short' }}</td>
+    </tr>
   </tbody>
 </table>

--- a/engines/bastion/app/assets/bastion/systems/views/systems.html
+++ b/engines/bastion/app/assets/bastion/systems/views/systems.html
@@ -9,7 +9,7 @@
              placeholder="Search..."
              ng-model="table.searchTerm"
              on-enter="table.search(table.searchTerm)">
-      <span class="result-count">Showing {{ table.resource.offset }} of {{ table.resource.subtotal }} ({{ table.resource.total }} Total) Systems</span>
+      <span class="result-count">Showing {{ table.rows.length }} of {{ table.resource.subtotal }} ({{ table.resource.total }} Total) Systems</span>
     </div>
     <div class="fr select-action">
       <span>{{ table.numSelected }} Selected</span>

--- a/engines/bastion/app/assets/bastion/widgets/nutupane.factory.js
+++ b/engines/bastion/app/assets/bastion/widgets/nutupane.factory.js
@@ -17,56 +17,63 @@
  *
  * @requires $location
  * @requires $q
- * @requires CurrentOrganization
+ * @requires $timeout
  *
  * @description
  *   Defines the Nutupane factory for adding common functionality to the Nutupane master-detail
- *   pattern.
+ *   pattern.  Note that the API Nutupane uses must provide a response of the following structure:
+ *
+ *   {
+ *      offset: 25,
+ *      subtotal: 50,
+ *      total: 100,
+ *      results: [...]
+ *   }
  *
  * @example
  *   <pre>
        angular.module('example').controller('ExampleController',
            ['Nutupane', function(Nutupane)) {
-               var nutupane                = new Nutupane();
+               var nutupane                = new Nutupane(ExampleResource);
                $scope.table                = nutupane.table;
            }]
        );
     </pre>
  */
 angular.module('Bastion.widgets').factory('Nutupane',
-    ['$location', '$q', '$timeout', 'CurrentOrganization',
-    function($location, $q, $timeout, CurrentOrganization) {
-        var Nutupane = function(resource) {
+    ['$location', '$q', '$timeout', function($location, $q, $timeout) {
+        var Nutupane = function(resource, params) {
             var self = this;
+            params = params || {};
 
             self.table = {
+                params: params,
                 resource: resource,
-                searchString: $location.search().search,
-                sort: {
-                    by: 'name',
-                    order: 'ASC'
-                }
+                rows: [],
+                searchTerm: $location.search().search
             };
 
+            // Set default resource values
+            resource.offset = 0;
+            resource.subtotal = "0";
+            resource.total = "0";
+            resource.results = [];
+
             self.query = function() {
-                var params = {
-                    'organization_id':  CurrentOrganization,
-                    'search':           $location.search().search || "",
-                    'sort_by':          self.table.sort.by,
-                    'sort_order':       self.table.sort.order,
-                    'paged':            true,
-                    'offset':           self.table.resource.offset
-                };
+                var deferred = $q.defer(), table = self.table;
+                table.working = true;
+                params.offset = table.rows.length;
+                params.search = table.searchTerm || "";
+                resource.query(params, function(response) {
+                    table.rows = table.rows.concat(response.results);
 
-                self.table.working = true;
-                var deferred = $q.defer();
-
-                self.table.resource.query(params, function(resource) {
-                    // This $timeout is necessary to cause a $digest cycle for displaying
+                    // This $timeout is necessary to cause a digest cycle
+                    // in order to prevent loading two sets of results.
                     $timeout(function() {
-                        deferred.resolve(resource);
+                        deferred.resolve(response);
+                        table.resource = response;
                     }, 0);
-                    self.table.working = false;
+                    table.working = false;
                 });
                 return deferred.promise;
             };
@@ -74,6 +81,7 @@ angular.module('Bastion.widgets').factory('Nutupane',
             self.table.search = function(searchTerm) {
                 $location.search('search', searchTerm);
                 self.table.resource.offset = 0;
+                self.table.rows = [];
                 self.table.closeItem();
 
                 if (!self.table.working) {
@@ -88,18 +96,20 @@ angular.module('Bastion.widgets').factory('Nutupane',
 
             self.table.nextPage = function() {
                 var table = self.table;
-                if (table.working || (table.resource.offset > 0 && table.hasMore())) {
+                if (table.working || !table.hasMore()) {
                     return;
                 }
                 return self.query();
             };
 
             self.table.hasMore = function() {
-                return self.table.resource.subtotal === self.table.resource.offset;
+                var length = self.table.rows.length;
+                var subtotal = self.table.resource.subtotal;
+                return ((length === 0 && subtotal !== 0) || (length < subtotal));
             };
 
             self.table.sortBy = function(column) {
-                var sort = self.table.sort;
+                var sort = self.table.resource.sort;
                 if (column.id === sort.by) {
                     sort.order = (sort.order === 'ASC') ? 'DESC' : 'ASC';
                 } else {
@@ -107,7 +117,7 @@ angular.module('Bastion.widgets').factory('Nutupane',
                     sort.by = column.id;
                 }
 
-                column.sortOrder = sort.order;
+                column.sortOrder = self.table.resource.sort.order;
                 column.active = true;
                 self.table.resource.offset = 0;
                 self.query();

--- a/engines/bastion/test/incubator/nutupane.factory.test.js
+++ b/engines/bastion/test/incubator/nutupane.factory.test.js
@@ -14,7 +14,6 @@
 describe('Factory: Nutupane', function() {
     var $timeout,
         $location,
-        CurrentOrganization,
         Resource,
         Nutupane;
 
@@ -23,14 +22,16 @@ describe('Factory: Nutupane', function() {
     beforeEach(module(function($provide) {
         Resource = {
             query: function(params, callback) {
-                callback();
+                return {results: []};
             },
             total: 10,
             subtotal: 8,
-            offset: 5
+            offset: 5,
+            sort: {
+                by: "description",
+                order: "ASC"
+            }
         };
-
-        $provide.value('CurrentOrganization', 'ACME');
     }));
 
     beforeEach(inject(function(_$location_, _$timeout_, _Nutupane_) {
@@ -102,9 +103,9 @@ describe('Factory: Nutupane', function() {
             expect(Resource.query).not.toHaveBeenCalled();
         });
 
-        it("refusing to fetch more data if the subtotal of records equals the offset", function() {
+        it("refusing to fetch more data if the subtotal of records equals the number of rows", function() {
             spyOn(Resource, 'query');
-            nutupane.table.resource.offset = 8;
+            nutupane.table.rows = new Array(8);
             nutupane.table.nextPage();
 
             expect(Resource.query).not.toHaveBeenCalled();
@@ -112,27 +113,27 @@ describe('Factory: Nutupane', function() {
 
         describe("provides a way to sort the table", function(){
             it ("defaults the sort to ascending if the previous sort does not match the new sort.", function() {
-                nutupane.table.sort = {};
+                nutupane.table.resource.sort = {};
                 nutupane.table.sortBy({id: "name"});
-                expect(nutupane.table.sort.by).toBe("name");
-                expect(nutupane.table.sort.order).toBe("ASC");
+                expect(nutupane.table.resource.sort.by).toBe("name");
+                expect(nutupane.table.resource.sort.order).toBe("ASC");
             });
 
             it("toggles the sort order if already sorting by that column", function() {
-                nutupane.table.sort = {
+                nutupane.table.resource.sort = {
                     by: 'name',
                     order: 'ASC'
                 };
                 nutupane.table.sortBy({id: "name"});
-                expect(nutupane.table.sort.by).toBe("name");
-                expect(nutupane.table.sort.order).toBe("DESC");
+                expect(nutupane.table.resource.sort.by).toBe("name");
+                expect(nutupane.table.resource.sort.order).toBe("DESC");
             });
 
             it("sets the column sort order and marks it as active.", function() {
                 var column = {id: "name"}
-                nutupane.table.sort = {};
+                nutupane.table.resource.sort = {};
                 nutupane.table.sortBy(column);
-                expect(column.sortOrder).toBe(nutupane.table.sort.order);
+                expect(column.sortOrder).toBe(nutupane.table.resource.sort.order);
                 expect(column.active).toBe(true);
             });
 

--- a/engines/bastion/test/systems/system.factory.test.js
+++ b/engines/bastion/test/systems/system.factory.test.js
@@ -14,6 +14,7 @@
 describe('Factory: System', function() {
     var $resource,
         $q,
+        System,
         Routes,
         releaseVersions,
         systemsCollection;
@@ -38,17 +39,17 @@ describe('Factory: System', function() {
         };
 
         $resource = function() {
-            this.get = function(args, callback) {
-                callback(systemsCollection.records[0]);
+            this.get = function(id) {
+                return systemsCollection.records[0];
+            };
+            this.update = function(data) {
+                systemsCollection.records[0] = data;
+            };
+            this.query = function() {
+                return systemsCollection;
             };
 
-            this.update = function() {};
-
-            this.query = function(args, callback) {
-                callback(systemsCollection);
-            };
-
-            this.releaseVersions = function(args, callback) {
+            this.releaseVersions = function() {
                 var deferred = $q.defer();
 
                 deferred.resolve(releaseVersions);
@@ -61,6 +62,7 @@ describe('Factory: System', function() {
 
         $provide.value('$resource', $resource);
         $provide.value('Routes', Routes);
+        $provide.value('CurrentOrganization', 'ACME');
     }));
 
     beforeEach(inject(function(_System_, _$q_) {
@@ -68,31 +70,10 @@ describe('Factory: System', function() {
         $q = _$q_;
     }));
 
-    it("provides a way to get a collection of systems", function() {
-        System.query();
-
-        expect(System.records).toEqual(systemsCollection.records);
-        expect(System.total).toEqual(systemsCollection.total);
-        expect(System.subtotal).toEqual(systemsCollection.subtotal);
-        expect(System.offset).toEqual(2);
-    });
-
-    it("provides a way to get a single system by the system ID", function() {
-        System.get({ id: systemsCollection.records[0].id });
-
-        expect(System.records).toEqual([systemsCollection.records[0]]);
-        expect(System.total).toEqual(1);
-        expect(System.subtotal).toEqual(1);
-        expect(System.offset).toEqual(1);
-    });
-
-    it("updates a single system's occurence within the collection", function() {
-        System.query();
-
-        systemsCollection.records[1].name = 'NewSystemName';
-        System.get({ id: systemsCollection.records[1].id });
-
-        expect(System.records[1].name).toEqual('NewSystemName');
+    it("provides a way to update a system", function() {
+        System.update({name: 'NewSystemName', id: 1});
+        var response = System.get({ id: 1 });
+        expect(response.name).toEqual('NewSystemName');
     });
 
     it("provides a way to get the possible release versions for a system via a promise", function() {

--- a/engines/bastion/test/systems/systems.controller.test.js
+++ b/engines/bastion/test/systems/systems.controller.test.js
@@ -38,7 +38,8 @@ describe('Controller: SystemsController', function() {
     // Initialize controller
     beforeEach(inject(function($controller, $rootScope) {
         $scope = $rootScope.$new();
-        $controller('SystemsController', {$scope: $scope, $state: $state, Nutupane: Nutupane, System: System});
+        $controller('SystemsController', {$scope: $scope, $state: $state, Nutupane: Nutupane,
+            System: System, CurrentOrganization: 'CurrentOrganization'});
     }));
 
     it("provides a way to get the status color for the system.", function() {


### PR DESCRIPTION
Nutupane should only require a $resource (or similar object) to work rather
than relying on an arbitrary Collection object.  This commit fixes that as
well as introduces a pattern for how our APIs should return lists of data.
