### PR TITLE
comps updates for upcoming changes

### DIFF
--- a/rel-eng/comps/comps-katello-pulp-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-fedora18.xml
@@ -20,6 +20,10 @@
        <packagereq type="default">pulp-builtins-admin-extensions</packagereq>
        <packagereq type="default">pulp-builtins-consumer-extensions</packagereq>
        <packagereq type="default">pulp-consumer-client</packagereq>
+       <packagereq type="default">pulp-nodes-admin-extensions</packagereq>
+       <packagereq type="default">pulp-nodes-child</packagereq>
+       <packagereq type="default">pulp-nodes-common</packagereq>
+       <packagereq type="default">pulp-nodes-parent</packagereq>
        <packagereq type="default">pulp-rpm-admin-extensions</packagereq>
        <packagereq type="default">pulp-rpm-consumer-extensions</packagereq>
        <packagereq type="default">pulp-rpm-handlers</packagereq>

--- a/rel-eng/comps/comps-katello-pulp-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-fedora19.xml
@@ -20,6 +20,10 @@
        <packagereq type="default">pulp-builtins-admin-extensions</packagereq>
        <packagereq type="default">pulp-builtins-consumer-extensions</packagereq>
        <packagereq type="default">pulp-consumer-client</packagereq>
+       <packagereq type="default">pulp-nodes-admin-extensions</packagereq>
+       <packagereq type="default">pulp-nodes-child</packagereq>
+       <packagereq type="default">pulp-nodes-common</packagereq>
+       <packagereq type="default">pulp-nodes-parent</packagereq>
        <packagereq type="default">pulp-rpm-admin-extensions</packagereq>
        <packagereq type="default">pulp-rpm-consumer-extensions</packagereq>
        <packagereq type="default">pulp-rpm-handlers</packagereq>

--- a/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
@@ -20,6 +20,10 @@
        <packagereq type="default">pulp-builtins-admin-extensions</packagereq>
        <packagereq type="default">pulp-builtins-consumer-extensions</packagereq>
        <packagereq type="default">pulp-consumer-client</packagereq>
+       <packagereq type="default">pulp-nodes-admin-extensions</packagereq>
+       <packagereq type="default">pulp-nodes-child</packagereq>
+       <packagereq type="default">pulp-nodes-common</packagereq>
+       <packagereq type="default">pulp-nodes-parent</packagereq>
        <packagereq type="default">pulp-rpm-admin-extensions</packagereq>
        <packagereq type="default">pulp-rpm-consumer-extensions</packagereq>
        <packagereq type="default">pulp-rpm-handlers</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -36,6 +36,7 @@
        <packagereq type="default">katello-repos-testing</packagereq>
        <packagereq type="default">katello-selinux</packagereq>
        <packagereq type="default">katello-utils</packagereq>
+       <packagereq type="default">pulp-katello-plugin</packagereq>
        <packagereq type="default">lucene3</packagereq>
        <packagereq type="default">lucene3-contrib</packagereq>
        <packagereq type="default">rubygem-acts_as_reportable</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -36,6 +36,7 @@
        <packagereq type="default">katello-repos-testing</packagereq>
        <packagereq type="default">katello-selinux</packagereq>
        <packagereq type="default">katello-utils</packagereq>
+       <packagereq type="default">pulp-katello-plugin</packagereq>
        <packagereq type="default">lucene3</packagereq>
        <packagereq type="default">lucene3-contrib</packagereq>
        <packagereq type="default">rubygem-acts_as_reportable</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -36,6 +36,7 @@
        <packagereq type="default">katello-repos-testing</packagereq>
        <packagereq type="default">katello-selinux</packagereq>
        <packagereq type="default">katello-utils</packagereq>
+       <packagereq type="default">pulp-katello-plugin</packagereq>
        <packagereq type="default">lucene3</packagereq>
        <packagereq type="default">lucene3-contrib</packagereq>
        <packagereq type="default">sigar-java</packagereq>


### PR DESCRIPTION
ensures that pulp nodes and new distributor are in the repos before merging.
