### PR TITLE
996247: copy po files into rpm for now

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -536,20 +536,22 @@ mkdir -p %{buildroot}/%{_mandir}/man8
 # remove build gem group
 rm -f bundler.d/build.rb
 
-#copy the application to the target directory
+# copy the application to the target directory
+# note that locale is listed here, which copies po files
 mkdir .bundle
-cp -R .bundle Gemfile.in bundler.d Rakefile app autotest ca config config.ru db integration_spec lib public script spec vendor engines %{buildroot}%{homedir}
+cp -R .bundle Gemfile.in bundler.d Rakefile app autotest ca config config.ru db integration_spec lib locale public script spec vendor engines %{buildroot}%{homedir}
 rm -f {buildroot}%{homedir}/script/katello-reset-dbs
 
-#copy MO files
-pushd locale
-for MOFILE in $(find . -name "*.mo"); do
-    DIR=$(dirname "$MOFILE")
-    install -d -m 0755 %{buildroot}%{_datadir}/katello/locale/$DIR
-    install -d -m 0755 %{buildroot}%{_datadir}/katello/locale/$DIR/LC_MESSAGES
-    install -m 0644 $DIR/*.mo %{buildroot}%{_datadir}/katello/locale/$DIR/LC_MESSAGES
-done
-popd
+# do not copy mo files for now, per tom
+##copy MO files
+#pushd locale
+#for MOFILE in $(find . -name "*.mo"); do
+#    DIR=$(dirname "$MOFILE")
+#    install -d -m 0755 %{buildroot}%{_datadir}/katello/locale/$DIR
+#    install -d -m 0755 %{buildroot}%{_datadir}/katello/locale/$DIR/LC_MESSAGES
+#    install -m 0644 $DIR/*.mo %{buildroot}%{_datadir}/katello/locale/$DIR/LC_MESSAGES
+#done
+#popd
 
 #copy configs and other var files (will be all overwriten with symlinks)
 touch %{buildroot}%{_sysconfdir}/%{name}/%{name}.yml


### PR DESCRIPTION
po files were not being copied from the buildroot into the rpm, which made translations not work.
