### PR TITLE
requiring specific runcible to prevent using new version

### DIFF
--- a/bundler.d/pulp.rb
+++ b/bundler.d/pulp.rb
@@ -3,7 +3,7 @@
 if Katello.early_config.katello?
   group :pulp do
     # Pulp API bindings
-    gem 'runcible', '~> 1.0.3'
+    gem 'runcible', '= 1.0.3'
     gem 'anemone'
   end
 end


### PR DESCRIPTION
this will allow new PRs to use a newer runcible without breaking master
