### PR TITLE
Fixing index_content typo

### DIFF
--- a/app/models/content_view.rb
+++ b/app/models/content_view.rb
@@ -330,7 +330,7 @@ class ContentView < ActiveRecord::Base
   end
 
   def index_repositories(env)
-    repos(env).each(&:index_contents)
+    repos(env).each(&:index_content)
   end
 
   def cp_environment_label(env)


### PR DESCRIPTION
I looked into writing a test for this but it would be hard and at best it would be pretty useless as we could only check for something along the lines that `index_content` is being called.
