### PR TITLE
proxy-compliance - don't break on first entry

### DIFF
--- a/app/controllers/api/v1/proxies_controller.rb
+++ b/app/controllers/api/v1/proxies_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::ProxiesController < Api::V1::ApiController
   def rules
     proxy_test = lambda {
       route, match, params = Rails.application.routes.router.recognize(request) do |route, match, params|
-        break route, match, params
+        break route, match, params if route.name
       end
 
       # route names are defined in routes.rb (:as => :name)


### PR DESCRIPTION
Bug 994992 - The status is unknown and the GUI is grey after subscribe a valid subscription against SAM
https://bugzilla.redhat.com/show_bug.cgi?id=994992

Bug 997740 - Failed to auto-attach in subscription-manager-gui against SAM.
https://bugzilla.redhat.com/show_bug.cgi?id=997740

Code was previously leaving loop on first match (which works for most routes). Update is to break from loop only when a route w/ name is found (the expected result).
