### PR TITLE
allowing admin permission to be recreated

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -116,13 +116,16 @@ class Role < ActiveRecord::Base
     superadmin_role = Role.find_or_create_by_name(
       :name => ADMINISTRATOR,
       :description => 'Super administrator with all access.')
-    raise "Unable to create super-admin role: #{format_errors superadmin_role}" if superadmin_role.nil? or superadmin_role.errors.size > 0
+    raise "Unable to create super-admin role: #{superadmin_role}" if superadmin_role.nil? || superadmin_role.errors.size > 0
+
+    #unlock role in case permission needs to be created
+    superadmin_role.update_attributes(:locked => false)
 
     superadmin_role_perm = Permission.find_or_create_by_name(
       :name=> "super-admin-perm",
       :description => 'Super Admin permission',
       :role => superadmin_role, :all_types => true)
-    raise "Unable to create super-admin role permission: #{format_errors superadmin_role_perm}" if superadmin_role_perm.nil? or superadmin_role_perm.errors.size > 0
+    raise "Unable to create super-admin role permission: #{superadmin_role_perm}" if superadmin_role_perm.nil? || superadmin_role_perm.errors.size > 0
 
     superadmin_role.update_attributes(:locked => true)
     superadmin_role

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -88,6 +88,24 @@ describe Role do
    end
  end
 
+ context "Admin permission should be recreated if role exists" do
+   before do
+     @admin_role = Role.make_super_admin_role
+     @admin_role.update_attributes(:locked=>false)
+     @admin_role.permissions.destroy_all
+     @admin_role.update_attributes(:locked=>true)
+   end
+
+   context "recreating permission" do
+     specify {
+       @admin_role.permissions.size.should == 0
+       @admin_role  = Role.make_super_admin_role
+       @admin_role.permissions.size.should == 1
+     }
+   end
+
+ end
+
  context "read ldap roles" do
    before do
      Katello.config[:ldap_roles] = true


### PR DESCRIPTION
The Role.make_super_admin_role is designed to create the admin role
with its permissions if it did not exist.  It does not handle the case
that the Role exists but the permission does not.  If minitests are run
before spec tests, this situation occurs and Role.make_super_admin_role will fail
as the Role is locked and no new permissions can be added.
