### PR TITLE
comps - get gofer into comps

### DIFF
--- a/rel-eng/comps/comps-katello-pulp-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-fedora18.xml
@@ -12,6 +12,7 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">createrepo</packagereq>
+       <packagereq type="default">gofer</packagereq>
        <packagereq type="default">grinder</packagereq>
        <packagereq type="default">m2crypto</packagereq>
        <packagereq type="default">mod_wsgi</packagereq>

--- a/rel-eng/comps/comps-katello-pulp-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-fedora19.xml
@@ -12,6 +12,7 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">createrepo</packagereq>
+       <packagereq type="default">gofer</packagereq>
        <packagereq type="default">grinder</packagereq>
        <packagereq type="default">m2crypto</packagereq>
        <packagereq type="default">mod_wsgi</packagereq>

--- a/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
@@ -12,6 +12,7 @@
     <uservisible>true</uservisible>
     <packagelist>
        <packagereq type="default">createrepo</packagereq>
+       <packagereq type="default">gofer</packagereq>
        <packagereq type="default">grinder</packagereq>
        <packagereq type="default">m2crypto</packagereq>
        <packagereq type="default">mod_wsgi</packagereq>


### PR DESCRIPTION
python-gofer needs newer version of gofer than it's available in the 
underlying distros: using our own build.
