### PR TITLE
951231 - Systems Custom Information - Keyname and value should not accept html characters < > /

### DIFF
--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -346,9 +346,9 @@ Src::Application.routes.draw do
       # api custom information
       match '/custom_info/:informable_type/:informable_id' => 'custom_info#create', :via => :post, :as => :create_custom_info
       match '/custom_info/:informable_type/:informable_id' => 'custom_info#index', :via => :get, :as => :custom_info
-      match '/custom_info/:informable_type/:informable_id/:keyname' => 'custom_info#show', :via => :get, :as => :show_custom_info
-      match '/custom_info/:informable_type/:informable_id/:keyname' => 'custom_info#update', :via => :put, :as => :update_custom_info
-      match '/custom_info/:informable_type/:informable_id/:keyname' => 'custom_info#destroy', :via => :delete, :as => :destroy_custom_info
+      match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#show', :via => :get, :as => :show_custom_info
+      match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#update', :via => :put, :as => :update_custom_info
+      match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#destroy', :via => :delete, :as => :destroy_custom_info
 
       match '*a', :to => 'errors#render_404'
 

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -276,9 +276,9 @@ Src::Application.routes.draw do
       # api custom information
       match '/custom_info/:informable_type/:informable_id' => 'custom_info#create', :via => :post, :as => :create_custom_info
       match '/custom_info/:informable_type/:informable_id' => 'custom_info#index', :via => :get, :as => :custom_info
-      match '/custom_info/:informable_type/:informable_id/:keyname' => 'custom_info#show', :via => :get, :as => :show_custom_info
-      match '/custom_info/:informable_type/:informable_id/:keyname' => 'custom_info#update', :via => :put, :as => :update_custom_info
-      match '/custom_info/:informable_type/:informable_id/:keyname' => 'custom_info#destroy', :via => :delete, :as => :destroy_custom_info
+      match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#show', :via => :get, :as => :show_custom_info
+      match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#update', :via => :put, :as => :update_custom_info
+      match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#destroy', :via => :delete, :as => :destroy_custom_info
 
       # subscription-manager support
       match '/users/:username/owners' => 'users#list_owners', :via => :get

--- a/spec/controllers/api/v1/custom_info_controller_spec.rb
+++ b/spec/controllers/api/v1/custom_info_controller_spec.rb
@@ -103,10 +103,16 @@ describe Api::V1::CustomInfoController do
       @system.custom_info.create(:keyname => "test_key1", :value => "test_value1")
       @system.custom_info.create(:keyname => "test_key2", :value => "test_value2")
       @system.custom_info.create(:keyname => "test_key3", :value => "test_value3")
+      @system.custom_info.create(:keyname => "<blink>fookey</blink>", :value => "<blink>foovalue</blink>")
     end
 
     it "should return 200 with successful show" do
       get :show, :informable_id => @system.id, :informable_type => "system", :keyname => "test_key1"
+      response.code.should == "200"
+    end
+
+    it "should show custom info that has html in the keyname" do
+      get :show, :informable_id => @system.id, :informable_type => "system", :keyname => "<blink>fookey</blink>"
       response.code.should == "200"
     end
 
@@ -132,42 +138,48 @@ describe Api::V1::CustomInfoController do
       @system.custom_info.create(:keyname => "test_key1", :value => "test_value1")
       @system.custom_info.create(:keyname => "test_key2", :value => "test_value2")
       @system.custom_info.create(:keyname => "test_key3", :value => "test_value3")
+      @system.custom_info.create(:keyname => "<blink>fookey</blink>", :value => "<blink>foovalue</blink>")
     end
 
     it "should return 200 with successful update" do
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "super_test_value1").size.should == 0
       put :update, :informable_id => @system.id, :informable_type => "system", :keyname => "test_key1", :value => "super_test_value1"
       response.code.should == "200"
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 0
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "super_test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
+    end
+
+    it "should return 200 with successful update on keyname with html characters" do
+      put :update, :informable_id => @system.id, :informable_type => "system", :keyname => "<blink>fookey</blink>", :value => "<blink>superfoovalue</blink>"
+      response.code.should == "200"
     end
 
     it "should require valid informable type" do
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
       put :update, :informable_id => @system.id, :informable_type => "telephone", :keyname => "test_key1", :value => "super_test_value1"
       response.code.should == "500"
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
     end
 
     it "should require valid informable id" do
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
       put :update, :informable_id => (@system.id + 3), :informable_type => "system", :keyname => "test_key1", :value => "super_test_value1"
       response.code.should == "404"
       System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
     end
 
     it "should respond with 404 if custom info cannot be found" do
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
       put :update, :informable_id => @system.id, :informable_type => "system", :keyname => "super_test_key1", :value => "chuck norris"
       response.code.should == "404"
-      System.find(@system.id).custom_info.size.should == 3
+      System.find(@system.id).custom_info.size.should == 4
     end
   end
 
@@ -180,36 +192,42 @@ describe Api::V1::CustomInfoController do
 
       @system.custom_info.create(:keyname => "test_key4", :value => "test_value4")
       @system.custom_info.create(:keyname => "test_key5", :value => "test_value5")
+      @system.custom_info.create(:keyname => "<blink>fookey</blink>", :value => "<blink>foovalue</blink>")
     end
 
     it "should return 200 with success" do
-      @system.custom_info.size.should == 5
+      @system.custom_info.size.should == 6
       @system.custom_info.where(:keyname => "test_key1").size.should == 1
       delete :destroy, :informable_id => @system.id, :informable_type => "system", :keyname => "test_key1"
       response.code.should == "200"
       @system.custom_info.where(:keyname => "test_key1").size.should == 0
-      @system.custom_info.size.should == 4
+      @system.custom_info.size.should == 5
+    end
+
+    it "should return 200 with success with html characters in the keyname" do
+      delete :destroy, :informable_id => @system.id, :informable_type => "system", :keyname => "<blink>fookey</blink>"
+      response.code.should == "200"
     end
 
     it "should respond 404 if keyname cannot be found" do
-      @system.custom_info.size.should == 5
+      @system.custom_info.size.should == 6
       delete :destroy, :informable_id => @system.id, :informable_type => "system", :keyname => "super_test_key1"
       response.code.should == "404"
-      @system.custom_info.size.should == 5
+      @system.custom_info.size.should == 6
     end
 
     it "should require valid informable type" do
-      @system.custom_info.size.should == 5
+      @system.custom_info.size.should == 6
       delete :destroy, :informable_id => @system.id, :informable_type => "super informed", :keyname => "test_key1"
       response.code.should == "500"
-      @system.custom_info.size.should == 5
+      @system.custom_info.size.should == 6
     end
 
     it "should require valid informable id" do
-      @system.custom_info.size.should == 5
+      @system.custom_info.size.should == 6
       delete :destroy, :informable_id => (@system.id + 5), :informable_type => "system", :keyname => "test_key1"
       response.code.should == "404"
-      @system.custom_info.size.should == 5
+      @system.custom_info.size.should == 6
     end
   end
 end


### PR DESCRIPTION
routes controller was 404'ing on keynames with a `/`in them because it was
including that in part of the route instead of being the custom_info keyname
