### PR TITLE
997634-migrate-roles - set 'type' value appropriately

### DIFF
--- a/db/migrate/20130129122435_add_type_to_roles.rb
+++ b/db/migrate/20130129122435_add_type_to_roles.rb
@@ -1,6 +1,12 @@
 class AddTypeToRoles < ActiveRecord::Migration
   def self.up
     add_column :roles, :type, :string
+    clause = %{
+      update roles set type = 'UserOwnRole' where id in (
+        select own_role_id from users where own_role_id IS NOT NULL
+      )
+    }
+    execute(clause)
   end
 
   def self.down


### PR DESCRIPTION
Correctly set the 'type' for newly added column in migration.
