### PR TITLE
System task checking caused duplicate task

### DIFF
--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -540,6 +540,20 @@ module Glue::Candlepin::Consumer
       return 'yellow' if self.compliance['partiallyCompliantProducts'].include? product_id
       return 'red'
     end
+
+    def import_candlepin_tasks
+      self.events.each do |event|
+        event_status = {:task_id => event[:id],
+                        :state => event[:type],
+                        :start_time => event[:timestamp],
+                        :finish_time => event[:timestamp],
+                        :progress => "100",
+                        :result => event[:messageText]}
+        unless self.task_statuses.where('task_statuses.uuid' => event_status[:task_id]).exists?
+         TaskStatus.make(self, event_status, :candlepin_event, :event => event)
+        end
+      end
+    end
   end
 
   module ClassMethods

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -213,7 +213,9 @@ class System < ActiveRecord::Base
   end
 
   def tasks
-    TaskStatus.refresh_for_system(self)
+    refresh_running_tasks
+    import_candlepin_tasks
+    self.task_statuses
   end
 
   # A rollback occurred while attempting to create the system; therefore, perform necessary cleanup.
@@ -225,6 +227,12 @@ class System < ActiveRecord::Base
   end
 
   private
+
+    def refresh_running_tasks
+      ids = self.task_statuses.where(:state => [:waiting, :running]).pluck(:id)
+      TaskStatus.refresh(ids)
+    end
+
     def save_task_status pulp_task, task_type, parameters_type, parameters
       TaskStatus.make(self, pulp_task, task_type, parameters_type => parameters)
     end


### PR DESCRIPTION
Previously whenever you called system.tasks all tasks
from candlepin were duplicated within the db every time.
It was not checking properly that the tasks already existed.
Also the logic was confusing.  This should clear it up a good bit
