### PR TITLE
WebUI elements throwing nomethod exception

### DIFF
--- a/app/assets/javascripts/common/katello.global.js
+++ b/app/assets/javascripts/common/katello.global.js
@@ -20,6 +20,10 @@ var i18n = {};
 //Setup underscorejs
 KT.utils = _.noConflict();
 
+KT.utils.unescape = function(code) {
+    return code.replace(/\\\\/g, '\\').replace(/\\'/g, "'");
+};
+
 function localize(data) {
     for (var key in data) {
         if(data.hasOwnProperty(key)) {


### PR DESCRIPTION
Added unescape method to KT.utils to get rid of the exception
