### PR TITLE
fixing NoMethodError in application_controller:

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -587,7 +587,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_panel_results(results, total, options)
-    options[:total_count] ||= results.empty? ? 0 : results.total
+    options[:total_count] ||= results.empty? ? 0 : results.size
     options[:total_results] = total
     options[:collection] = results
     options[:columns] = options[:col]


### PR DESCRIPTION
```
[FATAL 2013-08-29 15:22:24 app]
| NoMethodError (undefined method `total' for #<Array:0x00000007f73c38>):
|   app/controllers/application_controller.rb:590:in `render_panel_results'
|   app/controllers/subscriptions_controller.rb:104:in `items'
|   app/lib/util/thread_session.rb:111:in `thread_locals'
|   config/initializers/quiet_paths.rb:11:in `call_with_quiet'
|   lib/katello/middleware/log_request_uuid.rb:22:in `call'
|
|
```

/cc @jlsherrill
