### PR TITLE
Updated spec to deal with renaming of cp tomcat in f19

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -210,7 +210,13 @@ Requires:       %{name}-configure
 Requires:       %{name}-cli
 Requires:       postgresql-server
 Requires:       postgresql
+
+%if 0%{?fedora} > 18
+Requires(post): candlepin-tomcat
+%else
 Requires(post): candlepin-tomcat6
+%endif
+
 Requires:       candlepin-selinux
 # the following backend engine deps are required by <katello-configure>
 Requires:       mongodb

--- a/rel-eng/comps/comps-katello-candlepin-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-candlepin-server-fedora18.xml
@@ -14,7 +14,6 @@
        <packagereq type="default">akuma</packagereq>
        <packagereq type="default">candlepin</packagereq>
        <packagereq type="default">candlepin-devel</packagereq>
-       <packagereq type="default">candlepin-jboss</packagereq>
        <packagereq type="default">candlepin-selinux</packagereq>
        <packagereq type="default">candlepin-tomcat6</packagereq>
        <packagereq type="default">oauth</packagereq>

--- a/rel-eng/comps/comps-katello-candlepin-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-candlepin-server-fedora19.xml
@@ -14,9 +14,9 @@
        <packagereq type="default">akuma</packagereq>
        <packagereq type="default">candlepin</packagereq>
        <packagereq type="default">candlepin-devel</packagereq>
-       <packagereq type="default">candlepin-jboss</packagereq>
+       <packagereq type="default">candlepin-certgen-lib</packagereq>
        <packagereq type="default">candlepin-selinux</packagereq>
-       <packagereq type="default">candlepin-tomcat6</packagereq>
+       <packagereq type="default">candlepin-tomcat</packagereq>
        <packagereq type="default">oauth</packagereq>
        <packagereq type="default">thumbslug</packagereq>
        <packagereq type="default">thumbslug-selinux</packagereq>

--- a/rel-eng/comps/comps-katello-candlepin-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-candlepin-server-rhel6.xml
@@ -14,7 +14,6 @@
        <packagereq type="default">akuma</packagereq>
        <packagereq type="default">candlepin</packagereq>
        <packagereq type="default">candlepin-devel</packagereq>
-       <packagereq type="default">candlepin-jboss</packagereq>
        <packagereq type="default">candlepin-selinux</packagereq>
        <packagereq type="default">candlepin-tomcat6</packagereq>
        <packagereq type="default">netty</packagereq>


### PR DESCRIPTION
So in F19  -> Its candlepin-tomcat
F18, Rhel 6-> Its candlepin-tomcat6

Also updated comps files
