### PR TITLE
867435 - [RFE] Importing GPG file with some random text shouldn't be allowed

### DIFF
--- a/app/lib/validators/gpg_key_content_validator.rb
+++ b/app/lib/validators/gpg_key_content_validator.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Validators
+  class GpgKeyContentValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      #imported or pasted GpgKey must contain header and footer of an typical GPG Key
+      unless value.match(/-{5}BEGIN PGP PUBLIC KEY BLOCK-{5}/) && value.match(/-{5}END PGP PUBLIC KEY BLOCK-{5}/)
+        record.errors[attribute] << _("must contain GPG Key")
+      end
+    end
+  end
+end

--- a/app/models/gpg_key.rb
+++ b/app/models/gpg_key.rb
@@ -26,6 +26,7 @@ class GpgKey < ActiveRecord::Base
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates :content, :presence => true
   validates_with Validators::ContentValidator, :attributes => :content
+  validates_with Validators::GpgKeyContentValidator, :attributes => :content
   validates_length_of :content, :maximum => MAX_CONTENT_LENGTH
   validates_presence_of :organization
   validates_uniqueness_of :name, :scope => :organization_id, :message => N_("Label has already been taken")


### PR DESCRIPTION
Adding an validator for GpgKey creation so the imported or pasted string contained a header and footer typical for gpg public keys 

e.g. 
"-----BEGIN PGP PUBLIC KEY BLOCK-----" 
                   GPG KEY
"-----END PGP PUBLIC KEY BLOCK-----"
