### PR TITLE
Fix apidoc generation with new version of apipie-doc

### DIFF
--- a/app/controllers/api/v1/content_view_definitions_controller.rb
+++ b/app/controllers/api/v1/content_view_definitions_controller.rb
@@ -94,12 +94,9 @@ class Api::V1::ContentViewDefinitionsController < Api::V1::ApiController
   end
 
   api :PUT, "/organizations/:org/content_view_definitions/:id", "Update a definition"
-  param :id, :number, :desc => "Definition identifer", :required => true
+  param :id, :number, :desc => "Definition identifier", :required => true
   param :org, String, :desc => "Organization name", :required => true
   param_group :content_view_definition
-  param :content_view_definition, Hash do
-    param :name, :required => false
-  end
   def update
     @definition.update_attributes!(params[:content_view_definition])
     respond :resource => @definition
@@ -134,7 +131,7 @@ class Api::V1::ContentViewDefinitionsController < Api::V1::ApiController
   end
 
   api :POST, "/organizations/:org/content_view_definitions/:id/clone", "Clone a definition"
-  param :id, :identifier, :desc => "Definition identifer", :required => true
+  param :id, :identifier, :desc => "Definition identifier", :required => true
   param :org, String, :desc => "Organization name", :required => true
   param_group :content_view_definition do
     param :label, String, :desc => "New definition label", :required => true
@@ -166,7 +163,7 @@ class Api::V1::ContentViewDefinitionsController < Api::V1::ApiController
   api :GET, "/organizations/:organization_id/content_view_definitions/:id/repositories",
       "List all the repositories for a content view definition"
   param :organization_id, :identifier, :desc => "organization identifier", :required => true
-  param :id, :identifer, :required => true, :desc => "Definition id"
+  param :id, :identifier, :required => true, :desc => "Definition id"
   def list_repositories
     respond_for_index :collection => @definition.repositories
   end

--- a/app/controllers/api/v1/content_views_controller.rb
+++ b/app/controllers/api/v1/content_views_controller.rb
@@ -70,14 +70,14 @@ class Api::V1::ContentViewsController < Api::V1::ApiController
   end
 
   api :POST, "/content_views/:id/refresh", "Refresh a content view"
-  param :id, :identifer, :desc => "content view id"
+  param :id, :identifier, :desc => "content view id"
   def refresh
     version = @view.refresh_view(:async => true)
     respond_for_async :resource => version.task_status, :status => 202
   end
 
   api :DELETE, "/content_views/:id"
-  param :id, :identifer, :desc => "content view id"
+  param :id, :identifier, :desc => "content view id"
   def destroy
     @view.destroy
     if @view.destroyed?

--- a/app/controllers/api/v2/content_view_definitions_controller.rb
+++ b/app/controllers/api/v2/content_view_definitions_controller.rb
@@ -40,7 +40,7 @@ class Api::V2::ContentViewDefinitionsController < Api::V1::ContentViewDefinition
   end
 
   api :PUT, "/content_view_definitions/:id", "Update a definition"
-  param :id, :number, :desc => "Definition identifer", :required => true
+  param :id, :number, :desc => "Definition identifier", :required => true
   param :org, String, :desc => "Organization name", :required => true
   param_group :content_view_definition
   def update
@@ -58,7 +58,7 @@ class Api::V2::ContentViewDefinitionsController < Api::V1::ContentViewDefinition
   end
 
   api :POST, "/content_view_definitions/:id/clone", "Clone a definition"
-  param :id, :identifier, :desc => "Definition identifer", :required => true
+  param :id, :identifier, :desc => "Definition identifier", :required => true
   param_group :content_view_definition
   param :content_view_definition, Hash do
     param :label, String, :desc => "Content view identifier"
@@ -78,7 +78,7 @@ class Api::V2::ContentViewDefinitionsController < Api::V1::ContentViewDefinition
 
   api :GET, "/content_view_definitions/:content_view_definition_id/repositories",
       "List all the repositories for a content view definition"
-  param :content_view_definition_id, :identifer, :required => true, :desc => "Definition id"
+  param :content_view_definition_id, :identifier, :required => true, :desc => "Definition id"
   def list_repositories
     super
   end

--- a/engines/fort/app/controllers/api/v1/node_capabilities_controller.rb
+++ b/engines/fort/app/controllers/api/v1/node_capabilities_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::NodeCapabilitiesController < Api::V1::ApiController
   def_param_group :capability do
     param :capability, Hash, :required => true, :action_aware => true do
       param :type, String, :required => true, :desc => "Type of capability"
-      param :configuration, :Hash, :required => true, :desc => "Capability configuration"
+      param :configuration, Hash, :required => true, :desc => "Capability configuration"
     end
   end
 


### PR DESCRIPTION
There was additional check added to apipie to detect invalid param 
descriptions and there were some in our code.

This patch addresses them.
