### PR TITLE
nodes API updates allowing nodes self-registration

### DIFF
--- a/engines/fort/config/routes.rb
+++ b/engines/fort/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
         member do
           post :sync
         end
+        collection do
+          get '/by_uuid/:uuid' => "nodes#show_by_uuid"
+        end
         resources :capabilities, :controller=>'node_capabilities'
       end
     end
@@ -22,6 +25,9 @@ Rails.application.routes.draw do
       api_resources :nodes do
         member do
           :sync
+        end
+        collection do
+          get '/by_uuid/:uuid' => "nodes#show_by_uuid"
         end
         api_resources :capabilities, :controller=>'node_capabilities'
       end


### PR DESCRIPTION
The nodes creation takes the system_uuid instead of the system id to
make the things on the node side easier. Also the capability is possible to specify
in the initial call.

Also `/nodes/by_uuid/:uuid` was added for the node to be able to find out about
it's status.

The authentication allows the systems to perform this basic operation for them
with consumer certificate.
