### PR TITLE
994946 - Unable to run katello-gui and headpin-gui automation due to TypeError and Reference Error

### DIFF
--- a/app/assets/javascripts/widgets/jquery.jeditable.helpers.js
+++ b/app/assets/javascripts/widgets/jquery.jeditable.helpers.js
@@ -99,6 +99,7 @@ KT.editable = (function(){
 
     var initialize_textfield = function() {
         $('.edit_textfield').each(function() {
+            var element = $(this);
             $(this).editable('destroy');
             var settings = {
                 type        :  'text',


### PR DESCRIPTION
error was `ReferenceError: element is not defined`
