### PR TITLE
Source code test: Fixing source code error

### DIFF
--- a/test/source_code_test.rb
+++ b/test/source_code_test.rb
@@ -101,8 +101,9 @@ class SourceCodeTest < MiniTest::Rails::ActiveSupport::TestCase
       SourceCode.
           new('**/*.rb').
           check_lines(<<-DOC) { |line| (line !~ /rescue +Exception/) ? true : line =~ /#\s?ok/ }
-always rescue specific exception or at least `rescue => e` which equals to `rescue StandardError => e`
+always rescue a specific exception or at least `rescue` which evaluates to `rescue StandardError`
 see http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby
+for more info.
       DOC
     end
 


### PR DESCRIPTION
I found a lot of instances of `rescue => e` in our code which triggered rubocop since the e variable wasn't being used. I think it's better to just recommend `rescue` since it's also the same thing as `rescue StandardError`.
