### PR TITLE
994785 - Unable to log in with the new user created in ldap mode

### DIFF
--- a/app/lib/navigation/menus/user.rb
+++ b/app/lib/navigation/menus/user.rb
@@ -19,7 +19,7 @@ module Navigation
 
       def initialize(user)
         @key           = :user
-        @display       = Katello.config[:gravatar] ? "#{gravatar_image_tag(user.email)}#{user.username}" : user.username
+        @display       = "#{(Katello.config[:gravatar]  && user.email.present?) ? "#{gravatar_image_tag(user.email)} " : ""}#{user.username}"
         @authorization = true
         @type          = 'dropdown'
         @items         = [

--- a/test/lib/navigation/navigation_menus_test.rb
+++ b/test/lib/navigation/navigation_menus_test.rb
@@ -117,7 +117,7 @@ class NavigationMenusTest < MiniTest::Rails::ActiveSupport::TestCase
   def test_gravatar
     menu = Navigation::Menus::User.new(@admin)
 
-    Katello.config[:gravatar] ? assert_equal("<img src=\"https:///secure.gravatar.com/avatar/985b643b38ac0b1589b212197e27a143?d=mm&s=25\" class=\"gravatar\"><span class=\"gravatar-span\">admin", menu.display) : assert_equal(@admin.user, menu.display)
+    Katello.config[:gravatar] ? assert_equal("<img src=\"https:///secure.gravatar.com/avatar/985b643b38ac0b1589b212197e27a143?d=mm&s=25\" class=\"gravatar\"><span class=\"gravatar-span\"> admin", menu.display) : assert_equal(@admin.user, menu.display)
     assert        menu.accessible?
   end
 


### PR DESCRIPTION
gravatar stuff was trying to read an email address (String) that doesn't
exist. LDAP users in katello/headpin don't have email fields
