### PR TITLE
1001327-headpin-perms - remove environment related permissions during upgrade

### DIFF
--- a/app/models/user_own_role.rb
+++ b/app/models/user_own_role.rb
@@ -12,6 +12,8 @@
 
 class UserOwnRole < Role
 
+  use_index_of Role  if Katello.config.use_elasticsearch
+
   def self_role_for_user
     users.first
   end

--- a/db/migrate/20130715153703_headpin_migration.rb
+++ b/db/migrate/20130715153703_headpin_migration.rb
@@ -46,6 +46,12 @@ class HeadpinMigration < ActiveRecord::Migration
           end
         end
       end
+
+      # Delete environment permissions
+      execute("delete from permission_tags where permission_id in (select id from permissions where resource_type_id=(select id from resource_types where name='environments'))")
+      execute("delete from permissions_verbs where permission_id in (select id from permissions where resource_type_id=(select id from resource_types where name='environments'))")
+      execute("delete from permissions where resource_type_id=(select id from resource_types where name='environments')")
+      execute("delete from resource_types where name='environments'")
     end
   end
 


### PR DESCRIPTION
Two changes:
1) remove environment permissions from roles during upgrade of headpin (thanks @partha)
2) corrected elasticsearch index for user_own_role (thanks @jsherrill)
