### PR TITLE
Rubocop: Locking version to prevent breakages

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -25,5 +25,5 @@ group :development do
   gem 'minitest-rails'
 
   gem 'factory_girl_rails', "~> 1.4.0"
-  gem 'rubocop'
+  gem 'rubocop', "~> 0.12.0"
 end


### PR DESCRIPTION
The new version (0.13.0) adds cops that'll break on our code.
