### PR TITLE
issue 2928: Bastion: fix org selector on nutupane

### DIFF
--- a/app/views/layouts/_allowed_orgs.html.haml
+++ b/app/views/layouts/_allowed_orgs.html.haml
@@ -1,6 +1,7 @@
 - for org in user.allowed_organizations
   %li.dropdown-item
     %div.dropdown-item-link
-      = render :partial=>"common/fav", :locals => {:org=>org, :current_user=>current_user}
-      %a.org-link{ "href"=>set_org_user_session_path(:org_id=>org.id), 'data-method'=>"POST", :rel=>"nofollow" }
+      = render :partial => "common/fav", :locals => { :org => org, :current_user => current_user }
+      %a.org-link{ "href" => set_org_user_session_path(:org_id => org.id), 'data-method' => "POST", :rel => "nofollow",
+        "ng-click" => "orgSwitcher.selectOrg($event, #{org.id})" }
         = org.name

--- a/engines/bastion/app/assets/bastion/stylesheets/bastion.scss
+++ b/engines/bastion/app/assets/bastion/stylesheets/bastion.scss
@@ -26,6 +26,7 @@ $spritePath: url("../alchemy/icons/action-icons.png");
 @import "nutupane";
 @import "systems";
 @import "widgets/path_selector";
+@import "widgets/org-switcher";
 
 @import "widgets/tipsy_custom";
 @import "jquery.tipsy";

--- a/engines/bastion/app/assets/bastion/widgets/org-switcher.widget.js
+++ b/engines/bastion/app/assets/bastion/widgets/org-switcher.widget.js
@@ -15,7 +15,9 @@
  * @ngdoc directive
  * @name Bastion.widgets.directive:orgSwitcher
  *
+ * @requires $compile
  * @requires $http
+ * @requires $window
  * @requires $document
  * @requires Routes
  *
@@ -29,7 +31,10 @@
  *  <span class="spinner"></span>
  *  <ul org-switcher></ul>
  */
-angular.module('Bastion.widgets').directive('orgSwitcher', ['$http', '$document', 'Routes', function($http, $document, Routes) {
+angular.module('Bastion.widgets').directive('orgSwitcher',
+    ['$compile', '$http', '$window', '$document', 'Routes',
+    function($compile, $http, $window, $document, Routes) {
+
     return {
         restrict: 'A',
         transclude: true,
@@ -50,6 +55,15 @@ angular.module('Bastion.widgets').directive('orgSwitcher', ['$http', '$document'
                 $http.get(Routes.allowedOrgsUserSessionPath()).then(function(response) {
                     $spinner.fadeOut();
                     $element.html(response.data);
+                    $compile($element.find('li'))($scope);
+                });
+            };
+
+            $scope.orgSwitcher.selectOrg = function(event, organizationId) {
+                event.preventDefault();
+
+                $http.post(Routes.setOrgUserSessionPath({'org_id': organizationId})).success(function() {
+                    $window.location = Routes.dashboardIndexPath();
                 });
             };
 

--- a/engines/bastion/test/widgets/org-switcher.test.js
+++ b/engines/bastion/test/widgets/org-switcher.test.js
@@ -26,6 +26,9 @@ describe('Directive:orgSwitcher', function() {
             var Routes = {
                 allowedOrgsUserSessionPath: function() {
                     return "orgs/";
+                },
+                setOrgUserSessionPath: function(organizationId) {
+                    return "set_org/";
                 }
             };
             $provide.value('Routes', Routes);
@@ -48,7 +51,7 @@ describe('Directive:orgSwitcher', function() {
         var orgListHtml;
 
         beforeEach(function() {
-            orgListHtml = '<li style="height: 10px;">1</li><li style="height: 10px;">2</li><li style="height: 10px;">3</li>';
+            orgListHtml = '<li style="height: 10px;" class="ng-scope">1</li><li style="height: 10px;" class="ng-scope">2</li><li style="height: 10px;" class="ng-scope">3</li>';
             $httpBackend.expectGET('orgs/').respond(200, orgListHtml);
         });
 
@@ -94,5 +97,13 @@ describe('Directive:orgSwitcher', function() {
             $('<div id="#organizationSwitcher"></div>').trigger('click');
             expect($scope.orgSwitcher.visible).toBe(true);
         });
+    });
+
+    it("provides a way to select an org", function() {
+        // mock the event argument
+        event = { preventDefault: function() {}};
+
+        $httpBackend.expectPOST('set_org/').respond();
+        $scope.orgSwitcher.selectOrg(event, 3);
     });
 });


### PR DESCRIPTION
This commit is to fix the org selector so that when a user clicks
on a new org, they are placed in that org and redirected to the
Dashboard.  The behavior is intended to be consistent with the
legacy tupane.
