### PR TITLE
Fixed the "list" call in  system groups api 

### DIFF
--- a/app/controllers/api/v1/system_groups_controller.rb
+++ b/app/controllers/api/v1/system_groups_controller.rb
@@ -70,9 +70,9 @@ class Api::V1::SystemGroupsController < Api::V1::ApiController
   def index
     query_string = params[:name] ? "name:#{params[:name]}" : params[:search]
 
-    filters = [{ :id => SystemGroup.readable(@organization).pluck(:id)}]
+    filters = [:terms => { :id => SystemGroup.readable(@organization).pluck(:id)}]
     options = {
-        :filter => filters
+        :filters => filters
     }
     options.merge!(params.slice(:sort_by, :sort_order))
 

--- a/app/models/glue/elastic_search/items.rb
+++ b/app/models/glue/elastic_search/items.rb
@@ -40,7 +40,7 @@ module Glue
       #   The model field on which to sort
       # @option       search_options :sort_order
       #   The order to sort on, one of DESC or ASC
-      # @option       search_options :filter
+      # @option       search_options :filters
       #   Filter to apply to search. Array of hashes.  Each key/value within the hash
       #   is OR'd, whereas each HASH itself is AND'd together
       # @option search_options [true, false] :load_records?


### PR DESCRIPTION
The search syntax had recently changed but the code in the controller had not been updated,
so elastic was not recognizing any filters and returning everything
