### PR TITLE
1002624: Content Search: fix display of package details, fixes #2801

### DIFF
--- a/app/helpers/packages_helper.rb
+++ b/app/helpers/packages_helper.rb
@@ -20,6 +20,44 @@ module PackagesHelper
     format_time(DateTime.strptime(date.to_s, "%s").to_date, format: :long)
   end
 
+  # This method will format the package details provided using a format
+  # similar to what is used in an rpm spec.  For example:
+  #   package-a
+  #   package-b = 1.2.0
+  #   package-c = 9:1.2.0
+  #   package-d >= 9:1.2.0-3
+  #
+  # where, the operator, epoch (e.g. 9), version (e.g 1.2.0) and
+  # release (e.g. 3) are optional
+  def format_package_details(package)
+
+    package_details = package[:name]
+
+    unless package[:flags].blank?
+      package_details = [package_details, package_operator(package[:flags]), ''].join(' ')
+      package_details += package[:epoch] + ':' unless package[:epoch].blank?
+      package_details += package[:version] unless package[:version].blank?
+      package_details += '-' + package[:release] unless package[:release].blank?
+    end
+
+    package_details
+  end
+
+  def package_operator(flag)
+    case flag
+    when 'EQ'
+      '='
+    when 'LT'
+      '<'
+    when 'LE'
+      '<='
+    when 'GT'
+      '>'
+    when 'GE'
+      '>='
+    end
+  end
+
   def changelog_changes(changes)
     if (lines = changes.split(/\n/)).length > 10
       previewed_changelog(lines)

--- a/app/models/glue/pulp/package.rb
+++ b/app/models/glue/pulp/package.rb
@@ -22,7 +22,7 @@ module Glue::Pulp::Package
 
       attr_accessor :_id, :download_url, :checksum, :license, :group, :filename, :requires,  :provides, :description,
                     :size, :buildhost, :repoids, :name, :arch, :version, :_content_type_id, :epoch, :vendor, :relativepath,
-                    :children, :release, :checksumtype, :filelist, :changelog
+                    :children, :release, :checksumtype, :files, :changelog
 
       alias_method 'id=', '_id='
       alias_method 'id', '_id'

--- a/app/views/packages/_details.html.haml
+++ b/app/views/packages/_details.html.haml
@@ -48,7 +48,7 @@
       &nbsp;
     - @package.requires.each do |item|
       %p
-        = item
+        = format_package_details(item)
 
   .item-container
     %label.fl.ra
@@ -57,7 +57,7 @@
       &nbsp;
     - @package.provides.each do |item|
       %p
-        = item
+        = format_package_details(item)
 
   .details-link-container
     %a{class: "package-filelist-link", data: {id: "#{@package.id}"}}View package files
@@ -66,8 +66,8 @@
     %a{class: "package-changelog-link", data: {id: "#{@package.id}"}}View package changelog
 
 .package-filelist{id: "package-filelist-#{@package.id}", title: (_("Files for %s") % @package.name)}
-  - if @package.filelist.length > 0
-    - @package.filelist.each do |file|
+  - if @package.files[:file].length > 0
+    - @package.files[:file].each do |file|
       %p
         = file
   - else

--- a/test/helpers/packages_helper_test.rb
+++ b/test/helpers/packages_helper_test.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require "minitest_helper"
+
+class PackagesHelperTest < MiniTest::Rails::ActionView::TestCase
+
+  def test_format_package_details
+    package = { :name => 'package-a' }
+    assert_equal "package-a", format_package_details(package)
+
+    package[:flags] = 'EQ'
+    package[:version] = '1.2.0'
+    assert_equal "package-a = 1.2.0", format_package_details(package)
+
+    package[:epoch] = '9'
+    assert_equal "package-a = 9:1.2.0", format_package_details(package)
+
+    package[:release] = '3'
+    assert_equal "package-a = 9:1.2.0-3", format_package_details(package)
+  end
+end


### PR DESCRIPTION
Prior to this commit, the package details was showing package:

Requires and Provides similar to:
{"release"=>"12.P1.el6", "epoch"=>"12", "version"=>"4.1.1", "flags"=>"EQ", "name"=>"dhclient"}

Now, the format for the above would be:
dhclient = 12:4.1.1-12.P1.el6

File listing previously would look like:
["file", ["/etc/NetworkManager/dispatcher.d/10-dhclient", "/sbin/dhclient", "/sbin/dhclient-script", "/usr/lib64/pm-utils/sleep.d/56dhclient", "/usr/share/doc/dhclient-4.1.1/README.dhclient.d", "/usr/share/doc/dhclient-4.1.1/dhclient.conf.sample", "/usr/share/doc/dhclient-4.1.1/dhclient6.conf.sample", "/usr/share/man/man5/dhclient.conf.5.gz", "/usr/share/man/man5/dhclient.leases.5.gz", "/usr/share/man/man5/dhcp-eval.5.gz", "/usr/share/man/man5/dhcp-options.5.gz", "/usr/share/man/man8/dhclient-script.8.gz", "/usr/share/man/man8/dhclient.8.gz"]]

Now, the format for the above would be:
/etc/NetworkManager/dispatcher.d/10-dhclient
/sbin/dhclient
...
...
