### PR TITLE
994987: destroy content view definition archives when a definition is destroyed

### DIFF
--- a/app/models/content_view_definition.rb
+++ b/app/models/content_view_definition.rb
@@ -17,7 +17,7 @@ class ContentViewDefinition < ContentViewDefinitionBase
   include AsyncOrchestration
 
   has_many :content_views, :dependent => :destroy
-  has_many :content_view_definition_archives, :foreign_key => :source_id
+  has_many :content_view_definition_archives, :foreign_key => :source_id, :dependent => :destroy
   alias_method :archives, :content_view_definition_archives
 
   validates :label, :uniqueness => {:scope => :organization_id},


### PR DESCRIPTION
Whenever a definition is destroyed, the corresponding archives for that
definition should also be destroyed.

Without this change, a foreign key error will be observed when
deleting the definition.  E.g.

[DEBUG 2013-09-13 16:06:34 glue] Katello::Actions::RepositoryDestroy:success:nil -> nil
[DEBUG 2013-09-13 16:06:35 app] Setting current user thread-local variable to nil
[ INFO 2013-09-13 16:06:35 app] Completed 500 Internal Server Error in 5544ms
[FATAL 2013-09-13 16:06:35 app]
 | PG::ForeignKeyViolation (ERROR:  update or delete on table "content_view_definition_bases" violates foreign key constraint "content_view_definition_bases_source_id_fk" on table "content_view_definition_bases"
 | DETAIL:  Key (id)=(4) is still referenced from table "content_view_definition_bases".
 | ):
 |   app/controllers/content_view_definitions_controller.rb:147:in `destroy'
 |   app/lib/util/thread_session.rb:110:in`thread_locals'
 |   config/initializers/quiet_paths.rb:11:in `call_with_quiet'
 |   lib/katello/middleware/log_request_uuid.rb:22:in`call'
 |
 |
