### PR TITLE
Rubocop: Fix deprecated hash methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,9 +79,6 @@ DotPosition:
 Lambda:
   Enabled: false # don't require -> for single line lambdas
 
-HashMethods:
-  Enabled: false # we use Configuration#has_key? which rubocop mistakes for the hash method
-
 FavorSprintf:
   Enabled: false # we use % for i18n
 

--- a/app/controllers/activation_keys_controller.rb
+++ b/app/controllers/activation_keys_controller.rb
@@ -125,7 +125,7 @@ class ActivationKeysController < ApplicationController
   end
 
   def add_subscriptions
-    if params.has_key? :subscription_id
+    if params.key? :subscription_id
       params[:subscription_id].keys.each do |pool|
         kt_pool = ::Pool.where(:cp_id => pool)[0]
 
@@ -141,7 +141,7 @@ class ActivationKeysController < ApplicationController
   end
 
   def remove_subscriptions
-    if params.has_key? :subscription_id
+    if params.key? :subscription_id
       params[:subscription_id].keys.each do |pool|
         kt_pool = Pool.where(:cp_id => pool)[0]
 

--- a/app/controllers/api/v1/activation_keys_controller.rb
+++ b/app/controllers/api/v1/activation_keys_controller.rb
@@ -140,7 +140,7 @@ class Api::V1::ActivationKeysController < Api::V1::ApiController
   private
 
   def find_environment
-    return unless params.has_key?(:environment_id)
+    return unless params.key?(:environment_id)
 
     @environment = KTEnvironment.find(params[:environment_id])
     raise HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
@@ -170,7 +170,7 @@ class Api::V1::ActivationKeysController < Api::V1::ApiController
   end
 
   def verify_presence_of_organization_or_environment
-    return if params.has_key?(:organization_id) || params.has_key?(:environment_id)
+    return if params.key?(:organization_id) || params.key?(:environment_id)
     raise HttpErrors::BadRequest, _("Either organization ID or environment ID needs to be specified")
   end
 end

--- a/app/controllers/api/v1/distributors_controller.rb
+++ b/app/controllers/api/v1/distributors_controller.rb
@@ -139,9 +139,9 @@ class Api::V1::DistributorsController < Api::V1::ApiController
   api :GET, "/distributors/:id/pools", "List pools a distributor is subscribed to"
   param :id, String, :desc => "UUID of the distributor", :required => true
   def pools
-    match_distributor = params.has_key?(:match_distributor) ? params[:match_distributor].to_bool : false
-    match_installed   = params.has_key?(:match_installed) ? params[:match_installed].to_bool : false
-    no_overlap        = params.has_key?(:no_overlap) ? params[:no_overlap].to_bool : false
+    match_distributor = params.key?(:match_distributor) ? params[:match_distributor].to_bool : false
+    match_installed   = params.key?(:match_installed) ? params[:match_installed].to_bool : false
+    no_overlap        = params.key?(:no_overlap) ? params[:no_overlap].to_bool : false
 
     cp_pools = @distributor.filtered_pools(match_distributor, match_installed, no_overlap)
 
@@ -249,7 +249,7 @@ class Api::V1::DistributorsController < Api::V1::ApiController
   protected
 
   def find_only_environment
-    if !@environment && @organization && !params.has_key?(:environment_id)
+    if !@environment && @organization && !params.key?(:environment_id)
       if @organization.environments.empty?
         raise HttpErrors::BadRequest, _("Organization %{org} has the '%{env}' environment only. Please create an environment for distributor registration.") %
           { :org => @organization.name, :env => "Library" }
@@ -279,7 +279,7 @@ class Api::V1::DistributorsController < Api::V1::ApiController
   end
 
   def find_environment
-    return unless params.has_key?(:environment_id)
+    return unless params.key?(:environment_id)
 
     @environment = KTEnvironment.find(params[:environment_id])
     raise HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
@@ -290,7 +290,7 @@ class Api::V1::DistributorsController < Api::V1::ApiController
   def verify_presence_of_organization_or_environment
     # This has to grab the first default org associated with this user AND
     # the environment that goes with him.
-    return if params.has_key?(:organization_id) || params.has_key?(:owner) || params.has_key?(:environment_id)
+    return if params.key?(:organization_id) || params.key?(:owner) || params.key?(:environment_id)
 
     #At this point we know that they didn't supply an org or environment, so we can look up the default
     @environment = current_user.default_environment

--- a/app/controllers/api/v1/environments_controller.rb
+++ b/app/controllers/api/v1/environments_controller.rb
@@ -100,7 +100,7 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
     # The following is a workaround to handle the fact that rhsm currently requests the
     # environment using the 'name' parameter; however, the value is actually the environment label.
     if request_from_rhsm? && @environments.empty?
-      if query_params.has_key?(:name)
+      if query_params.key?(:name)
         query_params[:label] = query_params[:name]
         query_params.delete(:name)
       end

--- a/app/controllers/api/v1/errata_controller.rb
+++ b/app/controllers/api/v1/errata_controller.rb
@@ -59,10 +59,10 @@ class Api::V1::ErrataController < Api::V1::ApiController
   private
 
   def find_environment
-    if params.has_key?(:environment_id)
+    if params.key?(:environment_id)
       @environment = KTEnvironment.find(params[:environment_id])
       raise HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
-    elsif params.has_key?(:repoid)
+    elsif params.key?(:repoid)
       @repo = Repository.find(params[:repoid])
       raise HttpErrors::NotFound, _("Couldn't find repository '%s'") % params[:repoid] if @repo.nil?
       @environment = @repo.environment
@@ -71,7 +71,7 @@ class Api::V1::ErrataController < Api::V1::ApiController
   end
 
   def find_repository
-    if params.has_key?(:repository_id)
+    if params.key?(:repository_id)
       @repo = Repository.find(params[:repository_id])
       raise HttpErrors::NotFound, _("Couldn't find repository '%s'") % params[:repository_id] if @repo.nil?
       @environment ||= @repo.environment

--- a/app/controllers/api/v1/filter_rules_controller.rb
+++ b/app/controllers/api/v1/filter_rules_controller.rb
@@ -63,10 +63,10 @@ class Api::V1::FilterRulesController < Api::V1::ApiController
     rule         = JSON.parse(rule_params[:rule]).with_indifferent_access
     inclusion    = rule_params[:inclusion].to_s.to_bool
     content_type = rule_params[:content]
-    if rule.has_key?(:date_range)
+    if rule.key?(:date_range)
       date_range = rule[:date_range]
-      date_range[:start] = date_range[:start].to_time.to_i if date_range.has_key?(:start)
-      date_range[:end] = date_range[:end].to_time.to_i if date_range.has_key?(:end)
+      date_range[:start] = date_range[:start].to_time.to_i if date_range.key?(:start)
+      date_range[:end] = date_range[:end].to_time.to_i if date_range.key?(:end)
     end
     FilterRule.create_for(content_type, :filter => @filter, :inclusion => inclusion, :parameters => rule)
   end

--- a/app/controllers/api/v1/system_group_errata_controller.rb
+++ b/app/controllers/api/v1/system_group_errata_controller.rb
@@ -80,7 +80,7 @@ class Api::V1::SystemGroupErrataController < Api::V1::ApiController
     @group.systems.each do |system|
       errata = system.errata
       errata.each do |erratum|
-        if errata_hash.has_key?(erratum.id)
+        if errata_hash.key?(erratum.id)
           # add the system to the existing erratum entry
           errata_hash[erratum.id][:systems].push(system.name)
         else

--- a/app/controllers/api/v1/systems_controller.rb
+++ b/app/controllers/api/v1/systems_controller.rb
@@ -176,7 +176,7 @@ Schedules the consumer identity certificate regeneration
       attrs[:environment_id] = params[:environment][:id] if params[:environment]
     end
 
-    attrs[:installedProducts] = [] if attrs.has_key?(:installedProducts) && attrs[:installedProducts].nil?
+    attrs[:installedProducts] = [] if attrs.key?(:installedProducts) && attrs[:installedProducts].nil?
 
     @system.update_attributes!(attrs.slice(*slice_attrs))
 
@@ -259,9 +259,9 @@ Schedules the consumer identity certificate regeneration
   api :GET, "/systems/:id/pools", "List pools a system is subscribed to"
   param :id, String, :desc => "UUID of the system", :required => true
   def pools
-    match_system    = params.has_key?(:match_system) ? params[:match_system].to_bool : false
-    match_installed = params.has_key?(:match_installed) ? params[:match_installed].to_bool : false
-    no_overlap      = params.has_key?(:no_overlap) ? params[:no_overlap].to_bool : false
+    match_system    = params.key?(:match_system) ? params[:match_system].to_bool : false
+    match_installed = params.key?(:match_installed) ? params[:match_installed].to_bool : false
+    no_overlap      = params.key?(:no_overlap) ? params[:no_overlap].to_bool : false
 
     cp_pools = @system.filtered_pools(match_system, match_installed, no_overlap)
 
@@ -294,7 +294,7 @@ A hint for choosing the right value for the releaseVer param
   param :id, String, :desc => "UUID of the system", :required => true
   def upload_package_profile
     if Katello.config.katello?
-      raise HttpErrors::BadRequest, _("No package profile received for %s") % @system.name unless params.has_key?(:_json)
+      raise HttpErrors::BadRequest, _("No package profile received for %s") % @system.name unless params.key?(:_json)
       @system.upload_package_profile(params[:_json])
     end
     respond_for_update
@@ -475,7 +475,7 @@ This information is then used for computing the errata available for the system.
   protected
 
   def find_only_environment
-    if !@environment && @organization && !params.has_key?(:environment_id)
+    if !@environment && @organization && !params.key?(:environment_id)
       if @organization.environments.empty?
         raise HttpErrors::BadRequest, _("Organization %{org} has the '%{env}' environment only. Please create an environment for system registration.") %
           { :org => @organization.name, :env => "Library" }
@@ -529,7 +529,7 @@ This information is then used for computing the errata available for the system.
   end
 
   def find_environment
-    return unless params.has_key?(:environment_id)
+    return unless params.key?(:environment_id)
 
     @environment = KTEnvironment.find(params[:environment_id])
     raise HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
@@ -541,10 +541,10 @@ This information is then used for computing the errata available for the system.
     # There are some scenarios (primarily create) where a system may be
     # created using the content_view_environment.cp_id which is the
     # equivalent of "environment_id"-"content_view_id".
-    return unless params.has_key?(:environment_id)
+    return unless params.key?(:environment_id)
 
     if params[:environment_id].is_a? String
-      if !params.has_key?(:content_view_id)
+      if !params.key?(:content_view_id)
         cve = get_content_view_environment_by_cp_id(params[:environment_id])
         @environment = cve.environment
         @organization = @environment.organization
@@ -564,7 +564,7 @@ This information is then used for computing the errata available for the system.
   def verify_presence_of_organization_or_environment
     # This has to grab the first default org associated with this user AND
     # the environment that goes with him.
-    return if params.has_key?(:organization_id) || params.has_key?(:owner) || params.has_key?(:environment_id)
+    return if params.key?(:organization_id) || params.key?(:owner) || params.key?(:environment_id)
 
     #At this point we know that they didn't supply an org or environment, so we can look up the default
     @environment = current_user.default_environment

--- a/app/controllers/api/v2/errata_controller.rb
+++ b/app/controllers/api/v2/errata_controller.rb
@@ -54,7 +54,7 @@ class Api::V2::ErrataController < Api::V2::ApiController
   private
 
   def find_environment
-    if params.has_key?(:environment_id)
+    if params.key?(:environment_id)
       @environment = KTEnvironment.find(params[:environment_id])
       raise HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
       @environment
@@ -62,7 +62,7 @@ class Api::V2::ErrataController < Api::V2::ApiController
   end
 
   def find_repository
-    if params.has_key?(:repository_id)
+    if params.key?(:repository_id)
       @repo = Repository.find(params[:repository_id])
       raise HttpErrors::NotFound, _("Couldn't find repository '%s'") % params[:repository_id] if @repo.nil?
       @environment ||= @repo.environment

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -159,7 +159,7 @@ class ChangesetsController < ApplicationController
     render :text => "This promotion changeset is already promoted, no content modifications can be made.",
            :status => :bad_request if @changeset.state == Changeset::PROMOTED
 
-    if params.has_key? :data
+    if params.key? :data
       params[:data].each do |item|
         adding = item["adding"]
         type   = item["type"]
@@ -305,7 +305,7 @@ class ChangesetsController < ApplicationController
   end
 
   def update_artifacts_valid?
-    if params.has_key?(:data)
+    if params.key?(:data)
       params[:data].each do |item|
         return false if !update_item_valid?(item["type"], item["item_id"])
       end

--- a/app/controllers/content_view_definitions_controller.rb
+++ b/app/controllers/content_view_definitions_controller.rb
@@ -159,7 +159,7 @@ class ContentViewDefinitionsController < ApplicationController
 
   def publish
     # perform the publish
-    if params.has_key?(:content_view)
+    if params.key?(:content_view)
       @view_definition.publish(params[:content_view][:name], params[:content_view][:description],
                                params[:content_view][:label], {:notify => true})
       notify.success(_("Started publish of content view '%{view_name}' from definition '%{definition_name}'.") %
@@ -222,7 +222,7 @@ class ContentViewDefinitionsController < ApplicationController
   end
 
   def update_content
-    if params.has_key?(:products)
+    if params.key?(:products)
       products_ids = params[:products].blank? ? [] : Product.readable(current_organization).
           where(:id => params[:products]).pluck("products.id")
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -107,7 +107,7 @@ class DashboardController < ApplicationController
 
   def update_user_preference(key, value)
     current_user.preferences = HashWithIndifferentAccess.new  unless current_user.preferences
-    current_user.preferences[:dashboard] = {} unless current_user.preferences.has_key? :dashboard
+    current_user.preferences[:dashboard] = {} unless current_user.preferences.key? :dashboard
     current_user.preferences[:dashboard][key] = value
     current_user.save!
   end

--- a/app/controllers/distributors_controller.rb
+++ b/app/controllers/distributors_controller.rb
@@ -38,7 +38,7 @@ class DistributorsController < ApplicationController
     bulk_delete_distributors = lambda{@distributors.collect{|s| false unless s.deletable?}.compact.empty?}
     register_distributor = lambda do
       if current_organization
-        if params.has_key?(:distributor) && !params[:distributor][:content_view_id].blank?
+        if params.key?(:distributor) && !params[:distributor][:content_view_id].blank?
           content_view = ContentView.readable(current_organization).
             find_by_id(params[:distributor][:content_view_id])
           Distributor.registerable?(@environment, current_organization, content_view) if content_view
@@ -59,7 +59,7 @@ class DistributorsController < ApplicationController
 
     edit_distributor = lambda do
       subscribable = true
-      if params.has_key?(:distributor) && !params[:distributor][:content_view_id].blank?
+      if params.key?(:distributor) && !params[:distributor][:content_view_id].blank?
         content_view = ContentView.readable(current_organization).
           find_by_id(params[:distributor][:content_view_id])
         subscribable = content_view ? content_view.subscribable? : false
@@ -225,7 +225,7 @@ class DistributorsController < ApplicationController
   end
 
   def update_subscriptions
-    if params.has_key? :subscription
+    if params.key? :subscription
       params[:subscription].keys.each do |pool|
         @distributor.subscribe pool, params[:spinner][pool] if params[:subscribe_action].downcase == "subscribe"
         @distributor.unsubscribe pool if params[:subscribe_action].downcase == "unsubscribe"
@@ -269,7 +269,7 @@ class DistributorsController < ApplicationController
   end
 
   def update
-    params[:distributor][:content_view_id] = nil if params[:distributor].has_key? :environment_id
+    params[:distributor][:content_view_id] = nil if params[:distributor].key? :environment_id
 
     @distributor.update_attributes!(params[:distributor])
     notify.success _("Distributor '%s' was updated.") % @distributor["name"]
@@ -362,7 +362,7 @@ class DistributorsController < ApplicationController
   end
 
   def find_environment_in_distributor
-    if params.has_key?(:distributor) && params[:distributor].has_key?(:environment_id)
+    if params.key?(:distributor) && params[:distributor].key?(:environment_id)
       @environment = KTEnvironment.distributors_readable(current_organization).
                       where(:id => params[:distributor][:environment_id]).first
     end
@@ -452,7 +452,7 @@ class DistributorsController < ApplicationController
   def first_objects(objects)
     offset = current_user.page_size
     if objects.length > 0
-      if params.has_key? :order
+      if params.key? :order
         if params[:order].downcase == "desc"
           objects.reverse!
         end
@@ -469,18 +469,18 @@ class DistributorsController < ApplicationController
     size = current_user.page_size
     if objects.length > 0
       #check for the params offset (start of array chunk)
-      if params.has_key? :offset
+      if params.key? :offset
         offset = params[:offset].to_i
       else
         offset = current_user.page_size
       end
-      if params.has_key? :order
+      if params.key? :order
         if params[:order].downcase == "desc"
           #reverse if order is desc
           objects.reverse!
         end
       end
-      if params.has_key? :reverse
+      if params.key? :reverse
         next_objects = objects[0...params[:reverse].to_i]
       else
         next_objects = objects[offset...offset + size]

--- a/app/controllers/filter_rules_controller.rb
+++ b/app/controllers/filter_rules_controller.rb
@@ -103,7 +103,7 @@ class FilterRulesController < ApplicationController
   def update
     @rule.update_attributes!(params[:filter_rule])
 
-    result = params[:filter_rule].has_key?(:inclusion) ? included_text(@rule) : params[:filter_rule].values.first
+    result = params[:filter_rule].key?(:inclusion) ? included_text(@rule) : params[:filter_rule].values.first
 
     notify.success(_("Rule '%{type}' was successfully updated.") %
                    {:type => FilterRule::CONTENT_OPTIONS.key(@rule.content_type)})

--- a/app/controllers/gpg_keys_controller.rb
+++ b/app/controllers/gpg_keys_controller.rb
@@ -91,7 +91,7 @@ class GpgKeysController < ApplicationController
   def create
     gpg_key_params = params[:gpg_key]
     return render_bad_parameters if gpg_key_params.nil?
-    file_uploaded = gpg_key_params.has_key?("content_upload") && !gpg_key_params.has_key?("content")
+    file_uploaded = gpg_key_params.key?("content_upload") && !gpg_key_params.key?("content")
 
     if file_uploaded
       gpg_key_params['content'] = params[:gpg_key][:content_upload].read
@@ -122,7 +122,7 @@ class GpgKeysController < ApplicationController
   def update
     gpg_key_params = params[:gpg_key]
 
-    file_uploaded = gpg_key_params.has_key?("content_upload") && !gpg_key_params.has_key?("content")
+    file_uploaded = gpg_key_params.key?("content_upload") && !gpg_key_params.key?("content")
     if file_uploaded
       gpg_key_params['content'] = params[:gpg_key][:content_upload].read
       gpg_key_params.delete('content_upload')

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -94,7 +94,7 @@ class ProductsController < ApplicationController
     @product.name = params[:product][:name] if params[:product][:name]
     @product.description = params[:product][:description] if params[:product][:description]
 
-    if params[:product].has_key?(:gpg_key)
+    if params[:product].key?(:gpg_key)
       if params[:product][:gpg_key] != ""
         @product.gpg_key = GpgKey.readable(current_organization).find(params[:product][:gpg_key])
         result = @product.gpg_key.id.to_s

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -183,21 +183,21 @@ class RolesController < ApplicationController
     attributes = params[:permission]
     @permission = Permission.find(params[:permission_id])
 
-    if attributes.has_key?(:tag_names) && @permission.all_tags
+    if attributes.key?(:tag_names) && @permission.all_tags
       @permission.all_tags = false
     end
 
-    if attributes.has_key?(:verb_values) && @permission.all_verbs
+    if attributes.key?(:verb_values) && @permission.all_verbs
       @permission.all_verbs = false
     end
 
-    if attributes.has_key?(:all_verbs)
+    if attributes.key?(:all_verbs)
       @permission.verbs.each do |verb|
         @permission.verbs.delete(Verb.find_or_create_by_verb(verb.name))
       end
     end
 
-    if attributes.has_key?(:all_tags)
+    if attributes.key?(:all_tags)
       @permission.tags.each do |tag|
         @permission.tags.delete(tag)
       end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -184,7 +184,7 @@ class SubscriptionsController < ApplicationController
   end
 
   def upload
-    if !params[:provider].blank? && params[:provider].has_key?(:contents)
+    if !params[:provider].blank? && params[:provider].key?(:contents)
       begin
         temp_file_path = create_temp_file('import') {|tmp| tmp.write params[:provider][:contents].read }
         # force must be a string value

--- a/app/controllers/system_group_events_controller.rb
+++ b/app/controllers/system_group_events_controller.rb
@@ -72,7 +72,7 @@ class SystemGroupEventsController < ApplicationController
   end
 
   def more_items
-    if params.has_key?(:offset)
+    if params.key?(:offset)
       offset = params[:offset].to_i
     else
       offset = current_user.page_size

--- a/app/controllers/system_group_packages_controller.rb
+++ b/app/controllers/system_group_packages_controller.rb
@@ -143,7 +143,7 @@ class SystemGroupPackagesController < ApplicationController
       notify.success _("Update of Package Groups '%{groups}' scheduled for System Group '%{name}'.") %
         {:groups => groups.join(','), :name => @group.name}
 
-    elsif params.has_key?(:packages)
+    elsif params.key?(:packages)
       if !params[:packages].empty?
         # user entered one or more package names (as comma-separated list) in the content box
         packages = Util::Package.validate_package_list_format(params[:packages])

--- a/app/controllers/system_packages_controller.rb
+++ b/app/controllers/system_packages_controller.rb
@@ -133,7 +133,7 @@ class SystemPackagesController < ApplicationController
     packages = @system.simple_packages.sort {|a, b| a.nvrea.downcase <=> b.nvrea.downcase}
     total_packages = packages.length
     if total_packages > 0
-      if params.has_key? :pkg_order
+      if params.key? :pkg_order
         if params[:pkg_order].downcase == "desc"
           packages.reverse!
         end
@@ -157,7 +157,7 @@ class SystemPackagesController < ApplicationController
   def more_packages
     packages = @system.simple_packages.sort {|a, b| a.nvrea.downcase <=> b.nvrea.downcase}
 
-    if params.has_key? :pkg_order
+    if params.key? :pkg_order
       if params[:pkg_order].downcase == "desc"
         packages.reverse!
       end

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -43,7 +43,7 @@ class SystemsController < ApplicationController
     bulk_edit_systems = lambda{@systems.collect{|s| false unless s.editable?}.compact.empty?}
     register_system = lambda do
       if current_organization
-        if params.has_key?(:system) && !params[:system][:content_view_id].blank?
+        if params.key?(:system) && !params[:system][:content_view_id].blank?
           content_view = ContentView.readable(current_organization).
             find_by_id(params[:system][:content_view_id])
           System.registerable?(@environment, current_organization, content_view) if content_view
@@ -64,7 +64,7 @@ class SystemsController < ApplicationController
 
     edit_system = lambda do
       subscribable = true
-      if params.has_key?(:system) && !params[:system][:content_view_id].blank?
+      if params.key?(:system) && !params[:system][:content_view_id].blank?
         content_view = ContentView.readable(current_organization).
           find_by_id(params[:system][:content_view_id])
         subscribable = content_view ? content_view.subscribable? : false
@@ -225,7 +225,7 @@ class SystemsController < ApplicationController
   end
 
   def update_subscriptions
-    if params.has_key? :subscription
+    if params.key? :subscription
       params[:subscription].keys.each do |pool|
         @system.subscribe pool, params[:spinner][pool] if params[:subscribe_action].downcase == "subscribe"
         @system.unsubscribe pool if params[:subscribe_action].downcase == "unsubscribe"
@@ -700,7 +700,7 @@ class SystemsController < ApplicationController
   end
 
   def find_environment_in_system
-    if params.has_key?(:system) && params[:system].has_key?(:environment_id)
+    if params.key?(:system) && params[:system].key?(:environment_id)
       @environment = KTEnvironment.systems_readable(current_organization).
                       where(:id => params[:system][:environment_id]).first
     end
@@ -791,7 +791,7 @@ class SystemsController < ApplicationController
   def first_objects(objects)
     offset = current_user.page_size
     if objects.length > 0
-      if params.has_key? :order
+      if params.key? :order
         if params[:order].downcase == "desc"
           objects.reverse!
         end
@@ -810,18 +810,18 @@ class SystemsController < ApplicationController
     size = current_user.page_size
     if objects.length > 0
       #check for the params offset (start of array chunk)
-      if params.has_key? :offset
+      if params.key? :offset
         offset = params[:offset].to_i
       else
         offset = current_user.page_size
       end
-      if params.has_key? :order
+      if params.key? :order
         if params[:order].downcase == "desc"
           #reverse if order is desc
           objects.reverse!
         end
       end
-      if params.has_key? :reverse
+      if params.key? :reverse
         next_objects = objects[0...params[:reverse].to_i]
       else
         next_objects = objects[offset...(offset + size)]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -193,7 +193,7 @@ class UsersController < ApplicationController
   def update_preference
     preference = params[:preference]
     if preference
-      @user.preferences[:user] = { } unless @user.preferences.has_key? :user
+      @user.preferences[:user] = { } unless @user.preferences.key? :user
       if params[:value] == "true"
         value = true
       elsif  params[:value] == "false"
@@ -271,7 +271,7 @@ class UsersController < ApplicationController
   end
 
   def update_roles
-    params[:user] = { "role_ids" => [] } unless params.has_key? :user
+    params[:user] = { "role_ids" => [] } unless params.key? :user
 
     #Add in the own role if updating roles, cause the user shouldn't see his own role
     params[:user][:role_ids] << @user.own_role.id

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -194,7 +194,7 @@ module ApplicationHelper
   end
 
   def generate_url(path, options, entity)
-    panel_page = options.has_key?(:panel_page) ? ("&panelpage=" + options[:panel_page]) : ""
+    panel_page = options.key?(:panel_page) ? ("&panelpage=" + options[:panel_page]) : ""
     path + "?list_search=id%3D#{options[:id]}#panel=#{entity}_#{options[:id]}" + panel_page
   end
 

--- a/app/helpers/content_view_definitions_helper.rb
+++ b/app/helpers/content_view_definitions_helper.rb
@@ -90,7 +90,7 @@ module ContentViewDefinitionsHelper
 
   def view_checked?(view_id, views_hash = nil)
     return false if views_hash.nil?
-    return views_hash.has_key?(view_id)
+    return views_hash.key?(view_id)
   end
 
   def view_repos(definitions)

--- a/app/lib/api/constraints/api_version_constraint.rb
+++ b/app/lib/api/constraints/api_version_constraint.rb
@@ -13,7 +13,7 @@
 class ApiVersionConstraint
   def initialize(options)
     @version = options[:version]
-    @default = options.has_key?(:default) ? options[:default] : false
+    @default = options.key?(:default) ? options[:default] : false
   end
 
   def matches?(req)

--- a/app/lib/lazy_accessor.rb
+++ b/app/lib/lazy_accessor.rb
@@ -71,7 +71,7 @@ module LazyAccessor
         send :define_method, symbol do
           attr = symbol.to_s
 
-          excepted = options.has_key?(:unless) ? self.instance_eval(&options[:unless]) : new_record?
+          excepted = options.key?(:unless) ? self.instance_eval(&options[:unless]) : new_record?
           if !instance_variable_defined?("@#{attr}") && !excepted
             remote_values = run_initializer(args.size > 1, initializer)
             if args.size > 1
@@ -97,7 +97,7 @@ module LazyAccessor
     end
 
     def remote_attribute_changed?(attr)
-      changed_remote_attributes.has_key?(attr)
+      changed_remote_attributes.key?(attr)
     end
 
     def save(*)

--- a/app/lib/validators/erratum_rule_params_validator.rb
+++ b/app/lib/validators/erratum_rule_params_validator.rb
@@ -14,7 +14,7 @@ module Validators
   class ErratumRuleParamsValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       if value
-        if value.has_key?(:date_range)
+        if value.key?(:date_range)
           date_range = value[:date_range]
           start_date_int = date_range[:start]
           end_date_int = date_range[:end]
@@ -31,7 +31,7 @@ module Validators
           end
         end
 
-        if value.has_key?(:errata_type)
+        if value.key?(:errata_type)
           errata_type = value[:errata_type]
           if errata_type.is_a?(Array)
             invalid_types = errata_type.collect(&:to_s) - ErratumRule::ERRATA_TYPES.keys

--- a/app/lib/validators/package_group_rule_params_validator.rb
+++ b/app/lib/validators/package_group_rule_params_validator.rb
@@ -19,7 +19,7 @@ module Validators
             record.errors.add(attribute, _("Invalid package rule specified. Units must be an array."))
           else
             value[:units].each do |unit|
-              unless unit.has_key?(:name)
+              unless unit.key?(:name)
                 record.errors.add(attribute, _("Invalid package group rule specified. Missing package 'name'."))
                 break
               end

--- a/app/lib/validators/rule_params_validator.rb
+++ b/app/lib/validators/rule_params_validator.rb
@@ -20,7 +20,7 @@ module Validators
           record.errors.add(attribute, _("Invalid %s rule specified. Units must be an array.") % rule_type)
         else
           value[:units].each do |unit|
-            unless unit.has_key?(:name)
+            unless unit.key?(:name)
               record.errors.add(attribute, _("Invalid %s rule specified. Missing 'name'.") % rule_type)
               break
             end

--- a/app/lib/validators/rule_version_validator.rb
+++ b/app/lib/validators/rule_version_validator.rb
@@ -15,7 +15,7 @@ module Validators
     def validate_each(record, attribute, value)
       if value && value[:units].present? && value[:units].is_a?(Array)
         value[:units].each do |unit|
-          if unit.has_key?(:version) && (unit.has_key?(:min_version) || unit.has_key?(:max_version))
+          if unit.key?(:version) && (unit.key?(:min_version) || unit.key?(:max_version))
             ver_msg = _("Invalid rule combination specified, 'version'" +
                         " and 'min_version' or 'max_version' cannot be specified in the same tuple")
 

--- a/app/models/content_view.rb
+++ b/app/models/content_view.rb
@@ -388,7 +388,7 @@ class ContentView < ActiveRecord::Base
 
   def prepare_repos_for_promotion(repos_to_replace, repos_to_promote)
     tasks = repos_to_replace.inject([]) do |result, repo|
-      if repos_to_promote.has_key?(repo.library_instance_id)
+      if repos_to_promote.key?(repo.library_instance_id)
         # a version of this repo is being promoted, so clear it and later
         # we'll regenerate the content... this is more efficient than
         # destroying the repo and recreating it...

--- a/app/models/erratum_rule.rb
+++ b/app/models/erratum_rule.rb
@@ -54,7 +54,7 @@ class ErratumRule < FilterRule
 
   def generate_clauses(repo)
     rule_clauses = []
-    if parameters.has_key? :units
+    if parameters.key? :units
       # TODO: WIll add this when we have a proper analyzer for
       # errata_id..
       # ids = parameters[:units].collect do |unit|
@@ -69,7 +69,7 @@ class ErratumRule < FilterRule
 
       {"id" => {"$in" => ids}}  unless ids.empty?
     else
-      if parameters.has_key? :date_range
+      if parameters.key? :date_range
         dr = {}
         dr["$gte"] = start_date.as_json if start_date
         dr["$lte"] = end_date.as_json if end_date
@@ -80,7 +80,7 @@ class ErratumRule < FilterRule
         rule_clauses << {"type" => {"$in" => errata_types}}
       end
 
-      if parameters.has_key?(:severity) && !parameters[:severity].empty?
+      if parameters.key?(:severity) && !parameters[:severity].empty?
           # {"severity": {"$in": ["low", "moderate", "important", "critical"]}
         rule_clauses << {"severity" => {"$in" => parameters[:severity]}}
       end

--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -63,9 +63,9 @@ module Glue::Candlepin::Consumer
       if attrs.nil?
         super
       elsif
-        type_key = attrs.has_key?('type') ? 'type' : :type
+        type_key = attrs.key?('type') ? 'type' : :type
         #rename "type" to "cp_type" (activerecord and candlepin variable name conflict)
-        if attrs.has_key?(type_key) && !(attrs.has_key?(:cp_type) || attrs.has_key?('cp_type'))
+        if attrs.key?(type_key) && !(attrs.key?(:cp_type) || attrs.key?('cp_type'))
           attrs[:cp_type] = attrs[type_key]
         end
 
@@ -222,11 +222,11 @@ module Glue::Candlepin::Consumer
     end
 
     def convert_from_cp_fields(cp_json)
-      cp_json.merge(:cp_type => cp_json.delete(:type)) if cp_json.has_key?(:type)
+      cp_json.merge(:cp_type => cp_json.delete(:type)) if cp_json.key?(:type)
       cp_json = reject_db_columns(cp_json)
 
-      cp_json[:guestIds] = remove_hibernate_fields(cp_json[:guestIds]) if cp_json.has_key?(:guestIds)
-      cp_json[:installedProducts] = remove_hibernate_fields(cp_json[:installedProducts]) if cp_json.has_key?(:installedProducts)
+      cp_json[:guestIds] = remove_hibernate_fields(cp_json[:guestIds]) if cp_json.key?(:guestIds)
+      cp_json[:installedProducts] = remove_hibernate_fields(cp_json[:installedProducts]) if cp_json.key?(:installedProducts)
 
       cp_json
     end
@@ -501,7 +501,7 @@ module Glue::Candlepin::Consumer
 
         serials = []
         entitlement['certificates'].each do |certificate|
-          if certificate.has_key?('serial')
+          if certificate.key?('serial')
             serials << certificate['serial']
           end
         end

--- a/app/models/glue/candlepin/product.rb
+++ b/app/models/glue/candlepin/product.rb
@@ -81,13 +81,13 @@ module Glue::Candlepin::Product
 
     def initialize(attribs = nil, options = {})
       unless attribs.nil?
-        attributes_key = attribs.has_key?(:attributes) ? :attributes : 'attributes'
-        if attribs.has_key?(attributes_key)
+        attributes_key = attribs.key?(:attributes) ? :attributes : 'attributes'
+        if attribs.key?(attributes_key)
           attribs[:attrs] = attribs[attributes_key]
           attribs.delete(attributes_key)
         end
 
-        @productContent = [] unless attribs.has_key?(:productContent)
+        @productContent = [] unless attribs.key?(:productContent)
 
         # ugh. hack-ish. otherwise we have to modify code every time things change on cp side
         attribs = attribs.reject do |k, v|
@@ -136,9 +136,9 @@ module Glue::Candlepin::Product
     end
 
     def convert_from_cp_fields(cp_json)
-      ar_safe_json = cp_json.has_key?(:attributes) ? cp_json.merge(:attrs => cp_json.delete(:attributes)) : cp_json
+      ar_safe_json = cp_json.key?(:attributes) ? cp_json.merge(:attrs => cp_json.delete(:attributes)) : cp_json
       ar_safe_json[:productContent] = ar_safe_json[:productContent].collect { |pc| ::Candlepin::ProductContent.new(pc, self.id) }
-      ar_safe_json[:attrs] = remove_hibernate_fields(cp_json[:attrs]) if ar_safe_json.has_key?(:attrs)
+      ar_safe_json[:attrs] = remove_hibernate_fields(cp_json[:attrs]) if ar_safe_json.key?(:attrs)
       ar_safe_json[:attrs] ||= []
       ar_safe_json.except('id')
     end

--- a/app/models/glue/elastic_search/errata.rb
+++ b/app/models/glue/elastic_search/errata.rb
@@ -125,17 +125,17 @@ module Glue::ElasticSearch::Errata
             size page_size
             from start
           end
-          if filters.has_key?(:type)
+          if filters.key?(:type)
             filter :term, :type => filters[:type]
           end
-          if filters.has_key?(:severity)
+          if filters.key?(:severity)
             filter :term, :severity => filters[:severity]
           end
 
           sort { by sort[0], sort[1] } unless !all_rows
         end
 
-        if filters.has_key?(:repoids)
+        if filters.key?(:repoids)
           search_mode = filters[:search_mode] || :all
           repoids = filters[:repoids]
           Util::Package.setup_shared_unique_filter(repoids, search_mode, search)

--- a/app/models/glue/pulp/package.rb
+++ b/app/models/glue/pulp/package.rb
@@ -42,7 +42,7 @@ module Glue::Pulp::Package
 
     def initialize(params = {})
       params.delete(:repodata)
-      params[:repoids] =  params.delete(:repository_memberships) if params.has_key?(:repository_memberships)
+      params[:repoids] =  params.delete(:repository_memberships) if params.key?(:repository_memberships)
       params.each_pair {|k, v| instance_variable_set("@#{k}", v) unless v.nil? }
     end
 

--- a/app/models/glue/pulp/puppet_module.rb
+++ b/app/models/glue/pulp/puppet_module.rb
@@ -33,7 +33,7 @@ module Glue::Pulp::PuppetModule
 
   module InstanceMethods
     def initialize(params = {}, options = {})
-      params['repoids'] = params.delete(:repository_memberships) if params.has_key?(:repository_memberships)
+      params['repoids'] = params.delete(:repository_memberships) if params.key?(:repository_memberships)
       params.each_pair {|k, v| instance_variable_set("@#{k}", v) unless v.nil? }
     end
 

--- a/app/models/package_rule.rb
+++ b/app/models/package_rule.rb
@@ -40,9 +40,9 @@ class PackageRule < FilterRule
   protected
 
   def version_filter(unit)
-    if unit.has_key?(:version)
+    if unit.key?(:version)
       Util::Package.version_eq_filter(unit[:version])
-    elsif unit.has_key?(:min_version) || unit.has_key?(:max_version)
+    elsif unit.key?(:min_version) || unit.key?(:max_version)
       Util::Package.version_filter(unit[:min_version], unit[:max_version])
     else
       nil

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -70,8 +70,8 @@ class Product < ActiveRecord::Base
       attrs = attrs.with_indifferent_access
 
       #rename "id" to "cp_id" (activerecord and candlepin variable name conflict)
-      if attrs.has_key?(:id)
-        if !attrs.has_key?(:cp_id)
+      if attrs.key?(:id)
+        if !attrs.key?(:cp_id)
           attrs[:cp_id] = attrs[:id]
         end
         attrs.delete(:id)

--- a/app/models/pulp_sync_status.rb
+++ b/app/models/pulp_sync_status.rb
@@ -59,7 +59,7 @@ class PulpSyncProgress
   def format_errors(details)
     errors_array = []
 
-    if details && !details.has_key?(:finished_count)
+    if details && !details.key?(:finished_count)
       errors_array = details.each_with_object([]) do |(step, report), list|
         if !report[:error].blank?
           list << report[:error]

--- a/app/models/pulp_task_status.rb
+++ b/app/models/pulp_task_status.rb
@@ -61,7 +61,7 @@ class PulpTaskStatus < TaskStatus
   end
 
   def self.dump_state(pulp_status, task_status)
-    if !pulp_status.has_key?(:state) && pulp_status[:result] == "success"
+    if !pulp_status.key?(:state) && pulp_status[:result] == "success"
       # Note: if pulp_status doesn't contain a state, the status is coming from pulp sync history
       pulp_status[:state] = Status::FINISHED.to_s
     end

--- a/app/models/puppet_module_rule.rb
+++ b/app/models/puppet_module_rule.rb
@@ -43,9 +43,9 @@ class PuppetModuleRule < FilterRule
   protected
 
   def version_filter(unit)
-    if unit.has_key?(:version)
+    if unit.key?(:version)
       {:term => {:version => unit[:version]}}
-    elsif unit.has_key?(:min_version) || unit.has_key?(:max_version)
+    elsif unit.key?(:min_version) || unit.key?(:max_version)
       range = {}
       range[:gt] = sortable_version(unit[:min_version]) if unit[:min_version]
       range[:lt] = sortable_version(unit[:max_version]) if unit[:max_version]
@@ -56,7 +56,7 @@ class PuppetModuleRule < FilterRule
   end
 
   def author_filter(unit)
-    if unit.has_key?(:author) && unit[:author].present?
+    if unit.key?(:author) && unit[:author].present?
       {:term => {:author => unit[:author]}}
     else
       nil

--- a/app/models/resource_type.rb
+++ b/app/models/resource_type.rb
@@ -92,7 +92,7 @@ class ResourceType < ActiveRecord::Base
   end
 
   def self.check_type(resource_type)
-    raise ResourceTypeNotFound.new(resource_type, TYPES.keys) unless TYPES.has_key? resource_type
+    raise ResourceTypeNotFound.new(resource_type, TYPES.keys) unless TYPES.key? resource_type
   end
 
   if Katello.config.katello?

--- a/app/models/task_status.rb
+++ b/app/models/task_status.rb
@@ -88,10 +88,10 @@ class TaskStatus < ActiveRecord::Base
     # the overall status of tasks (e.g. associated with a system) are determined by a
     # combination of the task state and the status of the unit within the task.
     unit_status = true
-    if (self.result.is_a? Hash) && (self.result.has_key? :details)
-      if self.result[:details].has_key? :rpm
+    if (self.result.is_a? Hash) && (self.result.key? :details)
+      if self.result[:details].key? :rpm
         unit_status = self.result[:details][:rpm][:succeeded]
-      elsif self.result[:details].has_key? :package_group
+      elsif self.result[:details].key? :package_group
         unit_status = self.result[:details][:package_group][:succeeded]
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,7 +238,7 @@ class User < ActiveRecord::Base
   end
 
   def default_locale=(locale)
-    self.preferences[:user] = { } unless self.preferences.has_key? :user
+    self.preferences[:user] = { } unless self.preferences.key? :user
     self.preferences[:user][:locale] = locale
   end
 
@@ -247,7 +247,7 @@ class User < ActiveRecord::Base
   end
 
   def legacy_mode=(use_legacy_mode)
-    self.preferences[:user] = { } unless self.preferences.has_key? :user
+    self.preferences[:user] = { } unless self.preferences.key? :user
     self.preferences[:user][:legacy_mode] = use_legacy_mode.to_bool
   end
 
@@ -263,7 +263,7 @@ class User < ActiveRecord::Base
 
   #set the default org if it's an actual org_id
   def default_org=(org_id)
-    self.preferences[:user] = { } unless self.preferences.has_key? :user
+    self.preferences[:user] = { } unless self.preferences.key? :user
     if !org_id.nil? && org_id != "nil"
       organization = Organization.find_by_id(org_id)
       self.preferences[:user][:default_org] = organization.id
@@ -277,7 +277,7 @@ class User < ActiveRecord::Base
   end
 
   def subscriptions_match_system_preference=(flag)
-    self.preferences[:user] = { } unless self.preferences.has_key? :user
+    self.preferences[:user] = { } unless self.preferences.key? :user
     self.preferences[:user][:subscriptions_match_system] = flag
   end
 
@@ -286,7 +286,7 @@ class User < ActiveRecord::Base
   end
 
   def subscriptions_match_installed_preference=(flag)
-    self.preferences[:user] = { } unless self.preferences.has_key? :user
+    self.preferences[:user] = { } unless self.preferences.key? :user
     self.preferences[:user][:subscriptions_match_installed] = flag
   end
 
@@ -295,7 +295,7 @@ class User < ActiveRecord::Base
   end
 
   def subscriptions_no_overlap_preference=(flag)
-    self.preferences[:user] = { } unless self.preferences.has_key? :user
+    self.preferences[:user] = { } unless self.preferences.key? :user
     self.preferences[:user][:subscriptions_no_overlap] = flag
   end
 

--- a/app/views/content_view_definitions/filters/rules/_parameter_list.html.haml
+++ b/app/views/content_view_definitions/filters/rules/_parameter_list.html.haml
@@ -26,7 +26,7 @@
           %td{:colspan => 2}
             = _("This rule does not currently have any parameters defined.")
 
-        - if rule.parameters.has_key?(:units)
+        - if rule.parameters.key?(:units)
           - rule.parameters[:units].each do |unit|
             = render :partial => item_partial, :locals => {:rule => rule, :editable => editable, :unit => unit}
 

--- a/app/views/system_groups/packages/_items.html.haml
+++ b/app/views/system_groups/packages/_items.html.haml
@@ -8,7 +8,7 @@
 
 - job.task_statuses.each do |task|
 
-  - if task.parameters.has_key?(:packages)
+  - if task.parameters.key?(:packages)
     - if task.parameters[:packages].empty?
       %tr.package{:class => "#{shading}"}
         %td{'data-name' => "update_all_packages"}

--- a/lib/katello/configuration/validator.rb
+++ b/lib/katello/configuration/validator.rb
@@ -63,7 +63,7 @@ module Katello
       end
 
       def has_key(key)
-        unless config.has_key? key.to_sym
+        unless config.key? key.to_sym
           raise error_format(key.to_sym, 'is required')
         end
       end

--- a/lib/katello/load_configuration.rb
+++ b/lib/katello/load_configuration.rb
@@ -90,7 +90,7 @@ module Katello
                                          end
 
           root = config.logging.loggers.root
-          root[:path] = "#{Rails.root}/log" unless root.has_key?(:path) if environment
+          root[:path] = "#{Rails.root}/log" unless root.key?(:path) if environment
           root[:type] ||= 'file'
 
           config[:katello_version] = begin

--- a/lib/katello/logging.rb
+++ b/lib/katello/logging.rb
@@ -107,9 +107,9 @@ module Katello
       loggers_hash.keys.tap { |a| a.delete(:root) }.each do |logger_name|
         logger_config = configuration.loggers[logger_name]
         logger        = ::Logging.logger[logger_name]
-        logger.level = logger_config.level if logger_config.has_key?(:level)
-        logger.additive = logger_config.enabled if logger_config.has_key?(:enabled)
-        enable_tailing logger, logger_config if logger_config.has_key?(:tail_command)
+        logger.level = logger_config.level if logger_config.key?(:level)
+        logger.additive = logger_config.enabled if logger_config.key?(:enabled)
+        enable_tailing logger, logger_config if logger_config.key?(:tail_command)
         logger.trace = configuration.log_trace
       end
     end

--- a/spec/helpers/search_helper_methods.rb
+++ b/spec/helpers/search_helper_methods.rb
@@ -25,12 +25,12 @@ module SearchHelperMethods
       define_method(:perform) do
         unless block_given?
           data = to_hash
-          (data[:fields].should == options[:fields]) if options.has_key?(:fields)
-          (data[:query].should == options[:query]) if options.has_key?(:query)
-          (SearchHelperMethods.compare_filter_params(options[:filter], data[:filter]).should == true) if options.has_key?:filter
-          (data[:size].should == options[:size]) if options.has_key?(:size)
-          (data[:sort].should == options[:sort])if options.has_key?(:sort)
-          (data[:from].should == options[:from])if options.has_key?(:from)
+          (data[:fields].should == options[:fields]) if options.key?(:fields)
+          (data[:query].should == options[:query]) if options.key?(:query)
+          (SearchHelperMethods.compare_filter_params(options[:filter], data[:filter]).should == true) if options.key?(:filter)
+          (data[:size].should == options[:size]) if options.key?(:size)
+          (data[:sort].should == options[:sort])if options.key?(:sort)
+          (data[:from].should == options[:from])if options.key?(:from)
 
           #http://www.fngtps.com/2007/using-openstruct-as-mock-for-activerecord/
           OpenStruct.instance_eval do


### PR DESCRIPTION
See for more info:

http://batsov.com/articles/2013/08/21/the-elements-of-style-in-ruby-number-9-hash-number-has-key-and-hash-number-has-value-are-deprecated/
