### PR TITLE
867435 - Importing GPG file with some random text shouldn't be allowed

### DIFF
--- a/app/lib/validators/gpg_key_content_validator.rb
+++ b/app/lib/validators/gpg_key_content_validator.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Validators
+  class GpgKeyContentValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      if value
+        GpgKeyContentValidator.validate_line_length(record, attribute, value)
+        gpg_key_line_array = value.split("\n")
+        gpg_key_line_array.delete("")
+
+        if gpg_key_line_array.first.match(/-{5}BEGIN PGP PUBLIC KEY BLOCK-{5}/) && gpg_key_line_array.last.match(/-{5}END PGP PUBLIC KEY BLOCK-{5}/)
+
+          gpg_key_line_array.shift
+          gpg_key_line_array.pop
+
+          if gpg_key_line_array.empty?
+            record.errors[attribute] << _("must contain valid Public GPG Key")
+          else
+            unless gpg_key_line_array.drop(1).join.match(/[a-zA-Z0-9+\/=]*/)
+              record.errors[attribute] << _("must contain valid Public GPG Key")
+            end
+          end
+
+        else
+          record.errors[attribute] << _("must contain valid Public GPG Key")
+        end
+
+      else
+        record.errors[attribute] << _("must contain GPG Key")
+      end
+
+    end
+
+    def self.validate_line_length(record, attribute, value)
+      value.each_line do |line|
+        record.errors[attribute] << _("must contain valid  Public GPG Key") if line.length > GpgKey::MAX_CONTENT_LINE_LENGTH
+      end
+    end
+
+  end
+end

--- a/app/models/gpg_key.rb
+++ b/app/models/gpg_key.rb
@@ -15,6 +15,7 @@ class GpgKey < ActiveRecord::Base
   include Glue::ElasticSearch::GpgKey if Katello.config.use_elasticsearch
   include Authorization::GpgKey
   MAX_CONTENT_LENGTH = 100_000
+  MAX_CONTENT_LINE_LENGTH = 65
 
   has_many :repositories, :inverse_of => :gpg_key
   has_many :products, :inverse_of => :gpg_key
@@ -27,6 +28,7 @@ class GpgKey < ActiveRecord::Base
   validates :organization, :presence => true
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates_with Validators::ContentValidator, :attributes => :content
+  validates_with Validators::GpgKeyContentValidator, :attributes => :content, :if => Proc.new{ Katello.config.gpg_strict_validation }
 
   def as_json(options = {})
     options ||= {}

--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -26,6 +26,7 @@ common:
   ldap_roles: false
   validate_ldap: false
   rest_client_timeout: 30
+  gpg_strict_validation: false
 
   url_prefix: "/katello"
 

--- a/spec/controllers/api/v1/gpg_keys_controller_spec.rb
+++ b/spec/controllers/api/v1/gpg_keys_controller_spec.rb
@@ -24,7 +24,8 @@ describe Api::V1::GpgKeysController, :katello => true do
     disable_org_orchestration
 
     @organization = new_test_org
-    @gpg_key      = GpgKey.create!(:name => "Another Test Key", :content => "This is the key data string", :organization => @organization)
+    @test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+    @gpg_key      = GpgKey.create!(:name => "Another Test Key", :content => @test_gpg_content, :organization => @organization)
   end
 
   describe "GET content" do
@@ -78,7 +79,7 @@ describe Api::V1::GpgKeysController, :katello => true do
       let(:req) { post :create, req_params }
       let(:action) { :create }
       let(:req_params) do
-        { :organization_id => @organization.name, :gpg_key => { :name => "Gpg Key", :content => "This is the key string" } }.with_indifferent_access
+        { :organization_id => @organization.name, :gpg_key => { :name => "Gpg Key", :content => @test_gpg_content } }.with_indifferent_access
       end
       it_should_behave_like "protected action"
 
@@ -102,7 +103,7 @@ describe Api::V1::GpgKeysController, :katello => true do
   end
 
   describe "update gpg key" do
-    let(:req_params) { { :id => @gpg_key.id.to_s, :gpg_key => { :name => "Gpg Key", :content => "This is the key string" } }.with_indifferent_access }
+    let(:req_params) { { :id => @gpg_key.id.to_s, :gpg_key => { :name => "Gpg Key", :content => @test_gpg_content } }.with_indifferent_access }
     let(:req) { put :update, req_params }
     let(:action) { :update }
     it_should_behave_like "protected action"

--- a/spec/controllers/api/v1/products_controller_spec.rb
+++ b/spec/controllers/api/v1/products_controller_spec.rb
@@ -32,6 +32,8 @@ describe Api::V1::ProductsController, :katello => true do
 
     @organization = new_test_org
 
+    @test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+
     @environment = create_environment(:name => "foo123", :label => "foo123", :organization => @organization, :prior => @organization.library)
     @provider    = Provider.create!(:name         => "provider", :provider_type => Provider::CUSTOM,
                                     :organization => @organization, :repository_url => "https://something.url/stuff")
@@ -77,7 +79,7 @@ describe Api::V1::ProductsController, :katello => true do
   end
 
   describe "update product" do
-    let(:gpg_key) { GpgKey.create!(:name => "Gpg key", :content => "100", :organization => @organization) }
+    let(:gpg_key) { GpgKey.create!(:name => "Gpg key", :content => @test_gpg_content, :organization => @organization) }
 
     before do
       Katello.pulp_server.extensions.repository.stub(:retrieve).and_return(RepoTestData::REPO_PROPERTIES)

--- a/spec/controllers/api/v1/repositories_controller_spec.rb
+++ b/spec/controllers/api/v1/repositories_controller_spec.rb
@@ -52,6 +52,7 @@ describe Api::V1::RepositoriesController, :katello => true do
       PulpSyncStatus.stub(:using_pulp_task).and_return(task_stub)
       Katello.pulp_server.extensions.package_group.stub(:all => {})
       Katello.pulp_server.extensions.package_category.stub(:all => {})
+      @test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
     end
 
     describe "for create" do
@@ -155,6 +156,8 @@ describe Api::V1::RepositoriesController, :katello => true do
       @request.env["HTTP_ACCEPT"] = "application/json"
       login_user_api
 
+      @test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+
       disable_authorization_rules
     end
 
@@ -228,8 +231,8 @@ describe Api::V1::RepositoriesController, :katello => true do
       end
 
       context 'some gpg key is assigned to the product' do
-        let(:product_gpg) { GpgKey.create!(:name => "Product GPG", :content => "100", :organization => @organization) }
-        let(:repo_gpg) { GpgKey.create!(:name => "Repo GPG", :content => "200", :organization => @organization) }
+        let(:product_gpg) { GpgKey.create!(:name => "Product GPG", :content => @test_gpg_content, :organization => @organization) }
+        let(:repo_gpg) { GpgKey.create!(:name => "Repo GPG", :content => @test_gpg_content, :organization => @organization) }
 
         before do
           @product.update_attributes!(:gpg_key => product_gpg)

--- a/spec/controllers/gpg_keys_controller_spec.rb
+++ b/spec/controllers/gpg_keys_controller_spec.rb
@@ -23,7 +23,7 @@ describe GpgKeysController, :katello => true do
     GPGKEY_INVALID = {}
     GPGKEY_NAME_INVALID = {:name => ""}
     GPGKEY_NAME = {:name => "Test GPG Key Updated"}
-    GPGKEY_CONTENT = {:content => "Test GPG Key Updated key contents."}
+    GPGKEY_CONTENT = {:content => File.open("#{Rails.root}/spec/assets/gpg_test_key").read}
     GPGKEY_CONTENT_UPLOAD = {}
   end
 
@@ -35,8 +35,9 @@ describe GpgKeysController, :katello => true do
     @file = Rack::Test::UploadedFile.new(test_document, "text/plain")
 
     @organization = new_test_org
-    @gpg_key = GpgKey.create!(:name => "Another Test Key", :content => "This is the key data string", :organization => @organization)
-    @gpg_key_params_pasted = { :gpg_key => { :name => "Test Key", :content => "This is the pasted key data string" } }
+    test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+    @gpg_key = GpgKey.create!( :name => "Another Test Key", :content => test_gpg_content, :organization => @organization )
+    @gpg_key_params_pasted = { :gpg_key => { :name => "Test Key", :content => test_gpg_content } }
     @gpg_key_params_uploaded = { :gpg_key => { :name => "Test Key", :content_upload => @file } }
   end
 

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -90,7 +90,8 @@ describe ProductsController, :katello => true do
       @organization = new_test_org
       @provider = Provider.create!(:provider_type=>Provider::CUSTOM, :name=>"foo1", :organization=>@organization)
       Provider.stub!(:find).and_return(@provider)
-      @gpg = GpgKey.create!(:name =>"GPG", :organization=>@organization, :content=>"bar")
+      test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+      @gpg = GpgKey.create!(:name =>"GPG", :organization=>@organization, :content=>test_gpg_content)
     end
     context "when creating a product" do
       before do

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -117,7 +117,8 @@ describe RepositoriesController, :katello => true do
 
       @org = new_test_org
       @product = new_test_product(@org, @org.library)
-      @gpg = GpgKey.create!(:name => "foo", :organization => @organization, :content => "222")
+      test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+      @gpg = GpgKey.create!(:name => "foo", :organization => @organization, :content => test_gpg_content)
       controller.stub!(:current_organization).and_return(@org)
       Resources::Candlepin::Content.stub(:create => {:id => "123"})
     end

--- a/spec/models/gpg_key_spec.rb
+++ b/spec/models/gpg_key_spec.rb
@@ -23,7 +23,7 @@ describe GpgKey, :katello => true do
         Organization.create!(:name=>"Duh", :label => "ahaha")
     end
 
-    let(:gpg) {GpgKey.create!(:name => "hazard", :organization => organization, :content => "Barn")}
+    let(:gpg) {GpgKey.create!(:name => "Gpg key", :organization => organization, :content => File.open("#{Rails.root}/spec/assets/gpg_test_key").read )}
 
     describe "check on read operations" do
       [[:gpg, :organizations],[:read, :organizations],[:read, :providers]].each do |(perm, resource)|
@@ -60,10 +60,11 @@ describe GpgKey, :katello => true do
   describe "create gpg key" do
     before(:each) do
       new_test_org_model
+      @test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
     end
 
     it "should be successful with valid parameters" do
-      gpg_key = GpgKey.new(:name => "Gpg Key 1", :content => "This is the fake GPG Key content text that is valid", :organization => @organization)
+      gpg_key = GpgKey.new(:name => "Gpg Key 1", :content => @test_gpg_content, :organization => @organization)
       gpg_key.should be_valid
     end
 
@@ -73,7 +74,12 @@ describe GpgKey, :katello => true do
     end
 
     it "should be unsuccessful without a name" do
-      gpg_key = GpgKey.new(:content => "This is the fake GPG Key content text that is valid", :organization => @organization)
+      gpg_key = GpgKey.new(:content => @test_gpg_content, :organization => @organization)
+      gpg_key.should_not be_valid
+    end
+
+    it "should be unsuccessful without proper gpg key" do
+      gpg_key = GpgKey.new(:name => "Gpg Key 1", :content => "foo-bar-baz", :organization => @organization)
       gpg_key.should_not be_valid
     end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -343,7 +343,8 @@ describe Product, :katello => true do
       disable_repo_orchestration
 
       suffix = (rand 10 **6).to_s
-      @gpg = GpgKey.create!(:name =>"GPG", :organization=>@organization, :content=>"bar")
+      test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+      @gpg = GpgKey.create!(:name =>"GPG", :organization=>@organization, :content=>test_gpg_content)
       @provider = Provider.create!({:organization =>@organization, :name => 'provider' + suffix,
                               :repository_url => "https://something.url", :provider_type => Provider::CUSTOM})
       @product = Product.new({:name=>"prod#{suffix}", :label=> "prod#{suffix}"})


### PR DESCRIPTION
Adding an validator for GpgKey creation so the imported or pasted string contained a header and footer typical for gpg public keys
e.g. 
-----BEGIN PGP PUBLIC KEY BLOCK-----

GPG KEY

-----END PGP PUBLIC KEY BLOCK-----

GPG key itself should not be longer than 65 characters per line and should contain only base64 characters.

Also added attribute to the katello_default.yml 
https://github.com/Katello/katello/pull/2956/files#L2R29

so now the gpg key validation strictness is optional
