### PR TITLE
953656 - Removed all 'disable_with' references

### DIFF
--- a/app/views/content_view_definitions/_new.html.haml
+++ b/app/views/content_view_definitions/_new.html.haml
@@ -31,6 +31,6 @@
                                                              :view_definitions => view_definitions,
                                                              :views => nil}
 
-      = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'create_button'
+      = form.submit _("Create"), :class => 'create_button'
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/content_view_definitions/_publish.html.haml
+++ b/app/views/content_view_definitions/_publish.html.haml
@@ -15,6 +15,6 @@
 
     = form.text_area :description, :size => "40x5", :label => _('Description'), :maxlength => default_description_limit
 
-    = form.submit _('Publish'), :disable_with => _('Publishing...'), :class => 'publish_button subpanel_create'
+    = form.submit _('Publish'), :class => 'publish_button subpanel_create'
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/content_view_definitions/filters/_new.html.haml
+++ b/app/views/content_view_definitions/filters/_new.html.haml
@@ -9,6 +9,6 @@
 
       = form.text_field :name, :label => _("Name"), :class => :name_input
 
-      = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'create_button'
+      = form.submit _("Create"), :class => 'create_button'
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/content_view_definitions/filters/rules/_new.html.haml
+++ b/app/views/content_view_definitions/filters/rules/_new.html.haml
@@ -14,7 +14,7 @@
         = form.select :content_type, options, {},
           {:label => _("Filter on"), :size=>1, :tabindex => form.tabindex}
 
-        = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'create_button'
+        = form.submit _("Create"), :class => 'create_button'
 
     - else
 

--- a/app/views/environments/_new.html.haml
+++ b/app/views/environments/_new.html.haml
@@ -21,6 +21,6 @@
 
     = form.select :prior, options_for_select(@env_labels, @selected), {}, {:label => _("Prior Environment"), :size=>1, :tabindex => form.tabindex}
 
-    = form.submit _("Create"), :disable_with => _("Creating..."), :class => 'subpanel_create create_button'
+    = form.submit _("Create"), :class => 'subpanel_create create_button'
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/products/_new.html.haml
+++ b/app/views/products/_new.html.haml
@@ -22,6 +22,6 @@
       - else
         = _("None defined for this Organization.")
 
-    = form.submit _("Create"), :class => 'subpanel_create create_button', :disable_with => _("Creating...")
+    = form.submit _("Create"), :class => 'subpanel_create create_button'
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/repositories/_new.html.haml
+++ b/app/views/repositories/_new.html.haml
@@ -55,6 +55,6 @@
           #{_("None defined for this Organization.")}
 
     .grid_5.prefix_2
-      = submit_tag _("Create"), :class => 'fr subpanel_create create_button', :tabindex => auto_tab_index, :disable_with => _("Creating...")
+      = submit_tag _("Create"), :class => 'fr subpanel_create create_button', :tabindex => auto_tab_index
 
 = render :template => "layouts/tupane_layout"


### PR DESCRIPTION
Rails haml form builder provides an attribute called disable_with
that lets one to set a 'disabled' text on the butten when a form is
submitted. For example a button with  "Create" can be changed to
"Creating" when clicked on. However this automagical attribute doesnot
go well with ajax based calls. So this caused issues like bz 953656,
where validation failures wouldnt change "Creating" to "Create" if the
submit failed.
We are automatically disabling the button anyway without changing
the text on a form submit even without the disable_with attribute.
So removed them from all haml files. So the new behaviour will be that
"Create" button will still be "Create" but disabled instead of
"Creating...".
