### PR TITLE
Fix rubocop issues preventing successful builds in master.

### DIFF
--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -79,7 +79,7 @@ class FiltersController < ApplicationController
   end
 
   def update
-    if params.has_key?(:products)
+    if params.key?(:products)
       products_ids = params[:products].blank? ? [] : Product.readable(current_organization).
           where(:id => params[:products]).pluck("products.id")
 


### PR DESCRIPTION
All builds are failing with:

```
Offences:
app/controllers/filters_controller.rb:82:15: C: has_key? is deprecated in favor of key?.
    if params.has_key?(:products)
              ^^^^^^^^
754 files inspected, 1 offence detected
```

See https://travis-ci.org/Katello/katello/jobs/11529563 for example.
