### PR TITLE
Travis: Dropping ruby 2.0 jobs for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language:
 
 rvm:
   - "1.9.3"
-  - "2.0.0"
+  #- "2.0.0"
 
 before_install:
   - cp script/ci/katello.yml config/katello.yml
@@ -19,7 +19,7 @@ env:
   - JOB=other
   - JOB=javascript
 
-matrix:
-  exclude:
-    - rvm: "1.9.3"
-      env: "JOB=javascript"
+#matrix:
+  #exclude:
+    #- rvm: "1.9.3"
+      #env: "JOB=javascript"


### PR DESCRIPTION
Since ruby 2.0 is backwards compatible for the most part, it's probably not necessary to check every PR before it gets merged. Instead we could probably use Jenkins to check master to make sure it's ruby 2.0 compatible after each PR. I added a card to leverage Jenkins to run our code against ruby 2.0:

https://trello.com/c/3cvCYc5c/219-have-jenkins-check-our-code-against-ruby-2-0

I think this should speed up Travis.
