### PR TITLE
994917: Content Search: Errata: show null severity as ''

### DIFF
--- a/app/controllers/content_search_controller.rb
+++ b/app/controllers/content_search_controller.rb
@@ -307,7 +307,7 @@ class ContentSearchController < ApplicationController
       { :name => errata_display(e), :id => e.id, :data_type => "errata", :value => e.id,
         :cols => { :title => { :display => e[:title] },
                    :type => { :display => e[:type] },
-                   :severity => { :display => e[:severity] }
+                   :severity => { :display => e[:severity] || '' }
                  }
       }
     end


### PR DESCRIPTION
There is currently a bug in pulp
(https://bugzilla.redhat.com/show_bug.cgi?id=1009966) which
is resulting all errata not having a severity.  As a result,
when content search shows the errata listing it shows as 'null'.
This commit will simply render a '' (instead of null) when
there is no errata.
