### PR TITLE
981613: Filter names: add one-line-ellipsis to filter list

### DIFF
--- a/app/views/content_view_definitions/filters/_index.html.haml
+++ b/app/views/content_view_definitions/filters/_index.html.haml
@@ -28,11 +28,12 @@
               %tr
                 %td
                   - if editable
-                    .panel_link
+                    .panel_link.grid_11.one-line-ellipsis
                       = check_box_tag "filters[#{filter.id}]", filter.name, false, {'data-id' => filter.id}
                       = link_to(filter.name, edit_content_view_definition_filter_path(view_definition.id, filter.id))
                   - else
-                    = filter.name
+                    %span.grid_11.one-line-ellipsis
+                      = filter.name
 
         - if editable
           %input.button.fr.disabled{:type=>"button", :id=>"remove_button", :value=>_("Remove")}


### PR DESCRIPTION
This small commit is to address the formatting issue that
could arise if the user entered a very long filter name
(e.g. 200 characters).
