### PR TITLE
971140 - Fixed issue with CVD vs CV permissions

### DIFF
--- a/app/controllers/api/v1/content_views_controller.rb
+++ b/app/controllers/api/v1/content_views_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::ContentViewsController < Api::V1::ApiController
     show_test    = lambda { @view.readable? }
     promote_test = lambda { @view.promotable? && @environment.changesets_promotable? }
     refresh_test = lambda { @view.content_view_definition.publishable? }
-    delete_test  = lambda { @view.content_view_definition.publishable? }
+    delete_test  = lambda { @view.deletable? }
 
     {
         :index   => index_test,

--- a/app/controllers/content_views_controller.rb
+++ b/app/controllers/content_views_controller.rb
@@ -15,14 +15,15 @@ class ContentViewsController < ApplicationController
   helper ContentViewDefinitionsHelper
 
   before_filter :find_content_view_definition, :except => [:auto_complete]
-  before_filter :authorize #after find_content_view_definition, since the definition is required for authorization
   before_filter :find_content_view, :only => [:destroy, :refresh]
+  before_filter :authorize #after find_content_view_definition, since the definition is required for authorization
 
   def rules
+    delete_rule = lambda { @view.deletable? }
     manage_view_rule = lambda { @view_definition.publishable? }
     auto_complete_rule = lambda { ContentView.any_readable?(current_organization) }
     {
-      :destroy => manage_view_rule,
+      :destroy => delete_rule,
       :refresh => manage_view_rule,
       :auto_complete => auto_complete_rule
     }

--- a/app/models/authorization/content_view.rb
+++ b/app/models/authorization/content_view.rb
@@ -26,6 +26,12 @@ module Authorization::ContentView
     User.allowed_to?(READ_PERM_VERBS, :content_views, self.id, self.organization)
   end
 
+  def deletable?
+    return true if !Katello.config.katello?
+    return false if self.content_view_definition.nil?
+    self.content_view_definition.deletable? || self.content_view_definition.publishable?
+  end
+
   def promotable?
     User.allowed_to?([:promote], :content_views, self.id, self.organization)
   end

--- a/app/views/content_view_definitions/_tupane_header.html.haml
+++ b/app/views/content_view_definitions/_tupane_header.html.haml
@@ -7,7 +7,7 @@
       %a.pane_action.separator.copy-tipsy{'data-url' => clone_content_view_definition_path(@view_definition.id)}
         = _('Clone')
 
-    - if @view_definition.editable?
+    - if @view_definition.deletable?
       - if @view_definition.has_promoted_views?
         %a.pane_action.remove.disabled
           = _('Remove')

--- a/app/views/content_view_definitions/views/_view.html.haml
+++ b/app/views/content_view_definitions/views/_view.html.haml
@@ -6,7 +6,7 @@
               'original-title' => _("Browse the content view details using Content Search"),
               :class => 'tipsify separator')
 
-    - if view_definition.publishable?
+    - if view.deletable?
       - if view.promoted?
         %a.disabled.tipsify{'original-title' => unable_to_remove_view} #{_('Remove')}
       - else

--- a/spec/controllers/content_views_controller_spec.rb
+++ b/spec/controllers/content_views_controller_spec.rb
@@ -80,4 +80,16 @@ describe ContentViewsController do
     it_should_behave_like "protected action"
   end
 
+  describe "DELETE destroy with delete" do
+    let(:action) { :destroy }
+    let(:req) { delete :destroy, :content_view_definition_id => @definition.id, :id => @view.id }
+    let(:authorized_user) do
+      user_with_permissions { |u| u.can(:delete, :content_view_definitions, @definition.id, @organization) }
+    end
+    let(:unauthorized_user) do
+      user_without_permissions
+    end
+    it_should_behave_like "protected action"
+  end
+
 end

--- a/test/controllers/content_views_controller_test.rb
+++ b/test/controllers/content_views_controller_test.rb
@@ -40,13 +40,14 @@ class ContentViewsControllerTest < MiniTest::Rails::ActionController::TestCase
 
   test "DELETE destroy should be successful" do
     content_view = content_views(:library_view)
-
+    content_view.content_view_definition = @content_view_definition
+    content_view.save!
     # success notice created
     notify = Notifications::Notifier.new
     notify.expects(:success).at_least_once
     @controller.expects(:notify).at_least_once.returns(notify)
 
-    delete :destroy, :content_view_definition_id => @content_view_definition.id, :id => content_view.id
+    delete :destroy, :content_view_definition_id => content_view.content_view_definition.id, :id => content_view.id
 
     assert_response :success
     assert_nil ContentView.find_by_id(content_view.id)


### PR DESCRIPTION
Changed controller instances to state that
1) Content Views are deletable if user has perms to delete the
Definitions of the content view. Previously user required publish
permissions to delete content views.
2) Another fix was to show the Remove link for content view definition
if the user had "delete" permission.
