### PR TITLE
1010034: Content View Definitions: fix UI issues for readonly users

### DIFF
--- a/app/assets/javascripts/content_view_definitions/product_repo_selector.js
+++ b/app/assets/javascripts/content_view_definitions/product_repo_selector.js
@@ -15,8 +15,19 @@ KT.product_input = (function(){
 
     var register = function() {
 
-        var select = $('#product_select');
-        if (select.length === 0){
+        var select = $('#product_select'),
+            readonly = $('#readonly_products');
+
+        if (readonly.length > 0) {
+            readonly.treeTable({
+                expandable: true,
+                initialState: "expanded",
+                clickableNodeNames: true,
+                onNodeShow: function(){$.sparkline_display_visible();}
+            });
+            return;
+
+        } else if (select.length === 0) {
             return;
         }
 

--- a/app/controllers/filter_rules_controller.rb
+++ b/app/controllers/filter_rules_controller.rb
@@ -30,16 +30,17 @@ class FilterRulesController < ApplicationController
   end
 
   def rules
+    show_rule    = lambda { @view_definition.readable? }
     manage_rule  = lambda { @view_definition.editable? }
 
     {
       :new => manage_rule,
       :create => manage_rule,
 
-      :edit => manage_rule,
-      :edit_inclusion => manage_rule,
-      :edit_parameter_list => manage_rule,
-      :edit_date_type_parameters => manage_rule,
+      :edit => show_rule,
+      :edit_inclusion => show_rule,
+      :edit_parameter_list => show_rule,
+      :edit_date_type_parameters => show_rule,
       :update => manage_rule,
 
       :add_parameter => manage_rule,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -381,4 +381,28 @@ module ApplicationHelper
       (html + groups.join).html_safe
     end
   end
+
+  # Using the record provided, return a hash where the
+  # keys are the products associated with the record and the
+  # values are arrays listing the repositories associated
+  # with the given product.
+  # For example: {product1 => [repo1, repo2]}
+  def get_product_and_repos(record, content_types)
+
+    products_hash = record.resulting_products.inject({}) do |hash, product|
+      if record.repositories.empty?
+        hash[product] = []
+      else
+        repos = product.repos(current_organization.library).where(:content_type => content_types)
+        repos.each do |repo|
+          hash[product] ||= []
+          hash[product] << repo
+        end
+      end
+      hash
+    end
+
+    products_hash
+  end
+
 end

--- a/app/helpers/content_view_definitions_helper.rb
+++ b/app/helpers/content_view_definitions_helper.rb
@@ -93,6 +93,15 @@ module ContentViewDefinitionsHelper
     return views_hash.key?(view_id)
   end
 
+  # Does the definition provided have one or more of it's views
+  # defined as a component view in the views hash provided?
+  def has_a_component_view?(definition, views_hash = nil)
+    definition.content_views.each do |view|
+      return true if view_checked?(view.id, views_hash)
+    end
+    return false
+  end
+
   def view_repos(definitions)
     view_repos = {}
     definitions.each do |definition|

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -66,4 +66,5 @@ module ProductsHelper
     end
     @product_hash
   end
+
 end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -63,6 +63,10 @@ class Filter < ActiveRecord::Base
     filter
   end
 
+  def resulting_products
+    (self.products + self.repositories.collect{|r| r.product}).uniq
+  end
+
   def repos(env)
     repos = self.products.map { |prod| prod.repos(env) }.flatten.reject(&:puppet?)
     repos + repositories

--- a/app/views/common/_common_product_repo_selector.html.haml
+++ b/app/views/common/_common_product_repo_selector.html.haml
@@ -1,19 +1,20 @@
 - content_types ||= nil
 - title ||= _("Product")
 
-= render :partial => "common/common_products",
-         :locals => {:record => record,
-                     :content_types => content_types,
-                     :readable_products => readable_products || nil,
-                     :editable_products => editable_products || nil}
+-if editable
 
-#package_filter
-  %table
-    %thead
-      %tr
-        %th #{title}
+  = render :partial => "common/common_products",
+           :locals => {:record => record,
+                       :content_types => content_types,
+                       :readable_products => readable_products || nil,
+                       :editable_products => editable_products || nil}
 
-    -if editable
+  #package_filter
+    %table
+      %thead
+        %tr
+          %th #{title}
+
       %tr
         %td
           %form#add_product_form
@@ -27,6 +28,36 @@
               .centered
                 %a#add_product #{_('+ Add')}
 
-    %tr
-      %td.no_padding
-        %table#product_list
+      %tr
+        %td.no_padding
+          %table#product_list
+
+-else
+
+  %table#readonly_products
+    %thead
+      %tr
+        %th #{title}
+
+    -product_and_repos = get_product_and_repos(record, content_types)
+    -if product_and_repos.empty?
+      %tr
+        %td #{_('No products or repositories selected.')}
+
+    -else
+      -product_and_repos.each_pair do |product, repos|
+        %tr{:id => "product_#{product.id}"}
+          %td
+            %label #{_('Product')}:
+            #{product.name}
+
+        -if repos.empty?
+          %tr{:class => "child-of-product_#{product.id}"}
+            %td #{_("All repositories")}
+
+        -else
+          -repos.each do |repo|
+            %tr{:class => "child-of-product_#{product.id}"}
+              %td
+                %label #{_('Repository')}:
+                #{repo.name}

--- a/app/views/content_view_definitions/_composite_definition_content.html.haml
+++ b/app/views/content_view_definitions/_composite_definition_content.html.haml
@@ -11,11 +11,13 @@
   #composite_definition_content
     = kt_form_for(view_definition, :html => {:id => "component_views_form"}) do |form|
 
-      = render :partial => "view_definitions", :locals => {:form => form,
+      = render :partial => "view_definitions", :locals => {:editable => editable,
+                                                           :form => form,
                                                            :view_definitions => view_definitions,
                                                            :views => views}
 
-      %input.fr.button{:id=>'update_component_views', :type=>'button', :value=>_("Save"),
-                       'data-url'=>update_component_views_content_view_definition_path(view_definition.id)}
+      -if editable
+        %input.fr.button{:id=>'update_component_views', :type=>'button', :value=>_("Save"),
+                         'data-url'=>update_component_views_content_view_definition_path(view_definition.id)}
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/content_view_definitions/_view_definitions.html.haml
+++ b/app/views/content_view_definitions/_view_definitions.html.haml
@@ -7,16 +7,25 @@
       = _('Published')
   %tbody
     - view_definitions.each do |definition|
-      - if definition.content_views.length > 0
+
+      - if definition.content_views.length > 0 && has_a_component_view?(definition, views)
         %tr.definition{:id => "definition_#{definition.id}"}
           %td{:colspan => 2}
             %label #{_('Definition')}:
             #{definition.name}
 
         - definition.content_views.each do |view|
-          %tr.view{:class => "child-of-definition_#{definition.id}"}
-            %td.view_checkbox
-              = check_box_tag "content_views[#{view.id}]", "1", view_checked?(view.id, views),
-                {:tabindex => form.tabindex, 'data-view_id' => view.id}
-              #{view.name}
-            %td #{view.version(current_organization.library).try(:task_status).try(:finish_time)}
+
+          -if editable
+            %tr.view{:class => "child-of-definition_#{definition.id}"}
+              %td.view_checkbox
+                = check_box_tag "content_views[#{view.id}]", "1", view_checked?(view.id, views),
+                  {:tabindex => form.tabindex, 'data-view_id' => view.id}
+                #{view.name}
+              %td #{view.version(current_organization.library).try(:task_status).try(:finish_time)}
+
+          -elsif view_checked?(view.id, views)
+            %tr.view{:class => "child-of-definition_#{definition.id}"}
+              %td
+                #{view.name}
+              %td #{view.version(current_organization.library).try(:task_status).try(:finish_time)}

--- a/app/views/content_view_definitions/filters/_index.html.haml
+++ b/app/views/content_view_definitions/filters/_index.html.haml
@@ -27,13 +27,10 @@
             - view_definition.filters.each do |filter|
               %tr
                 %td
-                  - if editable
-                    .panel_link.grid_11.one-line-ellipsis
+                  .panel_link.grid_11.one-line-ellipsis
+                    - if editable
                       = check_box_tag "filters[#{filter.id}]", filter.name, false, {'data-id' => filter.id}
-                      = link_to(filter.name, edit_content_view_definition_filter_path(view_definition.id, filter.id))
-                  - else
-                    %span.grid_11.one-line-ellipsis
-                      = filter.name
+                    = link_to(filter.name, edit_content_view_definition_filter_path(view_definition.id, filter.id))
 
         - if editable
           %input.button.fr.disabled{:type=>"button", :id=>"remove_button", :value=>_("Remove")}

--- a/app/views/content_view_definitions/filters/_list_rules.html.haml
+++ b/app/views/content_view_definitions/filters/_list_rules.html.haml
@@ -22,13 +22,11 @@
           - filter.rules.each do |rule|
             %tr
               %td.one-line-ellipsis
-                - if editable
-                  .panel_link
+                .panel_link
+                  - if editable
                     = check_box_tag "filter_rules[#{rule.id}]", FilterRule::CONTENT_OPTIONS.key(rule.content_type),
                       false, {'data-id' => rule.id}
-                    = filter_rule_url(rule)
-                - else
-                  = FilterRule::CONTENT_OPTIONS.key(rule.content_type)
+                  = filter_rule_url(rule)
 
       - if editable
         %input.button.fr.disabled{:type => "button", :id => "remove_button", :value => _("Remove")}

--- a/app/views/content_view_definitions/filters/rules/_edit.html.haml
+++ b/app/views/content_view_definitions/filters/rules/_edit.html.haml
@@ -20,8 +20,9 @@
 
         #inclusion{'data-initial_value' => included_text(rule)}
           = _("Specifying %{rule_type} to %{include}") % {:include => included_text(rule), :rule_type => rule_type}
-          %a.subpanel_element{"data-url" => edit_inclusion_content_view_definition_filter_rule_path(view_definition, filter, rule)}
-            = _("(Edit)")
+          - if editable
+            %a.subpanel_element{"data-url" => edit_inclusion_content_view_definition_filter_rule_path(view_definition, filter, rule)}
+              = _("(Edit)")
 
         - if rule.content_type == FilterRule::ERRATA
           %br

--- a/app/views/content_view_definitions/filters/rules/_edit_errata.html.haml
+++ b/app/views/content_view_definitions/filters/rules/_edit_errata.html.haml
@@ -1,17 +1,18 @@
 = javascript 'widgets/jquery.jeditable.helpers'
 
-%div
-  %strong #{_("Filter Errata by")}
+- if editable
+  %div
+    %strong #{_("Filter Errata by")}
 
-  = radio_button_tag("errata", "date_type", rule.parameters.include?(:units) ? false : true,
-                     {:class => :filter_method, :tabindex => auto_tab_index,
-                      'data-url' => edit_date_type_parameters_content_view_definition_filter_rule_path(view_definition.id, filter.id, rule.id)})
-  = label_tag(_('Date and Type'))
+    = radio_button_tag("errata", "date_type", rule.parameters.include?(:units) ? false : true,
+                       {:class => :filter_method, :tabindex => auto_tab_index,
+                        'data-url' => edit_date_type_parameters_content_view_definition_filter_rule_path(view_definition.id, filter.id, rule.id)})
+    = label_tag(_('Date and Type'))
 
-  = radio_button_tag("errata", "specify", rule.parameters.include?(:units) ? true : false,
-                     {:class => :filter_method, :tabindex => auto_tab_index,
-                      'data-url' => edit_parameter_list_content_view_definition_filter_rule_path(view_definition.id, filter.id, rule.id)})
-  = label_tag(_('Errata ID'))
+    = radio_button_tag("errata", "specify", rule.parameters.include?(:units) ? true : false,
+                       {:class => :filter_method, :tabindex => auto_tab_index,
+                        'data-url' => edit_parameter_list_content_view_definition_filter_rule_path(view_definition.id, filter.id, rule.id)})
+    = label_tag(_('Errata ID'))
 
 .rule_parameters
   - if rule.parameters.include?(:units)

--- a/app/views/content_view_definitions/filters/rules/_errata_item.html.haml
+++ b/app/views/content_view_definitions/filters/rules/_errata_item.html.haml
@@ -1,7 +1,7 @@
 %tr
   %td
-    - if editable
-      .panel_link
+    .panel_link
+      - if editable
         = check_box_tag "units[#{unit[:id]}]", unit[:id], false, {'data-id' => unit[:id]}
-        %label
-          = unit[:id]
+      %label
+        = unit[:id]

--- a/app/views/content_view_definitions/filters/rules/_parameter_list.html.haml
+++ b/app/views/content_view_definitions/filters/rules/_parameter_list.html.haml
@@ -10,19 +10,20 @@
           %th{:colspan => cols} #{_("Name")}
 
       %tbody
-        %tr
-          %td{:colspan => cols}
-            - help_text = _("Enter %{type} Name...") % {:type => rule_type.singularize}
-            %input{:type=>'text', :id=>'rule_input', :size=>'30', :placeholder => help_text,
-                   :title => help_text, :tabindex => auto_tab_index}
-            - if ["Errata", "Packages"].include?(rule_type)
-              %span.rule-search-tipsy.details_icon-grey{title: _('Autocomplete is enabled if the filter has been assigned content. The minimum number of characters is 1 for package names and 3 for erratum names.')}
-            %a#add_rule{:style => 'padding-left: 10px;', :tabindex => auto_tab_index,
-                        'data-url' => add_parameter_content_view_definition_filter_rule_path(view_definition.id, filter.id, rule.id),
-                        'data-rule_type' => rule.content_type,
-                        'data-filter_id' => rule.filter.id} #{_('+ Add')}
+        - if editable
+          %tr
+            %td{:colspan => cols}
+              - help_text = _("Enter %{type} Name...") % {:type => rule_type.singularize}
+              %input{:type => 'text', :id => 'rule_input', :size => '30', :placeholder => help_text,
+                     :title => help_text, :tabindex => auto_tab_index}
+              - if ["Errata", "Packages"].include?(rule_type)
+                %span.rule-search-tipsy.details_icon-grey{title: _('Autocomplete is enabled if the filter has been assigned content. The minimum number of characters is 1 for package names and 3 for erratum names.')}
+              %a#add_rule{:style => 'padding-left: 10px;', :tabindex => auto_tab_index,
+                          'data-url' => add_parameter_content_view_definition_filter_rule_path(view_definition.id, filter.id, rule.id),
+                          'data-rule_type' => rule.content_type,
+                          'data-filter_id' => rule.filter.id} #{_('+ Add')}
 
-        %tr#empty_row{:class=>(:hidden unless rule.parameters[:units].blank?)}
+        %tr#empty_row{:class => (:hidden unless rule.parameters[:units].blank?)}
           %td{:colspan => 2}
             = _("This rule does not currently have any parameters defined.")
 


### PR DESCRIPTION
There were several issues in the UI for readonly users.  This
commit addresses the ones observed/found.  This involved things
such as the following:
- disable several links/buttons/inputs that a readonly user
  should not see or use
- enable links that a readonly user needs to navigate through
  the UI (e.g. filters, fitler rules)
- provide readonly representation for the product/repo selector
- provide readonly representation for composite view
  'content'
- ...
