### PR TITLE
1011171: Bulk System Remove: remove rows on system deletion

### DIFF
--- a/engines/bastion/app/assets/bastion/systems/systems-bulk-action.controller.js
+++ b/engines/bastion/app/assets/bastion/systems/systems-bulk-action.controller.js
@@ -77,7 +77,7 @@ angular.module('Bastion.systems').controller('SystemsBulkActionController',
             success = function(data) {
                 deferred.resolve(data);
                 angular.forEach($scope.table.getSelected(), function(row) {
-                    $scope.removeRow(row);
+                    $scope.removeRow(row.id);
                 });
 
                 $scope.removeSystems.workingMode = false;


### PR DESCRIPTION
This commit fixes the issue where performing a bulk remove systems
action does not properly remove rows from the nutupane.  In the
past, removeRows took the row as an input; however, it appears to
have been modified to now take the row.id.
