### PR TITLE
1011854: Filter: initialize product/repo selector before the filter rules list

### DIFF
--- a/app/assets/javascripts/content_view_definitions/content_view_definition.js
+++ b/app/assets/javascripts/content_view_definitions/content_view_definition.js
@@ -28,11 +28,6 @@ $(document).ready(function() {
 
         btn.parent().find(".options").toggle();
     });
-
-    KT.panel.set_expand_cb(function(){
-        KT.product_input.register();
-        KT.repo_input.register();
-    });
 });
 
 KT.panel.list.registerPage('content_view_definitions', { create : 'new_content_view_definition' });
@@ -40,6 +35,9 @@ KT.panel.list.registerPage('content_view_definitions', { create : 'new_content_v
 KT.panel.set_expand_cb(function() {
     $('a.remove.disabled').tipsy({ fade:true, gravity:'s', delayIn:500, html:true, className:'content_definition-tipsy',
         title:function() { return $('.hidden-text.hidden').html();} });
+
+    KT.product_input.register();
+    KT.repo_input.register();
 
     KT.object.label.initialize();
     KT.content_view_definition.initialize();
@@ -503,6 +501,7 @@ KT.content_view_definition_filters = (function(){
         }
 
         filter_tabs.tabs().tabs('select', filter_tabs.data('active_tab')).show();
+
         $('a[href="##rules"]').click(function(){
             initialize_rules();
         });


### PR DESCRIPTION
This commit moves the initialization of the product and repo selectors
to occur before the filter rules list initialization.  This is necessary
so that we can correctly render the rules pane.  E.g. if there are
no products selected, we render a warning.
