### PR TITLE
1010100: manifest import: output from logger cleared before notice generated

### DIFF
--- a/app/models/glue/provider.rb
+++ b/app/models/glue/provider.rb
@@ -330,7 +330,7 @@ module Glue::Provider
           Notify.success message % values,
                          :request_type => 'providers__update_redhat_provider',
                          :organization => self.organization,
-                         :details      => output.read
+                         :details      => output.read.dup
         end
       rescue => error
         display_manifest_message(manifest_refresh ? 'refresh' : 'import', error, options)


### PR DESCRIPTION
The logger output is included in notice details; however, that output
was released before notice was generated, so the details were always
empty.
