### PR TITLE
Bug #1012104 - set width of container panel to 0px to avoid overlap.

### DIFF
--- a/app/assets/stylesheets/katello.scss
+++ b/app/assets/stylesheets/katello.scss
@@ -850,7 +850,7 @@ fieldset {
 
 #panel-frame {
   position: fixed;
-  max-width:700px;
+  width:0px;
   z-index: -1;
 
   .tupane_footer {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1012104
