### PR TITLE
989932: changeset: destroy changet_user when destroying changset

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -41,7 +41,7 @@ class Changeset < ActiveRecord::Base
   validates_with Validators::NotInLibraryValidator
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
-  has_many :users, :class_name => "ChangesetUser", :inverse_of => :changeset
+  has_many :users, :class_name => "ChangesetUser", :inverse_of => :changeset, :dependent => :destroy
   belongs_to :environment, :class_name => "KTEnvironment"
   belongs_to :task_status
   has_many :changeset_content_views, :dependent => :destroy

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -160,4 +160,13 @@ class ChangesetTest < MiniTest::Rails::ActiveSupport::TestCase
     end
   end
 
+  def test_destroy
+    content_view = ContentView.find(content_views(:library_view))
+
+    changeset = FactoryGirl.create(:promotion_changeset,
+                                   :environment => @dev)
+    changeset.add_content_view!(content_view)
+
+    assert changeset.destroy
+  end
 end


### PR DESCRIPTION
Without this change an error like the following will be generated in the logs:
    ERROR: update or delete on table "changesets" violates foreign key constraint "changeset_users_changeset_id_fk" on table "changeset_users" DETAIL: Key (id)=(23) is still referenced from table "changeset_users". (PGError)
