### PR TITLE
label generation: generate label on blur vs focusout

### DIFF
--- a/app/assets/javascripts/common/katello_object.js
+++ b/app/assets/javascripts/common/katello_object.js
@@ -32,7 +32,7 @@ KT.object.label = (function(){
 
             $('.create_button').mousedown(function() {retrieve_label = false;});
 
-            $('.name_input').focusout(function(event){
+            $('.name_input').blur(function(event){
                 var name_input = $(this),
                     name = name_input.val(),
                     label = $(this).closest('fieldset').next('fieldset'),


### PR DESCRIPTION
This change is being made to improve the ability to automate
a test for it.  From various manual tests, it appears to behave
the same as it did before the change.
