### PR TITLE
960618 & 961954: Remove the scroll bars on the system panes

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -549,7 +549,10 @@ $col_width: (($static_width) * 0.5);
   // about page css
 
   .dash {
-
+    height: auto;
+    .widget {
+      height: auto;
+    }
   }
 
   .column {
@@ -564,6 +567,7 @@ $col_width: (($static_width) * 0.5);
   .about-info {
     border: 1px solid #aaa;
     border-collapse: collapse;
+    margin-bottom: 2em;
 
     th, td {
       border: 1px solid #aaa;
@@ -581,9 +585,11 @@ $col_width: (($static_width) * 0.5);
 
   .support {
     height: 30px;
+    padding-bottom: 1.5em;
   }
-  .packages {
-    height: 320px;
+  .dash.packages .widget {
+    height: 340px;
+    padding-bottom: 1em;
   }
 }
 

--- a/app/views/application_info/about.html.haml
+++ b/app/views/application_info/about.html.haml
@@ -9,7 +9,7 @@
       .dash
         .dashhead
           %h4= _("System Status")
-        .widget.scroll-pane
+        .widget
           %table.about-info
             %tr.header
               %th
@@ -25,7 +25,7 @@
     .dash
       .dashhead
         %h4= _("System Information")
-      .widget.scroll-pane
+      .widget
         %table.about-info
           %tr.header
             %th= _("Parameter")
@@ -50,7 +50,7 @@
 
 
     - if can_read_system_info?
-      .dash
+      .dash.packages
         .dashhead
           %h4= _("Installed Packages")
         .widget.scroll-pane


### PR DESCRIPTION
Keeping the scroll bar on the packages pane though since its 600+ pixels. This should solve both bugs.
