### PR TITLE
Code to help with katello-upgrade and reindexing

### DIFF
--- a/db/migrate/20130622171955_legacy_promotion_content_view_changes.rb
+++ b/db/migrate/20130622171955_legacy_promotion_content_view_changes.rb
@@ -108,7 +108,7 @@ class LegacyPromotionContentViewChanges < ActiveRecord::Migration
         pulp_id = repo_data["pulp_id"]
         relative_path = repo_data["relative_path"]
         unprotected = repo_data["unprotected"] == "t"
-        pulp_repo = Runcible::Extensions::Repository.retrieve_with_details(pulp_id)
+        pulp_repo = Katello.pulp_server.extensions.repository.retrieve_with_details(pulp_id)
         distro_items = pulp_repo[:distributors].select do |dis|
           dis["distributor_type_id"] == "yum_distributor"
         end
@@ -118,11 +118,11 @@ class LegacyPromotionContentViewChanges < ActiveRecord::Migration
         end
 
         distro_ids.each do |distro_id|
-          Runcible::Extensions::Repository.delete_distributor(pulp_id, distro_id)
+          Katello.pulp_server.extensions.repository.delete_distributor(pulp_id, distro_id)
 
-          yum_distro =  Runcible::Extensions::YumDistributor.new(relative_path, (unprotected || false), true,
+          yum_distro =  Runcible::Models::YumDistributor.new(relative_path, (unprotected || false), true,
                                                                  {:protected => true})
-          Runcible::Extensions::Repository.associate_distributor(pulp_id,
+          Katello.pulp_server.extensions.repository.associate_distributor(pulp_id,
                                                                  "yum_distributor", yum_distro.config,
                                                                  "auto_publish" => true,
                                                                  "distributor_id" => distro_id)

--- a/lib/tasks/reindex.rake
+++ b/lib/tasks/reindex.rake
@@ -4,6 +4,7 @@ task :reindex=>["environment", "clear_search_indices"]  do
   Dir.glob(Rails.root.to_s + '/app/models/*.rb').each { |file| require file }
 
   Util::Search.active_record_search_classes.each do |model|
+    print "Re-indexing #{model.name}\n"
     model.create_elasticsearch_index
     sub_classes = model.subclasses
 
@@ -14,7 +15,7 @@ task :reindex=>["environment", "clear_search_indices"]  do
       objects = model.where(:type => ([nil, model.name]))
     end
 
-    model.index.import(objects) if model.count > 0
+    model.index.import(objects) if objects.count > 0
   end
 
   print "Re-indexing Repositories\n"


### PR DESCRIPTION
Had to update the legacy promotion code to work with new runcible changes.
Also made a slight tweak to the rake reindex call to reindex only
if there was content to reindex. This was done to avoid the following
error one gets when running katello-upgrade

[ERROR] Too many exceptions occured, giving up. The HTTP response was:
400 > {"error":"Failed to derive xcontent from
org.elasticsearch.common.bytes.BytesArray@0"}

Also added a print statement to print what is getting reindexed.
