### PR TITLE
Bug 1010096: Re-enables after sync notifications when Pulp sends

### DIFF
--- a/app/assets/stylesheets/katello.scss
+++ b/app/assets/stylesheets/katello.scss
@@ -1471,3 +1471,14 @@ pre {
 .instruction-page {
   padding: 10px 20px;
 }
+
+.info-tipsy {
+  opacity: 0.6;
+  color: orange;
+  font-size: 13px;
+
+  &:hover {
+    opacity: 1;
+    color: orange;
+  }
+}

--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -153,7 +153,7 @@ Pulp doesn't send correct headers."
     repo    = Repository.where(:pulp_id => repo_id).first
     raise _("Couldn't find repository '%s'") % repo.name if repo.nil?
     Rails.logger.info("Sync_complete called for #{repo.name}, running after_sync.")
-    repo.async(:organization => repo.environment.organization).after_sync(params[:task_id])
+    repo.async(:organization => repo.environment.organization).after_sync(params[:call_report][:task_id])
     respond_for_status
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -183,7 +183,7 @@ class Repository < ActiveRecord::Base
   end
 
   def after_sync(pulp_task_id)
-    #self.handle_sync_complete_task(pulp_task_id)
+    self.handle_sync_complete_task(pulp_task_id)
     self.index_content
   end
 

--- a/app/views/sync_management/_repo.html.haml
+++ b/app/views/sync_management/_repo.html.haml
@@ -13,14 +13,14 @@
     #{@repo_status[repo.id][:display_size]}
     (#{@repo_status[repo.id][:packages]})
   %td.result
-    %span.result-info
-      #{@repo_status[repo.id][:state]}
-    %span.info-tipsy.details_icon-grey{ "class" => "#{"hidden" if !error_state?(@repo_status[repo.id])}" }
+    %a.info-tipsy.clickable.icon-warning-sign{ "class" => "#{"hidden" if !error_state?(@repo_status[repo.id])}", :href => notices_path }
       %span.hidden-text.hidden
         .la.error-tipsy
           %ul
-            - if !@repo_status[repo.id][:error_details].is_a?(String)
-              - @repo_status[repo.id][:error_details].each do |error|
+            - if @repo_status[repo.id][:error_details]
+              - @repo_status[repo.id][:error_details][:messages].each do |error|
                 %li #{error}
+    %span.result-info
+      #{@repo_status[repo.id][:state]}
   - if @show_org
     %td

--- a/spec/controllers/api/v1/repositories_controller_spec.rb
+++ b/spec/controllers/api/v1/repositories_controller_spec.rb
@@ -383,7 +383,7 @@ describe Api::V1::RepositoriesController, :katello => true do
       it "should call async task correctly with no forwarded header" do
         @repo.should_receive(:async).and_return(@fake_async)
         @fake_async.should_receive(:after_sync)
-        params = { :task_id => "123", :payload => { :repo_id => "123" } }
+        params = { :call_report => {:task_id => "123"}, :payload => { :repo_id => "123" } }
         post :sync_complete, params
         response.should be_success
       end
@@ -392,7 +392,7 @@ describe Api::V1::RepositoriesController, :katello => true do
         request.env["HTTP_X_FORWARDED_FOR"] = '127.0.0.1'
         @repo.should_receive(:async).and_return(@fake_async)
         @fake_async.should_receive(:after_sync)
-        params = { :task_id => "123", :payload => { :repo_id => "123" } }
+        params = { :call_report => {:task_id => "123"}, :payload => { :repo_id => "123" } }
         post :sync_complete, params
         response.should be_success
       end
@@ -401,7 +401,7 @@ describe Api::V1::RepositoriesController, :katello => true do
         request.env["HTTP_X_FORWARDED_FOR"] = '::1'
         @repo.should_receive(:async).and_return(@fake_async)
         @fake_async.should_receive(:after_sync)
-        params = { :task_id => "123", :payload => { :repo_id => "123" } }
+        params = { :call_report => {:task_id => "123"}, :payload => { :repo_id => "123" } }
         post :sync_complete, params
         response.should be_success
       end

--- a/test/fixtures/vcr_cassettes/pulp/repository/after_sync.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/after_sync.yml
@@ -1,0 +1,346 @@
+--- 
+http_interactions: 
+- request: 
+    method: get
+    uri: https://katello-f18-rails32/pulp/api/v2/tasks/093f45a2-98b8-491c-90f5-4b92b9924be7/
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="gH8OGFkKsVWN7N3og6IJBP7Rj22njopernI3enLP2LM", oauth_signature="ZFNa5PTTm7OIHpddS69q7OpcflI%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380752074", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Wed, 02 Oct 2013 22:14:34 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Length: 
+      - "1106"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "{\"task_group_id\": \"fae9f5f6-9fb0-4d00-a6dc-ec8f2c129718\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/tasks/093f45a2-98b8-491c-90f5-4b92b9924be7/\", \"task_id\": \"093f45a2-98b8-491c-90f5-4b92b9924be7\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"reasons\": [], \"start_time\": \"2013-10-02T22:14:34Z\", \"tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"state\": \"running\", \"finish_time\": null, \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {\"yum_importer\": {\"content\": {\"size_total\": 0, \"items_left\": 0, \"items_total\": 0, \"state\": \"NOT_STARTED\", \"size_left\": 0, \"details\": {\"rpm_total\": 0, \"rpm_done\": 0, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"NOT_STARTED\"}, \"distribution\": {\"items_total\": 0, \"state\": \"NOT_STARTED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"NOT_STARTED\"}, \"metadata\": {\"state\": \"IN_PROGRESS\"}}}, \"call_request_group_id\": \"fae9f5f6-9fb0-4d00-a6dc-ec8f2c129718\", \"call_request_id\": \"093f45a2-98b8-491c-90f5-4b92b9924be7\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": null}"
+    http_version: 
+  recorded_at: Wed, 02 Oct 2013 22:14:35 GMT
+- request: 
+    method: get
+    uri: https://katello-f18-rails32/pulp/api/v2/tasks/093f45a2-98b8-491c-90f5-4b92b9924be7/
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="F2nUnK4sygnv9PlGibaOXh7QXwwgOcwU1lD8rgDFk", oauth_signature="koaWqJRhESAVqW%2BKamT%2Bz5%2F%2BiGQ%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380752090", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Wed, 02 Oct 2013 22:14:50 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Length: 
+      - "2076"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "{\"task_group_id\": \"fae9f5f6-9fb0-4d00-a6dc-ec8f2c129718\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/tasks/093f45a2-98b8-491c-90f5-4b92b9924be7/\", \"task_id\": \"093f45a2-98b8-491c-90f5-4b92b9924be7\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"reasons\": [], \"start_time\": \"2013-10-02T22:14:34Z\", \"tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"state\": \"finished\", \"finish_time\": \"2013-10-02T22:14:35Z\", \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {\"yum_importer\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}}, \"call_request_group_id\": \"fae9f5f6-9fb0-4d00-a6dc-ec8f2c129718\", \"call_request_id\": \"093f45a2-98b8-491c-90f5-4b92b9924be7\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": {\"importer_id\": \"yum_importer\", \"exception\": null, \"repo_id\": \"1\", \"traceback\": null, \"started\": \"2013-10-02T18:14:34-04:00\", \"_ns\": \"repo_sync_results\", \"completed\": \"2013-10-02T18:14:35-04:00\", \"importer_type_id\": \"yum_importer\", \"error_message\": null, \"summary\": {\"content\": {\"state\": \"FINISHED\"}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"state\": \"FINISHED\"}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"added_count\": 0, \"result\": \"success\", \"updated_count\": 14, \"details\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"id\": \"524c9acbf45cbb0db9d40859\", \"removed_count\": 0}}"
+    http_version: 
+  recorded_at: Wed, 02 Oct 2013 22:14:50 GMT
+- request: 
+    method: get
+    uri: https://katello-f18-rails32/pulp/api/v2/tasks/093f45a2-98b8-491c-90f5-4b92b9924be7/
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="7tTcUtjgRGZvCCJxYmQtdrmLxU0RtJe77QUzDLxts", oauth_signature="spDH7Kimdomq5zN%2F1owhnAmIPeg%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380752091", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Wed, 02 Oct 2013 22:14:51 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Length: 
+      - "2076"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "{\"task_group_id\": \"fae9f5f6-9fb0-4d00-a6dc-ec8f2c129718\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/tasks/093f45a2-98b8-491c-90f5-4b92b9924be7/\", \"task_id\": \"093f45a2-98b8-491c-90f5-4b92b9924be7\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"reasons\": [], \"start_time\": \"2013-10-02T22:14:34Z\", \"tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"state\": \"finished\", \"finish_time\": \"2013-10-02T22:14:35Z\", \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {\"yum_importer\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}}, \"call_request_group_id\": \"fae9f5f6-9fb0-4d00-a6dc-ec8f2c129718\", \"call_request_id\": \"093f45a2-98b8-491c-90f5-4b92b9924be7\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": {\"importer_id\": \"yum_importer\", \"exception\": null, \"repo_id\": \"1\", \"traceback\": null, \"started\": \"2013-10-02T18:14:34-04:00\", \"_ns\": \"repo_sync_results\", \"completed\": \"2013-10-02T18:14:35-04:00\", \"importer_type_id\": \"yum_importer\", \"error_message\": null, \"summary\": {\"content\": {\"state\": \"FINISHED\"}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"state\": \"FINISHED\"}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"added_count\": 0, \"result\": \"success\", \"updated_count\": 14, \"details\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"id\": \"524c9acbf45cbb0db9d40859\", \"removed_count\": 0}}"
+    http_version: 
+  recorded_at: Wed, 02 Oct 2013 22:14:51 GMT
+- request: 
+    method: post
+    uri: https://katello-f18-rails32/pulp/api/v2/repositories/
+    body: 
+      encoding: US-ASCII
+      string: "{\"id\":\"1\",\"display_name\":\"Fedora 17 x86_64\",\"importer_type_id\":\"yum_importer\",\"importer_config\":{\"ssl_ca_cert\":null,\"ssl_client_cert\":null,\"ssl_client_key\":null,\"feed\":\"file:///var/www/test_repos/zoo\"},\"notes\":{\"_repo-type\":\"rpm-repo\"},\"distributors\":[{\"distributor_type\":\"yum_distributor\",\"distributor_config\":{\"relative_url\":\"/test_path/\",\"http\":false,\"https\":true,\"protected\":true},\"auto_publish\":true,\"distributor_id\":\"1\"},{\"distributor_type\":\"yum_clone_distributor\",\"distributor_config\":{\"destination_distributor_id\":\"1\"},\"auto_publish\":false,\"distributor_id\":\"1_clone\"},{\"distributor_type\":\"nodes_http_distributor\",\"distributor_config\":{},\"auto_publish\":true,\"distributor_id\":\"1_nodes\"}]}"
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello", oauth_nonce="YYIsN4kUK7nYUH3vl54e0xwDeu6LwZLmM3WFbSFTU", oauth_signature="sJkiKCzAhr6OLoffkmZM2Kg%2BCeA%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380764070", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      Content-Length: 
+      - "694"
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 201
+      message: Created
+    headers: 
+      Date: 
+      - Thu, 03 Oct 2013 01:34:30 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Location: 
+      - "1"
+      Content-Length: 
+      - "252"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "{\"scratchpad\": {}, \"display_name\": \"Fedora 17 x86_64\", \"description\": null, \"_ns\": \"repos\", \"notes\": {\"_repo-type\": \"rpm-repo\"}, \"content_unit_counts\": {}, \"_id\": {\"$oid\": \"524cc9a6f45cbb0db9d415dd\"}, \"id\": \"1\", \"_href\": \"/pulp/api/v2/repositories/1/\"}"
+    http_version: 
+  recorded_at: Thu, 03 Oct 2013 01:34:30 GMT
+- request: 
+    method: post
+    uri: https://katello-f18-rails32/pulp/api/v2/repositories/1/actions/sync/
+    body: 
+      encoding: US-ASCII
+      string: "{\"override_config\":{\"num_threads\":4}}"
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello", oauth_nonce="vqn024qtnGpQeRhGaxLZ32Ieqwt6tFWA8rbwD7i60", oauth_signature="Ujx49Nimr2l6Ij7tN69GV4BP5pA%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380764070", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      Content-Length: 
+      - "37"
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 202
+      message: Accepted
+    headers: 
+      Date: 
+      - Thu, 03 Oct 2013 01:34:30 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Encoding: 
+      - utf-8
+      Content-Length: 
+      - "2134"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "[{\"task_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/task_groups/699aa43d-a249-4df4-834d-dda8134912e3/\", \"task_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"reasons\": [], \"start_time\": null, \"tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"state\": \"waiting\", \"finish_time\": null, \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {}, \"call_request_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"call_request_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": null}, {\"task_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/task_groups/699aa43d-a249-4df4-834d-dda8134912e3/\", \"task_id\": \"469a89f1-9d2d-4ffa-b9e3-70e302870b58\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:auto_publish\", \"pulp:action:publish\"], \"reasons\": [], \"start_time\": null, \"tags\": [\"pulp:repository:1\", \"pulp:action:auto_publish\", \"pulp:action:publish\"], \"state\": \"waiting\", \"finish_time\": null, \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {}, \"call_request_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"call_request_id\": \"469a89f1-9d2d-4ffa-b9e3-70e302870b58\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": null}, {\"task_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/task_groups/699aa43d-a249-4df4-834d-dda8134912e3/\", \"task_id\": \"afd93043-f66b-46bc-89af-3caf77bd8c03\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:auto_publish\", \"pulp:action:publish\"], \"reasons\": [], \"start_time\": null, \"tags\": [\"pulp:repository:1\", \"pulp:action:auto_publish\", \"pulp:action:publish\"], \"state\": \"waiting\", \"finish_time\": null, \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {}, \"call_request_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"call_request_id\": \"afd93043-f66b-46bc-89af-3caf77bd8c03\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": null}]"
+    http_version: 
+  recorded_at: Thu, 03 Oct 2013 01:34:30 GMT
+- request: 
+    method: get
+    uri: https://katello-f18-rails32/pulp/api/v2/tasks/3b88c79b-c570-4c0f-94d5-9cd91b7f189c/
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="92Evu1C2lcYhcQ4MhJzobImdQl7qusnU6KQZj3c", oauth_signature="lvYQbaJBaBAQYpsrtITdAIM5RJs%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380764070", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Thu, 03 Oct 2013 01:34:30 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Length: 
+      - "1110"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "{\"task_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/tasks/3b88c79b-c570-4c0f-94d5-9cd91b7f189c/\", \"task_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"reasons\": [], \"start_time\": \"2013-10-03T01:34:30Z\", \"tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"state\": \"running\", \"finish_time\": null, \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {\"yum_importer\": {\"content\": {\"size_total\": 17872, \"items_left\": 3, \"items_total\": 8, \"state\": \"IN_PROGRESS\", \"size_left\": 6692, \"details\": {\"rpm_total\": 8, \"rpm_done\": 5, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"NOT_STARTED\"}, \"distribution\": {\"items_total\": 0, \"state\": \"NOT_STARTED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"NOT_STARTED\"}, \"metadata\": {\"state\": \"FINISHED\"}}}, \"call_request_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"call_request_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": null}"
+    http_version: 
+  recorded_at: Thu, 03 Oct 2013 01:34:31 GMT
+- request: 
+    method: get
+    uri: https://katello-f18-rails32/pulp/api/v2/tasks/3b88c79b-c570-4c0f-94d5-9cd91b7f189c/
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="vFnrKGunUsGZTQBrpVUgIKq3KtNbZdevxgVJaWSPg", oauth_signature="tNzaa1bne%2F13KKTucLoUNiL%2Fi6A%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380764086", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Thu, 03 Oct 2013 01:34:46 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Length: 
+      - "2076"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "{\"task_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/tasks/3b88c79b-c570-4c0f-94d5-9cd91b7f189c/\", \"task_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"reasons\": [], \"start_time\": \"2013-10-03T01:34:30Z\", \"tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"state\": \"finished\", \"finish_time\": \"2013-10-03T01:34:31Z\", \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {\"yum_importer\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}}, \"call_request_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"call_request_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": {\"importer_id\": \"yum_importer\", \"exception\": null, \"repo_id\": \"1\", \"traceback\": null, \"started\": \"2013-10-02T21:34:30-04:00\", \"_ns\": \"repo_sync_results\", \"completed\": \"2013-10-02T21:34:31-04:00\", \"importer_type_id\": \"yum_importer\", \"error_message\": null, \"summary\": {\"content\": {\"state\": \"FINISHED\"}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"state\": \"FINISHED\"}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"added_count\": 0, \"result\": \"success\", \"updated_count\": 14, \"details\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"id\": \"524cc9a7f45cbb0db9d41607\", \"removed_count\": 0}}"
+    http_version: 
+  recorded_at: Thu, 03 Oct 2013 01:34:46 GMT
+- request: 
+    method: get
+    uri: https://katello-f18-rails32/pulp/api/v2/tasks/3b88c79b-c570-4c0f-94d5-9cd91b7f189c/
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="grxjP12QjjLYluGdr47gfkP8kiLKHlaDEQaeM1w048", oauth_signature="5jA7OMYrhoXuufuLvuPJQU%2FDMzA%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380764087", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Thu, 03 Oct 2013 01:34:47 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Length: 
+      - "2076"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "{\"task_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/tasks/3b88c79b-c570-4c0f-94d5-9cd91b7f189c/\", \"task_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"reasons\": [], \"start_time\": \"2013-10-03T01:34:30Z\", \"tags\": [\"pulp:repository:1\", \"pulp:action:sync\"], \"state\": \"finished\", \"finish_time\": \"2013-10-03T01:34:31Z\", \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {\"yum_importer\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}}, \"call_request_group_id\": \"699aa43d-a249-4df4-834d-dda8134912e3\", \"call_request_id\": \"3b88c79b-c570-4c0f-94d5-9cd91b7f189c\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": {\"importer_id\": \"yum_importer\", \"exception\": null, \"repo_id\": \"1\", \"traceback\": null, \"started\": \"2013-10-02T21:34:30-04:00\", \"_ns\": \"repo_sync_results\", \"completed\": \"2013-10-02T21:34:31-04:00\", \"importer_type_id\": \"yum_importer\", \"error_message\": null, \"summary\": {\"content\": {\"state\": \"FINISHED\"}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"state\": \"FINISHED\"}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"added_count\": 0, \"result\": \"success\", \"updated_count\": 14, \"details\": {\"content\": {\"size_total\": 17872, \"items_left\": 0, \"items_total\": 8, \"state\": \"FINISHED\", \"size_left\": 0, \"details\": {\"rpm_total\": 8, \"rpm_done\": 8, \"drpm_total\": 0, \"drpm_done\": 0}, \"error_details\": []}, \"comps\": {\"state\": \"FINISHED\"}, \"distribution\": {\"items_total\": 3, \"state\": \"FINISHED\", \"error_details\": [], \"items_left\": 0}, \"errata\": {\"state\": \"FINISHED\"}, \"metadata\": {\"state\": \"FINISHED\"}}, \"id\": \"524cc9a7f45cbb0db9d41607\", \"removed_count\": 0}}"
+    http_version: 
+  recorded_at: Thu, 03 Oct 2013 01:34:47 GMT
+- request: 
+    method: delete
+    uri: https://katello-f18-rails32/pulp/api/v2/repositories/1/
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Content-Type: 
+      - application/json
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="4t1LPcZzR4jP6zPo1jcRwX6y3DrTb0TmckEucWY", oauth_signature="Va8L0hyy2J4DXnIUo%2BEO6j3JUSk%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1380764087", oauth_version="1.0"
+      Pulp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 202
+      message: Accepted
+    headers: 
+      Date: 
+      - Thu, 03 Oct 2013 01:34:47 GMT
+      Server: 
+      - Apache/2.4.4 (Fedora) OpenSSL/1.0.1c-fips mod_wsgi/3.4 Python/2.7.3
+      Content-Encoding: 
+      - utf-8
+      Content-Length: 
+      - "674"
+      Content-Type: 
+      - application/json
+    body: 
+      encoding: US-ASCII
+      string: "[{\"task_group_id\": \"76003575-2713-454a-abc7-2d81acae4070\", \"exception\": null, \"traceback\": null, \"_href\": \"/pulp/api/v2/task_groups/76003575-2713-454a-abc7-2d81acae4070/\", \"task_id\": \"eb4ac8c9-dcf8-4107-9d48-1503901264fd\", \"call_request_tags\": [\"pulp:repository:1\", \"pulp:action:delete\"], \"reasons\": [], \"start_time\": null, \"tags\": [\"pulp:repository:1\", \"pulp:action:delete\"], \"state\": \"waiting\", \"finish_time\": null, \"dependency_failures\": {}, \"schedule_id\": null, \"progress\": {}, \"call_request_group_id\": \"76003575-2713-454a-abc7-2d81acae4070\", \"call_request_id\": \"eb4ac8c9-dcf8-4107-9d48-1503901264fd\", \"principal_login\": \"admin\", \"response\": \"accepted\", \"result\": null}]"
+    http_version: 
+  recorded_at: Thu, 03 Oct 2013 01:34:47 GMT
+recorded_with: VCR 2.5.0


### PR DESCRIPTION
a sync completed notification and updates the tooltip rendering on the
sync management page.

Previously we disabled task updates and notifications for sync complete
notifications from Pulp due to a missing task_id parameter. This fix
re-enables and updates the code to show the newly formatted error details
to the user. This also updates the tooltip shown on the sync management
page to give users a better error output. Further, the error icon is also
clickable and takes users to the notifications page.
