### PR TITLE
Fix intermittent javascript failures in PR script.

### DIFF
--- a/script/ci/katello_pr_javascript.sh
+++ b/script/ci/katello_pr_javascript.sh
@@ -13,6 +13,9 @@ export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
 npm install -g bower grunt-cli
+npm install grunt
+
 npm install
-bower install --dev
+bower install
+
 grunt ci


### PR DESCRIPTION
This will hopefully fix the intermittent javascript test failures we've been seeing.

```
Running "karma:ci" (karma) task
[2013-10-02 20:40:18.882] [DEBUG] config - autoWatch set to false, because of singleRun
INFO [karma]: Karma server started at http://localhost:8080/
INFO [launcher]: Starting browser PhantomJS
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/jquery/jquery.js" does not match any file.
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/angular/angular.js" does not match any file.
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/angular-mocks/angular-mocks.js" does not match any file.
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/angular-sanitize/angular-sanitize.js" does not match any file.
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/angular-resource/angular-resource.js" does not match any file.
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/ngInfiniteScroll/ng-infinite-scroll.js" does not match any file.
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/alchemy/alchemy.js" does not match any file.
WARN [watcher]: Pattern "/home/travis/build/Katello/katello/engines/bastion/vendor/assets/dev-components/underscore/underscore.js" does not match any file.
INFO [PhantomJS 1.9 (Linux)]: Connected on socket id KhEIUyg2VuKbu_0E5lrb
PhantomJS 1.9 (Linux) ERROR
    TypeError: 'undefined' is not an object (evaluating 'angular.isDefined')
    at /home/travis/build/Katello/katello/vendor/assets/javascripts/angular-ui-states.js:12
PhantomJS 1.9 (Linux): Executed 0 of 0
JS 1.9 (Linux): Executed 0 of 0 ERROR (0.045 secs / 0 secs)
Warning: Task "karma:ci" failed. Use --force to continue.
Aborted due to warnings.
The command "./script/ci/katello_pr_$JOB.sh" exited with 3.
```
