### PR TITLE
1015155 - cleanup the activation_keys and task_statuses tables

### DIFF
--- a/db/migrate/20130613090036_add_foreign_keys.rb
+++ b/db/migrate/20130613090036_add_foreign_keys.rb
@@ -19,6 +19,8 @@ class AddForeignKeys < ActiveRecord::Migration
     execute("delete from marketing_engineering_products where engineering_product_id not in (select id from products)")
     execute("delete from roles_users where role_id not in (select id from roles)")
     execute("delete from roles_users where user_id not in (select id from users)")
+    execute("update activation_keys set user_id = (select id from users  where hidden = false limit 1) where user_id not in (select id from users)")
+    execute("update task_statuses set user_id = (select id from users  where hidden = false limit 1) where user_id not in (select id from users)")
 
     add_foreign_key_deferred 'activation_keys', 'content_views',
                              :name => 'activation_keys_content_view_id_fk'


### PR DESCRIPTION
if you delete a user they will still have dangling references in the 2 tables.  This is a band-aid to assist with some stuck migrations.  We should really consider dropping these FK columns that serve no real purpose
