### PR TITLE
1015520: Fixing org not found error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -200,7 +200,7 @@ class ApplicationController < ActionController::Base
     rescue ActiveRecord::RecordNotFound => error
       log_exception error
       session.delete(:current_organization_id)
-      org_not_found_error(error)
+      org_not_found_error
     end
   end
 


### PR DESCRIPTION
Error:

```
 | ArgumentError (wrong number of arguments (1 for 0)):
 |   app/controllers/application_controller.rb:689:in `org_not_found_error'
 |   app/controllers/application_controller.rb:203:in `rescue in current_organization'
 |   app/controllers/application_controller.rb:190:in `current_organization'
 |   app/controllers/application_controller.rb:278:in `check_deleted_org'
 |   config/initializers/quiet_paths.rb:11:in `call_with_quiet'
 |   lib/katello/middleware/log_request_uuid.rb:22:in `call'
 |   app/controllers/application_controller.rb:192:in `current_organization'
```
