### PR TITLE
admin-role - static type for Role self_role and locked

### DIFF
--- a/app/models/glue/elastic_search/role.rb
+++ b/app/models/glue/elastic_search/role.rb
@@ -21,6 +21,8 @@ module Glue::ElasticSearch::Role
       mapping do
         indexes :name, :type => 'string', :analyzer => :kt_name_analyzer
         indexes :name_sort, :type => 'string', :index => :not_analyzed
+        indexes :self_role, :type => 'boolean'
+        indexes :locked, :type => 'boolean'
       end
     end
   end


### PR DESCRIPTION
After upgrading from SAM-1.2 to SAM-1.3, the Administrator role was not being listed in the UI. Querying elasticsearch directly showed the role, but not for the query katello is sending:

curl -X GET 'http://localhost:9200/katello_role/role/_search?from=0&size=20&pretty' -d '{"query":{"match_all":{}},"filter":{"terms":{"self_role":[false]}},"size":20,"from":0}'

@jlsherrill found that statically typing the self_role to boolean allowed the query to work.
