### PR TITLE
Fixed a cvd publish issue

### DIFF
--- a/app/models/content_view_definition.rb
+++ b/app/models/content_view_definition.rb
@@ -301,10 +301,10 @@ class ContentViewDefinition < ContentViewDefinitionBase
     end
 
     if process_errata_and_groups
-      [FilterRule::ERRATA, FilterRule::PACKAGE_GROUP].each do |content_type|
+      group_tasks = [FilterRule::ERRATA, FilterRule::PACKAGE_GROUP].collect do |content_type|
         repo.clone_contents_by_filter(cloned, content_type, nil)
       end
-
+      PulpTaskStatus.wait_for_tasks(group_tasks)
       cloned.purge_empty_groups_errata
     end
 


### PR DESCRIPTION
During the CVD publish we needed to wait till package groups and
errata were copied to the cloned repo before doing the
"purge_empty" operation. This is because "copy" is an async operation in
pulp.
