### PR TITLE
Fix deps specification for tire

### DIFF
--- a/katello.spec
+++ b/katello.spec
@@ -102,7 +102,7 @@ Requires:       %{?scl_prefix}rubygem(fssm)
 Requires:       %{?scl_prefix}rubygem(sass)
 Requires:       %{?scl_prefix}rubygem(ui_alchemy-rails) >= 1.0.0
 Requires:       %{?scl_prefix}rubygem(chunky_png)
-Requires:       %{?scl_prefix}rubygem(tire) = 0.6.0
+Requires:       %{?scl_prefix}rubygem(tire) >= 0.6.0
 Requires:       %{?scl_prefix}rubygem(ldap_fluff) >= 0.2.1
 Requires:       %{?scl_prefix}rubygem(anemone)
 Requires:       %{?scl_prefix}rubygem(apipie-rails) >= 0.0.18
@@ -194,8 +194,7 @@ BuildRequires:       %{?scl_prefix}rubygem(sass)
 BuildRequires:       %{?scl_prefix}rubygem(simple-navigation) >= 3.3.4
 BuildRequires:       %{?scl_prefix}rubygem(sqlite3)
 BuildRequires:       %{?scl_prefix}rubygem(thin)
-BuildRequires:       %{?scl_prefix}rubygem(tire) < 0.4
-BuildRequires:       %{?scl_prefix}rubygem(tire) >= 0.3.0
+BuildRequires:       %{?scl_prefix}rubygem(tire) >= 0.6.0
 BuildRequires:       %{?scl_prefix}rubygem(uuidtools)
 
 %description common


### PR DESCRIPTION
There was missing update on BuildRequires. Also, it usually not a good idea to
use '=' for versions, as it would fail if there is new version '0.6.1' that
usually shouldn't break compatibility. Using '>=' instead.
