### PR TITLE
Add missing comps: rubygem-ansi

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -43,6 +43,7 @@
        <packagereq type="default">rubygem-acts_as_reportable</packagereq>
        <packagereq type="default">rubygem-ui_alchemy-rails</packagereq>
        <packagereq type="default">rubygem-anemone</packagereq>
+       <packagereq type="default">rubygem-ansi</packagereq>
        <packagereq type="default">rubygem-apipie-rails</packagereq>
        <packagereq type="default">rubygem-apipie-params</packagereq>
        <packagereq type="default">rubygem-closure-compiler</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -43,6 +43,7 @@
        <packagereq type="default">rubygem-acts_as_reportable</packagereq>
        <packagereq type="default">rubygem-ui_alchemy-rails</packagereq>
        <packagereq type="default">rubygem-anemone</packagereq>
+       <packagereq type="default">rubygem-ansi</packagereq>
        <packagereq type="default">rubygem-apipie-rails</packagereq>
        <packagereq type="default">rubygem-apipie-params</packagereq>
        <packagereq type="default">rubygem-closure-compiler</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -68,6 +68,7 @@
        <packagereq type="default">ruby193-rubygem-activesupport</packagereq>
        <packagereq type="default">ruby193-rubygem-acts_as_reportable</packagereq>
        <packagereq type="default">ruby193-rubygem-anemone</packagereq>
+       <packagereq type="default">ruby193-rubygem-ansi</packagereq>
        <packagereq type="default">ruby193-rubygem-apipie-params</packagereq>
        <packagereq type="default">ruby193-rubygem-apipie-rails</packagereq>
        <packagereq type="default">ruby193-rubygem-arel</packagereq>


### PR DESCRIPTION
Required by rubygem-tire 0.6.0
