### PR TITLE
Bastion: fixing broken translate filter on system search page.

### DIFF
--- a/engines/bastion/app/assets/bastion/systems/views/systems.html
+++ b/engines/bastion/app/assets/bastion/systems/views/systems.html
@@ -15,7 +15,7 @@
     <div class="form">
       <input type="text"
              class="input input-search"
-             placeholder="'Search...' | translate"
+             placeholder="{{ 'Search...' | translate }}"
              ng-model="table.searchTerm"
              on-enter="table.search(table.searchTerm)">
       <span class="result-count" translate>Showing {{ table.rows.length }} of {{ table.resource.subtotal }} ({{ table.resource.total }} Total) Systems</span>


### PR DESCRIPTION
Here's the problem:

![screen shot 2013-10-08 at 2 40 40 pm](https://f.cloud.github.com/assets/4116405/1291934/626be7da-304b-11e3-8aa1-091e88442ed9.png)
