### PR TITLE
Bug 974486: Updating system task fetching to ensure that running and

### DIFF
--- a/app/controllers/api/v1/systems_controller.rb
+++ b/app/controllers/api/v1/systems_controller.rb
@@ -377,20 +377,12 @@ A hint for choosing the right value for the releaseVer param
   param :system_name, String, :desc => "Name of the system"
   param :system_uuid, String, :desc => "UUID of the system"
   def tasks
-    query = TaskStatus.joins(:system).where(:"task_statuses.organization_id" => @organization.id)
-    if @environment
-      query = query.where(:"systems.environment_id" => @environment.id)
-    end
     if params[:system_name]
-      query = query.where("systems.name" => params[:system_name])
+      @tasks = System.where(:name => params[:system_name]).first.tasks
     elsif params[:system_uuid]
-      query = query.where("systems.uuid" => params[:system_uuid])
+      @tasks = System.where(:uuid => params[:system_uuid]).first.tasks
     end
 
-    task_ids = query.select('task_statuses.id')
-    TaskStatus.refresh(task_ids)
-
-    @tasks = TaskStatus.where(:id => task_ids)
     respond_for_index :collection => @tasks
   end
 

--- a/app/controllers/api/v2/systems_controller.rb
+++ b/app/controllers/api/v2/systems_controller.rb
@@ -93,6 +93,7 @@ class Api::V2::SystemsController < Api::V1::SystemsController
 
   api :GET, "/systems/:id/tasks", "List async tasks for the system"
   def tasks
+    @system.refresh_tasks
     query_string = params[:name] ? "name:#{params[:name]}" : params[:search]
 
     filters = [{:terms => {:task_owner_id => [@system.id]}},

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -207,9 +207,13 @@ class System < ActiveRecord::Base
     end
   end
 
-  def tasks
+  def refresh_tasks
     refresh_running_tasks
     import_candlepin_tasks
+  end
+
+  def tasks
+    refresh_tasks
     self.task_statuses
   end
 

--- a/test/controllers/api/v2/systems_controller_test.rb
+++ b/test/controllers/api/v2/systems_controller_test.rb
@@ -64,6 +64,8 @@ class Api::V2::SystemsControllerTest < Minitest::Rails::ActionController::TestCa
     items.stubs(:retrieve).returns([], 0)
     items.stubs(:total_items).returns([])
     Glue::ElasticSearch::Items.stubs(:new).returns(items)
+    System.any_instance.expects(:import_candlepin_tasks)
+
     get :tasks, :id => @system.uuid
 
     assert_response :success


### PR DESCRIPTION
candlepin tasks are imported prior to returning data.
