### PR TITLE
Fixed a performance issue related to cv publish

### DIFF
--- a/app/models/content_view_definition.rb
+++ b/app/models/content_view_definition.rb
@@ -294,7 +294,7 @@ class ContentViewDefinition < ContentViewDefinitionBase
     # This implies that there are no packages to copy over.
 
     if applicable_rules_count == 0 || copy_clauses
-      pulp_task = repo.clone_contents_by_filter(cloned, FilterRule::PACKAGE, copy_clauses, :recursive => true)
+      pulp_task = repo.clone_contents_by_filter(cloned, FilterRule::PACKAGE, copy_clauses)
       PulpTaskStatus.wait_for_tasks([pulp_task])
       process_errata_and_groups = true
     end

--- a/test/models/content_view_definition_test.rb
+++ b/test/models/content_view_definition_test.rb
@@ -241,7 +241,7 @@ class ContentViewDefinitionTest < MiniTest::Rails::ActiveSupport::TestCase
 
     PulpTaskStatus.stubs(:wait_for_tasks).returns("")
 
-    repo.expects(:clone_contents_by_filter).once.with(cloned, FilterRule::PACKAGE, dumb_copy, {:recursive => true}).returns(100)
+    repo.expects(:clone_contents_by_filter).once.with(cloned, FilterRule::PACKAGE, dumb_copy).returns(100)
     repo.expects(:clone_contents_by_filter).once.with(cloned, FilterRule::ERRATA, nil).returns(200)
     repo.expects(:clone_contents_by_filter).once.with(cloned, FilterRule::PACKAGE_GROUP, nil).returns(300)
     repo.expects(:clone_distribution).once.with(cloned)


### PR DESCRIPTION
Made the publish process do a 'depsolve' on if
'inclusion' or 'whitelist' filter was specified
