### PR TITLE
Bug 1017238: Adds a filter for allowing uuid specification when hitting

### DIFF
--- a/app/controllers/api/v1/system_groups_controller.rb
+++ b/app/controllers/api/v1/system_groups_controller.rb
@@ -68,9 +68,11 @@ class Api::V1::SystemGroupsController < Api::V1::ApiController
   param :organization_id, :identifier, :desc => "organization identifier", :required => true
   param :name, String, :desc => "System group name to filter by"
   def index
-    query_string = params[:name] ? "name:#{params[:name]}" : params[:search]
+    query_string = params[:search]
 
-    filters = [:terms => { :id => SystemGroup.readable(@organization).pluck(:id)}]
+    filters = [:terms => {:id => SystemGroup.readable(@organization).pluck(:id)}]
+    filters << {:term => {:name => params[:name]}} if params[:name]
+
     options = {
         :filters => filters
     }

--- a/app/controllers/api/v1/systems_controller.rb
+++ b/app/controllers/api/v1/systems_controller.rb
@@ -197,6 +197,7 @@ Schedules the consumer identity certificate regeneration
   param :name, String, :desc => "Filter systems by name"
   param :pool_id, String, :desc => "Filter systems by subscribed pool"
   param :search, String, :desc => "Filter systems by advanced search query"
+  param :uuid, String, :desc => "Filter systems by uuid"
   def index
     query_string = params[:name] ? "name:#{params[:name]}" : params[:search]
     filters      = []
@@ -209,6 +210,7 @@ Schedules the consumer identity certificate regeneration
     end
 
     filters << {:terms => {:uuid => System.all_by_pool_uuid(params['pool_id']) }} if params['pool_id']
+    filters << {:terms => {:uuid => [params['uuid']] }} if params['uuid']
 
     options = {
         :filters        => filters,

--- a/app/lib/util/search.rb
+++ b/app/lib/util/search.rb
@@ -20,7 +20,7 @@ module Util
         "kt_name_analyzer" => {
           "type"      => "custom",
           "tokenizer" => "keyword",
-          "filter"    => %w(standard lowercase asciifolding ngram_filter)
+          "filter"    => %w(lowercase asciifolding)
         },
         "autcomplete_name_analyzer" => {
             "type"      => "custom",


### PR DESCRIPTION
the System index.

This bug fix also includes changing the kt_name_analyzer back to the use
of lowercase and asciifolding since the uuid filter returns no results
given that it uses the kt_name_analyzer. The analyzer was previously
changed to support spaces in system group names through the API index
method. This case has been accounted for by adding explicit, escaped
quotes around the system group name when specified as a parameter.
