### PR TITLE
1007731 - CLI - Ldap Groups error for 'posix'.

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -36,7 +36,7 @@ class Role < ActiveRecord::Base
 
   def add_ldap_group(group_name)
     self.ldap_group_roles.create!(:ldap_group => group_name)
-    User.all.each { |user| user.set_ldap_roles }
+    User.visible.each { |user| user.set_ldap_roles }
     self.save
   end
 


### PR DESCRIPTION
we should only loop through visible users here, because the ldap server isn't
going to know about katello's special hidden users
