### PR TITLE
Bug #1015240 - switch "changeset management" and "changeset" menus.

### DIFF
--- a/app/lib/navigation/items/changeset_management.rb
+++ b/app/lib/navigation/items/changeset_management.rb
@@ -11,19 +11,14 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Navigation
-  module Menus
-    class ChangesetManagement < Navigation::Menu
+  module Items
+    class ChangesetManagement < Navigation::Item
 
       def initialize(organization)
-        @key           = :changeset_management
+        @key           = :changesets
         @display       = _("Changeset Management")
         @authorization = lambda{ organization && KTEnvironment.any_viewable_for_promotions?(organization) }
-        @type          = 'flyout'
-        @items         = [
-          Navigation::Items::Changesets.new(organization),
-          Navigation::Items::ChangesetHistory.new(organization)
-        ]
-        super
+        @url           = promotions_path
       end
 
     end

--- a/app/lib/navigation/menus/changesets.rb
+++ b/app/lib/navigation/menus/changesets.rb
@@ -11,14 +11,19 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Navigation
-  module Items
-    class Changesets < Navigation::Item
+  module Menus
+    class Changesets < Navigation::Menu
 
       def initialize(organization)
-        @key           = :changesets
+        @key           = :changeset_management
         @display       = _("Changesets")
         @authorization = lambda{ organization && KTEnvironment.any_viewable_for_promotions?(organization) }
-        @url           = promotions_path
+        @type          = 'flyout'
+        @items         = [
+          Navigation::Items::ChangesetManagement.new(organization),
+          Navigation::Items::ChangesetHistory.new(organization)
+        ]
+        super
       end
 
     end

--- a/app/lib/navigation/menus/content.rb
+++ b/app/lib/navigation/menus/content.rb
@@ -25,7 +25,7 @@ module Navigation
           Navigation::Menus::SyncManagement.new(organization),
           Navigation::Items::ContentViewDefinitions.new(organization),
           Navigation::Items::ContentSearch.new(organization),
-          Navigation::Menus::ChangesetManagement.new(organization)
+          Navigation::Menus::Changesets.new(organization)
         ]
         super
       end

--- a/test/lib/navigation/navigation_items_test.rb
+++ b/test/lib/navigation/navigation_items_test.rb
@@ -114,9 +114,9 @@ class NavigationItemsTest < MiniTest::Rails::ActiveSupport::TestCase
   end
 
   def test_changesets_item
-    item = Navigation::Items::Changesets.new(@acme_corporation)
+    item = Navigation::Items::ChangesetManagement.new(@acme_corporation)
 
-    assert_equal  _('Changesets'), item.display
+    assert_equal  _('Changeset Management'), item.display
     assert_equal  promotions_path, item.url
     assert        item.accessible?
   end

--- a/test/lib/navigation/navigation_menus_test.rb
+++ b/test/lib/navigation/navigation_menus_test.rb
@@ -97,9 +97,9 @@ class NavigationMenusTest < MiniTest::Rails::ActiveSupport::TestCase
   end
 
   def test_changeset_management_menu
-    menu = Navigation::Menus::ChangesetManagement.new(@acme_corporation)
+    menu = Navigation::Menus::Changesets.new(@acme_corporation)
 
-    assert_equal  _('Changeset Management'), menu.display
+    assert_equal  _('Changesets'), menu.display
     assert_equal  2, menu.items.length
     assert_equal  'flyout', menu.type
     assert        menu.accessible?


### PR DESCRIPTION
This is a temporary workaround until we can get alch-header updated.

https://bugzilla.redhat.com/show_bug.cgi?id=1015240

See https://trello.com/c/wdmIaDLP/229-fix-alch-header-to-allow-reloading-of-nutupane-pages-and-remove-temporary-redirect-menu-hack for tracking the real fix.
