### PR TITLE
Bug #1010339 - uploading all repo content before generating metadata.

### DIFF
--- a/app/controllers/api/v1/content_uploads_controller.rb
+++ b/app/controllers/api/v1/content_uploads_controller.rb
@@ -51,15 +51,16 @@ class Api::V1::ContentUploadsController < Api::V1::ApiController
     render :nothing => true
   end
 
-  api :POST, "/repositories/:repo_id/content_uploads/:id/import_into_repo", "Import into a repository"
+  api :POST, "/repositories/:repo_id/content_uploads/import_into_repo", "Import into a repository"
   param :repo_id, :identifier, :required => true, :desc => "repository id"
-  param :id, :identifier, :required => true, :desc => "upload request id"
-  param :unit_key, Hash, :required => true, :desc => "unique identifier for the new unit"
-  param :unit_metadata, Hash, :required => false, :desc => "extra metadata describing the unit"
+  param :uploads, Array, :required => true, :desc => "array of uploads to import"
   def import_into_repo
-    Katello.pulp_server.resources.content.import_into_repo(@repo.pulp_id, @repo.unit_type_id,
-      params[:id], params[:unit_key], {:unit_metadata => params[:unit_metadata]})
-    @repo.trigger_contents_changed(:wait => false, :index_units => [params[:unit_key]], :reindex => false)
+    params[:uploads].each do |upload|
+      Katello.pulp_server.resources.content.import_into_repo(@repo.pulp_id, @repo.unit_type_id,
+        upload[:id], upload[:unit_key], {:unit_metadata => upload[:metadata]})
+    end
+
+    @repo.trigger_contents_changed(:wait => false, :index_units => params[:uploads], :reindex => false)
     render :nothing => true
   end
 

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -246,10 +246,10 @@ Src::Application.routes.draw do
         resources :content_uploads, :controller => :content_uploads, :only => [:create, :destroy] do
           member do
             put :upload_bits
-            post :import_into_repo
           end
           collection do
             post :file, :to => 'content_uploads#upload_file'
+            post :import_into_repo
           end
         end
         member do

--- a/test/controllers/api/v1/content_uploads_controller_test.rb
+++ b/test/controllers/api/v1/content_uploads_controller_test.rb
@@ -81,8 +81,8 @@ describe Api::V1::ContentUploadsController do
       Repository.any_instance.expects(:trigger_contents_changed).returns([])
       Repository.any_instance.expects(:unit_type_id).returns("rpm")
 
-      post action, :id => "1", :unit_type_id => "rpm", :unit_key => {}, :unit_metadata => {},
-           :repository_id => @repo.id
+      post action, :id => "1", :repository_id => @repo.id,
+           :uploads => [{:unit_type_id => "rpm", :unit_key => {}, :unit_metadata => {}}]
       assert_response :success
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1010339

Related katello-cli changes:  https://github.com/Katello/katello-cli/pull/107
