### PR TITLE
1014821 - fixing subscriptions showing up in incorrect orgs

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -73,11 +73,11 @@ class SubscriptionsController < ApplicationController
     filters = []
 
     # Limit subscriptions to current org and Red Hat provider
-    filters << {:org => [current_organization.label]}
-    filters << {:provider_id => [current_organization.redhat_provider.id]}
+    filters << {:term => {:org => current_organization.label}}
+    filters << {:term => {:provider_id => current_organization.redhat_provider.id}}
 
     options = {
-        :filter => filters,
+        :filters => filters,
         :load_records? => false,
         :default_field => :name
     }

--- a/app/models/glue/elastic_search/pool.rb
+++ b/app/models/glue/elastic_search/pool.rb
@@ -87,7 +87,7 @@ module Glue::ElasticSearch::Pool
         if !clear_filters.nil?
           items = Glue::ElasticSearch::Items.new(Pool)
           options = {
-              :filter => clear_filters,
+              :filters => clear_filters,
               :load_records? => false
           }
           results, _ = items.retrieve('', 0, options)

--- a/app/models/glue/provider.rb
+++ b/app/models/glue/provider.rb
@@ -444,7 +444,8 @@ module Glue::Provider
 
       # Index pools
       # Note: Only the Red Hat provider subscriptions are being indexed.
-      ::Pool.index_pools(subscriptions, [{:org => [self.organization.label]}, {:provider_id => [self.organization.redhat_provider.id]}])
+      ::Pool.index_pools(subscriptions, [{:term => {:org => self.organization.label}},
+                                         {:term => {:provider_id => self.organization.redhat_provider.id}}])
 
       subscriptions
     end


### PR DESCRIPTION
Items.rb had been changed to require the option
:filters instead of :filter, and to structure filters differently.
