### PR TITLE
Include new candlepin logs in katello-debug output.

### DIFF
--- a/script/katello-debug
+++ b/script/katello-debug
@@ -56,6 +56,7 @@ MISC = [
 ]
 
 CANDLEPIN = [
+"/var/log/candlepin",
 "/var/log/tomcat6",
 "/etc/candlepin/candlepin.conf",
 "/etc/tomcat6/server.xml"


### PR DESCRIPTION
As of candlepin-0.8.30 new logging was introduced which will result in
several new log files in /var/log/candlepin.

Leaving tomcat logs included as these still may contain tomcat/SSL
startup errors.

New version of candlepin is not tagged yet but the directory should already exist and contain an audit.log, previously not included in katello-debug.
