### PR TITLE
Bug #1019896 - explicitly setting accept headers for FF.

### DIFF
--- a/engines/bastion/app/assets/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/bastion/bastion.module.js
@@ -52,7 +52,7 @@ angular.module('Bastion', [
  */
 angular.module('Bastion').config(['$httpProvider', '$urlRouterProvider', function($httpProvider, $urlRouterProvider) {
     $httpProvider.defaults.headers.common['X-CSRF-TOKEN'] = $('meta[name=csrf-token]').attr('content');
-    $httpProvider.defaults.headers.common['ACCEPT'] = 'version=2,application/json';
+    $httpProvider.defaults.headers.common['ACCEPT'] = 'application/json, text/plain, */*, version=2';
     $urlRouterProvider.otherwise("/");
 }]);
 

--- a/engines/bastion/app/assets/bastion/stylesheets/widgets/_org-switcher.scss
+++ b/engines/bastion/app/assets/bastion/stylesheets/widgets/_org-switcher.scss
@@ -54,6 +54,7 @@
       max-height: 250px;
       overflow: auto;
       min-width: 220px;
+      padding: 0;
     }
 
     .org-link {


### PR DESCRIPTION
FF was replacing headers instead of appending them so this commit
explicitly includes 'text/plain' and '_/_' in order to fix the
org switcher.  Also includes a padding fix for the org switcher
in FF.
