### PR TITLE
1012073: Sync Mgmt: update to provide status bar for puppet repos

### DIFF
--- a/app/models/pulp_sync_status.rb
+++ b/app/models/pulp_sync_status.rb
@@ -30,11 +30,19 @@ class PulpSyncProgress
         @size_left   = @total_size - ht.null_safe_get(details, 0, ['finished_bytes'])
         @total_count = ht.null_safe_get(details, 0, ['num_isos'])
         @items_left  = @total_count - ht.null_safe_get(details, 0, ['num_isos_finished'])
+
       else
         @total_size  = ht.null_safe_get(details, 0, ['size_total'])
         @size_left   = ht.null_safe_get(details, 0, ['size_left'])
-        @total_count = ht.null_safe_get(details, 0, ['items_total'] || ['total_count'])
-        @items_left  = ht.null_safe_get(details, 0, ['items_left'] || ['total_count'] - ['finished_count'])
+
+        if progress_attrs['progress']['puppet_importer']
+          @total_count   = ht.null_safe_get(details, 0, ['total_count'])
+          finished_count = ht.null_safe_get(details, 0, ['finished_count'])
+          @items_left    = @total_count - finished_count
+        else
+          @total_count = ht.null_safe_get(details, 0, ['items_total'])
+          @items_left  = ht.null_safe_get(details, 0, ['items_left'])
+        end
       end
 
       @error_details = errors(progress_attrs['progress'])


### PR DESCRIPTION
This commit contains changes to enable 2 things for syncing puppet repos
in the ui:
1. list the number of puppet modules being syned (similar to # yum pkgs)
2. provide behavior for progress bar... since the pulp status/progress
   for puppet repos is different from yum repos, the status will
   be based module counts vs size (in bytes)
