### PR TITLE
1020463: content view definition: fix error when adding repo to definition

### DIFF
--- a/app/controllers/content_view_definitions_controller.rb
+++ b/app/controllers/content_view_definitions_controller.rb
@@ -234,7 +234,7 @@ class ContentViewDefinitionsController < ApplicationController
           where(:id => params[:repos].values.flatten).pluck("repositories.id")
 
       # don't unset the puppet repo
-      repo_ids += @view_definition.puppet_repository_id if @view_definition.puppet_repository_id
+      repo_ids << @view_definition.puppet_repository_id if @view_definition.puppet_repository_id
 
       @view_definition.repository_ids = repo_ids
     end


### PR DESCRIPTION
...on

This change is to fix an error that would occur if the user was
adding another repo to a definition that currently has a puppet
repo assigned.
