### PR TITLE
Engine: Fixes #3372: Inital work to enable the dashboard.

### DIFF
--- a/app/helpers/katello/dashboard_helper.rb
+++ b/app/helpers/katello/dashboard_helper.rb
@@ -23,8 +23,8 @@ module DashboardHelper
   end
 
   def systems_search_status_link(anchor_text, status)
-    href_params = {:systems_path => systems_path, :status => status}
-    href_format = "%{systems_path}#/systems?search=status:%{status}"
+    href_params = {:systems_path => katello_systems_path, :status => status}
+    href_format = "%{katello_systems_path}#/systems?search=status:%{status}"
     link_to(anchor_text, href_format % href_params)
   end
 
@@ -43,7 +43,7 @@ module DashboardHelper
 
   def content_view_name(version)
     if version.content_view.content_view_definition.readable?
-      link_to(version.content_view.name, content_view_path_helper(version))
+      link_to(version.content_view.name, katello_content_view_path_helper(version))
     else
       version.content_view.name
     end

--- a/app/lib/katello/dashboard/content_views_widget.rb
+++ b/app/lib/katello/dashboard/content_views_widget.rb
@@ -23,7 +23,7 @@ class Dashboard::ContentViewsWidget < Dashboard::Widget
   end
 
   def content_path
-    content_views_dashboard_index_path
+    content_views_katello_dashboard_index_path
   end
 
 end

--- a/app/lib/katello/dashboard/layout.rb
+++ b/app/lib/katello/dashboard/layout.rb
@@ -58,7 +58,7 @@ module Dashboard
     end
 
     def get_widget(name, org)
-      "Dashboard::#{name.camelcase}Widget".constantize.new(org)
+      "Katello::Dashboard::#{name.camelcase}Widget".constantize.new(org)
     end
   end
 end

--- a/app/lib/katello/dashboard/notices_widget.rb
+++ b/app/lib/katello/dashboard/notices_widget.rb
@@ -18,7 +18,7 @@ class Dashboard::NoticesWidget < Dashboard::Widget
   end
 
   def content_path
-    notices_dashboard_index_path
+    notices_katello_dashboard_index_path
   end
 end
 end

--- a/app/lib/katello/dashboard/promotions_widget.rb
+++ b/app/lib/katello/dashboard/promotions_widget.rb
@@ -23,7 +23,7 @@ class Dashboard::PromotionsWidget < Dashboard::Widget
   end
 
   def content_path
-    promotions_dashboard_index_path
+    promotions_katello_dashboard_index_path
   end
 
 end

--- a/app/lib/katello/dashboard/sync_widget.rb
+++ b/app/lib/katello/dashboard/sync_widget.rb
@@ -23,7 +23,7 @@ class Dashboard::SyncWidget < Dashboard::Widget
   end
 
   def content_path
-    sync_dashboard_index_path
+    sync_katello_dashboard_index_path
   end
 end
 end

--- a/app/models/katello/organization.rb
+++ b/app/models/katello/organization.rb
@@ -15,7 +15,7 @@ class Organization < ActiveRecord::Base
 
   ALLOWED_DEFAULT_INFO_TYPES = %w(system distributor)
 
-  #include Glue::Candlepin::Owner if Katello.config.use_cp
+  include Glue::Candlepin::Owner if Katello.config.use_cp
   include Glue if Katello.config.use_cp
 
   include Glue::Event

--- a/app/views/katello/dashboard/_errata.haml
+++ b/app/views/katello/dashboard/_errata.haml
@@ -52,7 +52,7 @@
                     .col_1
                       &nbsp;
                     .subcol_2.one-line-ellipsis
-                      = link_to system.name, system_path_helper(system)
+                      = link_to system.name, katello_system_path_helper(system)
                     .subcol_3.one-line-ellipsis
                       #{system.environment.name}
                     .subcol_4.one-line-ellipsis

--- a/app/views/katello/dashboard/_notices.html.haml
+++ b/app/views/katello/dashboard/_notices.html.haml
@@ -8,4 +8,4 @@
         %span
           %h5
             #{format_time note[:date]}
-          #{note[:text]}  #{link_to(_("More >>"), notices_path)}
+          #{note[:text]}  #{link_to(_("More >>"), katello_notices_path)}

--- a/app/views/katello/dashboard/_promotions.haml
+++ b/app/views/katello/dashboard/_promotions.haml
@@ -11,7 +11,7 @@
                 %span.fl{:class=>changeset_class(changeset)}
 
               %h5
-                = link_to changeset.name, changeset_path_helper(changeset)
+                = link_to changeset.name, katello_changeset_path_helper(changeset)
             .col_2
               #{changeset_message(changeset)}
             .col_1.environment

--- a/app/views/katello/dashboard/_subscriptions.haml
+++ b/app/views/katello/dashboard/_subscriptions.haml
@@ -42,4 +42,4 @@
           #{owner_info.total_consumers}
 
         %h4.fr
-          #{link_to(_("Total Systems"), "#{systems_path}#/systems")}
+          #{link_to(_("Total Systems"), "#{katello_systems_path}#/systems")}

--- a/app/views/katello/dashboard/_sync.haml
+++ b/app/views/katello/dashboard/_sync.haml
@@ -7,8 +7,8 @@
         %li
           .col_1
             %h5
-              = link_to product.name, sync_management_index_path
-          - if product.sync_status.state == PulpSyncStatus::RUNNING
+              = link_to product.name, katello_sync_management_index_path
+          - if product.sync_status.state == Katello::PulpSyncStatus::RUNNING
             .col_progress{:title=>product.sync_status.progress.step}
               %span
                 .progressbar{:percentage=>sync_percentage(product)}
@@ -17,19 +17,19 @@
                 #{sync_percentage(product)}%
           - else
             .col_2
-              - if product.sync_status.state == PulpSyncStatus::ERROR
+              - if product.sync_status.state == Katello::PulpSyncStatus::ERROR
                 .error_icon.fl
                   &nbsp;
                 #{_("Error")}
-              - elsif product.sync_status.state == PulpSyncStatus::FINISHED
+              - elsif product.sync_status.state == Katello::PulpSyncStatus::FINISHED
                 .check_icon.fl
                   &nbsp;
                 #{_("Success")}
-              - elsif product.sync_status.state == PulpSyncStatus::CANCELED
+              - elsif product.sync_status.state == Katello::PulpSyncStatus::CANCELED
                 #{_("Cancelled")}
-              - elsif product.sync_status.state == PulpSyncStatus::WAITING
+              - elsif product.sync_status.state == Katello::PulpSyncStatus::WAITING
                 #{_("Waiting")}
-              - elsif product.sync_status.state == PulpSyncStatus::RUNNING
+              - elsif product.sync_status.state == Katello::PulpSyncStatus::RUNNING
                 #{_("Running")}
               - else
                 #{product.sync_status.state}

--- a/app/views/katello/dashboard/_system_group_item.html.haml
+++ b/app/views/katello/dashboard/_system_group_item.html.haml
@@ -2,17 +2,17 @@
 
   .col_1
     - if updates == :critical
-      %a{:href => "#{generate_url(system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Critical')}"}
+      %a{:href => "#{generate_url(katello_system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Critical')}"}
         .status_icon.red
     - elsif updates == :warning
-      %a{:href => "#{generate_url(system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Warning')}"}
+      %a{:href => "#{generate_url(katello_system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Warning')}"}
         .status_icon.yellow
     - else
-      %a{:href => "#{generate_url(system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Up to date')}"}
+      %a{:href => "#{generate_url(katello_system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Up to date')}"}
         .status_icon.green
 
   .col_2.one-line-ellipsis
-    = link_to(group.name, generate_url(system_groups_path, {:id => group.id, :panel_page => "edit"}, "system_group"))
+    = link_to(group.name, generate_url(katello_system_groups_path, {:id => group.id, :panel_page => "edit"}, "system_group"))
 
   .col_3.one-line-ellipsis
-    = link_to(group.systems.length, generate_url(system_groups_path, {:id => group.id, :panel_page => "systems"}, "system_group"))
+    = link_to(group.systems.length, generate_url(katello_system_groups_path, {:id => group.id, :panel_page => "systems"}, "system_group"))

--- a/app/views/katello/dashboard/_systems.html.haml
+++ b/app/views/katello/dashboard/_systems.html.haml
@@ -13,7 +13,7 @@
                 .icon.red_icon.fl
           .col_1.one-line-ellipsis{:title=>system.name}
             %h5
-              = link_to system.name, generate_url(systems_path, {:id => system.id}, "system")
+              = link_to system.name, generate_url(katello_systems_path, {:id => system.id}, "system")
           .col_2{:title=>_("Distribution")}
             = system.distribution
           .col_3{:title=>_("Last Checked in Date")}

--- a/app/views/katello/dashboard/index.html.haml
+++ b/app/views/katello/dashboard/index.html.haml
@@ -1,4 +1,4 @@
-= javascript :dashboard
+= javascript 'katello/dashboard'
 
 - if current_user && current_user.allowed_organizations.length == 0
   .grid_16.flash_hud


### PR DESCRIPTION
This initial work fixes the basics of the Dashboard. The System and
Notices widgets are enabled and working. The Content Views, Promotions,
and Sync Overview widgets rely upon further work in those areas to come
to life.
