### PR TITLE
Engine: UI: Organization and Environment: support CRUD actions

### DIFF
--- a/app/assets/javascripts/katello/organizations/organization.js
+++ b/app/assets/javascripts/katello/organizations/organization.js
@@ -11,7 +11,7 @@
  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 */
 
-KT.panel.list.registerPage('organizations', { create : 'new_organization' });
+KT.panel.list.registerPage('organizations', { create : 'new_katello_organization' });
 
 $(document).ready(function() {
 

--- a/app/controllers/katello/api/v1/api_controller.rb
+++ b/app/controllers/katello/api/v1/api_controller.rb
@@ -75,7 +75,7 @@ class Api::V1::ApiController < Api::ApiController
 
   def get_organization(org_id)
     # name/label is always unique
-    return Organization.without_deleting.having_name_or_label(org_id).first
+    return Katello::Organization.without_deleting.having_name_or_label(org_id).first
   end
 
   def organization_id

--- a/app/controllers/katello/environments_controller.rb
+++ b/app/controllers/katello/environments_controller.rb
@@ -11,7 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Katello
-class EnvironmentsController < ApplicationController
+class EnvironmentsController < Katello::ApplicationController
   respond_to :html, :js
 
   before_filter :find_organization, :only => [:show, :edit, :update, :destroy, :index, :new, :create, :default_label, :products]
@@ -68,10 +68,10 @@ class EnvironmentsController < ApplicationController
 
   # POST /environments
   def create
-    env_params = {:name => params[:kt_environment][:name],
-                  :description => params[:kt_environment][:description],
-                  :prior => params[:kt_environment][:prior],
-                  :label => params[:kt_environment][:label],
+    env_params = {:name => params[:katello_kt_environment][:name],
+                  :description => params[:katello_kt_environment][:description],
+                  :prior => params[:katello_kt_environment][:prior],
+                  :label => params[:katello_kt_environment][:label],
                   :organization_id => @organization.id}
 
     env_params[:label], label_assigned = generate_label(env_params[:name], 'environment') if env_params[:label].blank?
@@ -113,7 +113,8 @@ class EnvironmentsController < ApplicationController
     @environment.destroy
     if @environment.destroyed?
       notify.success _("Environment '%s' was deleted.") % @environment.name
-      render :partial => "common/post_delete_close_subpanel", :locals => {:path => edit_organization_path(@organization.label)}
+      render :partial => "katello/common/post_delete_close_subpanel",
+             :locals => { :path => edit_katello_organization_path(@organization.label) }
     else
       err_msg = N_("Removal of the environment failed. If you continue having trouble with this, please contact an Administrator.")
       notify.error err_msg
@@ -161,7 +162,7 @@ class EnvironmentsController < ApplicationController
 
   def find_organization
     org_id = params[:organization_id] || params[:org_id]
-    @organization = Organization.first(:conditions => {:label => org_id})
+    @organization = Katello::Organization.first(:conditions => {:label => org_id})
     notify.error _("Couldn't find organization '%s'") % org_id if @organization.nil?
   end
 

--- a/app/lib/katello/navigation/organization_menu.rb
+++ b/app/lib/katello/navigation/organization_menu.rb
@@ -32,7 +32,7 @@ module Navigation
     def menu_org_list
       {:key => :org_list,
        :name => _("List"),
-       :url => organizations_path,
+       :url => katello_organizations_path,
        :options => {:class => 'organizations second_level', "data-menu" => "organizations"}
       }
     end
@@ -41,20 +41,20 @@ module Navigation
       [
         { :key => :organization_details,
           :name => _("Details"),
-          :url => lambda{edit_organization_path(@organization.label)},
+          :url => lambda{edit_katello_organization_path(@organization.label)},
           :if => lambda{@organization},
           :options => {:class => "panel_link"}
         },
         {:key => :organization_default_info,
          :name => _("Default Custom Info"),
-         :url => lambda{organization_default_info_path(@organization.label, "system")},
+         :url => lambda{katello_organization_default_info_path(@organization.label, "system")},
          :if => lambda{@organization},
          :options => {:class => "panel_link menu_parent"},
          :items => default_info_subnav
         },
         { :key => :organization_history,
           :name => _("History"),
-          :url => lambda{events_organization_path(@organization.label)},
+          :url => lambda{events_katello_organization_path(@organization.label)},
           :if => lambda{@organization},
           :options => {:class => "panel_link"}
         }
@@ -65,13 +65,13 @@ module Navigation
       [
         { :key => :org_system_default_info,
           :name => _("System Default Info"),
-          :url => lambda{organization_default_info_path(@organization.label, "system")},
+          :url => lambda{katello_organization_default_info_path(@organization.label, "system")},
           :if => lambda{@organization},
           :options => {:class => "third_level panel_link"}
         },
         { :key => :org_distributor_default_info,
           :name => _("Distributor Default Info"),
-          :url => lambda{organization_default_info_path(@organization.label, "distributor")},
+          :url => lambda{katello_organization_default_info_path(@organization.label, "distributor")},
           :if => lambda{@organization},
           :options => {:class => "third_level panel_link"}
         }

--- a/app/models/katello/async_operation.rb
+++ b/app/models/katello/async_operation.rb
@@ -10,6 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
+module Katello
 AsyncOperation = Struct.new(:status_id, :username, :object, :method_name, :args) do
   #delegate :method, :to => :object
 

--- a/app/models/katello/async_orchestration.rb
+++ b/app/models/katello/async_orchestration.rb
@@ -26,9 +26,9 @@ module AsyncOrchestration
 
     # under 1.9.3 ActiveSupport::BasicObject inherits from ::BasicObject, which is outside of standard library namespace.
     def method_missing(method, *args)
-      t = ::TaskStatus.create!(:uuid => ::UUIDTools::UUID.random_create.to_s, :user_id => ::User.current.id,
-                               :organization => @organization, :state => ::TaskStatus::Status::WAITING, :task_type => @task_type)
-      ::Delayed::Job.enqueue({:payload_object => ::AsyncOperation.new(t.id, ::User.current.username, @target, method.to_sym, args)}.merge(@options))
+      t = TaskStatus.create!(:uuid => ::UUIDTools::UUID.random_create.to_s, :user_id=>::User.current.id,
+                             :organization => @organization, :state => TaskStatus::Status::WAITING, :task_type => @task_type)
+      ::Delayed::Job.enqueue({:payload_object => AsyncOperation.new(t.id, ::User.current.login, @target, method.to_sym, args)}.merge(@options))
       t
     end
   end

--- a/app/models/katello/glue/elastic_search/task_status.rb
+++ b/app/models/katello/glue/elastic_search/task_status.rb
@@ -54,7 +54,7 @@ module Glue::ElasticSearch::TaskStatus
 
     if task_type
       tt = task_type
-      if (::System.class.name == task_owner_type)
+      if (System.class.name == task_owner_type)
         tt = TaskStatus::TYPES[task_type][:english_name]
       end
       ret[:status] += " #{tt}"

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -115,7 +115,7 @@ class KTEnvironment < ActiveRecord::Base
   def content_views(reload = false)
     @content_views = nil if reload
     @content_views ||= ContentView.joins(:content_view_versions => :content_view_version_environments).
-        where("content_view_version_environments.environment_id" => self.id)
+        where("#{Katello::ContentViewVersionEnvironment.table_name}.environment_id" => self.id)
   end
 
   def successor
@@ -160,8 +160,9 @@ class KTEnvironment < ActiveRecord::Base
 
   #list changesets promoting
   def promoting
-    Changeset.joins(:task_status).where('changesets.environment_id' => self.id,
-                                        'task_statuses.state' => [TaskStatus::Status::WAITING,  TaskStatus::Status::RUNNING])
+    Changeset.joins(:task_status).where('#{Katello::Changeset.table_name}.environment_id' => self.id,
+                                        '#{Katello::TaskStatus.table_name}.state' => [TaskStatus::Status::WAITING,
+                                                                                      TaskStatus::Status::RUNNING])
   end
 
   def is_deletable?

--- a/app/models/katello/organization.rb
+++ b/app/models/katello/organization.rb
@@ -232,7 +232,7 @@ class Organization < ActiveRecord::Base
 
     #Lambda to continually update the task
     found_func = lambda do |found_url|
-      task = ::TaskStatus.find(task_id)
+      task = TaskStatus.find(task_id)
       task.result << found_url
       task.save!
     end
@@ -241,7 +241,7 @@ class Organization < ActiveRecord::Base
     #  Using the saved task_id to compare current providers
     #  task id
     continue_func = lambda do
-      task = ::TaskStatus.find(task_id)
+      task = TaskStatus.find(task_id)
       !task.canceled?
     end
 

--- a/app/views/katello/common/_config.html.haml
+++ b/app/views/katello/common/_config.html.haml
@@ -1,6 +1,6 @@
 :plain
-  KT.routes.options.prefix = "#{root_path()}";
-  angular.module('Katello.globals').constant("RootURL", "#{root_path()}");
+  KT.routes.options.prefix = "#{Katello.config.url_prefix}";
+  angular.module('Katello.globals').constant("RootURL", "#{Katello.config.url_prefix}");
 
 -if current_organization
   :plain

--- a/app/views/katello/common/_fav.html.haml
+++ b/app/views/katello/common/_fav.html.haml
@@ -10,11 +10,12 @@
   have received a copy of GPLv2 along with this software; if not, see
   http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-= check_box_tag "org_#{org.id}", org.id, current_user.default_org == org, {:class=>"default_org", "data-url"=>setup_default_org_katello_user_path(current_user.id)}
+= check_box_tag "org_#{org.id}", org.id, current_user.default_org == org,
+  { :class => "default_org", "data-url" => setup_default_org_katello_user_path(current_user.id) }
 
 - if current_user.default_org == org
-  %i.fl.favorite.icon-star.tipsify{:title=>_("This is your default organization."), :id=>"favorite_#{org.id}"}
+  %i.fl.favorite.icon-star.tipsify{ :title => _("This is your default organization."), :id => "favorite_#{org.id}" }
 - else
-  %i.fl.favorite.icon-star-empty.tipsify{:title=>_("Make this your default organization."), :id=>"favorite_#{org.id}"}
+  %i.fl.favorite.icon-star-empty.tipsify{ :title => _("Make this your default organization."), :id => "favorite_#{org.id}" }
 
-= image_tag( "icons/spinner.gif", :class=>"hidden fl fav_spinner")
+= image_tag( "katello/icons/spinner.gif", :class => "hidden fl fav_spinner")

--- a/app/views/katello/environments/_edit.html.haml
+++ b/app/views/katello/environments/_edit.html.haml
@@ -1,4 +1,4 @@
-= javascript 'widgets/jquery.jeditable.helpers', 'environments/environment_edit'
+= javascript 'katello/widgets/jquery.jeditable.helpers', 'katello/environments/environment_edit'
 
 = content_for :title do
   = _("Environment") + ": " + @environment.name
@@ -7,7 +7,7 @@
   -# editable on the org means CRUD on the environments
   -if editable
     - if @environment.successor.nil?
-      = link_to _("Remove Environment"), {:controller=>"environments", :action=>"destroy"}, :confirm => _('Are you sure? If any users have this environment set as their default, it will unset it.'), :method => :delete, :class=>"remove_item", :remote=>true, "data-forward"=>edit_organization_path(@organization.label)
+      = link_to _("Remove Environment"), {:controller=>"environments", :action=>"destroy"}, :confirm => _('Are you sure? If any users have this environment set as their default, it will unset it.'), :method => :delete, :class=>"remove_item", :remote=>true, "data-forward"=>edit_katello_organization_path(@organization.label)
     - else
       %span{ :class => "remove_item disabled tipsify", :title => _("The selected environment is not the last environment in its promotion path.  Only the last environment can be deleted.") }
         = _("Remove Environment")
@@ -19,7 +19,7 @@
     %fieldset.clearfix
       .grid_2.ra
         %label #{_("Name")}:
-      .grid_5.la{'name' => 'kt_environment[name]', :class=>("editable edit_env_name" if editable), "data-url"=>organization_environment_path(@organization.label, @environment.id),  "data-forward"=>edit_organization_path(@organization.label)}<> #{@environment.name}
+      .grid_5.la{'name' => 'kt_environment[name]', :class=>("editable edit_env_name" if editable), "data-url"=>katello_organization_environment_path(@organization.label, @environment.id),  "data-forward"=>edit_katello_organization_path(@organization.label)}<> #{@environment.name}
 
     %fieldset
       .grid_2.ra
@@ -29,7 +29,7 @@
     %fieldset.clearfix
       .grid_2.ra
         %label #{_("Description")}:
-      .grid_5.la{:style => "word-wrap: break-word;", :class=>("editable edit_textarea" if editable), 'data-maxlength' => default_description_limit, "data-url"=>organization_environment_path(@organization.label, @environment.id), 'name' => 'kt_environment[description]'}<> #{@environment.description}
+      .grid_5.la{:style => "word-wrap: break-word;", :class=>("editable edit_textarea" if editable), 'data-maxlength' => default_description_limit, "data-url"=>katello_organization_environment_path(@organization.label, @environment.id), 'name' => 'kt_environment[description]'}<> #{@environment.description}
 
     %fieldset.clearfix
       %input{ :type => "hidden", :name => "prior_envs", :value => @env_labels_json }
@@ -37,4 +37,4 @@
         %label #{_("Prior Environment")}:
       .grid_5.la #{@environment.prior.name}
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/environments/_new.html.haml
+++ b/app/views/katello/environments/_new.html.haml
@@ -1,4 +1,4 @@
-= javascript 'widgets/subpanel_new'
+= javascript 'katello/widgets/subpanel_new'
 
 = content_for :title do
   #{_("Create Application Life Cycle Management Environment")}
@@ -9,13 +9,13 @@
 = content_for :subcontent do
   .clear
     &nbsp;
-  = kt_form_for KTEnvironment.new, :url => organization_environments_path(@organization.label), :remote=>true, :html => {:id=>"new_subpanel"} do |form|
+  = kt_form_for Katello::KTEnvironment.new, :url => katello_organization_environments_path(@organization.label), :remote=>true, :html => {:id=>"new_subpanel"} do |form|
 
     = form.text_field :name, :label => _("Name"), :class => :name_input
 
     = form.field :label, :label => _("Label") do
-      = text_field_tag 'kt_environment[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_organization_environments_path(@organization.label)
-      = image_tag "icons/spinner.gif", :class => 'label_spinner hidden'
+      = text_field_tag 'katello_kt_environment[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_katello_organization_environments_path(@organization.label)
+      = image_tag "katello/icons/spinner.gif", :class => 'label_spinner hidden'
 
     = form.text_area :description, :size => "40x5", :label => _("Description"), :maxlength => default_description_limit
 
@@ -23,4 +23,4 @@
 
     = form.submit _("Create"), :class => 'subpanel_create create_button'
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/organizations/_default_info.html.haml
+++ b/app/views/katello/organizations/_default_info.html.haml
@@ -1,5 +1,5 @@
 -# org, informable_type, task_state, and task_uuid from locals
-= javascript 'widgets/jquery.jeditable.helpers'
+= javascript 'katello/widgets/jquery.jeditable.helpers'
 
 = javascript do
   :plain
@@ -24,21 +24,20 @@
         = _('%s Default Custom Info') % informable_type.capitalize
     .grid_4
       #apply_default_info_button_container
-        %input.btn.fullwidth#apply_default_info_button{ :value => _("Sync default info to all %s") % informable_type.pluralize, :type => "button", "data-url" => api_organization_apply_default_info_path(org.label, informable_type), "data-method" => "post", :disabled => org.default_info[informable_type].empty?, "data-taskstate" => task_state, "data-taskuuid" => task_uuid }
+        %input.btn.fullwidth#apply_default_info_button{ :value => _("Sync default info to all %s") % informable_type.pluralize, :type => "button", "data-url" => katello_api_organization_apply_default_info_path(org.label, informable_type), "data-method" => "post", :disabled => org.default_info[informable_type].empty?, "data-taskstate" => task_state, "data-taskuuid" => task_uuid }
       %table#default_info_table.default_info
         %tbody
           %tr#new_default_info_row
             %td
               %input#new_default_info_keyname{ :placeholder => _("Keyname"), :required => true }
             %td
-              %input.btn.primary#add_default_info_button{ :value => _("Add"), :type => "submit", "data-url" => api_organization_create_default_info_path(org.label, informable_type), "data-method" => "post", :disabled => true }
+              %input.btn.primary#add_default_info_button{ :value => _("Add"), :type => "submit", "data-url" => katello_api_organization_create_default_info_path(org.label, informable_type), "data-method" => "post", :disabled => true }
           - org.default_info[informable_type].sort.each do |info|
             - escaped_info = url_encode(info)
             %tr.multiline{"data-id" => "default_info_#{escaped_info}" }
               %td.ra
                 = label :default_info, escaped_info, info
               %td
-                %input.btn.warning.remove_default_info_button{ :value => _("Remove"), :type => "submit", "data-url" => api_organization_destroy_default_info_path(org.label, informable_type, info), "data-method" => "delete", "data-id" => "default_info_#{escaped_info}" }
+                %input.btn.warning.remove_default_info_button{ :value => _("Remove"), :type => "submit", "data-url" => katello_api_organization_destroy_default_info_path(org.label, informable_type, info), "data-method" => "delete", "data-id" => "default_info_#{escaped_info}" }
 
-
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/organizations/_download_debug_certificate.html.haml
+++ b/app/views/katello/organizations/_download_debug_certificate.html.haml
@@ -3,12 +3,12 @@
 %ul.fl.clear
   %li#debug_cert.clickable
     .fl
-      = image_tag('icons/expander-collapsed.png', :alt => _('Expand'))
+      = image_tag('katello/icons/expander-collapsed.png', :alt => _('Expand'))
     .grid_7.la
       #{_("Debug Certificate")}:
     .grid_12.la#show_debug_button
       %div.helptip-open
         %p
           = _('Generating and downloading the debug certificate allows a user to view the repositories in any environment from a browser.')
-      .button#download_debug_cert_key{"data-url"=>download_debug_certificate_organization_path(@organization.id)}
+      .button#download_debug_cert_key{"data-url"=>download_debug_certificate_katello_organization_path(@organization.id)}
         = _("Generate and Download")

--- a/app/views/katello/organizations/_edit.html.haml
+++ b/app/views/katello/organizations/_edit.html.haml
@@ -3,7 +3,7 @@
     localize({
         "orgSelectAutoheal": '#{escape_javascript(_("No Service Level Preference"))}'
     });
-= javascript 'widgets/jquery.jeditable.helpers', 'organizations/organization_edit'
+= javascript 'katello/widgets/jquery.jeditable.helpers', 'katello/organizations/organization_edit'
 
 = content_for :title do
   #{@organization.name}
@@ -23,12 +23,12 @@
   #organizations
     %input#panel_element_id{:name => @organization.id, :type => "hidden", :value => "#{name}_#{@organization.label}", "data-ajax_url"=>url_for(:action => 'update')}
     .full#organization
-      = form_for(@organization, :html => {:multipart => true, :method => :put, :id => 'organization_edit', :remote => true}, :url => organization_path(@organization.id)) do |f|
+      = form_for(@organization, :html => {:multipart => true, :method => :put, :id => 'organization_edit', :remote => true}, :url => katello_organization_path(@organization.id)) do |f|
 
         %fieldset.fl.clear
           .grid_3.ra
             %label #{_("Name")}:
-          .grid_8.la#organization_name{:title=>@organization[:name], 'name' => 'organization[name]', 'data-url' => organization_path(@organization.label),
+          .grid_8.la#organization_name{:title=>@organization[:name], 'name' => 'organization[name]', 'data-url' => katello_organization_path(@organization.label),
                                        :class=>editable_class(editable)} #{@organization[:name]}
 
         %fieldset.clear
@@ -39,13 +39,13 @@
         %fieldset.clearfix
           .grid_3.ra
             %label #{_("Description")}:
-          .grid_8.la{:style => "word-wrap: break-word;", 'name' => 'organization[description]', :class=>("editable edit_textarea" if editable), 'data-maxlength' => default_description_limit, 'data-url'=>edit_organization_path(@organization.label)} #{@organization[:description]}
+          .grid_8.la{:style => "word-wrap: break-word;", 'name' => 'organization[description]', :class=>("editable edit_textarea" if editable), 'data-maxlength' => default_description_limit, 'data-url'=>edit_katello_organization_path(@organization.label)} #{@organization[:description]}
 
         %fieldset
           .grid_3.ra
             %label #{_("Default System SLA")}:
           .grid_8.la
-            .org_servicelevel{'name' => 'organization[service_level]', 'class' => ("editable edit_select_org_servicelevel grid_8" if editable), 'data-url' => edit_organization_path(@organization.label), 'data-options' => organization_servicelevel_edit(@organization)}
+            .org_servicelevel{'name' => 'organization[service_level]', 'class' => ("editable edit_select_org_servicelevel grid_8" if editable), 'data-url' => edit_katello_organization_path(@organization.label), 'data-options' => organization_servicelevel_edit(@organization)}
               = organization_servicelevel(@organization)
 
         - if Katello.config.katello?
@@ -63,7 +63,7 @@
                     =link_to 'Library', "#", :class => "crumb-nohover"
                   - for env in path
                     %li
-                      %a.subpanel_element{"data-url"=>edit_organization_environment_path(@organization.label, env.id)}
+                      %a.subpanel_element{"data-url"=>edit_katello_organization_environment_path(@organization.label, env.id)}
                         %div
                           #{env.name}
 
@@ -75,13 +75,13 @@
           &nbsp;
 
         - if editable && Katello.config.katello?
-          .button.subpanel_element{"data-url"=>new_organization_environment_path(@organization.label)}
+          .button.subpanel_element{"data-url"=>new_katello_organization_environment_path(@organization.label)}
             = _("Add New Environment")
 
         - if editable && Katello.config.katello?
           = render :partial=>"download_debug_certificate"
 
 = content_for :footer do
-  = render :partial => "organizations/footer"
+  = render :partial => "katello/organizations/footer"
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/organizations/_events.html.haml
+++ b/app/views/katello/organizations/_events.html.haml
@@ -1,4 +1,4 @@
-= javascript 'widgets/jquery.jeditable.helpers'
+= javascript 'katello/widgets/jquery.jeditable.helpers'
 
 = content_for :title do
   = @organization.name
@@ -26,4 +26,4 @@
           %tr
             %td{:colspan=>"3"} #{_("No event history found for %s") % [@organization.name]}
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/organizations/_footer.html.haml
+++ b/app/views/katello/organizations/_footer.html.haml
@@ -12,4 +12,4 @@
 
 %label{:for=>"org_#{@organization.id}", :class=>"label_default_org clickable", :id=>"label_org_#{@organization.id}"}
   #{@org_label}
-= render :partial=>"common/fav", :locals => {:org=>@organization, :current_user=>current_user}
+= render :partial=>"katello/common/fav", :locals => {:org=>@organization, :current_user=>current_user}

--- a/app/views/katello/organizations/_new.html.haml
+++ b/app/views/katello/organizations/_new.html.haml
@@ -5,12 +5,12 @@
   / pretty
 
 = content_for :content do
-  = kt_form_for Organization.new do |form|
+  = kt_form_for Katello::Organization.new do |form|
 
     = form.text_field :name, :label => _("Name"), :class => :name_input
     = form.field :orglabel, :label => _("Label") do
-      = text_field_tag 'organization[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_organizations_path()
-      = image_tag "icons/spinner.gif", :class => 'label_spinner hidden'
+      = text_field_tag 'katello_organization[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_katello_organizations_path()
+      = image_tag "katello/icons/spinner.gif", :class => 'label_spinner hidden'
 
     = form.text_area :description, :label => _("Description"), :size => "40x5", :maxlength => default_description_limit
 
@@ -18,22 +18,22 @@
       %h5 #{_("Initial Application Life Cycle Management Environment")}:
 
       = form.field :envname, :label => _("Name") do
-        = text_field_tag 'environment[name]', nil, :tabindex => form.tabindex, :size => 30, :class => :name_input
+        = text_field_tag 'katello_environment[name]', nil, :tabindex => form.tabindex, :size => 30, :class => :name_input
 
       = form.field :envlabel, :label => _("Label") do
-        = text_field_tag 'environment[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_organizations_path()
-        = image_tag "icons/spinner.gif", :class => 'label_spinner hidden'
+        = text_field_tag 'katello_environment[label]', nil, :tabindex => form.tabindex, :size => 30, :class => :label_input, 'data-url' => default_label_katello_organizations_path()
+        = image_tag "katello/icons/spinner.gif", :class => 'label_spinner hidden'
 
       = form.field :envdescription, :label => _("Description") do
-        = text_area_tag 'environment[description]', nil, :tabindex => form.tabindex, :size => "40x5"
+        = text_area_tag 'katello_environment[description]', nil, :tabindex => form.tabindex, :size => "40x5"
 
       %fieldset
         %div.prefix_2
           %label= _("Note: This will be set as your initial default environment.")
 
     - else
-      = hidden_field_tag 'environment[label]', 'Library'
+      = hidden_field_tag 'katello_environment[label]', 'Library'
 
     = form.submit _("Save"), :class => :create_button
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/organizations/index.html.haml
+++ b/app/views/katello/organizations/index.html.haml
@@ -1,4 +1,4 @@
-= stylesheet :orgs
+= stylesheet 'katello/orgs'
 
 #orgs
   .grid_16
@@ -13,4 +13,4 @@
   .grid_16#main
     = two_panel(@organizations, @panel_options)
 
-= javascript :organizations
+= javascript 'katello/organizations'


### PR DESCRIPTION
This is an initial PR to enable CRUD actions for Katello organizations and environments in the UI.
