### PR TITLE
Engine: Fixes #3323: Sync schedule initial conversion to engine

### DIFF
--- a/app/controllers/katello/sync_schedules_controller.rb
+++ b/app/controllers/katello/sync_schedules_controller.rb
@@ -11,7 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Katello
-class SyncSchedulesController < ApplicationController
+class SyncSchedulesController < Katello::ApplicationController
 
   before_filter :find_products, :only => [:apply]
   before_filter :authorize

--- a/app/helpers/katello/application_helper.rb
+++ b/app/helpers/katello/application_helper.rb
@@ -115,7 +115,7 @@ module ApplicationHelper
     options[:accessor] ||= "id"
     panel_id ||= "panel"
 
-    render :partial => "katello/commonone_panel",
+    render :partial => "katello/common/one_panel",
            :locals => {
              :single_select => options[:single_select] || false,
              :hover_text_cb => options[:hover_text_cb],

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -215,7 +215,7 @@ class Product < ActiveRecord::Base
   def self.with_repos(env, enabled_only)
     query = Repository.in_environment(env.id).select(:product_id)
     query = query.enabled if enabled_only
-    joins(:provider).where("#{Katello::Providers.table_name}.organization_id" => env.organization).
+    joins(:provider).where("#{Katello::Provider.table_name}.organization_id" => env.organization).
         where("(#{Katello::Provider.table_name}.provider_type ='#{Provider::CUSTOM}') OR (#{Katello::Provider.table_name}.provider_type ='#{Provider::REDHAT}' AND #{Katello::Product.table_name}.id in (#{query.to_sql}))")
   end
 end

--- a/app/views/katello/common/_one_panel.html.haml
+++ b/app/views/katello/common/_one_panel.html.haml
@@ -11,5 +11,5 @@
               %div{:class => 'column_' + column_titles.length.to_s}
                 = cname
         - for item in collection
-          = render :partial=>"common/one_panel_list_item", :locals=>{:item=>item, :accessor=>accessor, :columns=>columns,
+          = render :partial=>"katello/common/one_panel_list_item", :locals=>{:item=>item, :accessor=>accessor, :columns=>columns,
             :panel_id => panel_id, :hover_text => (send(hover_text_cb, item) if hover_text_cb)}

--- a/app/views/katello/sync_schedules/index.html.haml
+++ b/app/views/katello/sync_schedules/index.html.haml
@@ -1,4 +1,4 @@
-= javascript :sync_schedules
+= javascript 'katello/sync_schedules'
 
 = javascript do
   :plain
@@ -9,7 +9,7 @@
 #main.container_16
   = one_panel('products', @products, @products_options)
   = one_panel('plans', @plans, @plans_options)
-  = form_tag sync_schedules_apply_path, :method => "post", :id => "sync_schedule_form" do
+  = form_tag katello_sync_schedules_apply_path, :method => "post", :id => "sync_schedule_form" do
     = hidden_field_tag :data
     = button_to _("Apply Selected Plan to Selected Products"), {:action => "apply",
       :controller => "sync_schedules"}, :disabled => !@organization.syncable?, :method => :post, :class => 'dialogbutton fr', :id => 'apply_button'


### PR DESCRIPTION
This commit includes changes to allow user to associate sync plans
to products.
