### PR TITLE
Engine: about-engine - fixes #3333

### DIFF
--- a/app/views/katello/application_info/about.html.haml
+++ b/app/views/katello/application_info/about.html.haml
@@ -1,4 +1,4 @@
-= javascript :dashboard
+= javascript 'katello/dashboard'
 
 .about-information
   %h2.about-header= _("About")


### PR DESCRIPTION
About page renders correctly

http://projects.theforeman.org/issues/3333
