### PR TITLE
Engine: Updating katello reset DBS to only reset Pulp and Candlepin.

### DIFF
--- a/script/katello-reset-dbs
+++ b/script/katello-reset-dbs
@@ -26,7 +26,7 @@ KATELLO_ENV=${KATELLO_ENV:-production}
 DEPLOYMENT="katello"
 
 function usage {
-  echo "Reset your Katello databases.  Wipes all Katello, Pulp and Candlepin"
+  echo "Reset your Katello backend databases.  Wipes all Pulp and Candlepin"
   echo "Usage: `basename $0` [-f|--force] [-h|--help] "
   echo "       <env: development, production> <katello-rakefile-dir>"
   echo "example:"
@@ -51,49 +51,28 @@ if [ "$USAGE" = "1" ];
     usage
 fi
 
-# If we are using arguments
-if ([ $# -gt 0 ])
-then
-  KATELLO_ENV=$1
-  KATELLO_HOME=$2
-  echo "Resetting [$KATELLO_ENV] environment found @: [$KATELLO_HOME]"
-else
-  KATELLO_ENV=${KATELLO_ENV:-production}
-  KATELLO_HOME=${KATELLO_HOME:-/usr/share/katello}
-  echo "Defaulting [$KATELLO_ENV] environment found @: [$KATELLO_HOME]"
-fi
-
 if [ $KATELLO_PREFIX = "/headpin" -o $KATELLO_PREFIX = "/sam" ] ; then
     DEPLOYMENT="sam"
 fi
 
 echo -e "\n"
 echo '***********************************************************'
-echo "THIS SCRIPT WILL ERASE KATELLO / CANDLEPIN / PULP DATABASES"
+echo "THIS SCRIPT WILL ERASE CANDLEPIN / PULP DATABASES"
 echo '***********************************************************'
 echo -e "\n"
-echo "All data from all systems will be erased completely!"
-echo -e "\n"
-echo "This script only works with PostgreSQL database."
+echo "All data from Pulp and Candlepin will be erased completely!"
 echo -e "\n"
 echo "It is strongly recommended to back up databases:"
 if [ $DEPLOYMENT = "katello" ] ; then
     echo " # mongodump --db pulp_database --out - > pulp_database.json"
 fi
 echo " # pg_dump -c candlepin > candlepin_db.sql"
-echo " # pg_dump -c katello > katello_db.sql"
 echo -e "\n"
 
 
 if [ ! "$FORCE" = "1" ]; then
-  read -p "Are you sure you want reset your [$KATELLO_ENV] environment? (yes/no)? "
+  read -p "Are you sure you want reset Pulp and Candlepin data? (yes/no)? "
   [ "$REPLY" != "yes" ] && exit 1
-fi
-
-if [ ! -f "$KATELLO_HOME/Rakefile" ]; then
-  echo "** ERROR **"
-  echo "Katello Rakefile not not found in $KATELLO_HOME" 1>&2
-  exit 1
 fi
 
 echo "Erasing all data..."
@@ -105,16 +84,6 @@ function stop_if_running {
 function start_unless_running {
   $SRV "$1" status >/dev/null || $SRV "$1" start
 }
-
-# Only stop the services if we are in production mode
-if [ $KATELLO_ENV = "production" ]
-then
-    echo "Stopping Katello instance"
-    stop_if_running katello
-
-    echo "Stopping Katello jobs instance"
-    stop_if_running katello-jobs
-fi
 
 if [ $DEPLOYMENT = "katello" ] ; then
     echo "Stopping Pulp instance"
@@ -156,26 +125,5 @@ fi
 
 echo "Starting Candlepin instance"
 $SRV $TOMCAT restart
-
-echo "Initializing Katello database"
-# cannot use initdb for this (BZ 745542)
-pushd $KATELLO_HOME >/dev/null
-
-# SCHEMA: return to schema usage after FKs fixed
-RAKE_TASKS=( 'clear_search_indices' 'db:drop' 'db:create' 'db:migrate' 'db:seed' )
-for i in ${RAKE_TASKS[@]}; do
-  RAILS_ENV=$KATELLO_ENV RAILS_RELATIVE_URL_ROOT=$KATELLO_PREFIX bundle exec rake $i --trace  2>&1
-done
-popd > /dev/null
-
-# Only stop the services if we are in production mode
-if [ $KATELLO_ENV = "production" ]
-then
-    echo "Starting Katello instance"
-    $SRV katello start
-
-    echo "Starting Katello jobs instance"
-    $SRV katello-jobs start
-fi
 
 echo "DONE. CHECK ALL THE MESSAGES ABOVE!"


### PR DESCRIPTION
This will not reset the Katello/Foreman DB like it did previously. That should
be done through the normal Foreman setup. This could be moved out to a rake
task in the future, but for now this is a utility method when needing to
reset your development environment.
