### PR TITLE
Engine: fixes #3318: Red Hat Repositories initial conversion

### DIFF
--- a/app/assets/javascripts/katello/providers/provider.js
+++ b/app/assets/javascripts/katello/providers/provider.js
@@ -11,7 +11,7 @@
  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 */
 
-KT.panel.list.registerPage('providers', { create : 'new_provider' });
+KT.panel.list.registerPage('providers', { create : 'new_katello_provider' });
 
 $(document).ready(function() {
 

--- a/app/assets/javascripts/katello/providers/redhat/index.js
+++ b/app/assets/javascripts/katello/providers/redhat/index.js
@@ -12,6 +12,6 @@
 */
 
 //= require "alchemy/jquery/plugins/jquery.treeTable"
-//= require "widgets/jquery.jeditable.helpers"
-//= require "widgets/tabs"
-//= require "providers/provider_redhat"
+//= require "katello/widgets/jquery.jeditable.helpers"
+//= require "katello/widgets/tabs"
+//= require "katello/providers/provider_redhat"

--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -11,7 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Katello
-class ProductsController < ApplicationController
+class ProductsController < Katello::ApplicationController
   respond_to :html, :js
 
   before_filter :find_product, :only => [:edit, :update, :destroy, :refresh_content, :disable_content]
@@ -55,7 +55,7 @@ class ProductsController < ApplicationController
   end
 
   def create
-    product_params = params[:product]
+    product_params = params[:katello_product]
     requested_label = String.new(product_params[:label]) unless product_params[:label].blank?
     product_params[:label], _ = generate_label(product_params[:name], 'product') if product_params[:label].blank?
 
@@ -78,7 +78,7 @@ class ProductsController < ApplicationController
       render_bad_parameters _('Repository sets are enabled by default for custom products.')
     else
       pc = @product.refresh_content(params[:content_id])
-      render :partial => 'providers/redhat/repos', :locals => { :product_content => pc }
+      render :partial => 'katello/providers/redhat/repos', :locals => { :product_content => pc }
     end
   end
 
@@ -120,7 +120,8 @@ class ProductsController < ApplicationController
   def destroy
     @product.destroy
     notify.success _("Product '%s' removed.") % @product[:name]
-    render :partial => "common/post_delete_close_subpanel", :locals => {:path => products_repos_provider_path(@product.provider_id)}
+    render :partial => "katello/common/post_delete_close_subpanel",
+           :locals => { :path => products_repos_katello_provider_path(@product.provider_id) }
   end
 
   def auto_complete

--- a/app/controllers/katello/repositories_controller.rb
+++ b/app/controllers/katello/repositories_controller.rb
@@ -11,8 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Katello
-class RepositoriesController < ApplicationController
-  include AutoCompleteSearch
+class RepositoriesController < Katello::ApplicationController
   include KatelloUrlHelper
 
   respond_to :html, :js
@@ -105,7 +104,8 @@ class RepositoriesController < ApplicationController
     @repository.destroy
     if @repository.destroyed?
       notify.success _("Repository '%s' removed.") % @repository.name
-      render :partial => "common/post_delete_close_subpanel", :locals => {:path => products_repos_provider_path(@provider.id)}
+      render :partial => "katello/common/post_delete_close_subpanel",
+             :locals => { :path => products_repos_katello_provider_path(@provider.id) }
     else
       err_msg = N_("Removal of the repository failed. If you continue having trouble with this, please contact an Administrator.")
       notify.error err_msg

--- a/app/views/katello/providers/_edit.html.haml
+++ b/app/views/katello/providers/_edit.html.haml
@@ -1,4 +1,4 @@
-= javascript 'widgets/jquery.jeditable.helpers'
+= javascript 'katello/widgets/jquery.jeditable.helpers'
 
 = content_for :title do
   #{@provider.name}
@@ -13,20 +13,20 @@
   #providers
     %input#panel_element_id{:name => @provider.id, :type => "hidden", :value => "#{name}_#{@provider.id}", "data-ajax_url"=>url_for(:action=> 'update')}
     .full#provider
-      = form_for(@provider, :html => {:multipart => true, :method => :put, :id => 'provider_edit', :remote => true}, :url => provider_path(@provider)) do |f|
+      = form_for(@provider, :html => {:multipart => true, :method => :put, :id => 'provider_edit', :remote => true}, :url => katello_provider_path(@provider)) do |f|
 
         %fieldset.fl.clear
           .grid_2.ra
             %label #{_("Name")}:
-          .grid_9.la#provider_name{:title=>@provider[:name], 'name' => 'provider[name]', 'data-url' => provider_path(@provider.id),
+          .grid_9.la#provider_name{:title=>@provider[:name], 'name' => 'provider[name]', 'data-url' => katello_provider_path(@provider.id),
                                   :class=>editable_class(editable)} #{@provider[:name]}
 
         %fieldset.fl.clear
           .grid_2.ra
             %label #{_("Description")}:
-          .grid_9.la{'name' => 'provider[description]', 'data-maxlength' => default_description_limit, 'data-url' => provider_path(@provider.id), :class=>("editable edit_textarea" if editable)}<> #{@provider.description}
+          .grid_9.la{'name' => 'provider[description]', 'data-maxlength' => default_description_limit, 'data-url' => katello_provider_path(@provider.id), :class=>("editable edit_textarea" if editable)}<> #{@provider.description}
 
 
 %input#provider_id{:name => @provider.id, :type => "hidden", :value => @provider.id, "data-ajax_url"=>url_for(:action=> 'update')}
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/providers/_new.html.haml
+++ b/app/views/katello/providers/_new.html.haml
@@ -1,4 +1,4 @@
-= javascript 'providers/provider_create'
+= javascript 'katello/providers/provider_create'
 
 = content_for :title do
   #{_("New Provider")}
@@ -8,4 +8,4 @@
     = kt_form_for @provider do |form|
       = render :partial => 'form', :locals => { :form => form }
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/providers/_new_discovered_repos.html.haml
+++ b/app/views/katello/providers/_new_discovered_repos.html.haml
@@ -1,5 +1,5 @@
-= javascript 'widgets/subpanel_new'
-= javascript 'providers/repo_discovery_create'
+= javascript 'katello/widgets/subpanel_new'
+= javascript 'katello/providers/repo_discovery_create'
 
 = content_for :title do
   #{_("Create Repositories Under A Product")}
@@ -26,7 +26,7 @@
             %input{:type=>:radio, :name=>:new_product, :value=>:true}
             = _("New Product:")
         .grid_10
-          #new_product{:style=>'display:none;', :data=>{:url=>provider_products_path(@provider.id)}}
+          #new_product{:style=>'display:none;', :data=>{:url=>katello_provider_products_path(@provider.id)}}
             %fieldset
               .grid_2.ra
                 = _('New Product Name')
@@ -37,7 +37,7 @@
                 = _('New Product Label')
               .grid_5.la
                 %input{:type=>:text, :name=>'product_label', :label => _("New Product Label"), :class => :label_input,
-                    :data=>{:url=>default_label_provider_products_path(@provider.id)}}
+                    :data=>{:url=>default_label_katello_provider_products_path(@provider.id)}}
 
       .grid_10
         %h3
@@ -71,11 +71,11 @@
                 .grid_5.la
                   %input{:type=>:text, :name=>"repo_label", :value=>label_from_url(@provider, url), :label => _("Repository Label"),
                     :class => :label_input, :size=>30,
-                    :data=>{:url=>default_label_provider_product_repositories_path(0, 0)}}
+                    :data=>{:url=>default_label_katello_provider_product_repositories_path(0, 0)}}
               %input{:type=>:hidden, :name=>"repo_url", :value=>url}
 
 
       .grid_10.ra
         %input.button#create_repos{:type=>:submit, :value=>_('Create Repositories')}
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/providers/_products_repos.html.haml
+++ b/app/views/katello/providers/_products_repos.html.haml
@@ -1,4 +1,4 @@
-= javascript 'providers/products_repos'
+= javascript 'katello/providers/products_repos'
 
 = content_for :title do
   #{@provider.name}
@@ -21,7 +21,7 @@
       %input{ :type => "hidden", :id=> "provider_id", :name => "provider_id", :value => @provider.id }
 
       -if editable
-        .button.subpanel_element.fl{"data-url"=>new_provider_product_path(@provider.id)}
+        .button.subpanel_element.fl{"data-url"=>new_katello_provider_product_path(@provider.id)}
           = _("Add Product")
 
       -@products.each do |product|
@@ -29,8 +29,8 @@
         %ul.fl.clear{:class=>cssclass}
           %li
             .grid_1.ra
-              = image_tag('icons/expander-expanded.png', :alt => _('Expanded'), :class => :clickable)
-            .grid_7.editable.subpanel_element{"data-url"=>edit_provider_product_path(@provider.id, product.id)}
+              = image_tag('katello/icons/expander-expanded.png', :alt => _('Expanded'), :class => :clickable)
+            .grid_7.editable.subpanel_element{"data-url"=>edit_katello_provider_product_path(@provider.id, product.id)}
               .multiline
                 %label #{_("Product")}:
                 &nbsp;#{product.name}
@@ -38,13 +38,13 @@
             %ul.fl.clear{:class=>cssclass}
               -product.repos(product.organization.library).each do |repo|
                 %li{:class=>'repo'}
-                  .grid_7.prefix_1.editable.subpanel_element{"data-url"=>edit_provider_product_repository_path(@provider.id, product.id, repo.id)}
+                  .grid_7.prefix_1.editable.subpanel_element{"data-url"=>edit_katello_provider_product_repository_path(@provider.id, product.id, repo.id)}
                     .multiline{:style => 'padding-left:2px'}
                       %label #{_("Repository")}:
                       &nbsp;#{repo.name}
               .prefix_1
                 - if editable
-                  .button.subpanel_element{"data-url"=>new_provider_product_repository_path(@provider.id, product.id)}
+                  .button.subpanel_element{"data-url"=>new_katello_provider_product_repository_path(@provider.id, product.id)}
                     #{_("Add Repository")}
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/providers/_repo_discovery.html.haml
+++ b/app/views/katello/providers/_repo_discovery.html.haml
@@ -21,7 +21,7 @@
 
 = content_for :content do
   .grid_10
-    %form#repo_discovery_form{:data=>{:url=>discover_provider_path(@provider.id)}}
+    %form#repo_discovery_form{:data=>{:url=>discover_katello_provider_path(@provider.id)}}
       .grid_1.ra
         = _("URL:")
       .grid_6.la
@@ -30,12 +30,12 @@
         %input{:type=>:submit, :value=>_("Discover")}
       .grid_2.la{:style=>'display: none;'}
         %input#cancel_discover.button{:type=>:button, :name=>:cancel, :value=>_('Cancel'),
-                              :data=>{:url=>cancel_discovery_provider_path(@provider.id)}}
-        = image_tag("icons/spinner.gif")
+                              :data=>{:url=>cancel_discovery_katello_provider_path(@provider.id)}}
+        = image_tag("katello/icons/spinner.gif")
 
   %br
   .grid_10
-    %table#discovered_repos{:data=>{:url=>discovered_repos_provider_path(@provider.id)}}
+    %table#discovered_repos{:data=>{:url=>discovered_repos_katello_provider_path(@provider.id)}}
       %thead
         %tr.underline
           %td
@@ -43,7 +43,7 @@
               %input#url_filter{:type=>'search', :name=>'search', :placeholder=>_('Filter paths...')}
           %td
             .grid_3
-              %button.button#new_repos{:data=>{:url=>new_discovered_repos_provider_path(@provider.id)}}
+              %button.button#new_repos{:data=>{:url=>new_discovered_repos_katello_provider_path(@provider.id)}}
                 = _("Create Within Product")
         %tr
           %th
@@ -54,4 +54,4 @@
         %td
         %td
 
-= render :template => "layouts/tupane_layout"
+= render :template => "katello/layouts/tupane_layout"

--- a/app/views/katello/providers/index.html.haml
+++ b/app/views/katello/providers/index.html.haml
@@ -7,7 +7,7 @@
 .grid_16#main
   = two_panel(@providers, @panel_options)
 
-= javascript :providers
+= javascript 'katello/providers'
 
 = javascript do
   :plain

--- a/app/views/katello/providers/redhat/_children.html.haml
+++ b/app/views/katello/providers/redhat/_children.html.haml
@@ -9,9 +9,9 @@
   - repo = child[:item]
   %tr{:class=>child[:class], :id=>child[:id], "data-product_id="=>repo.product.id, "data-id"=>repo.id}
     %td
-      =image_tag( "icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{repo.id}", :style=>"margin-right:1px;")
+      =image_tag( "katello/icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{repo.id}", :style=>"margin-right:1px;")
       =check_box_tag "repo", repo.id, repo.enabled?,{:id=>"input_repo_#{repo.id}",
-            "data-url" => enable_repo_path(repo.id),
+            "data-url" => katello_enable_repo_path(repo.id),
             :disabled =>(repo.promoted? || !can_enable_repo?),
             :class=>'fl'}
       %label.fl{:for=>"input_repo_#{repo.id}"}

--- a/app/views/katello/providers/redhat/_repo_sets.haml
+++ b/app/views/katello/providers/redhat/_repo_sets.haml
@@ -23,11 +23,11 @@
                   - content_enabled = product_content.katello_enabled?
                   %tr.collapsed.repo_set{:id=>"repo_set_#{product_content.content.id}", :class=>(:disable if !content_enabled)}
                     %td
-                      =image_tag( "icons/spinner.gif", :class=>"hidden fl repo_set_spinner",
+                      =image_tag( "katello/icons/spinner.gif", :class=>"hidden fl repo_set_spinner",
                           :id=>"spinner_set_#{product_content.content.id}", :style=>"margin-right:1px;")
                       %input.repo_set_enable{:type=>:checkbox, :value=>product_content.content.id,
-                                           :data=>{:url => refresh_content_product_path(product.id),
-                                                   :disable_url=>disable_content_product_path(product.id),
+                                           :data=>{:url => refresh_content_katello_product_path(product.id),
+                                                   :disable_url=>disable_content_katello_product_path(product.id),
                                                    :orphaned => orphaned.to_s},
                                            :disabled =>(!product_content.can_disable? || !@provider.editable? || (orphaned && !content_enabled)),
                                            :checked=>(:checked if content_enabled)}
@@ -39,6 +39,6 @@
                         .refresh_icon-black.repo_set_refresh{:title=>_('Refresh repositories'), :style=>('display: none' if !content_enabled)}
 
                       - if content_enabled
-                        = render :partial=>'providers/redhat/repos', :locals=>{:product_content=>product_content}
+                        = render :partial => 'katello/providers/redhat/repos', :locals => { :product_content => product_content }
                       - else
                         %table{:style=>'display:none;'}

--- a/app/views/katello/providers/redhat/_repos.html.haml
+++ b/app/views/katello/providers/redhat/_repos.html.haml
@@ -9,8 +9,8 @@
       %tr.repo{:id=>"repo_#{repo.id}"}
         %td
           %label
-            =image_tag( "icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{repo.id}", :style=>"margin-right:1px;")
-            %input.repo_enable{:id=>"input_repo_#{repo.id}", :type=>:checkbox, :value=>repo.id, "data-url" => enable_repo_path(repo.id),
+            =image_tag( "katello/icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{repo.id}", :style=>"margin-right:1px;")
+            %input.repo_enable{:id=>"input_repo_#{repo.id}", :type=>:checkbox, :value=>repo.id, "data-url" => katello_enable_repo_path(repo.id),
                   :disabled =>(repo.promoted? || !@provider.editable?), :checked=>(:checked if repo.enabled?)}
         %td
           #{repo.name}

--- a/app/views/katello/providers/redhat/show.html.haml
+++ b/app/views/katello/providers/redhat/show.html.haml
@@ -1,5 +1,5 @@
-= javascript 'providers/redhat'
-= stylesheet 'widgets/tabs', :dashboard
+= javascript 'katello/providers/redhat'
+= stylesheet 'katello/widgets/tabs', 'katello/dashboard'
 
 #redhat_provider
   .grid_16
@@ -20,7 +20,7 @@
     -#= _("You can encounter missing repositories because of errors during manifest import or new content was uploaded to CDN.")
     -#= _("Note that this action can take some time to complete.")
   - if @provider.products.empty?
-    = (_("No Red Hat products currently exist, please import a manifest <a href='%s'>here</a> to receive Red Hat content.") % subscriptions_path).html_safe
+    = (_("No Red Hat products currently exist, please import a manifest <a href='%s'>here</a> to receive Red Hat content.") % katello_subscriptions_path).html_safe
   - else
     - tabs = redhat_repo_tabs(@provider)
     #content_tabs.grid_16
@@ -36,6 +36,7 @@
             = _("No products are available containing this content type.")
           - else
             - reset_cycle
-            = render :partial=>"providers/redhat/repo_sets", :locals=>{:tab_id=>tab[:id], :provider=>@provider, :product_map=>tab[:products]}
+            = render :partial => "katello/providers/redhat/repo_sets",
+                     :locals => { :tab_id => tab[:id], :provider => @provider, :product_map => tab[:products] }
 
 


### PR DESCRIPTION
This commit contains initial changes to support the Red Hat Repositories
page in the UI.

It also has some changes for the 'old tupane' version of
providers/products/repos.  Although we'll be removing that in the
future, went ahead and updated the files since was in there anyway.
