### PR TITLE
1022013 - wait until subs apply before refreshing lists

### DIFF
--- a/engines/bastion/app/assets/bastion/systems/details/system-subscriptions.controller.js
+++ b/engines/bastion/app/assets/bastion/systems/details/system-subscriptions.controller.js
@@ -34,6 +34,7 @@ angular.module('Bastion.systems').controller('SystemSubscriptionsController',
             refresh;
 
         successHandler = function() {
+            refresh();
             $scope.saveSuccess = true;
         };
 
@@ -73,10 +74,6 @@ angular.module('Bastion.systems').controller('SystemSubscriptionsController',
                         successHandler, errorHandler);
                 });
             }
-
-            if (selectedRows.length > 0) {
-                refresh();
-            }
         };
 
         $scope.attachSubscriptions = function() {
@@ -87,9 +84,6 @@ angular.module('Bastion.systems').controller('SystemSubscriptionsController',
                 SystemSubscription.save({systemId: $scope.system.uuid, pool: row['cp_id'], quantity: quantity}, successHandler, errorHandler);
             });
 
-            if (selectedRows.length > 0) {
-                refresh();
-            }
         };
 
         $scope.autoAttach = function () {


### PR DESCRIPTION
On the system subscriptions page, the subscription lists were being
refreshed as soon as the request to add/remove subs was sent. On
a multi-process production install, this would result in subs showing
up in a list when they should not
