### PR TITLE
1023525 - fixing new provider page on repo discovery

### DIFF
--- a/engines/bastion/app/assets/bastion/products/discovery-form.controller.js
+++ b/engines/bastion/app/assets/bastion/products/discovery-form.controller.js
@@ -51,12 +51,15 @@ angular.module('Bastion.products').controller('DiscoveryFormController',
             fetchRepoLabel(repo);
         });
 
-        Provider.query(function(values) {
-            $scope.providers = filterEditable(values.results);
+        //We need to re-fetch the providers in case a new one was created
+        $scope.$on('$stateChangeSuccess', function() {
+            Provider.query(function(values) {
+                $scope.providers = filterEditable(values.results);
 
-            if ($scope.providers.length > 0) {
-                $scope.createRepoChoices.product['provider_id'] = $scope.providers[0].id;
-            }
+                if ($scope.providers.length > 0 && $scope.createRepoChoices.product['provider_id'] === undefined) {
+                    $scope.createRepoChoices.product['provider_id'] = $scope.providers[0].id;
+                }
+            });
         });
 
         Product.query({'organization_id': CurrentOrganization}, function(values) {

--- a/engines/bastion/app/assets/bastion/products/discovery.controller.js
+++ b/engines/bastion/app/assets/bastion/products/discovery.controller.js
@@ -52,7 +52,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
         $scope.setupSelected = function() {
             $scope.panel.loading = true;
             $scope.discovery.selected = $scope.discoveryTable.getSelected();
-            $scope.transitionTo('products.discovery.create');
+            $scope.transitionTo('products.discovery.create.repos');
         };
 
         $scope.defaultName = function(basePath) {

--- a/engines/bastion/app/assets/bastion/products/products.module.js
+++ b/engines/bastion/app/assets/bastion/products/products.module.js
@@ -100,10 +100,20 @@ angular.module('Bastion.products').config(['$stateProvider', function($stateProv
     })
     .state("products.discovery.create", {
         collapsed: true,
+        abstract: true,
+        controller: 'DiscoveryFormController',
+        template: '<div ui-view></div>'
+    })
+    .state("products.discovery.create.repos", {
+        collapsed: true,
         url: '/products/discovery/scan/create',
-        templateUrl: 'products/views/discovery_create.html',
-        controller: 'DiscoveryFormController'
-
+        templateUrl: 'products/views/discovery_create.html'
+    })
+    .state("products.discovery.create.new_provider", {
+        collapsed: true,
+        url: '/products/discovery/scan/new_provider',
+        controller: 'NewProviderController',
+        templateUrl: 'providers/views/new.html'
     })
 
     .state("products.details", {

--- a/engines/bastion/app/assets/bastion/products/views/discovery_create.html
+++ b/engines/bastion/app/assets/bastion/products/views/discovery_create.html
@@ -72,7 +72,7 @@
       ng-model="createRepoChoices.product.provider_id"
       ng-options="provider.id as provider.name for provider in providers">
     </select>
-    <a href="" ng-click="transitionTo('products.new.provider')">{{ "+ New Provider" | i18n }}</a>
+    <a href="" ng-click="transitionTo('products.discovery.create.new_provider')">{{ "+ New Provider" | i18n }}</a>
   </div>
 
   <div class="control-group" >

--- a/engines/bastion/app/assets/bastion/providers/new-provider.controller.js
+++ b/engines/bastion/app/assets/bastion/providers/new-provider.controller.js
@@ -48,7 +48,12 @@ angular.module('Bastion.providers').controller('NewProviderController',
         };
 
         function success() {
-            $scope.product['provider_id'] = $scope.provider.id;
+            if ($scope.product) {
+                $scope.product['provider_id'] = $scope.provider.id;
+            }
+            if ($scope.createRepoChoices){
+                $scope.createRepoChoices.product['provider_id'] = $scope.provider.id;
+            }
             $scope.transitionBack();
         }
 

--- a/engines/bastion/app/assets/bastion/providers/views/new.html
+++ b/engines/bastion/app/assets/bastion/providers/views/new.html
@@ -36,7 +36,7 @@
 
     <div class="control-group buttons">
       <div class="input">
-        <button type="button" ng-click="transitionTo('products.new.form')">{{ "Cancel" | i18n }}</button>
+        <button type="button" ng-click="transitionBack()">{{ "Cancel" | i18n }}</button>
         <button tabindex="2" class="btn-primary" ng-click="save(provider)">{{ "Create" | i18n }}</button>
       </div>
     </div>

--- a/engines/bastion/test/products/discovery-form.controller.test.js
+++ b/engines/bastion/test/products/discovery-form.controller.test.js
@@ -57,14 +57,6 @@ describe('Controller: DiscoveryFormController', function() {
         expect($scope.createRepoChoices).toBeDefined();
     });
 
-    it('should fetch available providers and put them on the scope', function() {
-        expect($scope.providers).toBeDefined();
-    });
-
-    it('should set the repository choices product provider id', function() {
-        expect($scope.createRepoChoices.product['provider_id']).toBeDefined();
-    });
-
     it('should fetch available products and put them on the scope', function() {
         expect($scope.products).toBeDefined();
     });

--- a/engines/bastion/test/products/discovery.controller.test.js
+++ b/engines/bastion/test/products/discovery.controller.test.js
@@ -74,7 +74,7 @@ describe('Controller: DiscoveryController', function() {
 
         expect($scope.panel.loading).toBe(true);
         expect($scope.discovery.selected).toBe(fakeSelected);
-        expect($scope.transitionTo).toHaveBeenCalledWith('products.discovery.create');
+        expect($scope.transitionTo).toHaveBeenCalledWith('products.discovery.create.repos');
     });
 
 


### PR DESCRIPTION
Previously the new provider state on repodiscovery
was trying to re-use the existing state, however this
results in none of the items being saved properly, and
all user selection is lost after creating the provider.

This sets up a child state so that all user selection is
saved, as well as ensures that the provider is selected
after the user returns to the repo discovery page.
