### PR TITLE
Bug 1024055: Changes content view definition puppet repo selector

### DIFF
--- a/app/assets/javascripts/content_view_definitions/repo_selector.js
+++ b/app/assets/javascripts/content_view_definitions/repo_selector.js
@@ -19,7 +19,7 @@ KT.repo_input = (function() {
             return;
         }
 
-        select.chosen({allow_single_deselect: true}).change(function(e) {
+        select.change(function(e) {
             var select = $(this),
                 data = {};
 


### PR DESCRIPTION
to basic HTMl select to prevent choices from being hidden from the user.

When adding content to a content view definition, the yum products and
repositories can push the puppet repo selector far enough down such that
all choices are hidden due to the use of Chosen. This can also occur if
the list of puppet repo choices is too long. Switching to a normal HTML
based selector allows the selector to appear a top of the details view
and prevents choices from being unreachable.
