### PR TITLE
1002495 -  Fixed a repo deletion issue

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -304,7 +304,9 @@ class Repository < ActiveRecord::Base
 
   def assert_deletable
     if self.environment.library? && self.content_view.default?
-      if self.custom? && self.deletable?
+      if self.environment.organization.being_deleted?
+        return true
+      elsif self.custom? && self.deletable?
         return true
       elsif !self.custom? && self.redhat_deletable?
         return true


### PR DESCRIPTION
Prior to this commit there was logic that said something along the lines
of 'Do not delete a RH repo unless its disabled'. Due to this when an org
was getting deleted, if there were any 'enabled' redhat repos in the org
there would be dangling repositories with nil references.
This commit adds an additional clause that says, "Allow deletion of the
redhat repo if org is getting deleted".
