### PR TITLE
Engine: Dashboard: fix error related to unserialized preferences

### DIFF
--- a/app/lib/katello/dashboard/layout.rb
+++ b/app/lib/katello/dashboard/layout.rb
@@ -40,7 +40,7 @@ module Dashboard
     end
 
     def setup_layout
-      if (user_layout = current_user.try(:preferences).try(:[], :dashboard).try(:[], :layout))
+      if (user_layout = current_user.preferences_hash.try(:[], :dashboard).try(:[], :layout))
         user_layout.each do |col|
           @columns << col.each_with_object([]) do |name, column|
             begin

--- a/app/models/katello/concerns/user_extensions.rb
+++ b/app/models/katello/concerns/user_extensions.rb
@@ -80,6 +80,10 @@ module Katello
           self.preferences = Hash.new unless self.preferences
         end
 
+        def preferences_hash
+          self.preferences.is_a?(Hash) ? self.preferences : self.preferences.unserialized_value
+        end
+
         def not_last_super_user?
           if !User.current.nil?
             if self.id == User.current.id


### PR DESCRIPTION
With katello running as an engine, we've seen multiple cases
where an error occurs when loading the dashboard.  It appears
that under certain circumstances the preferences are not being
unserialized.  This change will force unserialization, when
necessary.

When it occurs, the stack for the error looks similar to:

no member 'dashboard' in struct

activesupport (3.2.14) lib/active_support/core_ext/object/try.rb:36:in `[]'
activesupport (3.2.14) lib/active_support/core_ext/object/try.rb:36:in`try'
/home/bbucking/github/katello/app/lib/katello/dashboard/layout.rb:41:in `setup_layout'
/home/bbucking/github/katello/app/lib/katello/dashboard/layout.rb:37:in`initialize'
/home/bbucking/github/katello/app/helpers/katello/dashboard_helper.rb:188:in `new'
/home/bbucking/github/katello/app/helpers/katello/dashboard_helper.rb:188:in`dashboard_layout'
/home/bbucking/github/katello/app/helpers/katello/dashboard_helper.rb:193:in `render_dashboard'
/home/bbucking/github/katello/app/views/katello/dashboard/index.html.haml:14:in

A similar issue was reported in:
http://stackoverflow.com/questions/15588643/rails-3-unserialize-returns-only-activerecordattributemethodsserialization
