### PR TITLE
Bug 1011528: Fixing broken default environment by simplifying to the

### DIFF
--- a/app/assets/javascripts/common/katello.js
+++ b/app/assets/javascripts/common/katello.js
@@ -218,54 +218,57 @@ KT.orgswitcher = (function($) {
       if (checked){
         options = {user_id : $('#user_id').data("user_id")};
       } else {
-        options = {org : selected_org_id, user_id : $('#user_id').data("user_id")};
+        options = {org_id : selected_org_id, user_id : $('#user_id').data("user_id")};
       }
 
-      //hide the favorite icon temporarily while the ajax operation occurs
-      this_favorite.hide();
+      if (!checked) {
+          //hide the favorite icon temporarily while the ajax operation occurs
+          this_favorite.hide();
 
-      //show the spinner while waiting
-      this_spinner.removeClass('hidden').show();
+          //show the spinner while waiting
+          this_spinner.removeClass('hidden').show();
 
-      $.ajax({
-          type: "PUT",
-          url: url,
-          data: options,
-          cache: false,
-          success: function(data, textStatus, jqXHR){
-            //hide spinner
-            this_spinner.addClass('hidden').hide();
-            if(checked){
-              this_checkbox.attr("checked", false);
-              this_favorite.addClass("favorites_icon-grey");
-              this_favorite.removeClass("favorites_icon-black");
-              this_favorite.attr("title", i18n.make_default_org);
-              if(this_favorite.parent().find('label').length){
-                this_favorite.parent().find('label').html(i18n.make_default_org);
+          $.ajax({
+              type: "PUT",
+              url: url,
+              data: options,
+              cache: false,
+              success: function(data, textStatus, jqXHR){
+                //hide spinner
+                this_spinner.addClass('hidden').hide();
+                if(checked){
+                  this_checkbox.attr("checked", false);
+                  this_favorite.addClass("icon-star-empty").addClass('clickable');
+                  this_favorite.removeClass("icon-star");
+                  this_favorite.attr("title", i18n.make_default_org);
+                  if(this_favorite.parent().find('label').length){
+                    this_favorite.parent().find('label').html(i18n.make_default_org);
+                  }
+                } else {
+                  this_checkbox.attr("checked", true);
+                  all_favorites.removeClass("icon-star");
+                  all_favorites.attr("title", i18n.make_default_org);
+                  $('.favorite').addClass("icon-star").removeClass('clickable');
+                  this_favorite.removeClass("icon-star-empty").addClass("icon-star");
+                  this_favorite.attr("title", i18n.current_default_org);
+                  if(this_favorite.parent().find('label').length){
+                    this_favorite.parent().find('label').html(i18n.current_default_org);
+                  }
+                }
+                this_favorite.show();
+
+                this_checkbox.removeAttr("disabled");
+              },
+              error: function(data, textStatus, jqXHR){
+                //hide the spinner and show the favorite is not selected
+                this_spinner.addClass('hidden').hide();
+                this_checkbox.attr("checked", false);
+                this_favorite.show();
+                this_checkbox.removeAttr("disabled");
               }
-            } else {
-              this_checkbox.attr("checked", true);
-              all_favorites.removeClass("favorites_icon-black");
-              all_favorites.attr("title", i18n.make_default_org);
-              $('.favorite').addClass("favorites_icon-grey");
-              this_favorite.removeClass("favorites_icon-grey").addClass("favorites_icon-black");
-              this_favorite.attr("title", i18n.current_default_org);
-              if(this_favorite.parent().find('label').length){
-                this_favorite.parent().find('label').html(i18n.current_default_org);
-              }
-            }
-            this_favorite.show();
+          });
+      }
 
-            this_checkbox.removeAttr("disabled");
-          },
-          error: function(data, textStatus, jqXHR){
-            //hide the spinner and show the favorite is not selected
-            this_spinner.addClass('hidden').hide();
-            this_checkbox.attr("checked", false);
-            this_favorite.show();
-            this_checkbox.removeAttr("disabled");
-          }
-      });
       return false;
     };
     return {

--- a/app/assets/stylesheets/katello.scss
+++ b/app/assets/stylesheets/katello.scss
@@ -1091,7 +1091,7 @@ fieldset {
 }
 
 /* begin helptip */
-.helptip-open {
+.helptip, .helptip-open {
   background-color: $helptip-background_color;
   display: block;
   padding: 12px;
@@ -1481,4 +1481,13 @@ pre {
     opacity: 1;
     color: orange;
   }
+}
+
+#main .text-list {
+  padding-left: 20px;
+
+  &, li {
+    list-style-type: disc;
+  }
+
 }

--- a/app/assets/stylesheets/orgs.scss
+++ b/app/assets/stylesheets/orgs.scss
@@ -25,7 +25,7 @@
         @include unselectable();
         label {
           color: $g7;
-          padding: 8px;
+          padding-left: 4px;
           line-height: 16px;
         }
         input[type="checkbox"]{
@@ -37,10 +37,9 @@
           float: right;
         }
         .favorite {
-          float: right;
           text-align: left;
           text-transform: capitalize;
-          text-indent: -9999px;
+
           &:hover {
             background-position: -624px -16px;
             @include opacity(.75);

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -236,37 +236,18 @@ class UsersController < ApplicationController
   end
 
   def update_environment
-    if Katello.config.katello?
-      default_environment_id = params['env_id'].try(:[], 'env_id').try(:to_i)
+    if params['org_id'].present?
+      @organization = Organization.find_by_id(params['org_id'].try(:to_i))
+
+      @user.default_environment = @organization.library
+      @user.default_org         = @organization.id
+      @user.save!
+
+      notify.success _("User organization default updated successfully.")
+
+      render :json => { :org => @organization.name }
     else
-      default_environment_id = nil
-      if !params['org_id'].blank?
-        @organization = Organization.find_by_id(params['org_id'].try(:to_i))
-        default_environment_id = @organization.library.id
-      end
-    end
-
-    if @user.default_environment.try(:id) == default_environment_id
-      err_msg = N_("The system registration default you supplied was the same as the old system registration default.")
-      notify.error err_msg
-      render(:text => err_msg, :status => 400)
-      return
-    end
-
-    raise no_env_available_msg if default_environment_id.nil? && params['org_id'].present?
-
-    @environment              = default_environment_id.nil? ? nil : KTEnvironment.find(default_environment_id)
-    @user.default_environment = @environment
-    @user.save!
-
-    @organization             = @environment.try :organization
-
-    notify.success _("User System Registration Environment updated successfully.")
-
-    if @organization && @environment
-      render :json => { :org => @organization.name, :env => @environment.name, :env_id => @environment.id }
-    else
-      render :json => { :org => _("No system registration default set for this user."), :env => _("No system registration default set for this user.") }
+      render :json => { :org => _("No organization default set for this user.") }
     end
   end
 

--- a/app/views/common/_fav.html.haml
+++ b/app/views/common/_fav.html.haml
@@ -10,11 +10,11 @@
   have received a copy of GPLv2 along with this software; if not, see
   http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-= check_box_tag "org_#{org.id}", org.id, current_user.default_org == org, {:class=>"default_org", "data-url"=>setup_default_org_user_path(current_user.id)}
+= check_box_tag "org_#{org.id}", org.id, current_user.default_org == org, {:class=>"default_org", 'data-url'=>update_environment_user_path(current_user.id)}
 
 - if current_user.default_org == org
   %i.fl.favorite.icon-star.tipsify{:title=>_("This is your default organization."), :id=>"favorite_#{org.id}"}
 - else
-  %i.fl.favorite.icon-star-empty.tipsify{:title=>_("Make this your default organization."), :id=>"favorite_#{org.id}"}
+  %i.fl.favorite.icon-star-empty.tipsify.clickable{:title=>_("Make this your default organization."), :id=>"favorite_#{org.id}"}
 
 = image_tag( "icons/spinner.gif", :class=>"hidden fl fav_spinner")

--- a/app/views/organizations/_footer.html.haml
+++ b/app/views/organizations/_footer.html.haml
@@ -10,6 +10,7 @@
   have received a copy of GPLv2 along with this software; if not, see
   http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-%label{:for=>"org_#{@organization.id}", :class=>"label_default_org clickable", :id=>"label_org_#{@organization.id}"}
-  #{@org_label}
-= render :partial=>"common/fav", :locals => {:org=>@organization, :current_user=>current_user}
+.fr
+  %label.fr{:for=>"org_#{@organization.id}", :class=>"label_default_org", :id=>"label_org_#{@organization.id}"}
+    #{@org_label}
+  = render :partial=>"common/fav", :locals => {:org=>@organization, :current_user=>current_user}

--- a/app/views/users/_edit_environment.html.haml
+++ b/app/views/users/_edit_environment.html.haml
@@ -20,47 +20,27 @@
 = content_for :content do
   %fieldset.fl.clear
     %h5
-      #{_("Current System Registration Defaults")}
+      #{_("New System Registration Default:")}
+  .clear
+    %div.helptip
+      %p
+        = _('Setting a default organization for a user results in the following:')
+      %ul.text-list
+        %li
+          = _("During log in, the user will be automatically logged into the organization")
+        %li
+          = _("New systems registered by the user without specifying an environment will be automatically registered to this organization's Library environment.")
+  %fieldset.fl.clear
     .grid_2.ra
       = label :user, :org, _("Organization:")
+  - if editable
+    .grid_7.la
+      = organization_select(@organization ? @organization.id : nil, true, _('No Default'))
+    .grid_7.la
+      #update_user.disabled.button{'data-url'=>update_environment_user_path(@user.id)}
+        #{_("Save")}
+  - else
     .grid_7.la#org_name
       = @old_env ? @old_env.organization.name : _("No system registration default set for this user.")
-    - if Katello.config.katello?
-      .grid_2.ra.clear
-        = label :user, :env, _("Environment:")
-      .grid_7.la#env_name
-        = @old_env ? @old_env.name : _("No system registration default set for this user.")
-  - if editable
-    %fieldset.fl.clear
-      %h5
-        #{_("Choose New System Registration Defaults:")}
-    %fieldset.fl.clear
-      .grid_2.ra
-        = label :user, :org, _("Organization:")
-      .grid_7.la
-        = organization_select(@organization ? @organization.id : nil, true, _('No Default'))
-    %fieldset.fl.clear
-    .promotion_paths
-      = hidden_field_tag 'user[environment_id]', @environment.id unless @environment.nil?
-      - if Katello.config.katello?
-        .grid_2.ra
-          %label #{_("Environment")}:
-        .grid_7.la
-          = image_tag( "icons/spinner.gif", :id=>"org_spinner", :class=>"hidden fl")
-          - if @environment.nil?
-            #env_box
-              -if @organization.nil?
-                #{_("No system registration default environment. Select an organization to choose from available environments.")}
-              -else
-                #{_("No environments are currently available in this organization. Saving will set user to no system registration default environment.")}
-          - else
-            #env_box
-              = environment_selector(:path_widget_class=>"grid_10", :path_entries_class=>"grid_10", :library_clickable=>true,
-                :accessible_envs=>accessible_envs)
-      .clear
-        &nbsp;
-      .grid_5.la.prefix_2
-        #update_user.disabled.button{'data-url'=>update_environment_user_path(@user.id)}
-          #{_("Save")}
 
 = render :template => "layouts/tupane_layout"

--- a/app/views/users/_edit_form.html.haml
+++ b/app/views/users/_edit_form.html.haml
@@ -87,4 +87,3 @@
         - else
           .grid_5.la
             =  @user.default_locale  || "#{_('Browser Default Locale')}"
-


### PR DESCRIPTION
choice down to a default organization and preferring library registration
when no environment is given.

When content views were added, the default environment functionality
broke from the UI perspective since a user would need to select both
an environment and a content view. To simplify this interaction the
default environment selection was removed and replaced by choosing
just a default organization. This default organization is also
the user's favorite organization and will result in the user being
logged into that organization by default.
