### PR TITLE
Allow UUID to be passed through candlepin

### DIFF
--- a/app/lib/resources/candlepin.rb
+++ b/app/lib/resources/candlepin.rb
@@ -104,8 +104,10 @@ module Resources
           end
         end
 
+# rubocop:disable ParameterLists
         def create(env_id, key, name, type, facts, installed_products, autoheal = true, release_ver = nil,
-                   service_level = "", capabilities = nil)
+                   service_level = "", uuid = "", capabilities = nil)
+# rubocop:enable ParameterLists
 
           # These defaults give distributors full capabilities with all types of subscriptions
           if type == 'candlepin'
@@ -120,6 +122,7 @@ module Resources
                    :autoheal => autoheal,
                    :releaseVer => release_ver,
                    :serviceLevel => service_level,
+                   :uuid => uuid,
                    :capabilities => capabilities}
           response = self.post(url, attrs.to_json, self.default_headers).body
           JSON.parse(response).with_indifferent_access

--- a/app/models/glue/candlepin/consumer.rb
+++ b/app/models/glue/candlepin/consumer.rb
@@ -104,6 +104,7 @@ module Glue::Candlepin::Consumer
                                                             self.autoheal,
                                                             self.releaseVer,
                                                             self.serviceLevel,
+                                                            self.uuid,
                                                             self.capabilities)
 
       load_from_cp(consumer_json)

--- a/spec/models/system_spec.rb
+++ b/spec/models/system_spec.rb
@@ -77,7 +77,7 @@ describe System do
   it "registers system in candlepin and pulp on create", :katello => true do
     Resources::Candlepin::Consumer.should_receive(:create).once.with(@environment.id.to_s, @organization.name,
                                                                       system_name, cp_type, facts, installed_products,
-                                                                      nil, nil, nil, nil).and_return({:uuid => uuid,
+                                                                      nil, nil, nil, "1234", nil).and_return({:uuid => uuid,
                                                                                                 :owner => {:key => uuid}})
     Katello.pulp_server.extensions.consumer.should_receive(:create).once.with(uuid, {:display_name => system_name}).and_return({:id => uuid}) if Katello.config.katello?
     @system.save!

--- a/test/fixtures/vcr_cassettes/support/candlepin/distributor.yml
+++ b/test/fixtures/vcr_cassettes/support/candlepin/distributor.yml
@@ -71,7 +71,7 @@ http_interactions:
     uri: https://localhost:8443/candlepin/environments/7/consumers/
     body: 
       encoding: US-ASCII
-      string: "{\"name\":\"GlueCandlepinConsumerTestDistributor_1\",\"type\":\"candlepin\",\"facts\":{\"distributor_version\":\"sam-1.3\"},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"capabilities\":null}"
+      string: "{\"name\":\"GlueCandlepinConsumerTestDistributor_1\",\"type\":\"candlepin\",\"facts\":{\"distributor_version\":\"sam-1.3\"},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"uuid\":null,\"capabilities\":null}"
     headers: 
       Accept: 
       - application/json
@@ -147,7 +147,7 @@ http_interactions:
     uri: https://localhost:8443/candlepin/environments/7/consumers/
     body: 
       encoding: US-ASCII
-      string: "{\"name\":\"GlueCandlepinConsumerTestSecondDelete_2\",\"type\":\"candlepin\",\"facts\":{\"distributor_version\":\"sam-1.3\"},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"capabilities\":null}"
+      string: "{\"name\":\"GlueCandlepinConsumerTestSecondDelete_2\",\"type\":\"candlepin\",\"facts\":{\"distributor_version\":\"sam-1.3\"},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"uuid\":null,\"capabilities\":null}"
     headers: 
       Accept: 
       - application/json

--- a/test/fixtures/vcr_cassettes/support/candlepin/system.yml
+++ b/test/fixtures/vcr_cassettes/support/candlepin/system.yml
@@ -71,7 +71,7 @@ http_interactions:
     uri: https://localhost:8443/candlepin/environments/7/consumers/
     body: 
       encoding: US-ASCII
-      string: "{\"name\":\"GlueCandlepinConsumerTestSecondDelete_1\",\"type\":\"system\",\"facts\":{\"uname.machine\":\"x86_64\",\"cpu.cpu_socket(s)\":2,\"memory.memtotal\":\"256 MB\",\"virt.is_guest\":false},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"capabilities\":null}"
+      string: "{\"name\":\"GlueCandlepinConsumerTestSecondDelete_1\",\"type\":\"system\",\"facts\":{\"uname.machine\":\"x86_64\",\"cpu.cpu_socket(s)\":2,\"memory.memtotal\":\"256 MB\",\"virt.is_guest\":false},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"uuid\":null,\"capabilities\":null}"
     headers: 
       Accept: 
       - application/json
@@ -147,7 +147,7 @@ http_interactions:
     uri: https://localhost:8443/candlepin/environments/7/consumers/
     body: 
       encoding: US-ASCII
-      string: "{\"name\":\"GlueCandlepinConsumerTestSystem_1\",\"type\":\"system\",\"facts\":{\"uname.machine\":\"x86_64\",\"cpu.cpu_socket(s)\":2,\"memory.memtotal\":\"256 MB\",\"virt.is_guest\":false},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"capabilities\":null}"
+      string: "{\"name\":\"GlueCandlepinConsumerTestSystem_1\",\"type\":\"system\",\"facts\":{\"uname.machine\":\"x86_64\",\"cpu.cpu_socket(s)\":2,\"memory.memtotal\":\"256 MB\",\"virt.is_guest\":false},\"installedProducts\":null,\"autoheal\":null,\"releaseVer\":null,\"serviceLevel\":null,\"uuid\":null,\"capabilities\":null}"
     headers: 
       Accept: 
       - application/json


### PR DESCRIPTION
Previously, consumer UUIDs were not being passed through to candlepin on
consumer create calls. Candlepin would create a UUID and pass it back to
katello.

This patch sends the consumer UUID through to candlepin. This is usually set to
null, which results in candlepin choosing the UUID. However, a UUID can now be
optionally supplied.
