### PR TITLE
Remove rails-dev-boost gem from default set of gems for development

### DIFF
--- a/bundler.d/development_boost.rb
+++ b/bundler.d/development_boost.rb
@@ -1,6 +1,0 @@
-group :development_boost do
-  unless defined? JRUBY_VERSION
-    # devboost just for dev mode
-    gem 'rails-dev-boost', :require => 'rails_development_boost'
-  end
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ else
              when :production
                basic_groups
              when :development
-               basic_groups + [:development, :debugging, :build, :development_boost, :assets]
+               basic_groups + [:development, :debugging, :build, :assets]
              when :test
                # TODO: replace ENV['TRAVIS'] with configuration
                basic_groups + [:development, :test, (:debugging if ENV['TRAVIS'] != 'true')]

--- a/katello.spec
+++ b/katello.spec
@@ -357,8 +357,6 @@ Requires:        rubygem(gettext) >= 1.9.3
 Requires:        rubygem(ruby_parser)
 Requires:        rubygem(sexp_processor)
 Requires:        rubygem(factory_girl_rails) >= 1.4.0
-# dependencies from bundler.d/development_boost.rb
-Requires:        rubygem(rails-dev-boost)
 # dependencies from bundler.d/apipie.rb
 Requires:        rubygem(maruku)
 
@@ -453,7 +451,6 @@ rm -f .rubocop.yml
     rm -f bundler.d/coverage.rb
     rm -f bundler.d/debugging.rb
     rm -f bundler.d/development.rb
-    rm -f bundler.d/development_boost.rb
     rm -f bundler.d/optional.rb
     rm -rf bundler.d/assets.rb
 %endif
@@ -878,7 +875,6 @@ usermod -a -G katello-shared tomcat
 %files devel
 %{homedir}/bundler.d/development.rb
 %{homedir}/bundler.d/assets.rb
-%{homedir}/bundler.d/development_boost.rb
 %{homedir}/lib/tasks/yard.rake
 %{homedir}/lib/tasks/hudson.rake
 %{homedir}/lib/tasks/jsroutes.rake

--- a/rel-eng/comps/comps-katello-server-fedora18.xml
+++ b/rel-eng/comps/comps-katello-server-fedora18.xml
@@ -117,7 +117,6 @@
        <packagereq type="default">rubygem-newrelic_rpm</packagereq>
        <packagereq type="default">rubygem-parallel</packagereq>
        <packagereq type="default">rubygem-parallel_tests</packagereq>
-       <packagereq type="default">rubygem-rails-dev-boost</packagereq>
        <packagereq type="default">rubygem-ruby-prof</packagereq>
        <packagereq type="default">rubygem-uuid</packagereq>
        <packagereq type="default">signo-devel</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -110,7 +110,6 @@
        <packagereq type="default">rubygem-newrelic_rpm</packagereq>
        <packagereq type="default">rubygem-parallel</packagereq>
        <packagereq type="default">rubygem-parallel_tests</packagereq>
-       <packagereq type="default">rubygem-rails-dev-boost</packagereq>
        <packagereq type="default">rubygem-ruby-prof</packagereq>
        <packagereq type="default">rubygem-uuid</packagereq>
        <packagereq type="default">signo-devel</packagereq>


### PR DESCRIPTION
Since rails 3.2 there were radical improvements in reloading the code,
not making the rails-dev-boost as useful as before. Using it however
breaks the doc reloading feature in development mode.

If somebody misses that, he can still add it to some
bundler.d/local_*.rb file
