### PR TITLE
1021612: Check for duplicate puppet names before publish

### DIFF
--- a/app/controllers/content_view_definitions_controller.rb
+++ b/app/controllers/content_view_definitions_controller.rb
@@ -169,6 +169,14 @@ class ContentViewDefinitionsController < ApplicationController
     else
       render_bad_parameters
     end
+  rescue Errors::PuppetConflictException => e
+    details = _("Puppet repository name conflicts: %s.") % e.conflicts.join(", ")
+    notify.error(_("Failed to publish content view '%{view_name}' from definition '%{definition_name}'. %{error}") %
+                 {:view_name => params[:content_view][:name], :definition_name => @view_definition.name, :error => e},
+                 :details => details)
+    logger.error(_("%{exception}\n%{details}") % {:exception => e, :details => details})
+
+    render :text => e.to_s, :status => 500
   rescue => e
     notify.exception(_("Failed to publish content view '%{view_name}' from definition '%{definition_name}'.") %
                          {:view_name => params[:content_view][:name], :definition_name => @view_definition.name}, e)

--- a/app/controllers/content_views_controller.rb
+++ b/app/controllers/content_views_controller.rb
@@ -47,6 +47,14 @@ class ContentViewsController < ApplicationController
     render :partial => 'content_view_definitions/views/view',
            :locals => { :view_definition => @view.content_view_definition, :view => @view,
                         :task => new_version.task_status }
+  rescue Errors::PuppetConflictException => e
+    details = _("Puppet repository name conflicts: %s.") % e.conflicts.join(", ")
+    notify.error(_("Failed to generate a new version of content view '%{view_name}'. %{error}") %
+                 {:view_name => @view.name, :error => e},
+                 :details => details)
+    logger.error(_("%{exception}\n%{details}") % {:exception => e, :details => details})
+
+    render :text => e.to_s, :status => 500
   rescue => e
     current_version = @view.version(current_organization.library).try(:version)
 

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -73,4 +73,12 @@ module Errors
       end
     end
   end
+
+  class PuppetConflictException < StandardError
+    attr_accessor :conflicts
+
+    def initialize(conflicts)
+      self.conflicts = conflicts
+    end
+  end
 end

--- a/app/models/content_view.rb
+++ b/app/models/content_view.rb
@@ -263,6 +263,7 @@ class ContentView < ActiveRecord::Base
     if !content_view_definition.ready_to_publish?
       fail _("Cannot refresh view. Check definition for repository conflicts.")
     end
+    content_view_definition.check_puppet_names!
     options = { :async => true, :notify => false }.merge options
 
     # retrieve the 'next' version id to use

--- a/app/models/content_view_definition.rb
+++ b/app/models/content_view_definition.rb
@@ -36,6 +36,7 @@ class ContentViewDefinition < ContentViewDefinitionBase
   # TODO: break up method
   # rubocop:disable MethodLength
   def publish(name, description, label = nil, options = {})
+    check_puppet_names!
     fail _("Cannot publish definition. Please check for repository conflicts.") if !ready_to_publish?
     options = { :async => true, :notify => false }.merge options
 
@@ -148,6 +149,14 @@ class ContentViewDefinition < ContentViewDefinitionBase
       return repos.select(&:puppet?).length > 1
     end
     false
+  end
+
+  def check_puppet_names!
+    if puppet_repository && (name_conflicts = puppet_repository.name_conflicts).any?
+      fail Errors::PuppetConflictException.new(name_conflicts),
+        _("Selected puppet repository has %s name conflict(s) and cannot be published.") %
+        name_conflicts.length
+    end
   end
 
   def ready_to_publish?

--- a/app/models/glue/elastic_search/puppet_module.rb
+++ b/app/models/glue/elastic_search/puppet_module.rb
@@ -95,6 +95,7 @@ module Glue::ElasticSearch::PuppetModule
                  :sort => [:name_sort, "ASC"],
                  :search_mode => :all,
                  :default_field => 'name',
+                 :fields => [],
                  :filters => nil}.merge(options)
       options[:repoids] = Array(options[:repoids])
 
@@ -112,6 +113,8 @@ module Glue::ElasticSearch::PuppetModule
             string query, { :default_field => options[:default_field] }
           end
         end
+
+        fields options[:fields] unless options[:fields].blank?
 
         if options[:page_size] > 0
           size options[:page_size]

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -300,6 +300,18 @@ class Repository < ActiveRecord::Base
     feed.present?
   end
 
+  def name_conflicts
+    if puppet?
+      modules = PuppetModule.search("*", :repoids => self.pulp_id,
+                                         :fields => [:name],
+                                         :page_size => self.puppet_module_count)
+
+      modules.map(&:name).group_by(&:to_s).select { |_, v| v.size > 1 }.keys
+    else
+      []
+    end
+  end
+
   protected
 
   def assert_deletable

--- a/spec/controllers/content_view_definitions_controller_spec.rb
+++ b/spec/controllers/content_view_definitions_controller_spec.rb
@@ -263,6 +263,14 @@ describe ContentViewDefinitionsController, :katello => true do
         response.should be_bad_request
       end
 
+      it "should not publish a content view definition with puppet name conflicts" do
+        ContentViewDefinition.stub(:find).and_return(@definition)
+        @definition.stub_chain(:puppet_repository, :name_conflicts).and_return([:apache])
+        controller.should notify.error
+
+        post :publish, :id => @definition.id, :content_view => {:name => "published_view"}
+        response.should_not be_success
+      end
     end
 
     describe "GET content" do

--- a/test/models/content_view_definition_test.rb
+++ b/test/models/content_view_definition_test.rb
@@ -287,4 +287,13 @@ class ContentViewDefinitionTest < MiniTest::Rails::ActiveSupport::TestCase
     assert @content_view_def.destroy
     refute ContentViewDefinition.exists?(@content_view_def.id)
   end
+
+  def test_check_puppet_names
+    @content_view_def.stubs(:puppet_repository).returns(mock(:name_conflicts => ['ntp']))
+
+    assert_raises(Errors::PuppetConflictException) do
+      @content_view_def.check_puppet_names!
+    end
+  end
+
 end


### PR DESCRIPTION
There's also a separate [issue](https://github.com/Katello/katello/issues/3307) for handling publish errors from Pulp in general.
- [x] Handle refresh
- [x] Write tests
- [x] Address PR feedback
