### PR TITLE
Engine: org-switcher: updates to support working within engine

### DIFF
--- a/app/controllers/katello/api/v1/users_controller.rb
+++ b/app/controllers/katello/api/v1/users_controller.rb
@@ -65,7 +65,7 @@ class Api::V1::UsersController < Api::V1::ApiController
   api :GET, "/users/:id", "Show a user"
   def show
     @user[:allowed_organizations] = @user.allowed_organizations
-    @user[:roles] = @user.roles
+    @user[:roles] = @user.katello_roles
     respond
   end
 

--- a/app/models/katello/concerns/user_extensions.rb
+++ b/app/models/katello/concerns/user_extensions.rb
@@ -59,7 +59,7 @@ module Katello
         has_many :task_statuses, :dependent => :destroy, :class_name => "Katello::TaskStatus"
         has_many :search_favorites, :dependent => :destroy, :class_name => "Katello::SearchFavorite"
         has_many :search_histories, :dependent => :destroy, :class_name => "Katello::SearchHistory"
-        belongs_to :default_environment, :class_name => "KTEnvironment"
+        belongs_to :default_environment, :class_name => "Katello::KTEnvironment"
         serialize :preferences, Hash
 
         validates :default_locale, :inclusion => {:in => Katello.config.available_locales, :allow_nil => true, :message => _("must be one of %s") % Katello.config.available_locales.join(', ')}

--- a/app/views/katello/api/v2/users/show.json.rabl
+++ b/app/views/katello/api/v2/users/show.json.rabl
@@ -2,8 +2,11 @@ object @user
 
 attributes :id, :mail, :login, :disabled
 attributes :default_organization, :default_environment, :own_role_id
-attributes :allowed_organizations
+
+child :allowed_organizations, :root => :allowed_organizations do
+  attributes :id, :label, :name
+end
+
 attributes :preferences
 
-
-extends 'api/v2/common/timestamps'
+extends 'katello/api/v2/common/timestamps'

--- a/engines/bastion/app/assets/bastion/menu/views/menu.html
+++ b/engines/bastion/app/assets/bastion/menu/views/menu.html
@@ -28,7 +28,7 @@
           <a class="menu-item-link" ng-href="{{ foremanMenu.url }}" ng-class="{ 'active-item' : foreman.active }">
             <span>
               Foreman
-              <img src="assets/cross_link.png" class="link_icon icon"></img>
+              <img src="../assets/katello/cross_link.png" class="link_icon icon"></img>
             </span>
           </a>
         </li>

--- a/engines/bastion/app/assets/bastion/widgets/org-switcher.widget.js
+++ b/engines/bastion/app/assets/bastion/widgets/org-switcher.widget.js
@@ -37,7 +37,7 @@ angular.module('Bastion.widgets').directive('orgSwitcher',
     return {
         restrict: 'A',
         scope: true,
-        templateUrl: 'widgets/views/org-switcher.html',
+        templateUrl: '../widgets/views/org-switcher.html',
 
         controller: ['$scope', function($scope) {
             $scope.visible = false;
@@ -53,9 +53,13 @@ angular.module('Bastion.widgets').directive('orgSwitcher',
 
             $scope.refresh = function() {
                 $scope.working = true;
-                $scope.user = User.get({'id': CurrentUser}, function(user) {
+                $scope.user = User.get({'id': CurrentUser}, function(response) {
                     $scope.working = false;
-                    $scope.favoriteOrg = user.preferences.user['default_org'] || null;
+                    if (response.user.preferences.user) {
+                        $scope.favoriteOrg = response.user.preferences.user['default_org'];
+                    } else {
+                        $scope.favoriteOrg = null;
+                    }
                 });
             };
 


### PR DESCRIPTION
This commit contains several changes needed to enable the
org-switcher to work properly within the katello 'as an engine'.
