### PR TITLE
Fix for a content view migration issue

### DIFF
--- a/db/migrate/20130613090036_add_foreign_keys.rb
+++ b/db/migrate/20130613090036_add_foreign_keys.rb
@@ -23,6 +23,7 @@ class AddForeignKeys < ActiveRecord::Migration
     execute("delete from marketing_engineering_products where engineering_product_id not in (select id from products)")
     execute("delete from roles_users where role_id not in (select id from roles)")
     execute("delete from roles_users where user_id not in (select id from users)")
+    execute("delete from changeset_content_views where content_view_id not in (select id from content_views)")
 
     add_foreign_key_deferred 'activation_keys', 'content_views',
                              :name => 'activation_keys_content_view_id_fk'


### PR DESCRIPTION
Previously, a removal of a content view would not cascade properly across changesets
This caused dangling references in changesets. This commit fixes that issue
by removing all references in a changeset which has a content view that no longer exists.
