### PR TITLE
Engine: engine-api-params - remove format param from api calls

### DIFF
--- a/app/controllers/katello/api/v1/api_controller.rb
+++ b/app/controllers/katello/api/v1/api_controller.rb
@@ -34,6 +34,7 @@ class Api::V1::ApiController < Api::ApiController
     @query_params = params.clone
     @query_params.delete('controller')
     @query_params.delete('action')
+    @query_params.delete('format')
 
     @query_params.each_pair do |k, v|
 


### PR DESCRIPTION
The format param was being passed down to the api controller, causing errors in queries.
