### PR TITLE
1002495 - Fix related to org delete

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -29,7 +29,7 @@ class Provider < ActiveRecord::Base
   serialize :discovered_repos, Array
 
   belongs_to :organization, :inverse_of => :providers
-  belongs_to :task_status, :dependent => :destroy, :inverse_of => :provider
+  belongs_to :task_status, :inverse_of => :provider
   belongs_to :discovery_task, :class_name => 'TaskStatus', :dependent => :destroy, :inverse_of => :provider
   has_many :products, :inverse_of => :provider, :dependent => :destroy
   has_many :repositories, through: :products


### PR DESCRIPTION
An error related to modifying a new record was raised when deleting an organization.
During an org delete the provider gets deleted which inturn tries to
delete the tasks associated to it. The task had dependent => :nullify
set to true, which made the task update the provider marked for
deletion.
This fix removes the dependent destroy on task status when a provider is
deleted, since organization removes it. Also redhat provider is the only
kind with a task id associated to it and the redhat provider can be only
deleted when the org is deleted.
