### PR TITLE
Engine: UI: adding back the org aspect of a user's session

### DIFF
--- a/app/controllers/katello/user_sessions_controller.rb
+++ b/app/controllers/katello/user_sessions_controller.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  class UserSessionsController < Katello::ApplicationController
+    before_filter :require_user, :only => [:set_org]
+    skip_before_filter :require_org
+    protect_from_forgery
+
+    skip_before_filter :authorize # ok - need to skip all methods
+    skip_before_filter :check_deleted_org
+
+    def set_org
+      orgs = current_user.allowed_organizations
+      org = Organization.find_by_id(params[:org_id])
+      if org.nil? || !orgs.include?(org)
+        notify.error _("Invalid organization")
+        render :nothing => true
+        return
+      else
+        self.current_organization = org
+      end
+      if self.current_organization == org
+        respond_to do |format|
+          format.html { redirect_to dashboard_index_path }
+          format.js { render :js => "CUI.Login.Actions.redirecter('#{dashboard_index_url}')" }
+        end
+      end
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -503,7 +503,7 @@ Katello::Engine.routes.draw do
     end
   end
 
-  match 'about', :to => "application_info#about", :as => "about"
+  match '/user_session/set_org' => 'user_sessions#set_org', :via => :post
 
   match '/i18n/dictionary' => 'i18n#show', :via => :get
 


### PR DESCRIPTION
The code for the katello user's session was previously removed, since
the sessions (e.g. create/destroy) will be managed by the core app;
however, the session also included the ability to set the user's current
org.

Since orgs are currently handled differently between the core
app and the katello engine, this commit will add back the management
of the user's current katello org.  The goal in the future will be
to have a single org representation.
