### PR TITLE
Fixed a changeset migration issue

### DIFF
--- a/db/migrate/20130613090036_add_foreign_keys.rb
+++ b/db/migrate/20130613090036_add_foreign_keys.rb
@@ -24,6 +24,8 @@ class AddForeignKeys < ActiveRecord::Migration
     execute("delete from roles_users where role_id not in (select id from roles)")
     execute("delete from roles_users where user_id not in (select id from users)")
     execute("delete from changeset_content_views where content_view_id not in (select id from content_views)")
+    execute("delete from changeset_users where user_id not in (select id from users)")
+    execute("delete from changeset_users where changeset_id not in (select id from changesets)")
 
     add_foreign_key_deferred 'activation_keys', 'content_views',
                              :name => 'activation_keys_content_view_id_fk'


### PR DESCRIPTION
In 1.3 ChangesetUsers were not getting cleared in the following scenario
- Changeset was created
- Add content to the changeset
- Delete the changeset.
  The dependencies were not properly specified in the changeset model.
  The model has been hence been fixed.
  This commit clears the dirty data in ChangesetUsers table during migration
  before creating the new foreign key constraints.
