### PR TITLE
comps updates to add ceilometer_katello_dispatcher

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -126,4 +126,14 @@
        <packagereq type="optional">rubygem-rcov-doc</packagereq>
     </packagelist>
   </group>
+  <group>
+    <id>ceilometer-katello-dispatcher</id>
+    <name>Ceilometer Katello Dispatcher</name>
+    <description>RDO plugin to push events into Katello</description>
+    <uservisible>true</uservisible>
+    <packagelist>
+       <packagereq type="default">ceilometer_katello_dispatcher</packagereq>
+       <packagereq type="default">katello-cli</packagereq>
+    </packagelist>
+  </group>
 </comps>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -405,4 +405,14 @@
        <packagereq type="optional">ruby193-rubygem-thin-debuginfo</packagereq>
     </packagelist>
   </group>
+  <group>
+    <id>ceilometer-katello-dispatcher</id>
+    <name>Ceilometer Katello Dispatcher</name>
+    <description>RDO plugin to push events into Katello</description>
+    <uservisible>true</uservisible>
+    <packagelist>
+       <packagereq type="default">ceilometer_katello_dispatcher</packagereq>
+       <packagereq type="default">katello-cli</packagereq>
+    </packagelist>
+  </group>
 </comps>


### PR DESCRIPTION
This adds a new group for ceilometer_katello_dispatcher, the RDO katello plugin.

This will get installed on RDO instances to push data into Katello, not on the Katello machine itself.
