### PR TITLE
Fixed rspec controller tests

### DIFF
--- a/app/controllers/katello/api/v1/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v1/activation_keys_controller.rb
@@ -67,7 +67,6 @@ class Api::V1::ActivationKeysController < Api::V1::ApiController
   def index
     query_params[:organization_id] = @organization.id unless @organization.nil?
     query_params[:environment_id] = @environment.id unless @environment.nil?
-
     respond :collection => ActivationKey.where(query_params)
   end
 
@@ -155,7 +154,7 @@ class Api::V1::ActivationKeysController < Api::V1::ApiController
   end
 
   def find_pool
-    @pool = ::Pool.find_by_organization_and_id(@activation_key.organization, params[:poolid])
+    @pool = Katello::Pool.find_by_organization_and_id(@activation_key.organization, params[:poolid])
   end
 
   def find_system_groups

--- a/app/models/katello/custom_info.rb
+++ b/app/models/katello/custom_info.rb
@@ -38,7 +38,8 @@ class CustomInfo < ActiveRecord::Base
   # find the Katello object by type and ID (i.e. "system", 32)
   def self.find_informable(informable_type, informable_id)
     class_name = informable_type.classify
-    informable = "Katello::#{class_name}".constantize.find(informable_id)
+    class_name = "Katello::#{class_name}" unless class_name.start_with?("Katello::")
+    informable = class_name.constantize.find(informable_id)
     fail _("Resource %s does not support custom information") % class_name unless informable.respond_to? :custom_info
     return informable
   end

--- a/lib/katello/tasks/test.rake
+++ b/lib/katello/tasks/test.rake
@@ -4,10 +4,10 @@ namespace :test do
 
   desc "Run the Katello plugin test suite."
   task :katello => ['db:test:prepare'] do
-    # Set the test loader explicitly to ensure that the ci_reporter gem 
+    # Set the test loader explicitly to ensure that the ci_reporter gem
     # doesn't override our test runner
     ENV['TESTOPTS'] = "#{ENV['TESTOPTS']} #{Katello::Engine.root}/test/katello_test_runner.rb"
-    
+
     spec_task = Rake::TestTask.new('katello_spec_task') do |t|
       t.libs << ["test", "#{Katello::Engine.root}/test", "spec", "#{Katello::Engine.root}/spec"]
       t.test_files = [
@@ -16,6 +16,8 @@ namespace :test do
         "#{Katello::Engine.root}/spec/routing/**/*_spec.rb",
         "#{Katello::Engine.root}/spec/controllers/*.rb",
         "#{Katello::Engine.root}/spec/lib/**/*_spec.rb",
+        "#{Katello::Engine.root}/spec/controllers/*.rb",
+        "#{Katello::Engine.root}/spec/controllers/api/*.rb"
       ]
       t.verbose = true
     end

--- a/spec/controllers/api/v1/changesets_content_controller_spec.rb
+++ b/spec/controllers/api/v1/changesets_content_controller_spec.rb
@@ -10,22 +10,22 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-
+require 'katello_test_helper'
+module Katello
 #def self.it_should_require_admin_for_actions(*actions)
 #  actions.each do |action|
 #    it "#{action} action should require admin" do
 #      get action, :id => 1
 #      response.should redirect_to(login_url)
-#      flash[:error].should == "Unauthorized Access"
+#      flash[:error].must_equal "Unauthorized Access"
 #    end
 #  end
 #end
 
-describe Api::V1::ChangesetsContentController, :katello => true do
-  include LoginHelperMethods
+describe Api::V1::ChangesetsContentController do
   include AuthorizationHelperMethods
   include OrchestrationHelper
+  include OrganizationHelperMethods
 
   let(:changeset_id) { '1' }
 
@@ -36,16 +36,16 @@ describe Api::V1::ChangesetsContentController, :katello => true do
     @org = Organization.create!(:name=>'test_organization', :label=> 'test_organization')
     @library    = @org.library
     @environment    = create_environment(:name => 'environment', :label => 'environment', :prior => @library, :organization=>@org)
-    @library.stub(:successor).and_return(@environment)
+    @library.stubs(:successor).returns(@environment)
 
     @view = @environment.content_views.first
-    ContentView.stub(:find).and_return(@view)
+    ContentView.stubs(:find).returns(@view)
 
     @cs = PromotionChangeset.create!(:name => "changeset", :environment => @environment)
-    Changeset.stub(:find).and_return(@cs)
+    Changeset.stubs(:find).returns(@cs)
 
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
 
   let(:authorized_user) do
@@ -58,27 +58,28 @@ describe Api::V1::ChangesetsContentController, :katello => true do
     user_without_permissions
   end
 
-  describe "add_content_view" do
+  describe "add_content_view (katello)" do
     let(:action) { :add_content_view }
     let(:req) { post action, changeset_id: changeset_id, content_view_id: @view.id }
     it_should_behave_like "protected action"
 
     it "should add a content view" do
-      @cs.should_receive(:add_content_view!).with(@view).and_return(@view)
+      @cs.expects(:add_content_view!).with(@view).returns(@view)
       req
-      response.should be_success
+      must_respond_with(:success)
     end
   end
 
-  describe "remove_content_view" do
+  describe "remove_content_view (katello)" do
     let(:action) { :remove_content_view }
     let(:req) { post action, changeset_id: changeset_id, id: @view.id }
     it_should_behave_like "protected action"
 
     it "should remove a content view" do
-      @cs.should_receive(:remove_content_view!).with(@view).and_return(@view)
+      @cs.expects(:remove_content_view!).with(@view).returns(@view)
       req
-      response.should be_success
+      must_respond_with(:success)
     end
   end
+end
 end

--- a/spec/controllers/api/v1/content_view_definitions_controller_spec.rb
+++ b/spec/controllers/api/v1/content_view_definitions_controller_spec.rb
@@ -10,11 +10,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
-
-describe Api::V1::ContentViewDefinitionsController, :katello => true do
+require 'katello_test_helper'
+module Katello
+describe Api::V1::ContentViewDefinitionsController do
+  describe "(katello)" do
   include LoginHelperMethods
   include AuthorizationHelperMethods
+  include OrganizationHelperMethods
 
   before(:each) do
     disable_org_orchestration
@@ -24,7 +26,7 @@ describe Api::V1::ContentViewDefinitionsController, :katello => true do
     @organization = FactoryGirl.build_stubbed(:organization)
 
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
 
   describe "index" do
@@ -37,45 +39,45 @@ describe Api::V1::ContentViewDefinitionsController, :katello => true do
 
     context "with organization_id" do
       it "should assign the organiation's definitions" do
-        Organization.stub_chain(:without_deleting,
-                                :having_name_or_label, :first).and_return(@organization)
+        Organization.stubs(:without_deleting).returns(stub(:having_name_or_label =>
+                                                         stub(:first => @organization)))
         req = get action, :organization_id => @organization.name
-        req.should be_success
-        assigns[:definitions].map(&:id).should eql(@defs.map(&:id))
+              must_respond_with(:success)
+        assigns[:definitions].map(&:id).must_equal(@defs.map(&:id))
       end
     end
 
     context "with label" do
       it "should find the matching content view definition" do
-        Organization.stub_chain(:without_deleting,
-                                :having_name_or_label, :first).and_return(@organization)
+        Organization.stubs(:without_deleting).returns(stub(:having_name_or_label =>
+                                                         stub(:first => @organization)))
         get action, :organization_id => @organization.name,
             :label                   => @defs.last.label
-        assigns[:definitions].map(&:id).should eql([@defs.last.id])
+        assigns[:definitions].map(&:id).must_equal([@defs.last.id])
       end
     end
 
     context "with id" do
       it "should find the matching definition" do
         cvd = @defs.sample
-        Organization.stub_chain(:without_deleting,
-                                :having_name_or_label, :first).and_return(@organization)
+        Organization.stubs(:without_deleting).returns(stub(:having_name_or_label =>
+                                                         stub(:first => @organization)))
         get action, :organization_id => @organization.name,
             :id                      => cvd.id
-        assigns[:definitions].map(&:id).should eql([cvd.id])
+        assigns[:definitions].map(&:id).must_equal([cvd.id])
       end
     end
 
     context "with name" do
       it "should find the matching definitions" do
-        Organization.stub_chain(:without_deleting,
-                                :having_name_or_label, :first).and_return(@organization)
+        Organization.stubs(:without_deleting).returns(stub(:having_name_or_label =>
+                                                         stub(:first => @organization)))
         defs = FactoryGirl.create_list(:content_view_definition, 2,
                                        :organization => @organization)
         view = ContentViewDefinition.last
         get action, :organization_id => @organization.name, :name => view.name
-        assigns[:definitions].length.should eql(1)
-        assigns[:definitions].map(&:id).should eql([view.id])
+        assigns[:definitions].length.must_equal(1)
+        assigns[:definitions].map(&:id).must_equal([view.id])
       end
     end
   end
@@ -88,35 +90,35 @@ describe Api::V1::ContentViewDefinitionsController, :katello => true do
     let(:definition) { @organization.content_view_definitions.last }
 
     it "should create a content view" do
-      Organization.stub_chain(:without_deleting,
-                              :having_name_or_label, :first).and_return(@organization)
+      Organization.stubs(:without_deleting).returns(stub(:having_name_or_label =>
+                                                         stub(:first => @organization)))
       cv_count = ContentView.count
       req      = post :publish, :id    => definition.id,
                       :organization_id => @organization.id, :name => "TestView"
-      req.should be_success
-      ContentView.count.should eql(cv_count + 1)
+            must_respond_with(:success)
+      ContentView.count.must_equal(cv_count + 1)
     end
   end
 
   describe "create" do
     it "should create a composite definition if composite is supplied" do
-      Organization.stub_chain(:without_deleting,
-                              :having_name_or_label, :first).and_return(@organization)
+      Organization.stubs(:without_deleting).returns(stub(:having_name_or_label =>
+                                                         stub(:first => @organization)))
       post :create, content_view_definition: { name: "Test", composite: 1 },
            organization_id:                  @organization.id
-      response.should be_success
-      ContentViewDefinition.last.should be_composite
+      must_respond_with(:success)
+      ContentViewDefinition.last.must_be :composite?
     end
   end
 
   describe "destroy" do
     it "should delete the definition after checking it has no promoted views" do
       definition = FactoryGirl.build_stubbed(:content_view_definition)
-      ContentViewDefinition.stub(:find).with(definition.id.to_s).and_return(definition)
-      definition.should_receive(:destroy).and_return(true)
-      definition.should_receive(:has_promoted_views?).and_return(false)
+      ContentViewDefinition.stubs(:find).with(definition.id.to_s).returns(definition)
+      definition.expects(:destroy).returns(true)
+      definition.expects(:has_promoted_views?).returns(false)
       delete :destroy, :id => definition.id.to_s
-      response.should be_success
+      must_respond_with(:success)
     end
   end
 
@@ -129,7 +131,7 @@ describe Api::V1::ContentViewDefinitionsController, :katello => true do
       )
       put :update, :id             => content_view_definition.id, :organization_id => org1.id,
           :content_view_definition => { :organization_id => org2.id }
-      content_view_definition.reload.organization_id.should_not eql(org2.id)
+      content_view_definition.reload.organization_id.wont_equal(org2.id)
     end
   end
 
@@ -137,10 +139,12 @@ describe Api::V1::ContentViewDefinitionsController, :katello => true do
     it "should update the definition's components" do
       definition = FactoryGirl.create(:content_view_definition, :composite)
       views      = FactoryGirl.create_list(:content_view, 2)
-      ContentView.stub_chain(:readable, :where).and_return(views)
+      ContentView.stubs(:readable).returns(stub(:where => views))
       put :update_content_views, :id => definition.id, :views => views.map(&:id)
-      definition.component_content_views.reload.length.should eql(2)
+      definition.component_content_views.reload.length.must_equal(2)
     end
   end
 
+end
+end
 end

--- a/spec/controllers/api/v1/content_views_controller_spec.rb
+++ b/spec/controllers/api/v1/content_views_controller_spec.rb
@@ -10,11 +10,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
-
-describe Api::V1::ContentViewsController, :katello => true do
+require 'katello_test_helper'
+module Katello
+describe Api::V1::ContentViewsController do
+  describe "(katello)" do
   include LoginHelperMethods
   include AuthorizationHelperMethods
+  include OrganizationHelperMethods
 
   before(:each) do
     disable_org_orchestration
@@ -23,7 +25,7 @@ describe Api::V1::ContentViewsController, :katello => true do
 
     @org                        = FactoryGirl.create(:organization)
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
 
   describe "index" do
@@ -37,10 +39,9 @@ describe Api::V1::ContentViewsController, :katello => true do
       let(:org_view_ids) { @org.content_views.map(&:id) }
 
       subject { req }
-      it { should be_success }
+      it { req.must_respond_with(:success) }
 
-      specify { subject && assigns[:content_views].map(&:id).should
-      eql(org_view_ids) }
+      specify { subject && assigns[:content_views].map(&:id).must_equal(org_view_ids) }
     end
 
     context "with environment filter param" do
@@ -55,9 +56,9 @@ describe Api::V1::ContentViewsController, :katello => true do
         view_version.save!
 
         get "index", :organization_id => @org.name, :environment_id => env.id
-        response.should be_success
+        must_respond_with(:success)
         ids = env.content_views(true).map(&:id)
-        assigns[:content_views].map(&:id).sort.should eql(ids.sort)
+        assigns[:content_views].map(&:id).sort.must_equal(ids.sort)
       end
     end
 
@@ -69,8 +70,8 @@ describe Api::V1::ContentViewsController, :katello => true do
 
         subject { req }
 
-        it { should be_success }
-        specify { subject && (assigns[:content_views].map(&:id).should eql([view.id])) }
+        it { req.must_respond_with(:success) }
+        specify { subject && (assigns[:content_views].map(&:id).must_equal([view.id])) }
       end
 
     end
@@ -81,17 +82,19 @@ describe Api::V1::ContentViewsController, :katello => true do
       @def                          = FactoryGirl.build_stubbed(:content_view_definition)
       @view                         = FactoryGirl.build_stubbed(:content_view, :organization => @org)
       @view.content_view_definition = @def
-      ContentView.stub(:find).with(@view.id.to_s).and_return(@view)
+      ContentView.stubs(:find).with(@view.id.to_s).returns(@view)
     end
 
     it "should call ContentView#refresh" do
-      version = mock_model(ContentViewVersion)
-      @view.should_receive(:refresh_view).and_return(version)
-      version.should_receive(:task_status).and_return(TaskStatus.new)
-      @def.should_receive(:publishable?).and_return(true)
+      version = mock
+      @view.expects(:refresh_view).returns(version)
+      version.expects(:task_status).returns(TaskStatus.new)
+      @def.expects(:publishable?).returns(true)
       post "refresh", :id => @view.id.to_s
-      response.status.should eql(202)
+      response.status.must_equal(202)
     end
   end
 
+end
+end
 end

--- a/spec/controllers/api/v1/custom_info_controller_spec.rb
+++ b/spec/controllers/api/v1/custom_info_controller_spec.rb
@@ -10,28 +10,30 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-include OrchestrationHelper
-include SystemHelperMethods
-
+require 'katello_test_helper'
+module Katello
 describe Api::V1::CustomInfoController do
-  include LoginHelperMethods
+  include OrchestrationHelper
+  include SystemHelperMethods
+
   include LocaleHelperMethods
   include AuthorizationHelperMethods
+  include OrganizationHelperMethods
+
 
   let(:facts) { { "distribution.name" => "Fedora" } }
   let(:uuid) { '1234' }
 
   before (:each) do
-    login_user
-    set_default_locale
+    setup_controller_defaults_api
+
     disable_org_orchestration
     disable_consumer_group_orchestration
     disable_system_orchestration
 
-    Resources::Candlepin::Consumer.stub!(:create).and_return({ :uuid => uuid, :owner => { :key => uuid } })
+    Resources::Candlepin::Consumer.stubs(:create).returns({ :uuid => uuid, :owner => { :key => uuid } })
 
-    Katello.pulp_server.extensions.consumer.stub!(:create).and_return({ :id => uuid }) if Katello.config.katello?
+    Katello.pulp_server.extensions.consumer.stubs(:create).returns({ :id => uuid }) if Katello.config.katello?
 
     @org  = Organization.create!(:name => "test_org", :label => "test_org")
     @env1 = create_environment(:name => "test_env", :label => "test_env", :prior => @org.library.id, :organization => @org)
@@ -45,31 +47,31 @@ describe Api::V1::CustomInfoController do
   describe "create custom infoz" do
 
     it "should return 200 with successful create" do
-      System.find(@system.id).custom_info.size.should == 0
+      System.find(@system.id).custom_info.size.must_equal 0
       post :create, :informable_id => @system.id, :informable_type => "system", :keyname => "test_key", :value => "test_value"
-      response.code.should == "200"
-      System.find(@system.id).custom_info.size.should == 1
+      response.code.must_equal "200"
+      System.find(@system.id).custom_info.size.must_equal 1
     end
 
     it "should require valid informable type" do
-      System.find(@system.id).custom_info.empty?.should == true
+      System.find(@system.id).custom_info.empty?.must_equal true
       post :create, :informable_id => @system.id, :informable_type => "systemic", :keyname => "test_key", :value => "test_value"
-      response.code.should == "500"
-      System.find(@system.id).custom_info.empty?.should == true
+      response.code.must_equal "500"
+      System.find(@system.id).custom_info.empty?.must_equal true
     end
 
     it "should require valid system id" do
-      System.find(@system.id).custom_info.empty?.should == true
+      System.find(@system.id).custom_info.empty?.must_equal true
       post :create, :informable_id => (@system.id + 2), :informable_type => "system", :keyname => "test_key", :value => "test_value"
-      response.code.should == "404"
-      System.find(@system.id).custom_info.empty?.should == true
+      response.code.must_equal "404"
+      System.find(@system.id).custom_info.empty?.must_equal true
     end
 
     it "should require key + value pairs" do
-      System.find(@system.id).custom_info.empty?.should == true
+      System.find(@system.id).custom_info.empty?.must_equal true
       post :create, :informable_id => @system.id, :informable_type => "system"
-      response.code.should == "422"
-      System.find(@system.id).custom_info.empty?.should == true
+      response.code.must_equal "422"
+      System.find(@system.id).custom_info.empty?.must_equal true
     end
   end
 
@@ -83,17 +85,17 @@ describe Api::V1::CustomInfoController do
 
     it "should return 200 with successful index" do
       get :index, :informable_id => @system.id, :informable_type => "system"
-      response.code.should == "200"
+      response.code.must_equal "200"
     end
 
     it "should require valid informable type" do
       get :index, :informable_id => @system.id, :informable_type => "super duper"
-      response.code.should == "500"
+      response.code.must_equal "500"
     end
 
     it "should require valid informable id" do
       get :index, :informable_id => 9001, :informable_type => "system"
-      response.code.should == "404"
+      response.code.must_equal "404"
     end
   end
 
@@ -108,27 +110,27 @@ describe Api::V1::CustomInfoController do
 
     it "should return 200 with successful show" do
       get :show, :informable_id => @system.id, :informable_type => "system", :keyname => "test_key1"
-      response.code.should == "200"
+      response.code.must_equal "200"
     end
 
     it "should show custom info that has html in the keyname" do
       get :show, :informable_id => @system.id, :informable_type => "system", :keyname => "<blink>fookey</blink>"
-      response.code.should == "200"
+      response.code.must_equal "200"
     end
 
     it "should require valid  informable type" do
       get :show, :informable_id => @system.id, :informable_type => "orange juice", :keyname => "test_key2"
-      response.code.should == "500"
+      response.code.must_equal "500"
     end
 
     it "should require valid informable id" do
       get :show, :informable_id => -5, :informable_type => "system", :keyname => "test_key3"
-      response.code.should == "404"
+      response.code.must_equal "404"
     end
 
     it "should 404 if keyname is not found" do
       get :show, :informable_id => @system.id, :informable_type => "system", :keyname => "redhat"
-      response.code.should == "404"
+      response.code.must_equal "404"
     end
   end
 
@@ -142,44 +144,44 @@ describe Api::V1::CustomInfoController do
     end
 
     it "should return 200 with successful update" do
-      System.find(@system.id).custom_info.size.should == 4
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "super_test_value1").size.should == 0
+      System.find(@system.id).custom_info.size.must_equal 4
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.must_equal 1
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "super_test_value1").size.must_equal 0
       put :update, :informable_id => @system.id, :informable_type => "system", :keyname => "test_key1", :value => "super_test_value1"
-      response.code.should == "200"
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 0
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "super_test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 4
+      response.code.must_equal "200"
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.must_equal 0
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "super_test_value1").size.must_equal 1
+      System.find(@system.id).custom_info.size.must_equal 4
     end
 
     it "should return 200 with successful update on keyname with html characters" do
       put :update, :informable_id => @system.id, :informable_type => "system", :keyname => "<blink>fookey</blink>", :value => "<blink>superfoovalue</blink>"
-      response.code.should == "200"
+      response.code.must_equal "200"
     end
 
     it "should require valid informable type" do
-      System.find(@system.id).custom_info.size.should == 4
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
+      System.find(@system.id).custom_info.size.must_equal 4
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.must_equal 1
       put :update, :informable_id => @system.id, :informable_type => "telephone", :keyname => "test_key1", :value => "super_test_value1"
-      response.code.should == "500"
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 4
+      response.code.must_equal "500"
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.must_equal 1
+      System.find(@system.id).custom_info.size.must_equal 4
     end
 
     it "should require valid informable id" do
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 4
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.must_equal 1
+      System.find(@system.id).custom_info.size.must_equal 4
       put :update, :informable_id => (@system.id + 3), :informable_type => "system", :keyname => "test_key1", :value => "super_test_value1"
-      response.code.should == "404"
-      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.should == 1
-      System.find(@system.id).custom_info.size.should == 4
+      response.code.must_equal "404"
+      System.find(@system.id).custom_info.where(:keyname => "test_key1", :value => "test_value1").size.must_equal 1
+      System.find(@system.id).custom_info.size.must_equal 4
     end
 
     it "should respond with 404 if custom info cannot be found" do
-      System.find(@system.id).custom_info.size.should == 4
+      System.find(@system.id).custom_info.size.must_equal 4
       put :update, :informable_id => @system.id, :informable_type => "system", :keyname => "super_test_key1", :value => "chuck norris"
-      response.code.should == "404"
-      System.find(@system.id).custom_info.size.should == 4
+      response.code.must_equal "404"
+      System.find(@system.id).custom_info.size.must_equal 4
     end
   end
 
@@ -196,38 +198,39 @@ describe Api::V1::CustomInfoController do
     end
 
     it "should return 200 with success" do
-      @system.custom_info.size.should == 6
-      @system.custom_info.where(:keyname => "test_key1").size.should == 1
+      @system.custom_info.size.must_equal 6
+      @system.custom_info.where(:keyname => "test_key1").size.must_equal 1
       delete :destroy, :informable_id => @system.id, :informable_type => "system", :keyname => "test_key1"
-      response.code.should == "200"
-      @system.custom_info.where(:keyname => "test_key1").size.should == 0
-      @system.custom_info.size.should == 5
+      response.code.must_equal "200"
+      @system.custom_info.where(:keyname => "test_key1").size.must_equal 0
+      @system.custom_info.size.must_equal 5
     end
 
     it "should return 200 with success with html characters in the keyname" do
       delete :destroy, :informable_id => @system.id, :informable_type => "system", :keyname => "<blink>fookey</blink>"
-      response.code.should == "200"
+      response.code.must_equal "200"
     end
 
     it "should respond 404 if keyname cannot be found" do
-      @system.custom_info.size.should == 6
+      @system.custom_info.size.must_equal 6
       delete :destroy, :informable_id => @system.id, :informable_type => "system", :keyname => "super_test_key1"
-      response.code.should == "404"
-      @system.custom_info.size.should == 6
+      response.code.must_equal "404"
+      @system.custom_info.size.must_equal 6
     end
 
     it "should require valid informable type" do
-      @system.custom_info.size.should == 6
+      @system.custom_info.size.must_equal 6
       delete :destroy, :informable_id => @system.id, :informable_type => "super informed", :keyname => "test_key1"
-      response.code.should == "500"
-      @system.custom_info.size.should == 6
+      response.code.must_equal "500"
+      @system.custom_info.size.must_equal 6
     end
 
     it "should require valid informable id" do
-      @system.custom_info.size.should == 6
+      @system.custom_info.size.must_equal 6
       delete :destroy, :informable_id => (@system.id + 5), :informable_type => "system", :keyname => "test_key1"
-      response.code.should == "404"
-      @system.custom_info.size.should == 6
+      response.code.must_equal "404"
+      @system.custom_info.size.must_equal 6
     end
   end
+end
 end

--- a/spec/controllers/api/v1/distributions_controller_spec.rb
+++ b/spec/controllers/api/v1/distributions_controller_spec.rb
@@ -10,10 +10,11 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-
-describe Api::V1::DistributionsController, :katello => true do
-  include LoginHelperMethods
+require 'katello_test_helper'
+module Katello
+describe Api::V1::DistributionsController do
+  describe "(katello)" do
+  include OrganizationHelperMethods
   include AuthorizationHelperMethods
   include ProductHelperMethods
   include RepositoryHelperMethods
@@ -29,13 +30,13 @@ describe Api::V1::DistributionsController, :katello => true do
     @env          = @organization.library
     @product      = new_test_product(@organization, @env)
     @repo         = new_test_repo(@env, @product, "repo", "#{@organization.name}/Library/prod/repo")
-    @repo.stub(:has_distribution?).and_return(true)
-    Repository.stub(:find).and_return(@repo)
-    @repo.stub(:distributions).and_return([])
-    ::Distribution.stub(:find).and_return([])
+    @repo.stubs(:has_distribution?).returns(true)
+    Repository.stubs(:find).returns(@repo)
+    @repo.stubs(:distributions).returns([])
+    Katello::Distribution.stubs(:find).returns([])
 
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
   let(:authorized_user) do
     user_with_permissions do |u|
@@ -72,11 +73,12 @@ describe Api::V1::DistributionsController, :katello => true do
 
     describe "get a listing of distributions" do
       it "should call pulp find repo api" do
-        Repository.should_receive(:find).once.with(@repo.id.to_s).and_return(@repo)
-        @repo.should_receive(:distributions)
+        Repository.expects(:find).once.with(@repo.id.to_s).returns(@repo)
+        @repo.expects(:distributions)
         get 'index', :repository_id => @repo.id.to_s
       end
     end
   end
 end
-
+end
+end

--- a/spec/controllers/api/v1/errata_controller_spec.rb
+++ b/spec/controllers/api/v1/errata_controller_spec.rb
@@ -10,10 +10,11 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-
-describe Api::V1::ErrataController, :katello => true do
-  include LoginHelperMethods
+require 'katello_test_helper'
+module Katello
+describe Api::V1::ErrataController do
+  describe "(katello)" do
+  include OrganizationHelperMethods
   include AuthorizationHelperMethods
   include ProductHelperMethods
   include RepositoryHelperMethods
@@ -30,18 +31,18 @@ describe Api::V1::ErrataController, :katello => true do
     @product      = new_test_product(@organization, @env)
     @repo         = new_test_repo(@env, @product, "repo", "#{@organization.name}/Library/prod/repo")
 
-    @product.stub(:repos).and_return([@repository])
-    @repo.stub(:has_distribution?).and_return(true)
-    Repository.stub(:find).and_return(@repo)
+    @product.stubs(:repos).returns([@repository])
+    @repo.stubs(:has_distribution?).returns(true)
+    Repository.stubs(:find).returns(@repo)
 
-    KTEnvironment.stub(:find).and_return(@organization.library)
+    KTEnvironment.stubs(:find).returns(@organization.library)
     @erratum = {}
-    @erratum.stub(:repoids).and_return([@repo.pulp_id])
-    ::Errata.stub(:find_by_errata_id => @erratum)
-    ::Errata.stub(:filter => @erratum)
+    @erratum.stubs(:repoids).returns([@repo.pulp_id])
+    Katello::Errata.stubs(:find_by_errata_id => @erratum)
+    Katello::Errata.stubs(:filter => @erratum)
 
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
 
   let(:authorized_user) do
@@ -87,41 +88,41 @@ describe Api::V1::ErrataController, :katello => true do
 
     describe "get a listing of erratas" do
       before(:each) do
-        @repo = mock(Glue::Pulp::Repo)
+        @repo = mock
       end
 
       it "should call pulp find repo api" do
-        ::Errata.should_receive(:filter).once.with(:repoid => '1').and_return([])
+        Katello::Errata.expects(:filter).once.with(:repoid => '1').returns([])
         get 'index', :repoid => '1'
       end
 
       it "should accept type as filter attribute" do
-        ::Errata.should_receive(:filter).once.with(:repoid => '1', :type => 'security').and_return([])
+        Katello::Errata.expects(:filter).once.with(:repoid => '1', :type => 'security').returns([])
         get 'index', :repoid => '1', :type => 'security'
 
-        ::Errata.should_receive(:filter).once.with(:type => 'security', :environment_id => '123').and_return([])
+        Katello::Errata.expects(:filter).once.with(:type => 'security', :environment_id => '123').returns([])
         get 'index', :type => 'security', :environment_id => "123"
 
-        ::Errata.should_receive(:filter).once.with(:severity => 'critical', :environment_id => '123').and_return([])
+        Katello::Errata.expects(:filter).once.with(:severity => 'critical', :environment_id => '123').returns([])
         get 'index', :severity => 'critical', :environment_id => "123"
 
-        ::Errata.should_receive(:filter).once.with(:severity => 'critical', :product_id => 'product-123', :environment_id => '123').and_return([])
+        Katello::Errata.expects(:filter).once.with(:severity => 'critical', :product_id => 'product-123', :environment_id => '123').returns([])
         get 'index', :severity => 'critical', :product_id => 'product-123', :environment_id => "123"
       end
 
       it "should not accept a call without specifying envirovnemnt or repoid" do
         get 'index', :type => 'security'
-        response.response_code.should == 400
+        response.response_code.must_equal 400
       end
     end
 
     describe "show an erratum" do
       it "should call pulp find errata api" do
-        ::Errata.should_receive(:find_by_errata_id).once.with('1')
+        Katello::Errata.expects(:find_by_errata_id).once.with('1')
         get 'show', :id => '1', :repository_id => 1
       end
     end
   end
-
+  end
 end
-
+end

--- a/spec/controllers/api/v1/gpg_keys_controller_spec.rb
+++ b/spec/controllers/api/v1/gpg_keys_controller_spec.rb
@@ -9,38 +9,39 @@
 ## have received a copy of GPLv2 along with this software; if not, see
 ## http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
-
-describe Api::V1::GpgKeysController, :katello => true do
-  include LoginHelperMethods
+require 'katello_test_helper'
+module Katello
+describe Api::V1::GpgKeysController do
+  describe "(katello)" do
+  include OrganizationHelperMethods
   include AuthorizationHelperMethods
 
   let(:authorized_user) { user_with_permissions { |u| u.can(:gpg, :organizations, nil, @organization) } }
   let(:unauthorized_user) { user_without_permissions }
 
   before(:each) do
-    login_user_api
+    setup_controller_defaults_api
     @request.env["HTTP_ACCEPT"] = "application/json"
     disable_org_orchestration
 
     @organization = new_test_org
-    @test_gpg_content = File.open("#{Rails.root}/spec/assets/gpg_test_key").read
+    @test_gpg_content = File.open("#{Katello::Engine.root}/spec/assets/gpg_test_key").read
     @gpg_key      = GpgKey.create!(:name => "Another Test Key", :content => @test_gpg_content, :organization => @organization)
   end
 
   describe "GET content" do
     describe "with valid GPG Key id" do
 
-      it "should be successful" do
+      it "must_be successful" do
         get :content, :id => @gpg_key.id
-        response.body.should == @gpg_key.content
+        response.body.must_equal @gpg_key.content
       end
     end
 
     describe "with invalid GPG Key id" do
-      it "should be unsuccessful" do
+      it "must_be unsuccessful" do
         get :content, :id => 9999
-        response.response_code.should == 404
+        response.response_code.must_equal 404
       end
     end
   end
@@ -68,9 +69,12 @@ describe Api::V1::GpgKeysController, :katello => true do
       response.body == @gpg_key.to_json
     end
 
-    it "should include assigned repos and products" do
+    it "must_include assigned repos and products" do
       req
-      JSON.parse(response.body).should include("repositories" => [], "products" => [])
+      resp_json = JSON.parse(response.body)
+      resp_json.must_include("repositories", "products")
+      resp_json["products"].must_be_empty
+      resp_json["repositories"].must_be_empty
     end
   end
 
@@ -85,11 +89,11 @@ describe Api::V1::GpgKeysController, :katello => true do
 
       it "returns JSON with created key" do
         req
-        JSON.parse(response.body).slice(*%w[name content]).should == req_params[:gpg_key]
+        JSON.parse(response.body).slice(*%w[name content]).must_equal req_params[:gpg_key]
       end
     end
 
-    it_should_behave_like "bad request" do
+    describe "test invalid params" do
       let(:req) do
         bad_req = { :organization_id => @organization.name,
                     :gpg_key         =>
@@ -99,6 +103,7 @@ describe Api::V1::GpgKeysController, :katello => true do
         }.with_indifferent_access
         post :create, bad_req
       end
+      it_should_behave_like "bad request"
     end
   end
 
@@ -109,9 +114,9 @@ describe Api::V1::GpgKeysController, :katello => true do
     it_should_behave_like "protected action"
 
     it "returns JSON with updated key" do
-      GpgKey.stub(:find).with(@gpg_key.id.to_s).and_return(@gpg_key)
+      GpgKey.stubs(:find).with(@gpg_key.id.to_s).returns(@gpg_key)
       req
-      JSON.parse(response.body).slice(*%w[name content]).should == req_params[:gpg_key]
+      JSON.parse(response.body).slice(*%w[name content]).must_equal req_params[:gpg_key]
     end
   end
 
@@ -123,8 +128,9 @@ describe Api::V1::GpgKeysController, :katello => true do
 
     it "remove the record" do
       req
-      GpgKey.where(:id => @gpg_key.id).should be_empty
+      GpgKey.where(:id => @gpg_key.id).must_be_empty
     end
   end
 end
-
+end
+end

--- a/spec/controllers/api/v1/organization_default_info_controller_spec.rb
+++ b/spec/controllers/api/v1/organization_default_info_controller_spec.rb
@@ -10,28 +10,26 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-include OrchestrationHelper
-include SystemHelperMethods
+require 'katello_test_helper'
 
+module Katello
 describe Api::V1::OrganizationDefaultInfoController do
-  include LoginHelperMethods
-  include LocaleHelperMethods
+  include OrganizationHelperMethods
   include AuthorizationHelperMethods
-
+  include OrchestrationHelper
+  include SystemHelperMethods
   let(:facts) { { "distribution.name" => "Fedora" } }
   let(:uuid) { '1234' }
 
   before(:each) do
-    login_user
-    set_default_locale
+    setup_controller_defaults_api
     disable_org_orchestration
     disable_consumer_group_orchestration
     disable_system_orchestration
 
-    Resources::Candlepin::Consumer.stub!(:create).and_return({ :uuid => uuid, :owner => { :key => uuid } })
+    Resources::Candlepin::Consumer.stubs(:create).returns({ :uuid => uuid, :owner => { :key => uuid } })
 
-    Katello.pulp_server.extensions.consumer.stub!(:create).and_return({ :id => uuid }) if Katello.config.app_mode == "katello"
+    Katello.pulp_server.extensions.consumer.stubs(:create).returns({ :id => uuid }) if Katello.config.app_mode == "katello"
 
     @org  = Organization.create!(:name => "test_org", :label => "test_org")
     @env1 = create_environment(:name => "test_env", :label => "test_env", :prior => @org.library.id, :organization => @org)
@@ -42,50 +40,51 @@ describe Api::V1::OrganizationDefaultInfoController do
 
   describe "add default custom info to an org" do
 
-    it "should be successful" do
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+    it "must_be successful" do
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
       post :create, :organization_id => @org.label, :keyname => "test_key", :informable_type => "system"
-      response.code.should == "200"
-      Organization.find(@org.id).default_info["system"].include?("test_key").should == true
+      response.code.must_equal "200"
+      Organization.find(@org.id).default_info["system"].include?("test_key").must_equal true
     end
 
-    it "should be successful with html characters in the keyname" do
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+    it "must_be successful with html characters in the keyname" do
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
       post :create, :organization_id => @org.label, :keyname => "<blink>fookey</blink>", :informable_type => "system"
-      response.code.should == "200"
-      Organization.find(@org.id).default_info["system"].include?("<blink>fookey</blink>").should == true
+      response.code.must_equal "200"
+      Organization.find(@org.id).default_info["system"].include?("<blink>fookey</blink>").must_equal true
     end
 
     it "should fail without keyname" do
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
       post :create, :organization_id => @org.label, :informable_type => "system"
-      response.code.should == "422"
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+      response.code.must_equal "422"
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
     end
 
     it "should fail with wrong org id" do
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
       post :create, :organization_id => "blahblahblah", :keyname => "test_key", :informable_type => "system"
-      response.code.should == "404"
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+      response.code.must_equal "404"
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
     end
 
     it "should throw an error when you add default info that is already there" do
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
       post :create, :organization_id => @org.label, :keyname => "test_key", :informable_type => "system"
-      response.code.should == "200"
-      Organization.find(@org.id).default_info["system"].size.should == 1
+      response.code.must_equal "200"
+      Organization.find(@org.id).default_info["system"].size.must_equal 1
 
+      setup_controller_defaults_api
       post :create, :organization_id => @org.label, :keyname => "test_key", :informable_type => "system"
-      response.code.should == "400"
-      Organization.find(@org.id).default_info["system"].size.should == 1
+      response.code.must_equal "400"
+      Organization.find(@org.id).default_info["system"].size.must_equal 1
     end
 
     it "should fail if the type given is not an accepted type" do
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
       post :create, :organization_id => "blahblahblah", :keyname => "test_key", :informable_type => "nonstandardtype"
-      response.code.should == "404"
-      Organization.find(@org.id).default_info["system"].empty?.should == true
+      response.code.must_equal "404"
+      Organization.find(@org.id).default_info["system"].empty?.must_equal true
     end
 
   end
@@ -98,31 +97,31 @@ describe Api::V1::OrganizationDefaultInfoController do
       @org.save!
     end
 
-    it "should be successful" do
-      Organization.find(@org.id).default_info["system"].size.should == 2
+    it "must_be successful" do
+      Organization.find(@org.id).default_info["system"].size.must_equal 2
       post :destroy, :organization_id => @org.label, :keyname => "test_key", :informable_type => "system"
-      response.code.should == "200"
-      Organization.find(@org.id).default_info["system"].size.should == 1
+      response.code.must_equal "200"
+      Organization.find(@org.id).default_info["system"].size.must_equal 1
     end
 
-    it "should be successful with html characters in the keyname" do
-      Organization.find(@org.id).default_info["system"].size.should == 2
+    it "must_be successful with html characters in the keyname" do
+      Organization.find(@org.id).default_info["system"].size.must_equal 2
       post :destroy, :organization_id => @org.label, :keyname => "<blink>fookey</blink>", :informable_type => "system"
-      response.code.should == "200"
-      Organization.find(@org.id).default_info["system"].size.should == 1
+      response.code.must_equal "200"
+      Organization.find(@org.id).default_info["system"].size.must_equal 1
     end
 
     it "should fail with wrong org id" do
-      Organization.find(@org.id).default_info["system"].size.should == 2
+      Organization.find(@org.id).default_info["system"].size.must_equal 2
       post :destroy, :organization_id => "bad org label", :keyname => "test_key", :informable_type => "system"
-      response.code.should == "404"
-      Organization.find(@org.id).default_info["system"].size.should == 2
+      response.code.must_equal "404"
+      Organization.find(@org.id).default_info["system"].size.must_equal 2
     end
 
     it "should raise error with a bad keyname" do
-      Organization.find(@org.id).default_info["system"].include?("bad_keyname").should be_false
+      Organization.find(@org.id).default_info["system"].include?("bad_keyname").must_equal false
       post :destroy, :organization_id => @org.label, :keyname => "bad_keyname", :informable_type => "system"
-      response.code.should == "404"
+      response.code.must_equal "404"
     end
 
   end
@@ -135,34 +134,35 @@ describe Api::V1::OrganizationDefaultInfoController do
       end
     end
 
-    it "should be successful" do
+    it "must_be successful" do
       @org.systems.each do |s|
-        s.custom_info.empty?.should == true
+        s.custom_info.empty?.must_equal true
       end
       @org.default_info["system"] << "test_key"
       @org.save!
 
       get :apply_to_all, :organization_id => @org.label, :informable_type => "system", :async => false
-      response.code.should == "200"
-      JSON.parse(response.body)["informables"].should_not be_nil
-      JSON.parse(response.body)["task"].should be_nil
+      response.code.must_equal "200"
+      JSON.parse(response.body)["informables"].wont_be_nil
+      JSON.parse(response.body)["task"].must_be_nil
 
       @org.systems.each do |s|
-        s.custom_info.size.should == @org.default_info["system"].size
+        s.custom_info.size.must_equal @org.default_info["system"].size
       end
     end
 
     it "should kick off a task when running asynchronously" do
       @org.systems.each do |s|
-        s.custom_info.empty?.should == true
+        s.custom_info.empty?.must_equal true
       end
       @org.default_info["system"] << "test_key"
       @org.save!
 
       get :apply_to_all, :organization_id => @org.label, :informable_type => "system", :async => true
-      response.code.should == "200"
-      JSON.parse(response.body)["informables"].should be_empty
-      JSON.parse(response.body)["task"].should_not be_nil
+      response.code.must_equal "200"
+      JSON.parse(response.body)["informables"].must_be_empty
+      JSON.parse(response.body)["task"].wont_be_nil
     end
   end
+end
 end

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -10,10 +10,9 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
-
+require 'katello_test_helper'
+module Katello
 describe Api::V1::OrganizationsController do
-  include LoginHelperMethods
   include AuthorizationHelperMethods
   include OrganizationHelperMethods
 
@@ -30,9 +29,9 @@ describe Api::V1::OrganizationsController do
 
   before(:each) do
     @org = new_test_org
-    @controller.stub(:get_organization => @org)
+    @controller.stubs(:get_organization => @org)
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
 
   describe "create" do
@@ -47,7 +46,7 @@ describe Api::V1::OrganizationsController do
       it_should_behave_like "protected action"
 
       it 'should call katello create organization api' do
-        Organization.should_receive(:create!).once.with(:name => 'test org', :description => 'description', :label => 'test_org').and_return(@org)
+        Organization.expects(:create!).once.with(:name => 'test org', :description => 'description', :label => 'test_org').returns(@org)
         req
       end
     end
@@ -58,8 +57,8 @@ describe Api::V1::OrganizationsController do
       it_should_behave_like "protected action"
 
       it 'should call katello create organization api' do
-        Organization.should_receive(:create!).once.with(:name  => 'test org with spaces', :description => 'description',
-                                                        :label => 'test_org_with_spaces').and_return(@org)
+        Organization.expects(:create!).once.with(:name  => 'test org with spaces', :description => 'description',
+                                                        :label => 'test_org_with_spaces').returns(@org)
         req
       end
     end
@@ -70,8 +69,8 @@ describe Api::V1::OrganizationsController do
       it_should_behave_like "protected action"
 
       it 'should call katello create organization api' do
-        Organization.should_receive(:create!).once.with(:name  => 'test org', :description => 'description',
-                                                        :label => 'some_other_label').and_return(@org)
+        Organization.expects(:create!).once.with(:name  => 'test org', :description => 'description',
+                                                        :label => 'some_other_label').returns(@org)
         req
       end
     end
@@ -86,9 +85,9 @@ describe Api::V1::OrganizationsController do
     it_should_behave_like "protected action"
 
     it 'should find all readable orgs that are not being deleted' do
-      Organization.should_receive(:without_deleting).at_least(:once).and_return(Organization)
-      Organization.should_receive(:readable).at_least(:once).and_return(Organization)
-      Organization.should_receive(:where).once
+      Organization.expects(:without_deleting).at_least_once.returns(Organization)
+      Organization.expects(:readable).at_least_once.returns(Organization)
+      Organization.expects(:where).once
       req
     end
   end
@@ -102,7 +101,7 @@ describe Api::V1::OrganizationsController do
     it_should_behave_like "protected action"
 
     it 'should call katello organization find api' do
-      @controller.should_receive(:find_organization)
+      @controller.expects(:find_organization)
       req
     end
   end
@@ -116,12 +115,12 @@ describe Api::V1::OrganizationsController do
     it_should_behave_like "protected action"
 
     it 'should find org' do
-      @controller.should_receive(:find_organization)
+      @controller.expects(:find_organization)
       req
     end
 
     it 'should call organization destroyer' do
-      OrganizationDestroyer.should_receive(:destroy).with(@org).once
+      OrganizationDestroyer.expects(:destroy).with(@org).once
       req
     end
   end
@@ -134,7 +133,7 @@ describe Api::V1::OrganizationsController do
     it_should_behave_like "protected action"
 
     it "should call into Repo discovery" do
-      @org.should_receive(:discover_repos).and_return(TaskStatus.new)
+      @org.expects(:discover_repos).returns(TaskStatus.new)
       req
     end
   end
@@ -148,16 +147,16 @@ describe Api::V1::OrganizationsController do
     it_should_behave_like "protected action"
 
     it 'should find org' do
-      @controller.should_receive(:find_organization)
+      @controller.expects(:find_organization)
       req
     end
 
     it 'should call org update_attributes' do
-      @org.should_receive(:update_attributes!).once
+      @org.expects(:update_attributes!).once
       req
     end
 
-    it_should_behave_like "bad request" do
+    describe "invalid params" do
       let(:req) do
         bad_req = { :id           => 123,
                     :organization =>
@@ -167,6 +166,9 @@ describe Api::V1::OrganizationsController do
         }.with_indifferent_access
         put :update, bad_req
       end
+      it_should_behave_like "bad request"
+
     end
   end
+end
 end

--- a/spec/controllers/api/v1/packages_controller_spec.rb
+++ b/spec/controllers/api/v1/packages_controller_spec.rb
@@ -10,10 +10,11 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-
-describe Api::V1::PackagesController, :katello => true do
-  include LoginHelperMethods
+require 'katello_test_helper'
+module Katello
+describe Api::V1::PackagesController do
+  describe "(katello)" do
+  include OrganizationHelperMethods
   include AuthorizationHelperMethods
   include ProductHelperMethods
   include RepositoryHelperMethods
@@ -32,17 +33,17 @@ describe Api::V1::PackagesController, :katello => true do
     @product      = new_test_product(@organization, @env)
     @repo         = new_test_repo(@env, @product, "repo", "#{@organization.name}/Library/prod/repo")
 
-    @product.stub(:repos).and_return([@repository])
-    @repo.stub(:has_distribution?).and_return(true)
-    @repo.stub(:pulp_id).and_return(repo_id)
-    Repository.stub(:find).and_return(@repo)
+    @product.stubs(:repos).returns([@repository])
+    @repo.stubs(:has_distribution?).returns(true)
+    @repo.stubs(:pulp_id).returns(repo_id)
+    Repository.stubs(:find).returns(@repo)
 
-    @repo.stub(:packages).and_return([])
+    @repo.stubs(:packages).returns([])
     package = { 'repository_memberships' => [repo_id] }.with_indifferent_access
-    Katello.pulp_server.extensions.rpm.stub(:find_by_unit_id).and_return(package)
+    Katello.pulp_server.extensions.rpm.stubs(:find_by_unit_id).returns(package)
 
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
 
   let(:authorized_user) do
@@ -87,23 +88,25 @@ describe Api::V1::PackagesController, :katello => true do
     end
     describe "get a listing of packages" do
       it "should call pulp find packages api" do
-        Repository.should_receive(:find).with(repo_id)
+        Repository.expects(:find).with(repo_id)
         get 'index', :repository_id => repo_id
       end
     end
 
     describe "show a package" do
       it "should call pulp find package api" do
-        Katello.pulp_server.extensions.rpm.should_receive(:find_by_unit_id).once.with('1')
+        Katello.pulp_server.extensions.rpm.expects(:find_by_unit_id).once.with('1')
         get 'show', :id => '1', :repository_id => repo_id
       end
     end
 
     describe "search for a package" do
       it "should call glue layer" do
-        ::Package.should_receive(:search).once.with("cheetah*", 0, 0, [@repo.pulp_id])
+        Katello::Package.expects(:search).once.with("cheetah*", 0, 0, [@repo.pulp_id])
         get 'search', :repository_id => repo_id, :search => "cheetah*"
       end
     end
   end
+end
+end
 end

--- a/spec/controllers/api/v1/permissions_controller_spec.rb
+++ b/spec/controllers/api/v1/permissions_controller_spec.rb
@@ -10,11 +10,12 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-include OrchestrationHelper
-
+require 'katello_test_helper'
+module Katello
 describe Api::V1::PermissionsController do
-  include LoginHelperMethods
+  include OrchestrationHelper
+
+  include OrganizationHelperMethods
   include LocaleHelperMethods
   include AuthorizationHelperMethods
 
@@ -33,10 +34,10 @@ describe Api::V1::PermissionsController do
     @org  = Organization.create!(:name => 'test_org', :label => 'test_org')
     @role = Role.new(:name => "test_role", :description => "role description")
     @perm = Permission.new(:name => "permission_x", :description => "permission description", :role => @role)
-    Role.stub(:find).with(role_id).and_return(@role)
-    Permission.stub(:find).with(perm_id).and_return(@perm)
+    Role.stubs(:find).with(role_id).returns(@role)
+    Permission.stubs(:find).with(perm_id).returns(@perm)
 
-    login_user_api
+    setup_controller_defaults_api
   end
 
   describe "list permissions" do
@@ -47,12 +48,14 @@ describe Api::V1::PermissionsController do
     it_should_behave_like "protected action"
 
     it 'should find the role' do
-      Role.should_receive(:find).with(role_id.to_s)
+      Role.expects(:find).with(role_id.to_s)
       req
     end
 
     it 'should find all permissions associated with the role' do
-      @role.permissions.should_receive(:where).and_return([])
+      permissions = mock
+      permissions.expects(:where).returns([]).once
+      @role.expects(:permissions).at_least_once.returns(permissions)
       req
     end
   end
@@ -65,7 +68,7 @@ describe Api::V1::PermissionsController do
     it_should_behave_like "protected action"
 
     it 'should find the permission' do
-      Permission.should_receive(:find).with(perm_id)
+      Permission.expects(:find).with(perm_id)
       req
     end
   end
@@ -86,13 +89,13 @@ describe Api::V1::PermissionsController do
     it_should_behave_like "protected action"
 
     it 'should find the role' do
-      Role.should_receive(:find).with(role_id)
+      Role.expects(:find).with(role_id)
       req
     end
 
     it 'should create a permission' do
       @resource_type = ResourceType.new(:name => resource_type)
-      ResourceType.should_receive(:find_or_create_by_name).with(resource_type).and_return(@resource_type)
+      ResourceType.expects(:find_or_create_by_name).with(resource_type).returns(@resource_type)
 
       expected_params = {
           :name          => perm_name,
@@ -102,13 +105,13 @@ describe Api::V1::PermissionsController do
           :organization  => @org
       }
 
-      Permission.should_receive(:create!).with(hash_including(expected_params))
+      Permission.expects(:create!).with(has_entries(expected_params))
       req
     end
 
     it 'should create a permission for all tags' do
       @resource_type = ResourceType.new(:name => resource_type)
-      ResourceType.should_receive(:find_or_create_by_name).with(resource_type).and_return(@resource_type)
+      ResourceType.expects(:find_or_create_by_name).with(resource_type).returns(@resource_type)
 
       expected_params = {
           :name          => all_tags_perm_name,
@@ -120,18 +123,17 @@ describe Api::V1::PermissionsController do
           :all_verbs     => true
       }
 
-      Permission.should_receive(:create!).with(hash_including(expected_params))
+      Permission.expects(:create!).with(has_entries(expected_params))
       all_tags_req
     end
 
     describe "with invalid params" do
-      it_should_behave_like "bad request" do
-        let(:req) do
-          bad_req               = perm_params
-          perm_params[:bad_foo] = "bad"
-          post :create, bad_req
-        end
+      let(:req) do
+        bad_req               = perm_params
+        perm_params[:bad_foo] = "bad"
+        post :create, bad_req
       end
+      it_should_behave_like "bad request"
     end
   end
 
@@ -143,12 +145,12 @@ describe Api::V1::PermissionsController do
     it_should_behave_like "protected action"
 
     it 'should find the permission' do
-      Permission.should_receive(:find).with(perm_id)
+      Permission.expects(:find).with(perm_id)
       req
     end
 
     it 'should destroy the permission' do
-      @perm.should_receive(:destroy)
+      @perm.expects(:destroy)
       req
     end
 
@@ -156,3 +158,4 @@ describe Api::V1::PermissionsController do
 
 end
 
+end

--- a/spec/controllers/api/v1/products_controller_spec.rb
+++ b/spec/controllers/api/v1/products_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
+require 'katello_test_helper'
 
 describe Api::V1::ProductsController, :katello => true do
   include LoginHelperMethods
@@ -40,7 +40,7 @@ describe Api::V1::ProductsController, :katello => true do
     @product     = Product.new({ :name => "prod", :label => "prod" })
 
     @product.provider = @provider
-    @product.stub(:arch).and_return('noarch')
+    @product.stubs(:arch).returns('noarch')
     @product.save!
     @repo_library = new_test_repo(@organization.library, @product, "repo", "#{@organization.name}/Library/prod/repo")
 
@@ -51,20 +51,20 @@ describe Api::V1::ProductsController, :katello => true do
 
     @product = @products[0]
 
-    Product.stub!(:find_by_cp_id).and_return(@product)
-    Product.stub!(:find).and_return(@product)
+    Product.stubs(:find_by_cp_id).returns(@product)
+    Product.stubs(:find).returns(@product)
 
-    Product.stub!(:select).and_return(@products)
-    @product.stub(:repos).and_return(@repositories)
-    @product.stub(:sync_state => ::PulpSyncStatus::Status::NOT_SYNCED)
+    Product.stubs(:select).returns(@products)
+    @product.stubs(:repos).returns(@repositories)
+    @product.stubs(:sync_state => ::PulpSyncStatus::Status::NOT_SYNCED)
 
     @request.env["HTTP_ACCEPT"] = "application/json"
-    login_user_api
+    setup_controller_defaults_api
   end
 
   describe "show product" do
     before do
-      Katello.pulp_server.extensions.repository.stub(:retrieve).and_return(RepoTestData::REPO_PROPERTIES)
+      Katello.pulp_server.extensions.repository.stubs(:retrieve).returns(RepoTestData::REPO_PROPERTIES)
     end
 
     let(:action) { :show }
@@ -75,16 +75,16 @@ describe Api::V1::ProductsController, :katello => true do
 
     subject { req }
 
-    it { should be_success }
+    it { must_be_success }
   end
 
   describe "update product" do
     let(:gpg_key) { GpgKey.create!(:name => "Gpg key", :content => @test_gpg_content, :organization => @organization) }
 
     before do
-      Katello.pulp_server.extensions.repository.stub(:retrieve).and_return(RepoTestData::REPO_PROPERTIES)
-      Product.stub(:find_by_cp_id).with(@product.cp_id).and_return(@product)
-      @product.stub(:update_attributes! => true)
+      Katello.pulp_server.extensions.repository.stubs(:retrieve).returns(RepoTestData::REPO_PROPERTIES)
+      Product.stubs(:find_by_cp_id).with(@product.cp_id).returns(@product)
+      @product.stubs(:update_attributes! => true)
     end
 
     let(:action) { :update }
@@ -109,16 +109,16 @@ describe Api::V1::ProductsController, :katello => true do
     context "custom product" do
       subject { req }
 
-      it { should be_success }
+      it { must_be_success }
 
       it "should change allowed attributes" do
-        @product.should_receive(:gpg_key_name=)
-        @product.should_receive(:update_attributes!).with("description" => "another description")
+        @product.expects(:gpg_key_name=)
+        @product.expects(:update_attributes!).with("description" => "another description")
         req
       end
 
       it "should reset repos' GPGs, if updating recursive" do
-        @product.should_receive(:reset_repo_gpgs!)
+        @product.expects(:reset_repo_gpgs!)
         put 'update', :id => @product.cp_id, :organization_id => @organization.label, :product => { :gpg_key_name => gpg_key.name, :description => "another description", :recursive => true }
       end
     end
@@ -140,28 +140,28 @@ describe Api::V1::ProductsController, :katello => true do
   context "show all @products" do
     before do
       @dumb_prod = { :id => @product.id }
-      Product.stub!(:all_readable).and_return(@products)
-      @products.stub_chain(:select, :joins, :where, :all).and_return(@dumb_prod)
+      Product.stubs(:all_readable).returns(@products)
+      @products.stub_chain(:select, :joins, :where, :all).returns(@dumb_prod)
     end
 
     it "should find organization" do
-      @controller.should_receive(:find_optional_organization)
+      @controller.expects(:find_optional_organization)
       get 'index', :organization_id => @organization.label
     end
 
     it "should find library" do
       get 'index', :organization_id => @organization.label
-      response.should be_success
+      must_respond_with(:success)
     end
 
     it "should respond with success" do
       get 'index', :organization_id => @organization.label
-      response.should be_success
+      must_respond_with(:success)
     end
 
     it "should respond return product json" do
       get 'index', :organization_id => @organization.label
-      response.body.should == @dumb_prod.to_json
+      response.body.must_equal @dumb_prod.to_json
     end
   end
 
@@ -175,46 +175,46 @@ describe Api::V1::ProductsController, :katello => true do
     it_should_behave_like "protected action"
 
     it "should find environment" do
-      KTEnvironment.should_receive(:find_by_id).once.with(@environment.id.to_s).and_return([@environment])
+      KTEnvironment.expects(:find_by_id).once.with(@environment.id.to_s).returns([@environment])
       get 'repositories', :organization_id => @organization.label, :environment_id => @environment.id.to_s, :id => @product.id
     end
 
     it "should find product" do
-      Product.should_receive(:find_by_cp_id).once.with(@product.id.to_s, @organization).and_return(@products[0])
+      Product.expects(:find_by_cp_id).once.with(@product.id.to_s, @organization).returns(@products[0])
       get 'repositories', :organization_id => @organization.label, :environment_id => @environment.id, :id => @product.id
     end
 
     it "should retrieve all repositories for the product" do
-      @product.stub!(:readable?).and_return(true)
-      Product.stub!(:all_readable).and_return(@products)
-      @product.should_receive(:repos).once.with(@organization.library, nil, nil).and_return({})
+      @product.stubs(:readable?).returns(true)
+      Product.stubs(:all_readable).returns(@products)
+      @product.expects(:repos).once.with(@organization.library, nil, nil).returns({})
       get 'repositories', :organization_id => @organization.label, :id => @product.id
     end
 
     it "should return json of product repositories" do
-      Package.stub!(:search).and_return({})
-      PuppetModule.stub!(:search).and_return({})
-      Repository.any_instance.stub(:last_sync).and_return(nil)
+      Package.stubs(:search).returns({})
+      PuppetModule.stubs(:search).returns({})
+      Repository.any_instance.stubs(:last_sync).returns(nil)
 
-      @product.stub!(:readable?).and_return(true)
-      @repositories.stub!(:where).and_return(@repositories)
+      @product.stubs(:readable?).returns(true)
+      @repositories.stubs(:where).returns(@repositories)
       get 'repositories', :organization_id => @organization.label, :environment_id => @organization.library.id, :id => @product.id
-      response.body.should == @repositories.to_json
+      response.body.must_equal @repositories.to_json
     end
 
     it "should return 400 for a non-library environment with no content_view_id" do
-      @product.stub!(:readable?).and_return(true)
-      @repositories.stub!(:where).and_return(@repositories)
+      @product.stubs(:readable?).returns(true)
+      @repositories.stubs(:where).returns(@repositories)
       get 'repositories', :organization_id => @organization.label, :environment_id => @environment.id, :id => @product.id
-      response.status.should eql(400)
+      response.status.must_equal(400)
     end
 
     it "should call product repos with a content view" do
       @content_view = build_stubbed(:content_view)
-      @product.stub!(:readable?).and_return(true)
-      @repositories.stub!(:where).and_return(@repositories)
-      ContentView.stub_chain(:readable, :find).and_return(@content_view)
-      @product.should_receive(:repos).with(@environment, nil, @content_view)
+      @product.stubs(:readable?).returns(true)
+      @repositories.stubs(:where).returns(@repositories)
+      ContentView.stub_chain(:readable, :find).returns(@content_view)
+      @product.expects(:repos).with(@environment, nil, @content_view)
       get 'repositories', :organization_id => @organization.label,
         :environment_id => @environment.id, :id => @product.id,
         :content_view_id => @content_view.id

--- a/spec/controllers/api/v1/roles_controller_spec.rb
+++ b/spec/controllers/api/v1/roles_controller_spec.rb
@@ -10,13 +10,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-include OrchestrationHelper
-
+require 'katello_test_helper'
+module Katello
 describe Api::V1::RolesController do
-  include LoginHelperMethods
+  include OrganizationHelperMethods
   include LocaleHelperMethods
   include AuthorizationHelperMethods
+  include OrchestrationHelper
 
   let(:user_with_read_permissions) { user_with_permissions { |u| u.can(:read, :roles) } }
   let(:user_without_read_permissions) { user_without_permissions }
@@ -31,9 +31,9 @@ describe Api::V1::RolesController do
 
   before (:each) do
     @role= Role.new(:name => "test_role", :description => "role description")
-    Role.stub(:find).with(role_id.to_s).and_return(@role)
+    Role.stubs(:find).with(role_id.to_s).returns(@role)
 
-    login_user_api
+    setup_controller_defaults_api
   end
 
   describe "list roles" do
@@ -44,9 +44,9 @@ describe Api::V1::RolesController do
     it_should_behave_like "protected action"
 
     it 'should find all roles' do
-      Role.should_receive(:readable).and_return(Role)
-      Role.should_receive(:non_self).once.and_return(Role)
-      Role.should_receive(:where).once.and_return([@role])
+      Role.expects(:readable).returns(Role)
+      Role.expects(:non_self).once.returns(Role)
+      Role.expects(:where).once.returns([@role])
       req
     end
   end
@@ -59,7 +59,7 @@ describe Api::V1::RolesController do
     it_should_behave_like "protected action"
 
     it 'should find a role' do
-      Role.should_receive(:find).with(role_id.to_s)
+      Role.expects(:find).with(role_id.to_s)
       req
     end
   end
@@ -73,16 +73,15 @@ describe Api::V1::RolesController do
     it_should_behave_like "protected action"
 
     it 'should create a role' do
-      Role.should_receive(:create!).with(role_params)
+      Role.expects(:create!).with(role_params)
       req
     end
     describe "with invalid params" do
-      it_should_behave_like "bad request" do
-        let(:req) do
-          bad_req = { :role => { :bad_foo => "mwahaha" }.merge(role_params) }
-          post :create, bad_req
-        end
+      let(:req) do
+        bad_req = { :role => { :bad_foo => "mwahaha" }.merge(role_params) }
+        post :create, bad_req
       end
+      it_should_behave_like "bad request"
     end
   end
 
@@ -95,31 +94,31 @@ describe Api::V1::RolesController do
     it_should_behave_like "protected action"
 
     before :each do
-      @role.stub(:save!).and_return(true)
-      @role.stub(:update_attributes!).and_return(true)
+      @role.stubs(:save!).returns(true)
+      @role.stubs(:update_attributes!).returns(true)
     end
 
     it 'should find the role' do
-      Role.should_receive(:find).with(role_id.to_s)
+      Role.expects(:find).with(role_id.to_s)
       req
     end
 
     it 'should update role\'s params' do
-      @role.should_receive(:update_attributes!).with(role_params)
+      @role.expects(:update_attributes!).with(role_params)
       req
     end
 
     it 'should save the changes' do
-      @role.should_receive(:save!)
+      @role.expects(:save!)
       req
     end
     describe "with invalid params" do
-      it_should_behave_like "bad request" do
-        let(:req) do
-          bad_req = { :id => role_id, :role => { :bad_foo => "mwahaha" }.merge(role_params) }
-          put :update, bad_req
-        end
+      let(:req) do
+        bad_req = { :id => role_id, :role => { :bad_foo => "mwahaha" }.merge(role_params) }
+        put :update, bad_req
       end
+
+      it_should_behave_like "bad request"
     end
 
   end
@@ -132,12 +131,12 @@ describe Api::V1::RolesController do
     it_should_behave_like "protected action"
 
     it 'should find the role' do
-      Role.should_receive(:find).with(role_id)
+      Role.expects(:find).with(role_id)
       req
     end
 
     it 'should destroy the role' do
-      @role.should_receive(:destroy)
+      @role.expects(:destroy)
       req
     end
 
@@ -145,3 +144,4 @@ describe Api::V1::RolesController do
 
 end
 
+end

--- a/spec/controllers/api/v1/root_controller_spec.rb
+++ b/spec/controllers/api/v1/root_controller_spec.rb
@@ -10,13 +10,11 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
-
+require 'katello_test_helper'
+module Katello
 describe Api::V1::RootController do
-  include LoginHelperMethods
-
   before (:each) do
-    login_user
+    setup_controller_defaults_api
     @request.env["HTTP_ACCEPT"] = "application/json"
     @packages                   = { "rel" => "packages", "href" => "/api/packages/" }
     @systems                    = { "rel" => "systems", "href" => "/api/systems/" }
@@ -34,27 +32,27 @@ describe Api::V1::RootController do
 
   context "in headpin mode" do
     before (:each) do
-      Katello.config.stub!(:katello?).and_return(false)
+      Katello.config.stubs(:katello?).returns(false)
     end
     it "should not show katello apis" do
       resource_list
-      json(response).should include @systems
-      json(response).should_not include @packages
-      json(response).should_not include @tasks
-      json(response).should_not include @gpg_keys
+      json(response).must_include @systems
+      json(response).wont_include(@packages)
+      json(response).wont_include(@tasks)
+      json(response).wont_include(@gpg_keys)
     end
   end
 
   context "in katello mode" do
-
     before (:each) do
-      Katello.config.stub!(:katello?).and_return(true)
+      Katello.config.stubs(:katello?).returns(true)
     end
-    it "should show katello apis", :katello => true do #TODO headpin
+    it "should show katello apis (katello)" do #TODO headpin
       resource_list
-      json(response).should include @systems
-      json(response).should include @packages
+      json(response).must_include(@systems)
+      json(response).must_include(@packages)
     end
   end
 
+end
 end

--- a/spec/controllers/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/api/v1/subscriptions_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
+require 'katello_test_helper'
 include OrchestrationHelper
 
 describe Api::V1::SubscriptionsController do
@@ -32,16 +32,16 @@ describe Api::V1::SubscriptionsController do
     set_default_locale
     disable_org_orchestration
 
-    Resources::Candlepin::Consumer.stub!(:create).and_return({ :uuid => uuid, :owner => { :key => uuid } })
-    Resources::Candlepin::Consumer.stub!(:update).and_return(true)
+    Resources::Candlepin::Consumer.stubs(:create).returns({ :uuid => uuid, :owner => { :key => uuid } })
+    Resources::Candlepin::Consumer.stubs(:update).returns(true)
 
-    Katello.pulp_server.extensions.consumer.stub!(:create).and_return({ :id => uuid })
-    Katello.pulp_server.extensions.consumer.stub!(:update).and_return(true)
+    Katello.pulp_server.extensions.consumer.stubs(:create).returns({ :id => uuid })
+    Katello.pulp_server.extensions.consumer.stubs(:update).returns(true)
 
     @organization  = Organization.create!(:name => 'test_org', :label => 'test_org')
     @environment_1 = create_environment(:name => 'test_1', :label => 'test_1', :prior => @organization.library.id, :organization => @organization)
     @system        = create_system(:name => 'test', :environment => @environment_1, :cp_type => 'system', :facts => facts, :uuid => uuid)
-    System.stub!(:first).and_return(@system)
+    System.stubs(:first).returns(@system)
   end
 
   describe "create a subscription" do
@@ -53,29 +53,29 @@ describe Api::V1::SubscriptionsController do
 
     it "requires pool and quantity to be specified", :katello => true do #TODO headpin
       post :create, :system_id => @system.id
-      response.code.should == "400"
+      response.code.must_equal "400"
     end
 
     context "subscribes" do
       it "to one pool", :katello => true do #TODO headpin
-        Resources::Candlepin::Consumer.should_receive(:consume_entitlement).once.with(@system.uuid, "poolidXYZ", "1")
+        Resources::Candlepin::Consumer.expects(:consume_entitlement).once.with(@system.uuid, "poolidXYZ", "1")
         post :create, :system_id => @system.id, :pool => "poolidXYZ", :quantity => '1'
       end
     end
 
     context "unsubscribes" do
       it "from one pool", :katello => true do #TODO headpin
-        Resources::Candlepin::Consumer.should_receive(:remove_entitlement).once.with(@system.uuid, "poolidXYZ")
+        Resources::Candlepin::Consumer.expects(:remove_entitlement).once.with(@system.uuid, "poolidXYZ")
         post :destroy, :system_id => @system.id, :id => "poolidXYZ"
       end
 
       it "from one pool by serial", :katello => true do #TODO headpin
-        Resources::Candlepin::Consumer.should_receive(:remove_certificate).once.with(@system.uuid, "serialidXYZ")
+        Resources::Candlepin::Consumer.expects(:remove_certificate).once.with(@system.uuid, "serialidXYZ")
         post :destroy_by_serial, :system_id => @system.id, :serial_id => "serialidXYZ"
       end
 
       it "from all pools", :katello => true do #TODO headpin
-        Resources::Candlepin::Consumer.should_receive(:remove_entitlements).once.with(@system.uuid)
+        Resources::Candlepin::Consumer.expects(:remove_entitlements).once.with(@system.uuid)
         post :destroy_all, :system_id => @system.id
       end
     end
@@ -88,12 +88,12 @@ describe Api::V1::SubscriptionsController do
       it_should_behave_like "protected action"
 
       it "should find System", :katello => true do #TODO heapdin
-        System.should_receive(:first).once.with(hash_including(:conditions => { :uuid => @system.uuid })).and_return(@system)
+        System.expects(:first).once.with(has_entries(:conditions => { :uuid => @system.uuid })).returns(@system)
         get :index, :system_id => @system.uuid
       end
 
       it "should retrieve Consumer's errata from pulp", :katello => true do #TODO headpin
-        Resources::Candlepin::Consumer.should_receive(:entitlements).once.with(uuid).and_return([])
+        Resources::Candlepin::Consumer.expects(:entitlements).once.with(uuid).returns([])
         get :index, :system_id => @system.uuid
       end
     end

--- a/spec/controllers/api/v1/sync_controller_spec.rb
+++ b/spec/controllers/api/v1/sync_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
+require 'katello_test_helper'
 include OrchestrationHelper
 
 describe Api::V1::SyncController, :katello => true do
@@ -145,27 +145,27 @@ describe Api::V1::SyncController, :katello => true do
 
       it "should find provider if :provider_id is specified" do
         found_provider = {}
-        Provider.should_receive(:find).once.with(provider_id).and_return(found_provider)
-        controller.stub!(:params).and_return({ :provider_id => provider_id })
+        Provider.expects(:find).once.with(provider_id).returns(found_provider)
+        controller.stubs(:params).returns({ :provider_id => provider_id })
 
-        subject.should == found_provider
+        subject.must_equal found_provider
       end
 
       it "should find product if :product_id is specified" do
         stub_product_with_repo
-        controller.stub!(:params).and_return({ :organization_id => @organization.label, :product_id => @product.id })
+        controller.stubs(:params).returns({ :organization_id => @organization.label, :product_id => @product.id })
         controller.send(:find_optional_organization)
-        subject.should == @product
+        subject.must_equal @product
       end
 
       it "should find repository if :repository_id is specified" do
         found_repository = Repository.new
-        found_repository.stub!(:environment).and_return(KTEnvironment.new(:library => true))
+        found_repository.stubs(:environment).returns(KTEnvironment.new(:library => true))
 
-        Repository.should_receive(:find).once.with(repository_id).and_return(found_repository)
-        controller.stub!(:params).and_return({ :repository_id => repository_id })
+        Repository.expects(:find).once.with(repository_id).returns(found_repository)
+        controller.stubs(:params).returns({ :repository_id => repository_id })
 
-        subject.should == found_repository
+        subject.must_equal found_repository
       end
 
       it "should raise an error if none were specified" do
@@ -177,17 +177,17 @@ describe Api::V1::SyncController, :katello => true do
       before(:each) do
         stub_product_with_repo
 
-        Katello.pulp_server.extensions.repository.stub(:sync).with(@repository.pulp_id, anything()).and_return([async_task_1])
-        Katello.pulp_server.extensions.repository.stub(:sync).with(@repository2.pulp_id, anything()).and_return([async_task_2])
+        Katello.pulp_server.extensions.repository.stubs(:sync).with(@repository.pulp_id, anything()).returns([async_task_1])
+        Katello.pulp_server.extensions.repository.stubs(:sync).with(@repository2.pulp_id, anything()).returns([async_task_2])
       end
 
       it "should find provider" do
-        Provider.should_receive(:find).once.with(provider_id).and_return(@provider)
+        Provider.expects(:find).once.with(provider_id).returns(@provider)
         post :create, :provider_id => provider_id
       end
 
       it "should call sync on the object of synchronization" do
-        @provider.should_receive(:sync).once.and_return([async_task_1, async_task_2])
+        @provider.expects(:sync).once.returns([async_task_1, async_task_2])
         post :create, :provider_id => provider_id
       end
 
@@ -196,18 +196,18 @@ describe Api::V1::SyncController, :katello => true do
         post :create, :provider_id => provider_id
 
         found = PulpTaskStatus.all
-        found.size.should == count + 2
-        found.any? { |t| t['uuid'] == async_task_1['task_id'] }.should == true
-        found.any? { |t| t['uuid'] == async_task_2['task_id'] }.should == true
+        found.size.must_equal count + 2
+        found.any? { |t| t['uuid'] == async_task_1['task_id'] }.must_equal true
+        found.any? { |t| t['uuid'] == async_task_2['task_id'] }.must_equal true
       end
 
       it "should return sync objects" do
         post :create, :provider_id => provider_id
 
         status = JSON.parse(response.body)
-        status.size.should == 2
-        status.any? { |s| s['uuid'] == async_task_1['task_id'] }.should == true
-        status.any? { |s| s['uuid'] == async_task_2['task_id'] }.should == true
+        status.size.must_equal 2
+        status.any? { |s| s['uuid'] == async_task_1['task_id'] }.must_equal true
+        status.any? { |s| s['uuid'] == async_task_2['task_id'] }.must_equal true
       end
     end
 
@@ -216,27 +216,27 @@ describe Api::V1::SyncController, :katello => true do
         @organization = Organization.create!(:name => "organization", :label => "123")
 
         @syncable = mock('syncable')
-        @syncable.stub!(:id)
-        @syncable.stub!(:cance_sync)
-        @syncable.stub!(:organization).and_return(@organization)
-        @syncable.stub!(:sync)
+        @syncable.stubs(:id)
+        @syncable.stubs(:cance_sync)
+        @syncable.stubs(:organization).returns(@organization)
+        @syncable.stubs(:sync)
 
-        Provider.stub!(:find).and_return(@syncable)
+        Provider.stubs(:find).returns(@syncable)
       end
 
       it "should find provider" do
-        Provider.should_receive(:find).once.with(provider_id).and_return(@syncable)
+        Provider.expects(:find).once.with(provider_id).returns(@syncable)
         post :create, :provider_id => provider_id
       end
 
       it "should call cancel_sync on the object of synchronization" do
-        @syncable.stub(:sync_state).and_return(PulpSyncStatus::Status::RUNNING)
-        @syncable.should_receive(:cancel_sync)
+        @syncable.stubs(:sync_state).returns(PulpSyncStatus::Status::RUNNING)
+        @syncable.expects(:cancel_sync)
         delete :cancel, :provider_id => provider_id
       end
 
       it "should not call cancel_sync when the object is not being synchronized" do
-        @syncable.stub(:sync_state).and_return(PulpSyncStatus::Status::FINISHED)
+        @syncable.stubs(:sync_state).returns(PulpSyncStatus::Status::FINISHED)
         @syncable.should_not_receive(:cancel_sync)
         delete :cancel, :provider_id => provider_id
       end
@@ -248,20 +248,20 @@ describe Api::V1::SyncController, :katello => true do
         @organization = Organization.create!(:name => "organization", :label => "123")
 
         @syncable = mock()
-        @syncable.stub!(:latest_sync_statuses).once.and_return([async_task_1, async_task_2])
-        @syncable.stub!(:organization).and_return(@organization)
-        @syncable.stub!(:sync)
+        @syncable.stubs(:latest_sync_statuses).once.returns([async_task_1, async_task_2])
+        @syncable.stubs(:organization).returns(@organization)
+        @syncable.stubs(:sync)
 
-        Provider.stub!(:find).and_return(@syncable)
+        Provider.stubs(:find).returns(@syncable)
       end
 
       it "should find provider" do
-        Provider.should_receive(:find).once.with(provider_id).and_return(@syncable)
+        Provider.expects(:find).once.with(provider_id).returns(@syncable)
         post :create, :provider_id => provider_id
       end
 
       it "should call latest_sync_statuses on the object of synchronization" do
-        @syncable.should_receive(:sync_status)
+        @syncable.expects(:sync_status)
         get :index, :provider_id => provider_id
       end
     end
@@ -273,17 +273,17 @@ describe Api::V1::SyncController, :katello => true do
     @organization = new_test_org
 
     @provider = Provider.create!(:provider_type => Provider::CUSTOM, :name => "foo1", :organization => @organization)
-    Provider.stub!(:find).and_return(@provider)
+    Provider.stubs(:find).returns(@provider)
     @product          = Product.new({ :name => "prod", :label => "prod" })
     @product.provider = @provider
-    @product.stub(:arch).and_return('noarch')
+    @product.stubs(:arch).returns('noarch')
     @product.save!
-    Product.stub!(:find).and_return(@product)
-    Product.stub!(:find_by_cp_id).and_return(@product)
+    Product.stubs(:find).returns(@product)
+    Product.stubs(:find_by_cp_id).returns(@product)
     @repository  = new_test_repo(@organization.library, @product, "repo_1", "#{@organization.name}/Library/prod/repo")
     @repository2 = new_test_repo(@organization.library, @product, "repo_2", "#{@organization.name}/Library/prod/repo")
 
-    Repository.stub(:find).and_return(@repository)
+    Repository.stubs(:find).returns(@repository)
   end
 
 end

--- a/spec/controllers/api/v1/sync_plans_controller_spec.rb
+++ b/spec/controllers/api/v1/sync_plans_controller_spec.rb
@@ -10,14 +10,14 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper'
+require 'katello_test_helper'
 
 describe Api::V1::SyncPlansController do
   include LoginHelperMethods
   include AuthorizationHelperMethods
 
   before(:each) do
-    login_user_api
+    setup_controller_defaults_api
     @request.env["HTTP_ACCEPT"] = "application/json"
     disable_org_orchestration
 
@@ -46,11 +46,11 @@ describe Api::V1::SyncPlansController do
       end
     end
 
-    it "should be successful" do
+    it "must_be successful" do
       post :create, request_params
-      response.should be_success
-      SyncPlan.first.should_not be_nil
-      SyncPlan.first.name.should == request_params[:sync_plan][:name]
+      must_respond_with(:success)
+      SyncPlan.first.wont_be_nil
+      SyncPlan.first.name.must_equal request_params[:sync_plan][:name]
     end
   end
 
@@ -76,10 +76,10 @@ describe Api::V1::SyncPlansController do
       end
     end
 
-    it "should be successful" do
+    it "must_be successful" do
       put :update, request_params
-      response.should be_success
-      SyncPlan.first.name.should == request_params[:sync_plan][:name]
+      must_respond_with(:success)
+      SyncPlan.first.name.must_equal request_params[:sync_plan][:name]
     end
   end
 end

--- a/spec/controllers/api/v1/system_group_errata_controller_spec.rb
+++ b/spec/controllers/api/v1/system_group_errata_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
+require 'katello_test_helper'
 include OrchestrationHelper
 
 describe Api::V1::SystemGroupErrataController, :katello => true do
@@ -39,7 +39,7 @@ describe Api::V1::SystemGroupErrataController, :katello => true do
     @group = SystemGroup.new(:name => "test_group", :organization => @organization, :max_systems => 5)
     @group.save!
     @group.systems << @system
-    SystemGroup.stub!(:find).and_return(@group)
+    SystemGroup.stubs(:find).returns(@group)
   end
 
   describe "viewing errata" do
@@ -56,7 +56,7 @@ describe Api::V1::SystemGroupErrataController, :katello => true do
         errata.applicable_consumers = []
         to_ret << errata
       }
-      SystemGroup.any_instance.stub(:errata).and_return(to_ret)
+      SystemGroup.any_instance.stubs(:errata).returns(to_ret)
     end
 
     let(:action) { :index }
@@ -67,7 +67,7 @@ describe Api::V1::SystemGroupErrataController, :katello => true do
 
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should retrieve errata from pulp" do
       subject
@@ -76,7 +76,7 @@ describe Api::V1::SystemGroupErrataController, :katello => true do
 
   describe "install errata" do
     before do
-      @group.stub(:install_errata).and_return(TaskStatus.new)
+      @group.stubs(:install_errata).returns(TaskStatus.new)
     end
 
     let(:action) { :create }
@@ -87,10 +87,10 @@ describe Api::V1::SystemGroupErrataController, :katello => true do
 
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to install errata" do
-      @group.should_receive(:install_errata)
+      @group.expects(:install_errata)
       subject
     end
   end

--- a/spec/controllers/api/v1/system_group_packages_controller_spec.rb
+++ b/spec/controllers/api/v1/system_group_packages_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
+require 'katello_test_helper'
 include OrchestrationHelper
 
 describe Api::V1::SystemGroupPackagesController, :katello => true do
@@ -31,12 +31,12 @@ describe Api::V1::SystemGroupPackagesController, :katello => true do
 
     disable_consumer_group_orchestration
     @group = SystemGroup.create!(:name => "test_group", :organization => @organization, :max_systems => 5)
-    SystemGroup.stub!(:find).and_return(@group)
+    SystemGroup.stubs(:find).returns(@group)
   end
 
   describe "install package" do
     before do
-      @group.stub(:install_packages).and_return(TaskStatus.new())
+      @group.stubs(:install_packages).returns(TaskStatus.new())
     end
 
     let(:action) { :create }
@@ -47,10 +47,10 @@ describe Api::V1::SystemGroupPackagesController, :katello => true do
 
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to install packages" do
-      @group.should_receive(:install_packages)
+      @group.expects(:install_packages)
       subject
     end
 
@@ -58,22 +58,22 @@ describe Api::V1::SystemGroupPackagesController, :katello => true do
 
   describe "install package group" do
     before do
-      @group.stub(:install_package_groups).and_return(TaskStatus.new())
+      @group.stubs(:install_package_groups).returns(TaskStatus.new())
     end
 
     subject { post :create, :organization_id => @organization.name, :system_group_id => @group.id, :groups => package_groups }
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to install package groups" do
-      @group.should_receive(:install_package_groups)
+      @group.expects(:install_package_groups)
       subject
     end
   end
 
   describe "remove package" do
     before do
-      @group.stub(:uninstall_packages).and_return(TaskStatus.new())
+      @group.stubs(:uninstall_packages).returns(TaskStatus.new())
     end
 
     let(:action) { :destroy }
@@ -83,32 +83,32 @@ describe Api::V1::SystemGroupPackagesController, :katello => true do
     let(:unauthorized_user) { user_without_update_permissions }
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to remove packages" do
-      @group.should_receive(:uninstall_packages)
+      @group.expects(:uninstall_packages)
       subject
     end
   end
 
   describe "remove package group" do
     before do
-      @group.stub(:uninstall_package_groups).and_return(TaskStatus.new())
+      @group.stubs(:uninstall_package_groups).returns(TaskStatus.new())
     end
 
     subject { delete :destroy, :organization_id => @organization.name, :system_group_id => @group.id, :groups => package_groups }
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to remove package groups" do
-      @group.should_receive(:uninstall_package_groups)
+      @group.expects(:uninstall_package_groups)
       subject
     end
   end
 
   describe "update package" do
     before do
-      @group.stub(:update_packages).and_return(TaskStatus.new())
+      @group.stubs(:update_packages).returns(TaskStatus.new())
     end
 
     let(:action) { :create }
@@ -118,25 +118,25 @@ describe Api::V1::SystemGroupPackagesController, :katello => true do
     let(:unauthorized_user) { user_without_update_permissions }
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to update packages" do
-      @group.should_receive(:update_packages)
+      @group.expects(:update_packages)
       subject
     end
   end
 
   describe "update package groups" do
     before do
-      @group.stub(:install_package_groups).and_return(TaskStatus.new())
+      @group.stubs(:install_package_groups).returns(TaskStatus.new())
     end
 
     subject { put :update, :organization_id => @organization.name, :system_group_id => @group.id, :groups => package_groups }
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to update package groups" do
-      @group.should_receive(:install_package_groups)
+      @group.expects(:install_package_groups)
       subject
     end
   end

--- a/spec/controllers/api/v1/systems_packages_controller_spec.rb
+++ b/spec/controllers/api/v1/systems_packages_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
+require 'katello_test_helper'
 include OrchestrationHelper
 
 describe Api::V1::SystemPackagesController do
@@ -32,25 +32,25 @@ describe Api::V1::SystemPackagesController do
     set_default_locale
     disable_org_orchestration
     User.current = @user
-    Resources::Candlepin::Consumer.stub!(:create).and_return({ :uuid => uuid, :owner => { :key => uuid } })
-    Resources::Candlepin::Consumer.stub!(:update).and_return(true)
+    Resources::Candlepin::Consumer.stubs(:create).returns({ :uuid => uuid, :owner => { :key => uuid } })
+    Resources::Candlepin::Consumer.stubs(:update).returns(true)
 
     if Katello.config.katello?
-      Katello.pulp_server.extensions.consumer.stub!(:create).and_return({ :id => uuid })
-      Katello.pulp_server.extensions.consumer.stub!(:update).and_return(true)
+      Katello.pulp_server.extensions.consumer.stubs(:create).returns({ :id => uuid })
+      Katello.pulp_server.extensions.consumer.stubs(:update).returns(true)
     end
 
     @organization  = Organization.create!(:name => 'test_org', :label => 'test_org')
     @environment_1 = create_environment(:name => 'test_1', :label => 'test_1', :prior => @organization.library.id, :organization => @organization)
     @system        = create_system(:environment => @environment_1, :uuid => "1234", :name => "system.example.com", :cp_type => 'system', :facts => { :foo => :bar })
-    System.stub(:first => @system)
+    System.stubs(:first => @system)
   end
 
   describe "install package" do
 
     before do
       @task_status = stub_task_status(:package_install, :packages => packages)
-      @system.stub(:install_packages).and_return(@task_status)
+      @system.stubs(:install_packages).returns(@task_status)
     end
 
     let(:action) { :create }
@@ -60,10 +60,10 @@ describe Api::V1::SystemPackagesController do
     let(:unauthorized_user) { user_without_update_permissions }
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to install packages" do
-      @system.should_receive(:install_packages)
+      @system.expects(:install_packages)
       subject
     end
 
@@ -73,15 +73,15 @@ describe Api::V1::SystemPackagesController do
 
     before do
       @task_status = stub_task_status(:package_group_install, :groups => package_groups)
-      @system.stub(:install_package_groups).and_return(@task_status)
+      @system.stubs(:install_package_groups).returns(@task_status)
     end
 
     subject { post :create, :organization_id => @organization.name, :system_id => @system.uuid, :groups => package_groups }
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to install packages" do
-      @system.should_receive(:install_package_groups)
+      @system.expects(:install_package_groups)
       subject
     end
 
@@ -91,7 +91,7 @@ describe Api::V1::SystemPackagesController do
 
     before do
       @task_status = stub_task_status(:package_remove, :packages => packages)
-      @system.stub(:uninstall_packages).and_return(@task_status)
+      @system.stubs(:uninstall_packages).returns(@task_status)
     end
 
     let(:action) { :destroy }
@@ -101,10 +101,10 @@ describe Api::V1::SystemPackagesController do
     let(:unauthorized_user) { user_without_update_permissions }
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to remove packages" do
-      @system.should_receive(:uninstall_packages)
+      @system.expects(:uninstall_packages)
       subject
     end
 
@@ -114,15 +114,15 @@ describe Api::V1::SystemPackagesController do
 
     before do
       @task_status = stub_task_status(:package_group_remove, :groups => package_groups)
-      @system.stub(:uninstall_package_groups).and_return(@task_status)
+      @system.stubs(:uninstall_package_groups).returns(@task_status)
     end
 
     subject { delete :destroy, :organization_id => @organization.name, :system_id => @system.uuid, :groups => package_groups }
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to remove package groups" do
-      @system.should_receive(:uninstall_package_groups)
+      @system.expects(:uninstall_package_groups)
       subject
     end
 
@@ -132,7 +132,7 @@ describe Api::V1::SystemPackagesController do
 
     before do
       @task_status = stub_task_status(:package_update, :packages => packages)
-      @system.stub(:update_packages).and_return(@task_status)
+      @system.stubs(:update_packages).returns(@task_status)
     end
 
     let(:action) { :create }
@@ -142,10 +142,10 @@ describe Api::V1::SystemPackagesController do
     let(:unauthorized_user) { user_without_update_permissions }
     it_should_behave_like "protected action"
 
-    it { should be_successful }
+    it { must_be_successful }
 
     it "should call model to update packages" do
-      @system.should_receive(:update_packages)
+      @system.expects(:update_packages)
       subject
     end
 

--- a/spec/controllers/api/v1/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
+require 'katello_test_helper'
 
 describe Api::V1::TasksController do
   include LoginHelperMethods
@@ -19,24 +19,24 @@ describe Api::V1::TasksController do
   include OrganizationHelperMethods
 
   before(:each) do
-    login_user_api
+    setup_controller_defaults_api
 
     disable_product_orchestration
     disable_user_orchestration
 
     @organization = new_test_org
-    @controller.stub!(:get_organization).and_return(@organization)
+    @controller.stubs(:get_organization).returns(@organization)
     @provider = Provider.create!(:provider_type => Provider::CUSTOM, :name => "foo1", :organization => @organization)
-    Provider.stub!(:find).and_return(@provider)
+    Provider.stubs(:find).returns(@provider)
 
-    Organization.stub!(:find_by_label).and_return(@organization)
+    Organization.stubs(:find_by_label).returns(@organization)
 
     @task = mock(TaskStatus)
-    @task.stub(:organization).and_return(@organization)
-    @task.stub(:to_json).and_return({})
-    @task.stub(:refresh).and_return({})
-    @task.stub(:user).and_return({})
-    TaskStatus.stub!(:find_by_uuid!).and_return(@task)
+    @task.stubs(:organization).returns(@organization)
+    @task.stubs(:to_json).returns({})
+    @task.stubs(:refresh).returns({})
+    @task.stubs(:user).returns({})
+    TaskStatus.stubs(:find_by_uuid!).returns(@task)
   end
 
   context "get a listing of tasks" do
@@ -51,7 +51,7 @@ describe Api::V1::TasksController do
     it_should_behave_like "protected action"
 
     it "should retrieve all async tasks in the organization" do
-      Glue::ElasticSearch::Items.any_instance.should_receive(:retrieve).and_return([[@task], 1])
+      Glue::ElasticSearch::Items.any_instance.expects(:retrieve).returns([[@task], 1])
       req
     end
   end
@@ -68,12 +68,12 @@ describe Api::V1::TasksController do
     it_should_behave_like "protected action"
 
     it "should retrieve task specified by uuid" do
-      TaskStatus.should_receive(:find_by_uuid!).once.with('1').and_return(@t)
+      TaskStatus.expects(:find_by_uuid!).once.with('1').returns(@t)
       req
     end
 
     it "should refresh retrieved task" do
-      @task.should_receive(:refresh).once.and_return(@task)
+      @task.expects(:refresh).once.returns(@task)
       req
     end
   end

--- a/spec/controllers/api/v1/uebercerts_controller_spec.rb
+++ b/spec/controllers/api/v1/uebercerts_controller_spec.rb
@@ -10,7 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
+require 'katello_test_helper'
 
 describe Api::V1::UebercertsController do
   include LoginHelperMethods
@@ -20,7 +20,7 @@ describe Api::V1::UebercertsController do
   let(:org) { Organization.new(:label => OWNER_KEY) }
   before(:each) do
     login_user
-    @controller.stub(:get_organization).and_return(org)
+    @controller.stubs(:get_organization).returns(org)
   end
 
   describe "rules" do
@@ -41,17 +41,17 @@ describe Api::V1::UebercertsController do
 
   context "show" do
     before do
-      Resources::Candlepin::Owner.stub!(:get_ueber_cert).and_return({})
+      Resources::Candlepin::Owner.stubs(:get_ueber_cert).returns({})
       disable_authorization_rules
     end
 
     it "should find organization" do
-      @controller.should_receive(:find_organization)
+      @controller.expects(:find_organization)
       get :show, :organization_id => OWNER_KEY
     end
 
     it "should call Uebercert create api" do
-      org.should_receive(:debug_cert).once.and_return({})
+      org.expects(:debug_cert).once.returns({})
       get :show, :organization_id => OWNER_KEY
     end
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -10,13 +10,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'spec_helper.rb'
-include OrchestrationHelper
-
+require 'katello_test_helper'
+module Katello
 describe Api::V1::UsersController do
   include LoginHelperMethods
   include LocaleHelperMethods
   include AuthorizationHelperMethods
+  include OrchestrationHelper
 
   before do
     disable_user_orchestration
@@ -33,7 +33,7 @@ describe Api::V1::UsersController do
 
     before (:each) do
       @user = User.new(:login => "test_user", :password => "123")
-      User.stub(:find).with("123").and_return(@user)
+      User.stubs(:find).with("123").returns(@user)
     end
 
     describe "show users" do
@@ -79,7 +79,7 @@ describe Api::V1::UsersController do
 
   describe "create" do
     before do
-      login_user_api
+      setup_controller_defaults_api
       @request.env["HTTP_ACCEPT"] = "application/json"
     end
     let(:request_params) do
@@ -98,18 +98,18 @@ describe Api::V1::UsersController do
       end
     end
 
-    it "should be successful" do
+    it "must_be successful" do
       post :create, request_params
-      response.should be_success
-      User.last.should_not be_nil
-      User.last.login.should == request_params[:login]
-      User.last.disabled?.should == request_params[:disabled]
+      must_respond_with(:success)
+      User.last.wont_be_nil
+      User.last.login.must_equal request_params[:login]
+      User.last.disabled?.must_equal request_params[:disabled]
     end
   end
 
   describe "update" do
     before do
-      login_user_api
+      setup_controller_defaults_api
       @request.env["HTTP_ACCEPT"] = "application/json"
     end
 
@@ -132,15 +132,16 @@ describe Api::V1::UsersController do
       end
     end
 
-    it "should be successful" do
+    it "must_be successful" do
       old_pass = user.password
       put :update, request_params
-      response.should be_success
-      User.last.should_not be_nil
+      must_respond_with(:success)
+      User.last.wont_be_nil
       User.last.password.should_not == old_pass
-      User.last.disabled?.should == request_params[:user][:disabled]
+      User.last.disabled?.must_equal request_params[:user][:disabled]
     end
   end
 
 end
 
+end

--- a/spec/support/shared_examples/protected_action_shared_examples.rb
+++ b/spec/support/shared_examples/protected_action_shared_examples.rb
@@ -30,7 +30,7 @@ shared_examples_for "protected action" do
       before_success if defined?(before_success)
 
       if @controller.kind_of? Katello::Api::V1::ApiController
-        @controller.expects(:respond_for_exception).with { |e, options| options.try(:[], :status).must == :forbidden }
+        @controller.expects(:respond_for_exception).never.with { |e, options| options.try(:[], :status).must_equal(:forbidden) }
       else
         @controller.expects(:render_403).never
       end
@@ -47,6 +47,7 @@ shared_examples_for "protected action" do
       end
     end
   end
+
   describe "NOT ALLOWING me" do
     it "to it (katello)" do #TODO headpin
       if defined? unauthorized_user
@@ -58,7 +59,7 @@ shared_examples_for "protected action" do
         login_user_by_described_class(unauthorized_user) if defined?  unauthorized_user
         before_failure if defined?(before_failure)
         if @controller.kind_of? Katello::Api::V1::ApiController
-          @controller.expects(:respond_for_exception).with { |e, options| options.try(:[], :status).must == :forbidden }
+          @controller.expects(:respond_for_exception).with { |e, options| options.try(:[], :status).must_equal(:forbidden) }
         else
           @controller.expects(:render_403)
         end

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -5,7 +5,6 @@ require "mocha/setup"
 
 
 require "#{Katello::Engine.root}/test/support/minitest/spec/shared_examples"
-
 require "#{Katello::Engine.root}/spec/helpers/login_helper_methods"
 require "#{Katello::Engine.root}/spec/helpers/locale_helper_methods"
 require "#{Katello::Engine.root}/spec/helpers/authorization_helper_methods"
@@ -124,6 +123,28 @@ class ActionController::TestCase
   alias_method :login_user, :set_user
 end
 
+class ActionController::TestCase
+
+  def setup_controller_defaults
+    @routes = Katello::Engine.routes
+    set_user(User.current ? User.current : users(:admin))
+    set_default_locale
+  end
+
+  def set_user(user)
+    User.current = user
+    session[:user] = user.id
+    session[:expires_at] = 5.minutes.from_now
+  end
+
+  def setup_controller_defaults_api
+    @routes = Katello::Engine.routes
+    User.current = users(:admin) unless  User.current
+    @controller.stubs(:require_org).returns ({})
+  end
+
+end
+
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
   include FixtureTestCase
@@ -155,7 +176,7 @@ def disable_glue_layers(services=[], models=[], force_reload=false)
         load "#{Katello::Engine.root}/app/models/katello/#{model.underscore}.rb"
       rescue NameError
         Object.send(:remove_const, model)
-        load "#{Rails.root}/app/models/#{model.underscore}.rb"
+        load "#{Katello::Engine.root}/app/models/#{model.underscore}.rb"
       end
       if model == 'User'
         # Ugly hack to force the model to be loaded properly
@@ -173,5 +194,11 @@ def disable_glue_layers(services=[], models=[], force_reload=false)
   if change
     ActiveSupport::Dependencies::Reference.clear!
     FactoryGirl.reload
+  end
+end
+
+def hash_must_include(the_hash, items_to_check_hash)
+  items_to_check_hash.each_pair do |key, value|
+    the_hash[key].must_equal(value)
   end
 end


### PR DESCRIPTION
Fixed some rspec api controller tests to work with the enginification branch.
Following have been fixed so far
activation_keys_controller_spec.rb
changesets_content_controller_spec.rb
changesets_controller_spec.rb
content_views_controller_spec.rb
content_view_definitions_controller_spec.rb
custom_info_controller_spec.rb
distributions_controller_spec.rb
environments_controller_spec.rb

Yet to Fix:
errata_controller_spec.rb
gpg_keys_controller_spec.rb
organization_default_info_controller_spec.rb
organizations_controller_spec.rb
packages_controller_spec.rb
permissions_controller_spec.rb
ping_controller_spec.rb
products_controller_spec.rb
repositories_controller_spec.rb
roles_controller_spec.rb
root_controller_spec.rb
subscriptions_controller_spec.rb
sync_controller_spec.rb
sync_plans_controller_spec.rb
system_group_errata_controller_spec.rb
system_group_packages_controller_spec.rb
system_groups_controller_spec.rb
systems_controller_spec.rb
systems_packages_controller_spec.rb
tasks_controller_spec.rb
uebercerts_controller_spec.rb
users_controller_spec.rb
providers_controller_spec.rb
