### PR TITLE
Engine: API: changes to support subscription-manager interactions

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -16,19 +16,19 @@ class Api::V1::CandlepinProxiesController < Api::V1::ProxiesController
   # authorization rules are implemented in proxies_controller.rb
 
   def get
-    r = ::Resources::Candlepin::Proxy.get(@request_path)
+    r = Resources::Candlepin::Proxy.get(@request_path)
     logger.debug r
     render :json => r
   end
 
   def delete
-    r = ::Resources::Candlepin::Proxy.delete(@request_path)
+    r = Resources::Candlepin::Proxy.delete(@request_path)
     logger.debug r
     render :json => r
   end
 
   def post
-    r = ::Resources::Candlepin::Proxy.post(@request_path, @request_body)
+    r = Resources::Candlepin::Proxy.post(@request_path, @request_body)
     logger.debug r
     render :json => r
   end

--- a/app/controllers/katello/api/v1/content_views_controller.rb
+++ b/app/controllers/katello/api/v1/content_views_controller.rb
@@ -41,6 +41,7 @@ class Api::V1::ContentViewsController < Api::V1::ApiController
   param :name, String, :desc => "content view name", :required => false
   param :id, :identifier, :desc => "content view id", :required => false
   def index
+    query_params.delete(:content_view)
     query_params.delete(:environment_id)
     query_params.delete(:organization_id)
 

--- a/app/controllers/katello/api/v1/crls_controller.rb
+++ b/app/controllers/katello/api/v1/crls_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::CrlsController < Api::V1::ApiController
 
   api :GET, "/crls", "Regenerate X.509 CRL immediately and return them"
   def index
-    render :text => ::Resources::Candlepin::Proxy.get('/crl')
+    render :text => Resources::Candlepin::Proxy.get('/crl')
   end
 
 end

--- a/app/controllers/katello/api/v1/environments_controller.rb
+++ b/app/controllers/katello/api/v1/environments_controller.rb
@@ -80,8 +80,8 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
     {
         :create     => { :environment => %w(name label description prior) },
         :update     => { :environment => %w(name description prior) },
-        :index      => [:name, :library, :id, :organization_id],
-        :rhsm_index => [:name, :library, :id, :organization_id]
+        :index      => [:name, :library, :id, :organization_id, :environment],
+        :rhsm_index => [:name, :library, :id, :organization_id, :environment]
     }
   end
 
@@ -101,6 +101,7 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
   api :GET, "/organizations/:organization_id/environments", "List environments in an organization"
   param_group :search_params
   def index
+    query_params.delete(:environment)
     query_params[:organization_id] = @organization.id
     @environments                  = KTEnvironment.where query_params
 
@@ -219,13 +220,13 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
 
   def get_content_view_environments(name = nil)
     environments = ContentViewEnvironment.joins(:content_view => :organization).
-        where("organizations.id = ?", @organization.id)
-    environments = environments.where("content_view_environments.name = ?", name) if name
+        where("#{Katello::Organization.table_name}.id = ?", @organization.id)
+    environments = environments.where("#{Katello::ContentViewEnvironment.table_name}.name = ?", name) if name
 
     if environments.empty?
       environments = ContentViewEnvironment.joins(:content_view => :organization).
-          where("organizations.id = ?", @organization.id)
-      environments = environments.where("content_view_environments.label = ?", name) if name
+          where("#{Katello::Organization.table_name}.id = ?", @organization.id)
+      environments = environments.where("#{Katello::ContentViewEnvironment.table_name}.label = ?", name) if name
     end
 
     # remove any content view environments that aren't readable

--- a/app/controllers/katello/api/v1/proxies_controller.rb
+++ b/app/controllers/katello/api/v1/proxies_controller.rb
@@ -18,8 +18,9 @@ class Api::V1::ProxiesController < Api::V1::ApiController
   # TODO: break up method
   # rubocop:disable MethodLength
   def rules
+
     proxy_test = lambda do
-      route, _, params = Rails.application.routes.router.recognize(request) do |rte, match, parameters|
+      route, _, params = Engine.routes.router.recognize(request) do |rte, match, parameters|
         break rte, match, parameters if rte.name
       end
 

--- a/app/controllers/katello/api/v1/systems_controller.rb
+++ b/app/controllers/katello/api/v1/systems_controller.rb
@@ -29,7 +29,6 @@ class Api::V1::SystemsController < Api::V1::ApiController
   before_filter :find_content_view, :only => [:create, :update]
 
   before_filter :authorize, :except => [:activate, :upload_package_profile]
-  skip_before_filter :require_user, :only => [:activate, :upload_package_profile]
 
   def organization_id_keys
     [:organization_id, :owner]
@@ -100,9 +99,9 @@ class Api::V1::SystemsController < Api::V1::ApiController
   api :POST, "/environments/:environment_id/systems", "Register a system in environment"
   param_group :system
   def create
-    @system = System.create!(params.merge(:environment  => @environment,
-                                          :content_view => @content_view,
-                                          :serviceLevel => params[:service_level]))
+    @system = System.create!(system_params.merge(:environment  => @environment,
+                                                 :content_view => @content_view,
+                                                 :serviceLevel => params[:service_level]))
     respond_for_create
   end
 
@@ -132,7 +131,7 @@ DESC
     activation_keys = find_activation_keys
     ActiveRecord::Base.transaction do
       # create new system entry
-      @system = System.new(params.except(:activation_keys))
+      @system = System.new(system_params)
 
       # register system - we apply ak in reverse order so when they conflict e.g. in environment, the first wins.
       activation_keys.reverse_each { |ak| ak.apply_to_system(@system) }
@@ -297,16 +296,7 @@ A hint for choosing the right value for the releaseVer param
   api :PUT, "/consumers/:id/profile", "Update installed packages"
   param :id, String, :desc => "UUID of the system", :required => true
   def upload_package_profile
-    #BZ 1020550
-    # Subscription manager will not send the client cert and will exit with non-zero exit code
-    # if we return a 401, so manually try to auth, and return nothing if auth fails
-    allowed = false
-    catch(:warden) do
-      require_user
-      User.current = current_user
-      allowed = rules[:upload_package_profile].call
-    end
-
+    allowed = rules[:upload_package_profile].call
     if allowed && Katello.config.katello?
       fail HttpErrors::BadRequest, _("No package profile received for %s") % @system.name unless params.key?(:_json)
       @system.upload_package_profile(params[:_json])
@@ -638,6 +628,18 @@ This information is then used for computing the errata available for the system.
   # otherwise the index action doesn't have to know about the changes
   def refresh_index
     System.index.refresh if Katello.config.use_elasticsearch
+  end
+
+  def system_params
+    system_params = params.slice(:name, :owner, :facts, :installedProducts)
+
+    if params.key?(:cp_type)
+      system_params[:cp_type] = params[:cp_type]
+    elsif params.key?(:type)
+      system_params[:cp_type] = params[:type]
+    end
+
+    system_params
   end
 
 end

--- a/app/models/katello/authorization/system.rb
+++ b/app/models/katello/authorization/system.rb
@@ -65,17 +65,17 @@ module Authorization::System
 
   included do
     def readable?
-      sg_readable = !SystemGroup.systems_readable(self.organization).where(:id => self.system_group_ids).empty?
+      sg_readable = !Katello::SystemGroup.systems_readable(self.organization).where(:id => self.system_group_ids).empty?
       environment.systems_readable? || sg_readable
     end
 
     def editable?
-      sg_editable = !SystemGroup.systems_editable(self.organization).where(:id => self.system_group_ids).empty?
+      sg_editable = !Katello::SystemGroup.systems_editable(self.organization).where(:id => self.system_group_ids).empty?
       environment.systems_editable? || sg_editable
     end
 
     def deletable?
-      sg_deletable = !SystemGroup.systems_deletable(self.organization).where(:id => self.system_group_ids).empty?
+      sg_deletable = !Katello::SystemGroup.systems_deletable(self.organization).where(:id => self.system_group_ids).empty?
       environment.systems_deletable? || sg_deletable
     end
   end

--- a/app/models/katello/cp_consumer_user.rb
+++ b/app/models/katello/cp_consumer_user.rb
@@ -11,7 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Katello
-class CpConsumerUser < User
+class CpConsumerUser < ::User
 
   attr_accessor :uuid
 

--- a/app/models/katello/glue/candlepin/consumer.rb
+++ b/app/models/katello/glue/candlepin/consumer.rb
@@ -27,6 +27,8 @@ module Glue::Candlepin::Consumer
 
       as_json_hook :consumer_as_json
 
+      attr_accessible :cp_type, :owner, :serviceLevel, :installedProducts, :facts
+
       lazy_accessor :href, :facts, :cp_type, :href, :idCert, :owner, :lastCheckin, :created, :guestIds,
                     :installedProducts, :autoheal, :releaseVer, :serviceLevel, :capabilities, :entitlementStatus,
                     :initializer => (lambda do |s|

--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -26,6 +26,9 @@ class System < ActiveRecord::Base
   include Authorization::System
   include AsyncOrchestration
 
+  attr_accessible :name, :uuid, :description, :location, :environment, :content_view,
+                  :environment_id, :content_view_id
+
   after_rollback :rollback_on_create, :on => :create
 
   acts_as_reportable


### PR DESCRIPTION
This commit contains several changes to support various
subscription-manager actions from a client.

e.g.
- subscription-manager
  - register/unregister
  - subscribe/unsubscribe/list
  - environments
  - organizations

When interacting with the client, there are scenarios where
the client cert is needed to support interfacing with backend
engines.  As a result, 'require_user' has been extended to
utilize that certificate in a manner similar to what was
previously done by warden.rb (i.e. pre-engine).
