### PR TITLE
Engine: only create pulp_server if remote_id exists

### DIFF
--- a/app/lib/katello/util/thread_session.rb
+++ b/app/lib/katello/util/thread_session.rb
@@ -58,7 +58,7 @@ module Util
             end
             Thread.current[:user] = o
 
-            if Katello.config.use_pulp && o
+            if Katello.config.use_pulp && o && o.respond_to?(:remote_id)
               uri = URI.parse(Katello.config.pulp.url)
 
               Katello.pulp_server = Runcible::Instance.new(


### PR DESCRIPTION
The remote_id will almost always exist; however, this change
is to address a single scenario where we know that it will not.
When the katello engine is initially included in to the foreman
core and the user runs db:migrate, this logic will get hit;
however, it is prior to the migration that adds the remote_id.
