### PR TITLE
Bastion: ensure tables are properly scoped, fixes #3385.

### DIFF
--- a/engines/bastion/app/assets/bastion/products/discovery/discovery-form.controller.js
+++ b/engines/bastion/app/assets/bastion/products/discovery/discovery-form.controller.js
@@ -113,7 +113,7 @@ angular.module('Bastion.products').controller('DiscoveryFormController',
             $scope.createRepoChoices.newProduct = 'false';
             $scope.products.unshift(response);
             //add it to the main products table
-            $scope.table.addRow(response);
+            $scope.productTable.addRow(response);
             createNextRepo();
         }
 

--- a/engines/bastion/app/assets/bastion/products/discovery/views/discovery.html
+++ b/engines/bastion/app/assets/bastion/products/discovery/views/discovery.html
@@ -64,7 +64,9 @@
     </thead>
 
     <tbody>
-      <tr alch-table-row ng-repeat="urlRow in table.rows | filter:table.filterTerm" row-select="urlRow">
+      <tr alch-table-row
+          row-select="urlRow"
+          ng-repeat="urlRow in discoveryTable.rows | filter:discoveryTable.filterTerm">
         <td alch-table-cell>{{ urlRow.path }}</td>
       </tr>
     </tbody>

--- a/engines/bastion/app/assets/bastion/products/new/product-form.controller.js
+++ b/engines/bastion/app/assets/bastion/products/new/product-form.controller.js
@@ -73,7 +73,7 @@ angular.module('Bastion.products').controller('ProductFormController',
         }
 
         function success(response) {
-            $scope.table.addRow(response);
+            $scope.productTable.addRow(response);
             $scope.transitionTo('products.details.repositories.index', {productId: $scope.product.id});
         }
 

--- a/engines/bastion/app/assets/bastion/products/products.controller.js
+++ b/engines/bastion/app/assets/bastion/products/products.controller.js
@@ -41,11 +41,13 @@ angular.module('Bastion.products').controller('ProductsController',
         };
 
         var nutupane = new Nutupane(Product, params);
-        $scope.table = nutupane.table;
+        $scope.productTable = nutupane.table;
         $scope.removeRow = nutupane.removeRow;
 
-        $scope.table.closeItem = function() {
+        $scope.productTable.closeItem = function() {
             $scope.transitionTo('products.index');
         };
+
+        $scope.table = $scope.productTable;
     }]
 );

--- a/engines/bastion/app/assets/bastion/products/views/products-table-collapsed.html
+++ b/engines/bastion/app/assets/bastion/products/views/products-table-collapsed.html
@@ -1,4 +1,4 @@
-<table alch-table="table" class="table table-striped" ng-class="{'table-mask': table.working}">
+<table alch-table="table" class="table table-striped" ng-class="{'table-mask': productTable.working}">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column sortable>{{ "Name" | translate }}</th>
@@ -6,7 +6,7 @@
   </thead>
 
   <tbody>
-    <tr alch-table-row ng-repeat="product in table.rows" row-select="product">
+    <tr alch-table-row ng-repeat="product in productTable.rows" row-select="product">
       <td alch-table-cell>
         <a class="clickable" ui-sref="products.details.repositories.index({productId: product.id})">
           {{ product.name }}

--- a/engines/bastion/app/assets/bastion/products/views/products-table-full.html
+++ b/engines/bastion/app/assets/bastion/products/views/products-table-full.html
@@ -1,4 +1,4 @@
-<table alch-table="table" class="table table-striped" ng-class="{'table-mask': table.working}">
+<table alch-table="table" class="table table-striped" ng-class="{'table-mask': productTable.working}">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
@@ -9,7 +9,7 @@
   </thead>
 
   <tbody>
-    <tr alch-table-row ng-repeat="product in table.rows" row-select="product">
+    <tr alch-table-row ng-repeat="product in productTable.rows" row-select="product">
       <td alch-table-cell>
         <a class="clickable" ui-sref="products.details.repositories.index({productId: product.id})">
           {{ product.name }}

--- a/engines/bastion/app/assets/bastion/systems/content/views/system-errata.html
+++ b/engines/bastion/app/assets/bastion/systems/content/views/system-errata.html
@@ -31,8 +31,8 @@
 </div>
 
 <div alch-table="errataTable">
-  <div alch-container-scroll control-width="table" alch-infinite-scroll="table.nextPage()">
-    <table ng-class="{'table-mask': table.working}" class="table table-striped">
+  <div alch-container-scroll control-width="table" alch-infinite-scroll="errataTable.nextPage()">
+    <table ng-class="{'table-mask': errataTable.working}" class="table table-striped">
       <thead>
         <tr alch-table-head row-select>
           <th alch-table-column="type" translate>Type</th>
@@ -43,7 +43,7 @@
       </thead>
 
       <tbody>
-        <tr alch-table-row ng-repeat="erratum in table.rows | filter:table.errataCompare" row-select="erratum">
+        <tr alch-table-row ng-repeat="erratum in errataTable.rows | filter:errataTable.errataCompare" row-select="erratum">
           <td alch-table-cell >{{ erratum.type }}</td>
           <td alch-table-cell >
             <a ui-sref="systems.details.errata.details({errataId: erratum.errata_id})">

--- a/engines/bastion/app/assets/bastion/systems/content/views/system-packages.html
+++ b/engines/bastion/app/assets/bastion/systems/content/views/system-packages.html
@@ -35,30 +35,30 @@
   </div>
 
   <div alch-table="currentPackagesTable">
-    <div alch-container-scroll control-width="table" alch-infinite-scroll="table.nextPage()">
-      <table ng-class="{'table-mask': table.working}" class="table table-striped">
+    <div alch-container-scroll control-width="table" alch-infinite-scroll="currentPackagesTable.nextPage()">
+      <table ng-class="{'table-mask': currentPackagesTable.working}" class="table table-striped">
         <thead>
           <tr alch-table-head>
             <th alch-table-column="name" translate>Installed Package</th>
-            <th alch-table-column="remove" translate ng-hide="table.system.readonly">Remove</th>
+            <th alch-table-column="remove" translate ng-hide="currentPackagesTable.system.readonly">Remove</th>
           </tr>
         </thead>
 
         <tbody>
-          <tr alch-table-row ng-repeat="package in table.rows | filter:table.filter" >
+          <tr alch-table-row ng-repeat="package in currentPackagesTable.rows | filter:currentPackagesTable.filter" >
             <td alch-table-cell>{{ package.nvrea }}</td>
-            <td alch-table-cell ng-hide="table.system.readonly">
+            <td alch-table-cell ng-hide="currentPackagesTable.system.readonly">
 
                 <i class="clickable active icon-remove-sign" ng-hide="package.removeTask" title="{{ 'Remove' | translate }}"
-                   ng-click="table.removePackage(package)"></i>
+                   ng-click="currentPackagesTable.removePackage(package)"></i>
 
                 <i class="icon-spinner icon-spin" ng-show="package.removeTask.pending"></i>
                 <span ng-show="package.removeTask && !package.removeTask.pending">
 
-                  <i ng-show="table.taskFailed(package.removeTask)" class="icon-exclamation-sign" title="{{ 'Failed' | translate }}"></i>
-                  <i ng-hide="table.taskFailed(package.removeTask)" class="icon-check-sign" title="{{ 'Success' | translate }}"></i>
+                  <i ng-show="currentPackagesTable.taskFailed(package.removeTask)" class="icon-exclamation-sign" title="{{ 'Failed' | translate }}"></i>
+                  <i ng-hide="currentPackagesTable.taskFailed(package.removeTask)" class="icon-check-sign" title="{{ 'Success' | translate }}"></i>
 
-                  <a ng-click="table.openEventInfo(package.removeTask)" >
+                  <a ng-click="currentPackagesTable.openEventInfo(package.removeTask)" >
                     <span translate ng-show="package.removeTask.affected_units == 1">
                       {{ package.removeTask.affected_units }} package removed
                     </span>

--- a/engines/bastion/app/assets/bastion/systems/details/system-details.controller.js
+++ b/engines/bastion/app/assets/bastion/systems/details/system-details.controller.js
@@ -38,8 +38,8 @@ angular.module('Bastion.systems').controller('SystemDetailsController',
         }
 
         $scope.system = System.get({id: $scope.$stateParams.systemId}, function(system) {
-            $scope.$watch("table.rows.length > 0", function() {
-                $scope.table.replaceRow(system);
+            $scope.$watch("systemTable.rows.length > 0", function() {
+                $scope.systemTable.replaceRow(system);
             });
 
             $scope.$broadcast('system.loaded', system);

--- a/engines/bastion/app/assets/bastion/systems/details/views/system-events.html
+++ b/engines/bastion/app/assets/bastion/systems/details/views/system-events.html
@@ -13,8 +13,8 @@
 </div>
 
 <div alch-table="eventsTable">
-  <div alch-container-scroll control-width="table" alch-infinite-scroll="table.nextPage()">
-    <table ng-class="{'table-mask': table.working}" class="table table-striped">
+  <div alch-container-scroll control-width="table" alch-infinite-scroll="eventsTable.nextPage()">
+    <table ng-class="{'table-mask': eventsTable.working}" class="table table-striped">
       <thead>
       <tr alch-table-head>
         <th alch-table-column="Status" style="width: 10%" translate>Status</th>
@@ -25,7 +25,7 @@
       </thead>
 
       <tbody>
-        <tr alch-table-row ng-repeat="event in table.rows">
+        <tr alch-table-row ng-repeat="event in eventsTable.rows">
           <td alch-table-cell>
               <span title="{{ 'Running' | translate }}" class="table-icon icon-time" ng-show="event.pending"/>
               <span title="{{ 'Failed' | translate }}" class="table-icon icon-circle red" ng-show="event.failed" />

--- a/engines/bastion/app/assets/bastion/systems/details/views/system-info.html
+++ b/engines/bastion/app/assets/bastion/systems/details/views/system-info.html
@@ -76,7 +76,7 @@
       <div class="detail">
         <span class="info-label" translate>Subscription Status</span>
         <span class="info-value">
-          <i class="icon-circle" ng-class="table.getStatusColor(system.compliance.status)"></i>
+          <i class="icon-circle" ng-class="systemTable.getStatusColor(system.compliance.status)"></i>
           {{ system.compliance.status }}
         </span>
       </div>

--- a/engines/bastion/app/assets/bastion/systems/details/views/system-subscriptions.html
+++ b/engines/bastion/app/assets/bastion/systems/details/views/system-subscriptions.html
@@ -69,11 +69,11 @@
   </div>
 
   <div alch-table="currentSubscriptionsTable">
-    <p ng-show="table.rows.length == 0" translate>
+    <p ng-show="currentSubscriptionsTable.rows.length == 0" translate>
       This system does not have any current subscriptions
     </p>
-    <div ng-show="table.rows.length > 0">
-      <table ng-class="{'table-mask': table.working}" class="table table-striped">
+    <div ng-show="currentSubscriptionsTable.rows.length > 0">
+      <table ng-class="{'table-mask': currentSubscriptionsTable.working}" class="table table-striped">
         <thead>
           <tr alch-table-head row-select>
             <th alch-table-column="name" translate>Name</th>
@@ -86,7 +86,9 @@
         </thead>
 
         <tbody>
-          <tr alch-table-row ng-repeat="subscription in table.rows | filter:table.filter" row-select="subscription">
+          <tr alch-table-row
+              row-select="subscription"
+              ng-repeat="subscription in currentSubscriptionsTable.rows | filter:currentSubscriptionsTable.filter">
             <td alch-table-cell>{{ subscription.poolName }}</td>
             <td alch-table-cell>{{ subscription.sla }}</td>
             <td alch-table-cell>{{ subscription.contractNumber }}</td>
@@ -157,11 +159,11 @@
   </div>
 
   <div alch-table="availableSubscriptionsTable">
-    <p ng-show="table.rows.length == 0" translate>
+    <p ng-show="availableSubscriptionsTable.rows.length == 0" translate>
       There are no available subscriptions
     </p>
-    <div ng-show="table.rows.length > 0">
-      <table ng-class="{'table-mask': table.working}" class="table table-striped">
+    <div ng-show="availableSubscriptionsTable.rows.length > 0">
+      <table ng-class="{'table-mask': availableSubscriptionsTable.working}" class="table table-striped">
         <thead>
           <tr alch-table-head row-select>
             <th alch-table-column="name" translate>Name</th>
@@ -175,17 +177,17 @@
 
         <tbody>
           <tr alch-table-row row-select="subscription"
-              ng-repeat="subscription in table.rows | filter:table.formatAvailableDisplay | filter:table.filter">
+              ng-repeat="subscription in availableSubscriptionsTable.rows | filter:availableSubscriptionsTable.formatAvailableDisplay | filter:availableSubscriptionsTable.filter">
             <td alch-table-cell>{{ subscription.product_name }}</td>
             <td alch-table-cell>{{ subscription.support_level }}</td>
             <td alch-table-cell>{{ subscription.contract_number }}</td>
             <td alch-table-cell>
-              <span ng-show="table.showSelector(subscription)">
+              <span ng-show="availableSubscriptionsTable.showSelector(subscription)">
                 <select ng-show="subscription.selected" ng-model="subscription.amount"
-                        ng-options="value for value in table.range(1, subscription.available + 1)">
+                        ng-options="value for value in availableSubscriptionsTable.range(1, subscription.available + 1)">
                 </select>
               </span>
-              <span ng-hide="table.showSelector(subscription)">
+              <span ng-hide="availableSubscriptionsTable.showSelector(subscription)">
                 {{ subscription.availableDisplay }}
               </span>
             </td>

--- a/engines/bastion/app/assets/bastion/systems/systems-bulk-action.controller.js
+++ b/engines/bastion/app/assets/bastion/systems/systems-bulk-action.controller.js
@@ -76,7 +76,7 @@ angular.module('Bastion.systems').controller('SystemsBulkActionController',
 
             success = function(data) {
                 deferred.resolve(data);
-                angular.forEach($scope.table.getSelected(), function(row) {
+                angular.forEach($scope.systemTable.getSelected(), function(row) {
                     $scope.removeRow(row.id);
                 });
 
@@ -197,7 +197,7 @@ angular.module('Bastion.systems').controller('SystemsBulkActionController',
         };
 
         $scope.getSelectedSystemIds = function() {
-            var rows = $scope.table.getSelected();
+            var rows = $scope.systemTable.getSelected();
             return _.pluck(rows, 'id');
         };
 

--- a/engines/bastion/app/assets/bastion/systems/systems.controller.js
+++ b/engines/bastion/app/assets/bastion/systems/systems.controller.js
@@ -42,14 +42,16 @@ angular.module('Bastion.systems').controller('SystemsController',
         };
 
         var nutupane = new Nutupane(System, params);
-        $scope.table = nutupane.table;
+        $scope.systemTable = nutupane.table;
         $scope.removeRow = nutupane.removeRow;
 
-        $scope.table.getStatusColor = SystemsHelper.getStatusColor;
+        $scope.systemTable.getStatusColor = SystemsHelper.getStatusColor;
 
-        $scope.table.closeItem = function() {
+        $scope.systemTable.closeItem = function() {
             $scope.transitionTo('systems.index');
         };
+
+        $scope.table = $scope.systemTable;
 
         $scope.removeSystem = function (system) {
             system.$remove(function() {

--- a/engines/bastion/app/assets/bastion/systems/views/bulk-actions-list.html
+++ b/engines/bastion/app/assets/bastion/systems/views/bulk-actions-list.html
@@ -154,7 +154,7 @@
 
     <div class="inline-confirmation" ng-show="subscription.confirm">
       <div class="confirmation_text" translate>
-        Are you sure you want to auto-attach available subscriptions to all {{ table.resource.total }} systems?
+        Are you sure you want to auto-attach available subscriptions to all {{ systemTable.resource.total }} systems?
       </div>
       <button class="btn btn-primary" ng-click="performAutoAttachSubscriptions()" translate>Yes</button>
       <button class="btn btn-danger" ng-click="subscription.confirm = false" translate>No</button>

--- a/engines/bastion/app/assets/bastion/systems/views/bulk-actions.html
+++ b/engines/bastion/app/assets/bastion/systems/views/bulk-actions.html
@@ -22,8 +22,8 @@
       </button>
 
       <div alch-modal="performRemoveSystems()" model="table"
-           modal-header='Remove {{ table.getSelected().length }} Systems?'
-           modal-body='Are you sure you want to remove the {{ table.getSelected().length }} systems(s) selected?'></div>
+           modal-header='Remove {{ systemTable.getSelected().length }} Systems?'
+           modal-body='Are you sure you want to remove the {{ systemTable.getSelected().length }} systems(s) selected?'></div>
 
     </div>
   </header>

--- a/engines/bastion/app/assets/bastion/systems/views/systems-table-collapsed.html
+++ b/engines/bastion/app/assets/bastion/systems/views/systems-table-collapsed.html
@@ -1,4 +1,4 @@
-<table class="table table-striped" ng-class="{'table-mask': table.working}">
+<table class="table table-striped" ng-class="{'table-mask': systemTable.working}">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column sortable>{{ "Name" | translate }}</th>
@@ -6,7 +6,7 @@
   </thead>
 
   <tbody>
-    <tr alch-table-row ng-repeat="system in table.rows" row-select="system">
+    <tr alch-table-row ng-repeat="system in systemTable.rows" row-select="system">
       <td alch-table-cell>
         <a class="clickable" ui-sref="systems.details.info({systemId: system.uuid})">
           {{ system.name }}

--- a/engines/bastion/app/assets/bastion/systems/views/systems-table-full.html
+++ b/engines/bastion/app/assets/bastion/systems/views/systems-table-full.html
@@ -1,4 +1,4 @@
-<table class="table table-striped" ng-class="{'table-mask': table.working}">
+<table class="table table-striped" ng-class="{'table-mask': systemTable.working}">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
@@ -12,14 +12,14 @@
   </thead>
 
   <tbody>
-    <tr alch-table-row ng-repeat="system in table.rows" row-select="system">
+    <tr alch-table-row ng-repeat="system in systemTable.rows" row-select="system">
       <td alch-table-cell>
         <a class="clickable" ui-sref="systems.details.info({systemId: system.uuid})">
           {{ system.name }}
         </a>
       </td>
       <td alch-table-cell class="number-cell">
-        <span class="icon-circle" ng-class="table.getStatusColor(system.entitlementStatus)"></span>
+        <span class="icon-circle" ng-class="systemTable.getStatusColor(system.entitlementStatus)"></span>
       </td>
       <td alch-table-cell>{{ system.distribution }}</td>
       <td alch-table-cell>{{ system.environment.name }}</td>

--- a/engines/bastion/test/products/new/product-form.controller.test.js
+++ b/engines/bastion/test/products/new/product-form.controller.test.js
@@ -31,7 +31,7 @@ describe('Controller: ProductFormController', function() {
         FormUtils = $injector.get('FormUtils');
 
         $scope.productForm = $injector.get('MockForm');
-        $scope.table = {
+        $scope.productTable = {
             addRow: function() {},
             closeItem: function() {}
         };
@@ -54,13 +54,13 @@ describe('Controller: ProductFormController', function() {
     it('should save a new product resource', function() {
         var product = $scope.product;
 
-        spyOn($scope.table, 'addRow');
+        spyOn($scope.productTable, 'addRow');
         spyOn($scope, 'transitionTo');
         spyOn(product, '$save').andCallThrough();
         $scope.save(product);
 
         expect(product.$save).toHaveBeenCalled();
-        expect($scope.table.addRow).toHaveBeenCalled();
+        expect($scope.productTable.addRow).toHaveBeenCalled();
         expect($scope.transitionTo).toHaveBeenCalledWith('products.details.repositories.index',
                                                          {productId: $scope.product.id})
     });

--- a/engines/bastion/test/products/products.controller.test.js
+++ b/engines/bastion/test/products/products.controller.test.js
@@ -41,12 +41,12 @@ describe('Controller: ProductsController', function() {
     }));
 
     it('attaches the nutupane table to the scope', function() {
-        expect($scope.table).toBeDefined();
+        expect($scope.productTable).toBeDefined();
     });
 
     it('sets the closeItem function to transition to the index page', function() {
         spyOn($scope, "transitionTo");
-        $scope.table.closeItem();
+        $scope.productTable.closeItem();
 
         expect($scope.transitionTo).toHaveBeenCalledWith('products.index');
     });

--- a/engines/bastion/test/systems/systems-bulk-action.controller.test.js
+++ b/engines/bastion/test/systems/systems-bulk-action.controller.test.js
@@ -41,7 +41,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
     beforeEach(inject(function($controller, $rootScope, $q) {
         $scope = $rootScope.$new();
-        $scope.table = {
+        $scope.systemTable = {
             getSelected: function() {return [
                 {id: 1},
                 {id: 2},
@@ -63,7 +63,7 @@ describe('Controller: SystemsBulkActionController', function() {
         $scope.performRemoveSystems();
 
         expect(BulkAction.removeSystems).toHaveBeenCalledWith(
-            {ids: _.pluck($scope.table.getSelected(), 'id')},
+            {ids: _.pluck($scope.systemTable.getSelected(), 'id')},
             jasmine.any(Function), jasmine.any(Function)
         );
     });
@@ -86,7 +86,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.addSystemGroups).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 system_group_ids: _.pluck($scope.systemGroups.groups, 'id')
             },
             jasmine.any(Function), jasmine.any(Function)
@@ -104,7 +104,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.removeSystemGroups).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 system_group_ids: _.pluck($scope.systemGroups.groups, 'id')
             },
             jasmine.any(Function), jasmine.any(Function)
@@ -123,7 +123,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.installContent).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 content_type: $scope.content.contentType,
                 content: $scope.content.content.split(/ *, */)
             },
@@ -143,7 +143,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.updateContent).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 content_type: $scope.content.contentType,
                 content: $scope.content.content.split(/ *, */)
             },
@@ -163,7 +163,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.removeContent).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 content_type: $scope.content.contentType,
                 content: $scope.content.content.split(/ *, */)
             },
@@ -183,7 +183,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.installContent).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 content_type: $scope.content.contentType,
                 content: $scope.content.content.split(/ *, */)
             },
@@ -203,7 +203,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.updateContent).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 content_type: $scope.content.contentType,
                 content: $scope.content.content.split(/ *, */)
             },
@@ -223,7 +223,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.removeContent).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 content_type: $scope.content.contentType,
                 content: $scope.content.content.split(/ *, */)
             },
@@ -243,7 +243,7 @@ describe('Controller: SystemsBulkActionController', function() {
 
         expect(BulkAction.installContent).toHaveBeenCalledWith(
             {
-                ids: _.pluck($scope.table.getSelected(), 'id'),
+                ids: _.pluck($scope.systemTable.getSelected(), 'id'),
                 content_type: $scope.content.contentType,
                 content: $scope.content.content.split(/ *, */)
             },

--- a/engines/bastion/test/systems/systems.controller.test.js
+++ b/engines/bastion/test/systems/systems.controller.test.js
@@ -52,7 +52,7 @@ describe('Controller: SystemsController', function() {
 
     it("provides a way to close the details panel.", function() {
         spyOn($scope, "transitionTo");
-        $scope.table.closeItem();
+        $scope.systemTable.closeItem();
         expect($scope.transitionTo).toHaveBeenCalledWith('systems.index');
     });
 


### PR DESCRIPTION
We were relying on a bug in AngularJS, From the [changelog](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#breaking-changes):

> due to d0efd5ee, Child elements that are defined either in the application template or in some other directives template >do not get the isolate scope. In theory, nobody should rely on this behavior, as it is very rare - in most cases the >isolate directive has a template.
