### PR TITLE
we have so many branches under Katello/Katello

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ What's included in this repository:
  * script - various development scripts
  * actual Rails app of Katello
 
+| Branch          | Details                      |
+| --------------  | ---------------------------- |
+| **engine**      | current development branch   |
+| **KATELLO-X.X** | released versions of Katello |
+| **master**      | really old, don't use        |
+
 ## Contact & Resources
 
  * [Katello.org](http://katello.org)


### PR DESCRIPTION
we should probably have some small notes to others about what is what.
There are too many branches in the upstream repo. we should trim down
what's there.

I also set Katello/katello's default repo to 'engine' so that's what
shows up with you go to http://github.com/Katello/katello
