### PR TITLE
Add subscription totals portlet to the dashboard

### DIFF
--- a/app/assets/stylesheets/katello/dashboard.scss
+++ b/app/assets/stylesheets/katello/dashboard.scss
@@ -122,6 +122,46 @@ $col_width: (($static_width) * 0.5);
       }
     }
 
+    #dashboard_subscriptions_totals {
+      ul {
+        margin-left: 2px;
+      }
+      li {
+        float: left;
+        width: 146px;
+        height: 70px;
+        padding: 10px;
+        margin: 0;
+      }
+      li span {
+        display: inline-block;
+        vertical-align: top;
+        line-height: 1.2em;
+        font-size: .95em;
+      }
+      li.center-col {
+        @include border-radius(0);
+        border-left: 1px solid #d8d8d8;
+        border-right: 1px solid #d8d8d8;
+      }
+      li.right-col {
+        padding-right: 0;
+      }
+      li.left-col {
+        padding-left: 0;
+      }
+      h4 {
+        display: inline;
+        margin-left: 0px;
+        font-size: 110%;
+        font-weight: normal;
+      }
+      h5 {
+        display: inline;
+        font-size: 175%;
+      }
+    }
+
     #dashboard_errata {
       .scroll-pane {
         height: $height - 26;
@@ -587,3 +627,4 @@ $col_width: (($static_width) * 0.5);
     padding-bottom: 1em;
   }
 }
+

--- a/app/controllers/katello/dashboard_controller.rb
+++ b/app/controllers/katello/dashboard_controller.rb
@@ -72,6 +72,17 @@ class DashboardController < ApplicationController
     render :partial => "subscriptions", :locals => {:quantity => quantity}
   end
 
+  def subscriptions_totals
+    subscriptions = current_organization.redhat_provider.index_subscriptions
+
+    render :partial => "subscriptions_totals", :locals => {
+      :quantity                             => nil,
+      :total_active_subscriptions           => Katello::Pool.active(subscriptions).count,
+      :total_expiring_subscriptions         => Katello::Pool.expiring_soon(subscriptions).count,
+      :total_recently_expired_subscriptions => Katello::Pool.recently_expired(subscriptions).count
+    }
+  end
+
   def notices
     render :partial => "notices", :locals => {:quantity => quantity}
   end

--- a/app/helpers/katello/dashboard_helper.rb
+++ b/app/helpers/katello/dashboard_helper.rb
@@ -1,4 +1,4 @@
-  #
+#
 # Copyright 2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public
@@ -38,7 +38,7 @@ module DashboardHelper
 
   def content_view_versions(num = quantity)
     return ContentViewVersion.readable(current_organization).non_default_view.joins(:task_status).
-        order("#{Katello::TaskStatus.table_name}.updated_at DESC").limit(num)
+      order("#{Katello::TaskStatus.table_name}.updated_at DESC").limit(num)
   end
 
   def content_view_name(version)
@@ -80,8 +80,8 @@ module DashboardHelper
 
   def promotions(num = quantity)
     return  Changeset.joins(:task_status).
-        where("#{Katello::Changeset.table_name}.environment_id" => KTEnvironment.changesets_readable(current_organization)).
-        order("#{Katello::TaskStatus.table_name}.updated_at DESC").limit(num)
+      where("#{Katello::Changeset.table_name}.environment_id" => KTEnvironment.changesets_readable(current_organization)).
+      order("#{Katello::TaskStatus.table_name}.updated_at DESC").limit(num)
   end
 
   def changeset_class(cs)
@@ -198,13 +198,18 @@ module DashboardHelper
     output.html_safe
   end
 
+  def has_dropbutton_quantity(widget_name)
+    !(%w(subscriptions_totals subscriptions).include? widget_name)
+  end
+
   def render_column(column)
     output = ""
     column.each do |widget|
+      has_dropbutton = has_dropbutton_quantity(widget.name)
       if widget.content_path
-        output += dashboard_ajax_entry(widget.title, widget.name, widget.content_path, "widget", true)
+        output += dashboard_ajax_entry(widget.title, widget.name, widget.content_path, "widget", has_dropbutton)
       else
-        output += dashboard_entry(widget.title, widget.name, false)
+        output += dashboard_entry(widget.title, widget.name, has_dropbutton)
       end
     end
     output.html_safe

--- a/app/lib/katello/dashboard/layout.rb
+++ b/app/lib/katello/dashboard/layout.rb
@@ -16,6 +16,7 @@ module Dashboard
 
     AVAILABLE_WIDGETS = %w(
       subscriptions
+      subscriptions_totals
       notices
       content_views
       sync
@@ -69,6 +70,7 @@ module Dashboard
     def get_widget(name, org)
       "Katello::Dashboard::#{name.camelcase}Widget".constantize.new(org)
     end
+
   end
 end
 end

--- a/app/lib/katello/dashboard/subscriptions_totals_widget.rb
+++ b/app/lib/katello/dashboard/subscriptions_totals_widget.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  class Dashboard::SubscriptionsTotalsWidget < Dashboard::Widget
+
+    def accessible?
+      current_organization && current_organization.readable?
+    end
+
+    def title
+      _("Current Subscription Totals")
+    end
+
+    def content_path
+      subscriptions_totals_dashboard_index_path
+    end
+
+  end
+end

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -22,7 +22,8 @@ module Glue::Candlepin::Pool
       lazy_accessor :remote_data, :pool_derived, :product_name, :consumed, :quantity, :available, :support_level, :support_type,
         :start_date, :end_date, :attrs, :owner, :product_id, :account_number, :contract_number,
         :source_pool_id, :host_id, :virt_only, :virt_limit, :multi_entitlement, :stacking_id,
-        :arch, :sockets, :cores, :ram, :description, :product_family, :variant, :provided_products, :instance_multiplier, :suggested_quantity,
+        :arch, :sockets, :cores, :ram, :description, :product_family, :variant, :provided_products,
+        :active, :instance_multiplier, :suggested_quantity,
         :initializer => (lambda do |s|
                            json = Resources::Candlepin::Pool.find(cp_id)
                            # symbol "attributes" is reserved by Rails and cannot be used
@@ -45,7 +46,7 @@ module Glue::Candlepin::Pool
 
     def initialize(attrs = nil, options = {})
       if !attrs.nil? && attrs.member?('id')
-        # initializing from cadlepin json
+        # initializing from candlepin json
         load_remote_data(attrs)
         super({:cp_id => attrs['id']}, options)
       else
@@ -80,6 +81,7 @@ module Glue::Candlepin::Pool
       @account_number = attrs['accountNumber']
       @contract_number = attrs['contractNumber']
       @provided_products = attrs['providedProducts']
+      @active = attrs['activeSubscription']
       @source_pool_id = nil
       @host_id = nil
       @virt_only = false

--- a/app/models/katello/glue/elastic_search/pool.rb
+++ b/app/models/katello/glue/elastic_search/pool.rb
@@ -135,6 +135,17 @@ module Glue::ElasticSearch::Pool
       def self.index
         "#{Katello.config.elastic_index}_pool"
       end
+
+      def self.expiration_filter(filter_name)
+        if filter_name.present?
+          if filter_name == 'recent'
+            {:range => {:end => {:gte => Date.today - Pool::DAYS_RECENTLY_EXPIRED, :lt => Date.today}}}
+          elsif filter_name == 'soon'
+            {:range => {:end => {:lte => Date.today + Pool::DAYS_EXPIRING_SOON}}}
+          end
+        end
+      end
+
     end
   end
 

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -431,7 +431,7 @@ module Glue::Provider
       cp_pools = Resources::Candlepin::Owner.pools(self.organization.label)
       if cp_pools
         # Pool objects
-        pools = cp_pools.collect{|cp_pool| Pool.find_pool(cp_pool['id'], cp_pool)}
+        pools = cp_pools.collect{|cp_pool| Katello::Pool.find_pool(cp_pool['id'], cp_pool)}
 
         # Limit subscriptions to just those from Red Hat provider
         subscriptions = pools.collect do |pool|

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -26,6 +26,9 @@ class Pool < ActiveRecord::Base
   alias_method :provider_id, :cp_provider_id
   alias_method :provider_id=, :cp_provider_id=
 
+  DAYS_EXPIRING_SOON = 120
+  DAYS_RECENTLY_EXPIRED = 30
+
   # ActivationKey includes the Pool's json in its own'
   def as_json(*args)
     self.remote_data.merge(:cp_id => self.cp_id)
@@ -35,7 +38,27 @@ class Pool < ActiveRecord::Base
   # prior to this call the pool was already fetched.
   def self.find_pool(cp_id, pool_json = nil)
     pool_json = Resources::Candlepin::Pool.find(cp_id) if !pool_json
-    Pool.new(pool_json) if !pool_json.nil?
+    ::Pool.new(pool_json) if !pool_json.nil?
+  end
+
+  # Convert active, expiring_soon, and recently_expired into elasticsearch
+  # filters and move implementation into ES pool module if performance becomes
+  # an issue (though I doubt it will--just sayin')
+  def self.active(subscriptions)
+    subscriptions.select { |s| s.active }
+  end
+
+  def self.expiring_soon(subscriptions)
+    subscriptions.select { |s| (s.end_date - Date.today) <= DAYS_EXPIRING_SOON }
+  end
+
+  def self.recently_expired(subscriptions)
+    today_date = Date.today
+
+    subscriptions.select do |s|
+      end_date = s.end_date
+      today_date >= end_date && today_date - end_date <= DAYS_RECENTLY_EXPIRED
+    end
   end
 end
 end

--- a/app/views/katello/dashboard/_subscriptions_totals.haml
+++ b/app/views/katello/dashboard/_subscriptions_totals.haml
@@ -1,0 +1,19 @@
+- owner_info = current_organization.owner_info
+
+#dashboard_subscriptions_totals.widget
+  %ul
+    %li.left-col
+      %h5
+        .sub_count
+          = link_to number_with_delimiter(total_active_subscriptions), subscriptions_path
+      %span active subscriptions
+    %li.center-col
+      %h5
+        .sub_count
+          = link_to number_with_delimiter(total_expiring_subscriptions), subscriptions_path({:expiration_filter => "soon"})
+      %span subscriptions expiring in next 120 days
+    %li.right-col
+      %h5
+        .sub_count
+          = link_to number_with_delimiter(total_recently_expired_subscriptions), subscriptions_path({:expiration_filter => "recent"})
+      %span recently expired subscriptions

--- a/app/views/katello/dashboard/index.html.haml
+++ b/app/views/katello/dashboard/index.html.haml
@@ -1,4 +1,4 @@
-= javascript 'katello/dashboard'
+= javascript "katello/dashboard"
 
 - if current_user && current_user.allowed_organizations.length == 0
   .grid_16.flash_hud
@@ -19,8 +19,4 @@
       %select.num_of_results.popout
         - ['5', '15', '30'].each do |i|
           %option.popout{:value => i} #{i} results
-    -#.popout_row.popout
-    -#  %label.popout Over
-    -#  %select.num_of_hours.popout
-    -#    - [60.minutes, 24.hours, 48.hours, 168.hours].each do |i|
-    -#      %option.popout{:value => i} #{distance_of_time_in_words(i)}
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,7 @@ Katello::Engine.routes.draw do
       get :systems
       get :system_groups
       get :subscriptions
+      get :subscriptions_totals
       put :update
     end
   end

--- a/test/factories/pool_factory.rb
+++ b/test/factories/pool_factory.rb
@@ -1,0 +1,35 @@
+FactoryGirl.define do
+  factory :pool do
+    trait :active do
+      active true
+    end
+
+    trait :inactive do
+      active false
+    end
+
+    trait :unexpired do
+      end_date Date.today + 1.days
+    end
+
+    trait :expired do
+      end_date Date.today
+    end
+
+    trait :expiring_soon do
+      end_date Date.today + Katello::Pool::DAYS_EXPIRING_SOON
+    end
+
+    trait :not_expiring_soon do
+      end_date Date.today + Katello::Pool::DAYS_EXPIRING_SOON + 1
+    end
+
+    trait :recently_expired do
+      end_date Date.today - Katello::Pool::DAYS_RECENTLY_EXPIRED
+    end
+
+    trait :long_expired do
+      end_date Date.today - Katello::Pool::DAYS_RECENTLY_EXPIRED - 1
+    end
+  end
+end

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'minitest_helper'
+
+class PoolTest < MiniTest::Rails::ActiveSupport::TestCase
+
+  def test_active
+    active_pool = FactoryGirl.build(:pool, :active)
+    inactive_pool = FactoryGirl.build(:pool, :inactive)
+    all_subscriptions = [active_pool, inactive_pool]
+    active_subscriptions = Pool.active(all_subscriptions)
+    assert_equal active_subscriptions, all_subscriptions - [inactive_pool]
+  end
+
+  def test_expiring_soon
+    not_expiring_soon = FactoryGirl.build(:pool, :not_expiring_soon)
+    expiring_soon_pool = FactoryGirl.build(:pool, :expiring_soon)
+    all_subscriptions = [not_expiring_soon, expiring_soon_pool]
+    expiring_soon_subscriptions = Pool.expiring_soon(all_subscriptions)
+    assert_equal expiring_soon_subscriptions, all_subscriptions - [not_expiring_soon]
+  end
+
+  def test_recently_expired
+    unexpired = FactoryGirl.build(:pool, :unexpired)
+    recently_expired = FactoryGirl.build(:pool, :recently_expired)
+    all_subscriptions = [unexpired, recently_expired]
+    expired_subscriptions = Pool.recently_expired(all_subscriptions)
+    assert_equal expired_subscriptions, all_subscriptions - [unexpired]
+  end
+
+  def test_recently_expired_does_not_get_long_expired_subscriptions
+    unexpired = FactoryGirl.build(:pool, :unexpired)
+    recently_expired = FactoryGirl.build(:pool, :recently_expired)
+    long_expired = FactoryGirl.build(:pool, :long_expired)
+
+    all_subscriptions = [unexpired, recently_expired, long_expired]
+    expired_subscriptions = Pool.recently_expired(all_subscriptions)
+    assert_equal expired_subscriptions, all_subscriptions - [unexpired, long_expired]
+  end
+end


### PR DESCRIPTION
This "portlet" (aka widget) on the dashboard implements user story
"As a dashboard user, I want to see current subscription totals" in
SAM backlog sprint 10.

This portlet adds the following functionality:
- It links to the subscriptions search page, where the results shown
  are filtered by date range using elasticsearch.
- The counts shown are calculated from new methods on the Pool class
  in the katello app's models.
- I add a helper method to the DashboardHelper that permits a portlet
  or widget to exclude the quantity dropdown from displaying in cases
  such as this where quantity doesn't make sense.

**Note**: this branch was branched from engine at a point in time where integration between foreman/develop and katello/engine was already yielding the following error:

```
    lib/middleware/catch_json_parse_errors.rb:9:in `call'
```

Before I made these changes, this error was produced by visiting `/katello` when logged in as an admin user, and continues to persist:

```
     RestClient::ResourceNotFound in Katello::DashboardController#index
```
