### PR TITLE
Engine: Organization: deface core UI to include katello attributes

### DIFF
--- a/app/assets/javascripts/katello/organizations/download_certificate.js
+++ b/app/assets/javascripts/katello/organizations/download_certificate.js
@@ -1,0 +1,20 @@
+/**
+ Copyright 2013 Red Hat, Inc.
+
+ This software is licensed to you under the GNU General Public
+ License as published by the Free Software Foundation; either version
+ 2 of the License (GPLv2) or (at your option) any later version.
+ There is NO WARRANTY for this software, express or implied,
+ including the implied warranties of MERCHANTABILITY,
+ NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ have received a copy of GPLv2 along with this software; if not, see
+ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+*/
+
+$(document).ready(function() {
+    $('#download_debug_cert_key').live('click', function(e) {
+        e.preventDefault();
+        window.location.href = $("#download_debug_cert_key").data("url");
+        return false;
+    });
+});

--- a/app/helpers/katello/taxonomy_helper.rb
+++ b/app/helpers/katello/taxonomy_helper.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  # The TaxonomyHelper contains extensions to the core application's
+  # TaxonomyHelper
+  module TaxonomyHelper
+
+    def service_level_options
+      options = @taxonomy.service_levels.collect{ |level| [_("Service Level %s") % level, level] }
+      options.unshift([_("No Service Level Preference"), ""])
+      options
+    end
+
+    def service_level_selected
+      @taxonomy.service_level.blank? ? "" : @taxonomy.service_level
+    end
+
+  end
+end

--- a/app/overrides/add_organization_attributes.rb
+++ b/app/overrides/add_organization_attributes.rb
@@ -1,0 +1,11 @@
+# Add organization attributes to org creation
+Deface::Override.new(:virtual_path => "taxonomies/_step1",
+                     :name => "add_organization_attributes_on_create",
+                     :insert_after => 'erb[loud]:contains("text_f"):contains(":name")',
+                     :partial => 'katello/organizations/step_1_override')
+
+# Add organization attributes to org edit
+Deface::Override.new(:virtual_path => "taxonomies/_form",
+                     :name => "add_organization_attributes_on_edit",
+                     :insert_after => 'erb[loud]:contains("text_f"):contains(":name")',
+                     :partial => 'katello/organizations/edit_override')

--- a/app/views/katello/organizations/_edit_override.html.erb
+++ b/app/views/katello/organizations/_edit_override.html.erb
@@ -1,0 +1,20 @@
+<% if @taxonomy.is_a?(Organization) %>
+
+  <%= javascript_include_tag 'katello/organizations/download_certificate' %>
+
+  <%= text_f f, :label, :disabled => true, :class => 'input-xlarge' %>
+
+  <%= textarea_f f, :description, :class => 'input-xlarge', :rows => 4 %>
+
+  <%= field(f, _('Default System SLA')) do
+    select_tag 'organization[service_level]', options_for_select(service_level_options, service_level_selected)
+  end %>
+
+  <%= field(f, _('Debug Certificate'),
+            :help_inline => _('This certificate allows a user to view the repositories in any environment from a browser.')) do
+    button_tag _('Generate and Download'), :id => :download_debug_cert_key,
+               :type => :button, :style => 'margin-top: 8px;', :class => 'btn btn-small',
+               'data-url' => Katello::Engine.routes.url_helpers.download_debug_certificate_organization_path(@taxonomy.id)
+  end %>
+
+<% end%>

--- a/app/views/katello/organizations/_step_1_override.html.erb
+++ b/app/views/katello/organizations/_step_1_override.html.erb
@@ -1,0 +1,6 @@
+<% if @taxonomy.is_a?(Organization) %>
+
+  <%= text_f f, :label, :class => 'input-xlarge' %>
+  <%= textarea_f f, :description, :class => 'input-xlarge', :rows => 4 %>
+
+<% end %>

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -63,6 +63,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "compass-960-plugin"
   gem.add_dependency "haml-rails"
   gem.add_dependency "ui_alchemy-rails", '1.0.12'
+  gem.add_dependency "deface"
 
   # Testing
   gem.add_dependency "rubocop", "0.15.0"

--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -23,6 +23,7 @@ require "haml-rails"
 require "compass-rails"
 require "ninesixty"
 require "ui_alchemy-rails"
+require "deface"
 
 require "uuidtools"
 require "delayed_job"

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -28,6 +28,10 @@ module Katello
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/v2.rb"
     end
 
+    initializer "katello.helpers" do |app|
+      ActionView::Base.send :include, Katello::TaxonomyHelper
+    end
+
     initializer "logging" do |app|
       if caller.last =~ /script\/delayed_job:\d+$/ ||
           ((caller[-10..-1] || []).any? {|l| l =~ /\/rake/} && ARGV.include?("jobs:work"))


### PR DESCRIPTION
This commit contains changes that deface (extend) the core (foreman)
organization UI to include the following:
- on create:
  - label, description
- on edit:
  - label (readonly), description, default SLA
  - provide ability to download cert
