### PR TITLE
Allows development gems to be declared that can be ignored in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,18 @@ rake db:create db:migrate db:seed
 
 ### Setup Katello
 
-The Katello setup assumes that you have a previously setup Foreman checkout or have followed the instructions in the Setup Foreman section. 
+The Katello setup assumes that you have a previously setup Foreman checkout or have followed the instructions in the Setup Foreman section. The first step is to add the Katello engine and install dependencies:
+
+```bash
+echo "gemspec :path => '../katello'", :development_group => :katello_dev >> bundler.d/Gemfile.local.rb
+bundle update
+```
+
+Now add the Katello migrations and initial seed data:
+
+```bash
+rake db:migrate && rake db:seed
+```
 
 If you have set ```RAILS_RELATIVE_URL_ROOT``` in the past then you need to be sure to ```unset``` it and remove it from ```.bashrc``` or ```.bash_profile``` as appropriate.
 

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -59,20 +59,19 @@ Gem::Specification.new do |gem|
   gem.add_dependency "simple-navigation", ">= 3.3.4"
   gem.add_dependency "less-rails"
   gem.add_dependency "sass-rails"
-  gem.add_dependency "compass-rails"
-  gem.add_dependency "compass-960-plugin"
+  gem.add_development_dependency "compass-rails"
+  gem.add_development_dependency "compass-960-plugin"
   gem.add_dependency "haml-rails"
   gem.add_dependency "ui_alchemy-rails", '1.0.12'
   gem.add_dependency "deface"
 
   # Testing
-  gem.add_dependency "rubocop", "0.15.0"
-  gem.add_dependency "factory_girl_rails", "~> 1.4.0"
-  gem.add_dependency "minitest-tags"
-  gem.add_dependency "minitest-predicates"
-  gem.add_dependency "mocha", "~> 0.14.0"
-  gem.add_dependency "vcr"
-  gem.add_dependency "webmock"
-  gem.add_dependency "rubocop-checkstyle_formatter"
+  gem.add_development_dependency "rubocop", "0.15.0"
+  gem.add_development_dependency "factory_girl_rails", "~> 1.4.0"
+  gem.add_development_dependency "minitest-tags"
+  gem.add_development_dependency "mocha", "~> 0.14.0"
+  gem.add_development_dependency "vcr"
+  gem.add_development_dependency "webmock"
+  gem.add_development_dependency "rubocop-checkstyle_formatter"
 
 end


### PR DESCRIPTION
mode by bundler.

When using a gemspec to define all dependencies, if the gem is included
using 'gem' in Bundler all gems marked as 'add_dependency' will be included
when 'bundle install' is ran. However, this means that if development
dependencies are declared in this same manner, they will be required by
bundler in production. This can be avoided by including the gem using 'gemspec'.
Using the 'gemspec' notation places all gems marked with 'add_development_dependency'
into a development bundler group. Thus, in development a developer can run
'bundle install' and get all dependencies needed to develop. In production,
'bundle install --without development' can be run and the gems marked with
'add_development_dependency' will be excluded from the bundle.
