### PR TITLE
rabl-results - do not wrap outer collection

### DIFF
--- a/app/views/katello/api/v2/layouts/collection.json.haml
+++ b/app/views/katello/api/v2/layouts/collection.json.haml
@@ -1,2 +1,3 @@
-:plain
-  {"#{root_name}": #{yield}}
+#{yield}
+
+


### PR DESCRIPTION
Do not wrap collections in root_name. The purpose of root_name is to replace 'results' as described here:
http://theforeman.org/manuals/1.3/index.html#5.1.2JSONResponseFormatforCollections
