### PR TITLE
Engine: API: fix issue with resource_list for api_version in resource

### DIFF
--- a/app/controllers/katello/api/v1/root_controller.rb
+++ b/app/controllers/katello/api/v1/root_controller.rb
@@ -21,9 +21,12 @@ class Api::V1::RootController < Api::V1::ApiController
     all_routes = all_routes.collect { |r| r.path.spec.to_s }
 
     api_root_routes = all_routes.select do |path|
-      path =~ %r{^/api/[^/]+/:id\(\.:format\)$}
+      path =~ %r{^/api(\(/:api_version\))?/[^/]+/:id\(\.:format\)$}
     end
-    api_root_routes = api_root_routes.collect { |path| path[0..-(":id(.:format)".length + 1)] }.uniq
+    api_root_routes = api_root_routes.collect do |path|
+      path = path.sub("(/:api_version)", "")
+      path[0..-(":id(.:format)".length + 1)]
+    end
 
     api_root_routes.collect! { |r| { :rel => r["/api/".size..-2], :href => r } }
 


### PR DESCRIPTION
The API resources were recently updated to optionally include
the `:api_version`.  This broke the logic that returned
the list of resources in the resource_list api.  As a result,
subscription-manager commands (e.g. register, environments,
orgs) will not work.

This commit will ignore the `:api_version` in the RAILS
resources  when determining the list to return
as well as omit it from the results sent to the
client.

For example, without this change, the API returns:

``` json
{'entitlements': '/api/entitlements/', 'status': '/api/status/', 'packages': '/api/packages/', 'consumers': '/api/consumers/'}
```

With this change, it will return:

``` json
{'status': '/api/status/', 'organizations': '/api/organizations/', 'roles': '/api/roles/', 'tasks': '/api/tasks/', 'sync_plans': '/api/sync_plans/', 'users': '/api/users/', 'distributors': '/api/distributors/', 'providers': '/api/providers/', 'entitlements': '/api/entitlements/', 'gpg_keys': '/api/gpg_keys/', 'repositories': '/api/repositories/', 'environments': '/api/environments/', 'content_views': '/api/content_views/', 'system_groups': '/api/system_groups/', 'products': '/api/products/', 'systems': '/api/systems/', 'changesets': '/api/changesets/', 'activation_keys': '/api/activation_keys/', 'content_view_definitions': '/api/content_view_definitions/', 'packages': '/api/packages/', 'consumers': '/api/consumers/'}
```
