### PR TITLE
Serve Katello api documentation on '/apidoc` when Katello is loaded

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Katello::Engine.routes.draw do
 
-  apipie
-
   resources :system_groups do
     collection do
       get :items

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -12,6 +12,13 @@ module Katello
       SimpleNavigation.config_file_paths << File.expand_path("../../../config", __FILE__)
     end
 
+    initializer "katello.apipie" do
+      # When Katello is loaded, the apidoc is restricted just to the Katello controllers.
+      # This way, it's possible to generate both Foreman bindings (when Katello is not loaded)
+      # or just Katello bindings (when Katello loaded) the same way.
+      Apipie.configuration.api_controllers_matcher = "#{Katello::Engine.root}/app/controllers/katello/api/v2/*.rb"
+    end
+
     initializer "katello.load_app_instance_data" do |app|
       app.config.paths['db/migrate'] += Katello::Engine.paths['db/migrate'].existent
       app.config.autoload_paths += Dir["#{config.root}/app/lib)"]


### PR DESCRIPTION
We use the foreman `/apidoc` path to serve the Katello's resources when the
engine is loaded. This allows both Katello and Foreman to use apipie for their
bindings without affecting each other.

There are some issues with loaded the Katello code when loading apidoc. One of
the possible fixes is commenting out `wrap_parameters` call in Foreman's
`config/initializers/wrap_parameters.rb` file. When doing that,
http://localhost:3000/apidoc will serve as the Katello's original apidoc path,
using the api docs from the engine
