### PR TITLE
Update products controller's apipie bindings

### DIFF
--- a/app/controllers/katello/api/v2/system_groups_controller.rb
+++ b/app/controllers/katello/api/v2/system_groups_controller.rb
@@ -37,10 +37,6 @@ class Api::V2::SystemGroupsController <  Api::V2::ApiController
     }
   end
 
-  resource_description do
-    api_version "v2"
-  end
-
   def_param_group :system_group do
     param :name, String, :required => true, :desc => "System group name"
     param :system_ids, Array, :required => false, :desc => "List of system uuids to be in the group"

--- a/app/models/katello/authorization/product.rb
+++ b/app/models/katello/authorization/product.rb
@@ -15,8 +15,6 @@ module Katello
     module Product
       extend ActiveSupport::Concern
 
-      READ_PERM_VERBS = [:read, :create, :update, :delete]
-
       included do
         scope :readable, lambda{|org| all_readable(org).with_enabled_repos_only(org.library)}
         scope :editable, lambda {|org| all_editable(org).with_enabled_repos_only(org.library)}

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -25,7 +25,7 @@ class Product < Katello::Model
   include Ext::LabelFromName
 
   attr_accessible :name, :label, :description, :provider_id, :provider,
-                  :gpg_key_id, :gpg_key, :cp_id
+                  :gpg_key_id, :gpg_key, :cp_id, :sync_plan_id
 
   has_many :marketing_engineering_products, :class_name => "Katello::MarketingEngineeringProduct",
            :foreign_key => :engineering_product_id, :dependent => :destroy

--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -1,7 +1,6 @@
 object @resource
 
-attributes :cp_id => :id
-attributes :name, :label, :description
+attributes :id, :name, :label, :description
 
 extends 'katello/api/v2/common/org_reference'
 
@@ -12,16 +11,15 @@ attributes :gpg_key_id
 attributes :productContent
 
 node :repository_count do |product|
-  product.repositories.enabled.count
+  if product.repositories.to_a.any?
+    product.repositories.enabled.count
+  else
+    0
+  end
 end
 
-node :gpg_key do |product|
-  if !product.gpg_key.nil?
-    {
-      id: product.gpg_key.id,
-      name: product.gpg_key.name
-    }
-  end
+node(:gpg_key, :unless => lambda { |product| product.gpg_key.nil? }) do |product|
+  {:id => product.gpg_key.id, :name => product.gpg_key.name}
 end
 
 child :provider do

--- a/app/views/katello/api/v2/providers/show.json.rabl
+++ b/app/views/katello/api/v2/providers/show.json.rabl
@@ -1,3 +1,3 @@
-object @provider
+object @resource
 
 extends "katello/api/v2/providers/provider"

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -40,6 +40,8 @@ Katello::Engine.routes.draw do
           post :cancel_repo_discover
           post :autoattach_subscriptions
         end
+        api_resources :products, :only => [:index]
+        api_resources :providers, :only => [:index]
         api_resources :system_groups, :only => [:index, :create]
         api_resources :systems, :only => system_onlies do
           get :report, :on => :collection
@@ -47,8 +49,12 @@ Katello::Engine.routes.draw do
         scope :constraints => Katello::RegisterWithActivationKeyContraint.new do
           match '/systems' => 'systems#activate', :via => :post
         end
-        api_resources :providers, :only => [:index]
       end
+
+      api_resources :ping, :only => [:index]
+      match "/status" => "ping#server_status", :via => :get
+
+      api_resources :products, :only => [:index, :show, :create, :update, :destroy]
 
       api_resources :providers, :only => [:index, :create, :show, :destroy, :update] do
         member do
@@ -56,13 +62,10 @@ Katello::Engine.routes.draw do
           post :import_manifest
           post :product_create
           get :products
-          post :refresh_manifest
+          put :refresh_manifest
           put :refresh_products
         end
       end
-
-      api_resources :ping, :only => [:index]
-      match "/status" => "ping#server_status", :via => :get
 
       api_resources :system_groups, :only => system_onlies do
         member do

--- a/engines/bastion/app/assets/javascripts/bastion/providers/provider.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/providers/provider.factory.js
@@ -31,7 +31,7 @@ angular.module('Bastion.providers').factory('Provider',
                 'save':   {'method': 'POST', 'params': {'organization_id': CurrentOrganization}},
                 'update': {'method': 'PUT'},
                 'deleteManifest': {'method': 'POST', 'params': {'action': 'delete_manifest'}},
-                'refreshManifest': {'method': 'POST', 'params': {'action': 'refresh_manifest'}}
+                'refreshManifest': {'method': 'PUT', 'params': {'action': 'refresh_manifest'}}
             }
         );
     }]

--- a/engines/bastion/test/providers/provider.factory.test.js
+++ b/engines/bastion/test/providers/provider.factory.test.js
@@ -64,7 +64,7 @@ describe('Factory: Provider', function() {
     it('provides a way to refresh a manifest', function() {
         var provider = providers.records[0];
 
-        $httpBackend.expectPOST('/katello/api/providers/1/refresh_manifest').respond(provider);
+        $httpBackend.expectPUT('/katello/api/providers/1/refresh_manifest').respond(provider);
 
         Provider.refreshManifest({ organization_id: 'ACME', id: provider.id }, function(record) {
             expect(record.id).toBe(provider.id);

--- a/test/controllers/api/v2/providers_controller_test.rb
+++ b/test/controllers/api/v2/providers_controller_test.rb
@@ -71,7 +71,7 @@ class Api::V2::ProvidersControllerTest < ActionController::TestCase
   end
 
   def test_show_protected
-    allowed_perms = [@read_permission, @create_permission, @update_permission, @delete_permission]
+    allowed_perms = [@read_permission]
     denied_perms = [@no_permission]
 
     assert_protected_action(:show, allowed_perms, denied_perms) do
@@ -105,15 +105,8 @@ class Api::V2::ProvidersControllerTest < ActionController::TestCase
     end
   end
 
-  def test_update
-    put :update, :id => @provider.id, :name => 'CentOS Provider'
-
-    assert_response :success
-    assert_template %w(katello/api/v2/common/show katello/api/v2/layouts/resource)
-  end
-
   def test_redhat_update
-    put :update, :id => @rh_provider.id, :repository_url => 'http://google.com'
+    put :update, :id => @rh_provider.id, :provider => {:repository_url => 'http://google.com', :name => 'G+'}
 
     assert_response :success
     assert_template %w(katello/api/v2/common/show katello/api/v2/layouts/resource)
@@ -164,15 +157,6 @@ class Api::V2::ProvidersControllerTest < ActionController::TestCase
     end
   end
 
-  def test_show_protected
-    allowed_perms = [@read_permission]
-    denied_perms = [@no_permission]
-
-    assert_protected_action(:show, allowed_perms, denied_perms) do
-      get :show, :id => @provider.id
-    end
-  end
-
   def test_manifest_actions_protected
     allowed_perms = [@update_permission]
     denied_perms = [@no_permission, @read_permission]
@@ -188,7 +172,7 @@ class Api::V2::ProvidersControllerTest < ActionController::TestCase
 
   def test_delete_manifest
     Provider.stubs(:find).returns(@provider)
-    @provider.stubs(:yum_repo?).returns(false)
+    @provider.stubs(:redhat_provider?).returns(true)
     @provider.expects(:delete_manifest).returns(true)
 
     post :delete_manifest, :id => @provider.id
@@ -197,13 +181,15 @@ class Api::V2::ProvidersControllerTest < ActionController::TestCase
 
   def test_refresh_manifest
     Provider.stubs(:find).returns(@provider)
+    task_status = TaskStatus.new(:organization_id => @organization.id, :task_type => "refresh manifest")
+
+    @provider.stubs(:redhat_provider?).returns(true)
+    @provider.stubs(:manifest_task).returns(task_status)
     @provider.organization.stubs(:owner_details).returns({})
-    @provider.stubs(:yum_repo?).returns(false)
     @provider.expects(:refresh_manifest).returns(true)
 
-    post :refresh_manifest, :id => @provider.id
-    assert_response :success
+    put :refresh_manifest, :id => @provider.id
+    assert_response :accepted
   end
-
 end
 end


### PR DESCRIPTION
This now generates documentation for filtering by organization
under the Products section of the v2 docs.

These changes also include a namespacing fix in Provider.
