### PR TITLE
API v2 - v2 systems_controller and systems actions

### DIFF
--- a/app/controllers/katello/api/v1/systems_controller.rb
+++ b/app/controllers/katello/api/v1/systems_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::SystemsController < Api::V1::ApiController
 
   skip_before_filter :set_default_response_format, :only => :report
 
-  before_filter :verify_presence_of_organization_or_environment, :only => [:create, :index, :activate]
+  before_filter :find_default_organization_and_or_environment, :only => [:create, :index, :activate]
   before_filter :find_optional_organization, :only => [:create, :hypervisors_update, :index, :activate, :report, :tasks]
   before_filter :find_only_environment, :only => [:create]
   before_filter :find_environment, :only => [:index, :report, :tasks]
@@ -521,7 +521,7 @@ This information is then used for computing the errata available for the system.
     end
   end
 
-  def verify_presence_of_organization_or_environment
+  def find_default_organization_and_or_environment
     # This has to grab the first default org associated with this user AND
     # the environment that goes with him.
     return if params.key?(:organization_id) || params.key?(:owner) || params.key?(:environment_id)

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -12,15 +12,78 @@
 
 # rubocop:disable SymbolName
 module Katello
-class Api::V2::SystemsController < Api::V1::SystemsController
+class Api::V2::SystemsController < Api::V2::ApiController
+  respond_to :json
 
-  include Api::V2::Rendering
+  skip_before_filter :set_default_response_format, :only => :report
 
+  before_filter :find_default_organization_and_or_environment, :only => [:create, :index, :activate]
+  before_filter :find_optional_organization, :only => [:create, :hypervisors_update, :index, :activate, :report, :tasks]
+  before_filter :find_only_environment, :only => [:create]
+  before_filter :find_environment, :only => [:index, :report, :tasks]
+  before_filter :find_system_group, :only => [:index]
+  before_filter :find_environment_and_content_view, :only => [:create]
+  before_filter :find_hypervisor_environment_and_content_view, :only => [:hypervisors_update]
+  before_filter :find_system, :only => [:destroy, :show, :update, :regenerate_identity_certificates,
+                                        :upload_package_profile, :errata, :package_profile, :subscribe,
+                                        :unsubscribe, :subscriptions, :pools, :enabled_repos, :releases,
+                                        :add_system_groups, :remove_system_groups, :refresh_subscriptions, :checkin,
+                                        :subscription_status] # TODO: this should probably be :except
+  before_filter :find_content_view, :only => [:create, :update]
+
+  before_filter :authorize, :except => [:activate, :upload_package_profile]
+
+  def organization_id_keys
+    [:organization_id, :owner]
+  end
+
+  # TODO: break up this method
+  # rubocop:disable MethodLength
   def rules
-    hash = super
-    hash[:tasks] = lambda{find_system && @system.readable?}
-    hash[:task] = lambda{true}
-    hash
+    index_systems          = index_systems_perms_check
+    register_system        = lambda { System.registerable?(@environment, @organization, @content_view) }
+    consumer_only          = lambda { User.consumer? }
+    edit_system            = lambda do
+      subscribable = @content_view ? @content_view.subscribable? : true
+      subscribable && (@system.editable? || User.consumer?)
+    end
+    read_system            = lambda { @system.readable? || User.consumer? }
+    delete_system          = lambda { @system.deletable? || User.consumer? }
+
+    # After a system registers, it immediately uploads its packages. Although newer subscription-managers send
+    # certificate (User.consumer? == true), some do not. In this case, confirm that the user has permission to
+    # register systems in the system's organization and environment.
+   upload_system_packages = lambda { @system.editable? || System.registerable?(@system.environment, @system.organization) || User.consumer? }
+
+    {
+        :new                              => register_system,
+        :create                           => register_system,
+        :hypervisors_update               => consumer_only,
+        :regenerate_identity_certificates => edit_system,
+        :update                           => edit_system,
+        :index                            => index_systems,
+        :show                             => read_system,
+        :subscription_status              => read_system,
+        :destroy                          => delete_system,
+        :package_profile                  => read_system,
+        :errata                           => read_system,
+        :upload_package_profile           => upload_system_packages,
+        :report                           => index_systems,
+        :subscribe                        => edit_system,
+        :unsubscribe                      => edit_system,
+        :subscriptions                    => read_system,
+        :pools                            => read_system,
+        :releases                         => read_system,
+        :activate                         => register_system,
+        :tasks                            => lambda { find_system && @system.readable? },
+        :task                             => lambda { true },
+        :task_show                        => read_system,
+        :enabled_repos                    => consumer_only,
+        :add_system_groups                => edit_system,
+        :remove_system_groups             => edit_system,
+        :refresh_subscriptions            => edit_system,
+        :checkin                          => edit_system
+    }
   end
 
   def_param_group :system do
@@ -29,9 +92,53 @@ class Api::V2::SystemsController < Api::V1::SystemsController
     param :name, String, :desc => "Name of the system", :required => true, :action_aware => true
     param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true, :action_aware => true
     param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT", :action_aware => true
-    param :location, String, :desc => "Physical of the system"
+    param :location, String, :desc => "Physical location of the system"
     param :content_view_id, :identifier
     param :environment_id, :identifier
+  end
+
+  api :GET, "/environments/:environment_id/consumers", "List systems (compatibilty)" # according to v2 routes, this should go to v1 controller
+  api :GET, "/environments/:environment_id/systems", "List systems in environment"
+  api :GET, "/organizations/:organization_id/systems", "List systems in an organization"
+  api :GET, "/system_groups/:system_group_id/systems", "List systems in a system group"
+  api :GET, "/systems", "List systems"
+  param :name, String, :desc => "Filter systems by name"
+  param :pool_id, String, :desc => "Filter systems by subscribed pool"
+  param :search, String, :desc => "Filter systems by advanced search query"
+  param :uuid, String, :desc => "Filter systems by uuid"
+  param :organization_id, String, :desc => "Specify the organization", :required => true
+  param :environment_id, String, :desc => "Filter by environment"
+  param :system_group_id, String, :desc => "Filter by system group"
+  def index
+    filters = []
+
+    if params[:environment_id]
+      filters << {:terms => {:environment_id => [params[:environment_id]] }}
+    elsif params[:system_group_id]
+      filters << {:terms => {:system_group_id => [params[:system_group_id]] }}
+    else
+      filters << readable_filters
+    end
+
+    filters << {:terms => {:uuid => System.all_by_pool_uuid(params['pool_id']) }} if params['pool_id']
+    filters << {:terms => {:uuid => [params['uuid']] }} if params['uuid']
+
+    options = {
+        :filters       => filters,
+        :load_records? => true
+    }
+    respond_for_index(:collection => item_search(System, params, options))
+  end
+
+  api :POST, "/environments/:environment_id/consumers", "Register a system in environment (compatibility reason)"
+  api :POST, "/environments/:environment_id/systems", "Register a system in environment"
+  api :POST, "/systems", "Register a system"
+  param_group :system
+  def create
+    @system = System.create!(system_params.merge(:environment  => @environment,
+                                                 :content_view => @content_view,
+                                                 :serviceLevel => params[:service_level]))
+    respond_for_create
   end
 
   api :PUT, "/consumers/:id", "Update system information (compatibility)"
@@ -128,6 +235,113 @@ class Api::V2::SystemsController < Api::V1::SystemsController
   def task
     task = TaskStatus.find(params[:task_id]).refresh
     respond_for_show(:resource => task, :template => :task)
+  end
+
+  private
+
+  def find_system
+    @system = System.first(:conditions => { :uuid => params[:id] })
+    if @system.nil?
+      Resources::Candlepin::Consumer.get params[:id] # check with candlepin if system is Gone, raises RestClient::Gone
+      fail HttpErrors::NotFound, _("Couldn't find system '%s'") % params[:id]
+    end
+  end
+
+  def find_environment
+    return unless params.key?(:environment_id)
+
+    @environment = KTEnvironment.find(params[:environment_id])
+    fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
+    @organization = @environment.organization
+    @environment
+  end
+
+  def find_system_group
+    return unless params.key?(:system_group_id)
+
+    @system_group = SystemGroup.find(params[:system_group_id])
+    fail HttpErrors::NotFound, _("Couldn't find system group '%s'") % params[:system_group_id] if @system_group.nil?
+  end
+
+  def find_only_environment
+    if !@environment && @organization && !params.key?(:environment_id)
+      if @organization.environments.empty?
+        fail HttpErrors::BadRequest, _("Organization %{org} has the '%{env}' environment only. Please create an environment for system registration.") %
+          { :org => @organization.name, :env => "Library" }
+      end
+
+      # Some subscription-managers will call /users/$user/owners to retrieve the orgs that a user belongs to.
+      # Then, If there is just one org, that will be passed to the POST /api/consumers as the owner. To handle
+      # this scenario, if the org passed in matches the user's default org, use the default env. If not use
+      # the single env of the org or throw an error if more than one.
+      #
+      if @organization.environments.size > 1
+        if current_user.default_environment && current_user.default_environment.organization == @organization
+          @environment = current_user.default_environment
+        else
+          fail HttpErrors::BadRequest, _("Organization %s has more than one environment. Please specify target environment for system registration.") % @organization.name
+        end
+      else
+        if @environment = @organization.environments.first
+          return
+        end
+      end
+    end
+  end
+
+  def find_environment_and_content_view
+    # There are some scenarios (primarily create) where a system may be
+    # created using the content_view_environment.cp_id which is the
+    # equivalent of "environment_id"-"content_view_id".
+    return unless params.key?(:environment_id)
+
+    if params[:environment_id].is_a? String
+      if !params.key?(:content_view_id)
+        cve = get_content_view_environment_by_cp_id(params[:environment_id])
+        @environment = cve.environment
+        @organization = @environment.organization
+        @content_view = cve.content_view
+      else
+        # assumption here is :content_view_id is passed as a separate attrib
+        @environment = KTEnvironment.find(params[:environment_id])
+        @organization = @environment.organization
+        fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
+      end
+      return @environment, @content_view
+    else
+      find_environment
+    end
+  end
+
+  def find_content_view
+    if (content_view_id = (params[:content_view_id] || params[:system].try(:[], :content_view_id)))
+      setup_content_view(content_view_id)
+    end
+  end
+
+  def readable_filters
+    {:terms => {:environment_id => KTEnvironment.systems_readable(@organization).collect { |item| item.id } }}
+  end
+
+  def index_systems_perms_check
+    lambda do
+      perms = [(System.any_readable?(@organization) if @organization),
+               (System.any_readable?(@environment) if @environment),
+               (System.any_readable?(@system_group) if @system_group)]
+      perms.compact.inject { |t, v| t && v }
+    end
+  end
+
+  def system_params
+    system_params = params.slice(:name, :owner, :facts, :installedProducts)
+
+    if params.key?(:cp_type)
+      system_params[:cp_type] = params[:cp_type]
+    elsif params.key?(:type)
+      system_params[:cp_type] = params[:type]
+    end
+
+    system_params
   end
 
 end

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -19,7 +19,7 @@ class Product < ActiveRecord::Base
   include Glue::Pulp::Repos if Katello.config.use_pulp
   include Glue if Katello.config.use_cp || Katello.config.use_pulp
 
-  include Authorization::Product
+  include Katello::Authorization::Product
   include AsyncOrchestration
 
   include Ext::LabelFromName

--- a/test/controllers/api/v2/systems_controller_test.rb
+++ b/test/controllers/api/v2/systems_controller_test.rb
@@ -46,6 +46,13 @@ class Api::V2::SystemsControllerTest < ActionController::TestCase
     permissions
   end
 
+  def test_index
+    get :index, :organization_id => get_organization(:organization1).label
+
+    assert_response :success
+    assert_template 'api/v2/systems/index'
+  end
+
   def test_show
     get :show, :id => @system.uuid
 
@@ -76,9 +83,8 @@ class Api::V2::SystemsControllerTest < ActionController::TestCase
 
   def test_add_system_groups
     expected_ids = @system_groups.collect {|group| group.id}
-    post :add_system_groups, :id => @system.uuid, :system => {
-        :system_group_ids => expected_ids
-    }
+    post :add_system_groups, :id => @system.uuid,
+         :system => { :system_group_ids => expected_ids }
 
     assert_response :success
     assert_template 'api/v2/systems/add_system_groups'
@@ -87,9 +93,8 @@ class Api::V2::SystemsControllerTest < ActionController::TestCase
 
   def test_add_system_groups_empty
     expected_ids = []
-    post :add_system_groups, :id => @system.uuid, :system => {
-        :system_group_ids => expected_ids
-    }
+    post :add_system_groups, :id => @system.uuid,
+         :system => { :system_group_ids => expected_ids }
 
     assert_response :success
     assert_template 'api/v2/systems/add_system_groups'
@@ -97,9 +102,8 @@ class Api::V2::SystemsControllerTest < ActionController::TestCase
   end
 
   def test_add_system_groups_nil
-    post :add_system_groups, :id => @system.uuid, :system => {
-        :system_group_ids => nil
-    }
+    post :add_system_groups, :id => @system.uuid,
+         :system => { :system_group_ids => nil }
 
     assert_response :success
     assert_template 'api/v2/systems/add_system_groups'


### PR DESCRIPTION
- `Api::V2::SystemsController` extends `Api::V2::ApiController` instead
  of `Api::V1::SystemsController` so if a v2 action doesn't work, try
  the v1 action for now.
- moved a common method from `SystemsController` to `ApiController`
- fixed some indentations

---
- [x] fix broken tests
