### PR TITLE
Add Katello namespace to Authorization::Provider

### DIFF
--- a/app/models/katello/provider.rb
+++ b/app/models/katello/provider.rb
@@ -17,7 +17,7 @@ class Provider < ActiveRecord::Base
   include Glue::ElasticSearch::Provider if Katello.config.use_elasticsearch
   include Glue::Provider
   include Glue
-  include Authorization::Provider
+  include Katello::Authorization::Provider
   include AsyncOrchestration
 
   include Ext::PermissionTagCleanup


### PR DESCRIPTION
Fixes an error that occurs when using katello_api at
https://github.com/Katello/katello_api/pull/13 to generate v2 API
documentation for the changes I made to the ProductController in
https://github.com/Katello/katello/pull/3479
