### PR TITLE
add locale directory to gem.files

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.summary     = ""
   gem.description = ""
 
-  gem.files = Dir["{app,vendor,lib,db,config}/**/*"] + ["LICENSE.txt", "README.md"]
+  gem.files = Dir["{app,vendor,lib,db,config,locale}/**/*"] + ["LICENSE.txt", "README.md"]
   gem.files += Dir["engines/bastion/{app,vendor,lib}/**/*"]
   gem.files += Dir["engines/bastion/{README.md,Bastion.gemspec}"]
   gem.files += Dir["engines/fort/{app,config,db,lib}/**/*"]


### PR DESCRIPTION
If this directory is missing foreman fails to start with an error message to the effect that the directory is not available.
