### PR TITLE
Engine: Renaming katello gemfile to something less generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ rake db:create
 The Katello setup assumes that you have a previously setup Foreman checkout or have followed the instructions in the Setup Foreman section. The first step is to add the Katello engine and install dependencies:
 
 ```bash
-echo "gemspec :path => '../katello', :development_group => :katello_dev" >> bundler.d/Gemfile.local.rb
+echo "gemspec :path => '../katello', :development_group => :katello_dev" >> bundler.d/katello.local.rb
 bundle update
 ```
 


### PR DESCRIPTION
I have several *.local.rb files so Gemfile.local.rb seems really generic and I keep wondering what it's for. It should really be something specific like `katello.local.rb`.
