### PR TITLE
Update README with JavaScript troubleshooting solutions

### DIFF
--- a/engines/bastion/README.md
+++ b/engines/bastion/README.md
@@ -59,13 +59,51 @@ A set of files can be included by using an array instead of a string to list the
 
     grunt bower:install
 
-### Updating Dependency ###
+### Updating a Dependency ###
 
-To update a dependency, the version must be bumped in the `bower.json` file, installed and commited to source control. To bump the version, open `bower.json`, locate the proper entry and change the version number. Now, install the new version:
+To update a dependency, the version must be bumped in the `bower.json` file, installed and committed to source control. To bump the version, open `bower.json`, locate the proper entry and change the version number. Now, install the new version:
 
-    grunt bower:install
+    grunt bower:update
 
 Lastly, double check the new files with something like `git status`, add them and commit them with a message indicating that a new dependency version is being committed. We prefer that when committing a new depenendency, a single commit is generated with just the changes from the update.
+
+### Example Dependency Errors ###
+
+[See *Fixing Dependency Errors*](#fixing-dependency-errors) for more commands to help fix errors such as these:
+
+**Error 1: local Npm module not installed**
+
+`Local Npm module "grunt-angular-gettext" not found. Is it installed?`
+
+Running `npm install` and `grunt bower:dev` again should fix the issue.
+
+**Error 2: the unmet dependency**
+
+*Traceback abbreviated to highlight error*
+
+```
+npm WARN unmet dependency /usr/lib/node_modules/block-stream requires inherits@'~2.0.0' but will load
+npm WARN unmet dependency undefined
+```
+
+Running `sudo npm update -g phantomjs bower grunt-cli` should fix the issue.
+
+### Fixing Dependency Errors ###
+
+[See *Example Dependency Errors*](#example-dependency-errors) to see common errors and their fixes.
+
+Over time libraries, packages, and/or dependencies are often updated or added so you may have to rerun one or more
+of the following commands to fix them:
+
+**Note**: You only need to run `grunt bower update` when updating or pulling in changes to `bower.json` where the
+version of a component has been bumped.
+
+[See also *Installing a New Dependency*](#installing-a-new-dependency) as well as the related section
+[*Updating a New Dependency*](#updating-a-new-dependency)
+
+- `sudo npm update -g phantomjs bower grunt-cli`
+- `npm install`
+- `grunt bower:dev`
 
 ## Testing ##
 
@@ -102,14 +140,6 @@ Install the JavaScript asset libraries used for testing defined within the `devD
     grunt bower:dev
 
 Run 'grunt test' to ensure test setup is working.
-
-As libraries are updated or added over time, you may have to rerun `npm install` and `grunt bower:dev`.  If you encounter errors such as this:
-
-```
- Local Npm module "grunt-angular-gettext" not found. Is it installed?
-```
-
-Running `npm install` and `grunt bower:dev` again should fix the issue.
 
 #### Test Commands ####
 


### PR DESCRIPTION
These changes update the README to add a new solution for fixing dependency errors related to npm, bower, and grunt.

The error described in the README happened in when I ran `grunt bower:update` in engines/bastion.
The README now has an additional command for fixing these sorts of errors.
