### PR TITLE
Fixes issue where running 'rake katello:reset' wouldn't always reset

### DIFF
--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -18,11 +18,13 @@ namespace :katello do
     end
 
     task :candlepin do
-      system(service_stop.gsub("%s", "tomcat6"))
+      tomcat = File.exists?('/var/lib/tomcat') ? 'tomcat' : 'tomcat6'
+
+      system(service_stop.gsub("%s", tomcat))
       system("sudo /usr/share/candlepin/cpdb --drop --create")
       system("sudo /usr/share/candlepin/cpsetup -s -k `sudo cat /etc/katello/keystore_password-file`")
-      system("sudo cp /etc/tomcat6/server.xml.original /etc/tomcat6/server.xml")
-      system(service_start.gsub("%s", "tomcat6"))
+      system("sudo cp /etc/#{tomcat}/server.xml.original /etc/#{tomcat}/server.xml")
+      system(service_start.gsub("%s", tomcat))
       puts "Candlepin database reset."
     end
 


### PR DESCRIPTION
the Candlepin database correctly.

Prior to this patch, the reset script assumed the existence of 'tomcat6'
which is not always the case. On most Fedora's, tomcat is under 'tomcat'
which resulted in the service never being stopped and Candlepin database
not being properly reset. This updates the task to check which tomcat
is installed and use it.
