### PR TITLE
Add email for admin user to seeds

### DIFF
--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -58,6 +58,8 @@ namespace :katello do
 
     # Otherwise migration fails since it currently requires a reloaded environment
     system('rake db:migrate')
+    # Load configuration needed by db:seed first
+    require './config/initializers/foreman.rb'
     Rake::Task['db:seed'].invoke
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -60,6 +60,27 @@ class UserCreateTest < UserTestBase
 
 end
 
+class UserCreateFailNoEmailTest < UserTestBase
+
+  def setup
+    super
+    @user = build(:user, :batman)
+    @user.auth_source = auth_sources(:one)
+    @user.mail = nil
+  end
+
+  def teardown
+    @user.destroy
+  end
+
+  def test_create
+    @user.save
+    @user.valid?
+    assert @user.errors.messages.key?(:mail)
+  end
+
+end
+
 class UserTest < UserTestBase
 
   def setup


### PR DESCRIPTION
The rake task rake katello:reset was failing during seeding, because
the admin user being created didn't have an email address.  I also
added a test indicating that email is a required attribute.
