### PR TITLE
	Fix less parse error by removing bastion stylesheets from assets, fixes #3536

### DIFF
--- a/engines/bastion/lib/bastion/engine.rb
+++ b/engines/bastion/lib/bastion/engine.rb
@@ -6,7 +6,6 @@ module Bastion
 
     initializer "bastion.assets.paths", :group => :all do |app|
       app.config.assets.paths << Bastion::Engine.root.join('app', 'assets')
-      app.config.assets.paths << Bastion::Engine.root.join('vendor', 'assets', 'stylesheets', 'bastion')
       app.config.assets.paths << Bastion::Engine.root.join('vendor', 'assets', 'stylesheets', 'bastion',
                                                            'font-awesome', 'scss')
       app.config.assets.paths << Bastion::Engine.root.join('vendor', 'assets', 'fonts')


### PR DESCRIPTION
The issue here was that the less parser was trying to import the bootstrap
scss in foreman and was obviously unable to parse it because it was less
instead of scss.
