### PR TITLE
V2: Cleaning up find methods

### DIFF
--- a/app/controllers/katello/api/v2/changesets_content_controller.rb
+++ b/app/controllers/katello/api/v2/changesets_content_controller.rb
@@ -46,13 +46,11 @@ class Api::V2::ChangesetsContentController < Api::V2::ApiController
 
   def find_changeset
     @changeset = Changeset.find(params[:changeset_id])
-    @changeset
   end
 
   def find_content_view
     content_view_id = params.try(:[], :content_view).try(:[], :id) || params.try(:[], :id)
-    @view           = ContentView.find_by_id(content_view_id)
-    fail HttpErrors::NotFound, _("Couldn't find content view '%s'") % content_view_id if @view.nil?
+    @view           = ContentView.find(content_view_id)
   end
 
 end

--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -57,25 +57,19 @@ class Api::V2::ErrataController < Api::V2::ApiController
   def find_environment
     if params.key?(:environment_id)
       @environment = KTEnvironment.find(params[:environment_id])
-      fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
-      @environment
     end
   end
 
   def find_repository
     if params.key?(:repository_id)
       @repo = Repository.find(params[:repository_id])
-      fail HttpErrors::NotFound, _("Couldn't find repository '%s'") % params[:repository_id] if @repo.nil?
       @environment ||= @repo.environment
-      @repo
     end
   end
 
   def find_erratum
     @erratum = Errata.find(params[:id])
-    fail HttpErrors::NotFound, _("Erratum with id '%s' not found") % params[:id] if @erratum.nil?
     fail HttpErrors::NotFound, _("Erratum '%s' not found within the repository") % params[:id] unless @erratum.repoids.include? @repo.pulp_id
-    @erratum
   end
 
   def require_repo_or_environment

--- a/app/controllers/katello/api/v2/providers_controller.rb
+++ b/app/controllers/katello/api/v2/providers_controller.rb
@@ -132,7 +132,6 @@ class Api::V2::ProvidersController < Api::V2::ApiController
     def find_provider
       @provider = Provider.find(params[:id])
       @organization ||= @provider.organization
-      fail HttpErrors::NotFound, _("Couldn't find provider '%s'") % params[:id] if @provider.nil?
     end
 
     def provider_params

--- a/app/controllers/katello/api/v2/system_errata_controller.rb
+++ b/app/controllers/katello/api/v2/system_errata_controller.rb
@@ -40,8 +40,7 @@ class Api::V2::SystemErrataController < Api::V2::ApiController
   private
 
   def find_system
-    @system = System.first(:conditions => { :uuid => params[:system_id] })
-    fail HttpErrors::NotFound, _("Couldn't find system '%s'") % params[:system_id] if @system.nil?
+    @system = System.find_by_uuid!(params[:system_id])
     @system
   end
 end

--- a/app/controllers/katello/api/v2/system_groups_controller.rb
+++ b/app/controllers/katello/api/v2/system_groups_controller.rb
@@ -187,8 +187,7 @@ class Api::V2::SystemGroupsController <  Api::V2::ApiController
   private
 
   def find_system_group
-    @system_group = SystemGroup.where(:id => params[:id]).first
-    fail HttpErrors::NotFound, _("Couldn't find system group '%s'") % params[:id] if @system_group.nil?
+    @system_group = SystemGroup.find(params[:id])
   end
 
   def system_uuids_to_ids(ids)

--- a/app/controllers/katello/api/v2/system_packages_controller.rb
+++ b/app/controllers/katello/api/v2/system_packages_controller.rb
@@ -85,8 +85,7 @@ class Api::V2::SystemPackagesController < Api::V2::ApiController
   private
 
   def find_system
-    @system = System.first(:conditions => { :uuid => params[:system_id] })
-    fail HttpErrors::NotFound, _("Couldn't find system '%s'") % params[:system_id] if @system.nil?
+    @system = System.find_by_uuid!(params[:system_id])
     @system
   end
 

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -270,7 +270,6 @@ class Api::V2::SystemsController < Api::V2::ApiController
     return unless params.key?(:environment_id)
 
     @environment = KTEnvironment.find(params[:environment_id])
-    fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
     @organization = @environment.organization
     @environment
   end
@@ -278,8 +277,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
   def find_system_group
     return unless params.key?(:system_group_id)
 
-    @system_group = SystemGroup.find(params[:system_group_id])
-    fail HttpErrors::NotFound, _("Couldn't find system group '%s'") % params[:system_group_id] if @system_group.nil?
+    @system_group = SystemGroup.find_by_id(params[:system_group_id])
   end
 
   def find_only_environment


### PR DESCRIPTION
Calling find or find_by_field! automatically raises: 

``` ruby
ActiveRecord::RecordNotFound, _("Couldn't find User with id=1000")
```
