### PR TITLE
Bastion - System Groups details page fix

### DIFF
--- a/engines/bastion/app/assets/bastion/system-groups/details/system-group-details.controller.js
+++ b/engines/bastion/app/assets/bastion/system-groups/details/system-group-details.controller.js
@@ -48,6 +48,7 @@ angular.module('Bastion.system-groups').controller('SystemGroupDetailsController
             group.$update(function (response) {
                 deferred.resolve(response);
                 $scope.successMessages.push(gettext('System Group updated'));
+                $scope.table.replaceRow(response);
             }, function (response) {
                 deferred.reject(response);
                 $scope.errorMessages.push(gettext("An error occurred saving the System Group: ") + response.data.displayMessage);

--- a/engines/bastion/test/system-groups/details/system-group-details.controller.test.js
+++ b/engines/bastion/test/system-groups/details/system-group-details.controller.test.js
@@ -28,7 +28,10 @@ describe('Controller: SystemGroupDetailsController', function() {
 
         $scope.$stateParams = {systemGroupId: 1};
         $scope.removeRow = function() {};
-        $scope.table = {addRow: function() {}};
+        $scope.table = {
+            addRow: function() {},
+            replaceRow: function() {}
+        };
 
         gettext = function(message) {
             return message;


### PR DESCRIPTION
Fixed a minor issue in the system groups details page
where if you changed the name of the system group the
left panel holding the names of the system groups wouldnt get
updated. This should now work.
