### PR TITLE
Initial work on asset compilation as an engine.

### DIFF
--- a/app/assets/stylesheets/katello/katello.scss
+++ b/app/assets/stylesheets/katello/katello.scss
@@ -18,6 +18,8 @@
 @import "katello/widgets/scrollpane";
 @import "katello/widgets/env_select";
 @import "katello/widgets/tipsy_custom";
+@import "katello/widgets/tabs";
+@import "katello/widgets/path_selector";
 @import "katello/katello_sprites";
 
 @import "katello/jquery-ui-1.8.11.custom";
@@ -31,6 +33,17 @@
 @import "katello/ui.spinner";
 
 @import "katello/custom_info";
+@import "katello/activation_keys";
+@import "katello/content_search";
+@import "katello/contents";
+@import "katello/dashboard";
+@import "katello/distributors";
+@import "katello/generic";
+@import "katello/notifications";
+@import "katello/operations";
+@import "katello/orgs";
+@import "katello/subscriptions";
+@import "katello/systems";
 
 body {
   background-color: white;

--- a/app/assets/stylesheets/katello/widgets/path_selector.scss
+++ b/app/assets/stylesheets/katello/widgets/path_selector.scss
@@ -1,4 +1,4 @@
-@import "katello/katello_base";
+@import "katello/katello_mixins";
 
 //temporarily putting this here to speed development
 //TODO Move to env_select.scss
@@ -115,7 +115,6 @@ $widget-background-color: #F9F8F8;
     background: $breadcrumbbg_color;                    //fallback color
     display: block;
     font-weight: normal;
-    font-family: $screenfont;
     font-size: 10px;
     margin-bottom: 0;
 

--- a/app/views/katello/changesets/index.html.haml
+++ b/app/views/katello/changesets/index.html.haml
@@ -1,5 +1,3 @@
-= stylesheet 'katello/widgets/path_selector'
-
 .grid_16
   = environment_selector(:library_clickable=>false, :accessible_envs=>accessible_envs)
 

--- a/app/views/katello/content_search/index.html.haml
+++ b/app/views/katello/content_search/index.html.haml
@@ -1,5 +1,4 @@
 = javascript 'katello/content_search'
-= stylesheet 'katello/content_search', 'katello/widgets/path_selector'
 
 = javascript do
   :plain

--- a/app/views/katello/custom_info/_edit.html.haml
+++ b/app/views/katello/custom_info/_edit.html.haml
@@ -1,6 +1,3 @@
-
-= stylesheet "katello/custom_info"
-
 = javascript 'katello/widgets/jquery.jeditable.helpers'
 
 = content_for :content do

--- a/app/views/katello/distributors/index.html.haml
+++ b/app/views/katello/distributors/index.html.haml
@@ -1,4 +1,3 @@
-= stylesheet 'katello/widgets/path_selector'
 = javascript do
   :plain
     localize({

--- a/app/views/katello/layouts/katello.haml
+++ b/app/views/katello/layouts/katello.haml
@@ -7,7 +7,6 @@
 
 = content_for(:stylesheets) do
   = stylesheet "katello/katello"
-  = stylesheet "katello/#{controller.section_id}"
 
 = content_for(:javascripts) do
   = javascript_include_tag "katello/common/vendor"

--- a/app/views/katello/organizations/index.html.haml
+++ b/app/views/katello/organizations/index.html.haml
@@ -1,5 +1,3 @@
-= stylesheet 'katello/orgs'
-
 #orgs
   .grid_16
     = help_tip_button

--- a/app/views/katello/promotions/show.html.haml
+++ b/app/views/katello/promotions/show.html.haml
@@ -1,5 +1,4 @@
 = javascript 'katello/promotions'
-= stylesheet 'katello/widgets/path_selector'
 
 = javascript do
   :plain

--- a/app/views/katello/providers/redhat/show.html.haml
+++ b/app/views/katello/providers/redhat/show.html.haml
@@ -1,5 +1,4 @@
 = javascript 'katello/providers/redhat'
-= stylesheet 'katello/widgets/tabs', 'katello/dashboard'
 
 #redhat_provider
   .grid_16

--- a/app/views/katello/system_groups/index.html.haml
+++ b/app/views/katello/system_groups/index.html.haml
@@ -1,5 +1,3 @@
-= stylesheet 'katello/systems'
-
 = javascript do
   :plain
     localize({

--- a/app/views/katello/systems/index.html.haml
+++ b/app/views/katello/systems/index.html.haml
@@ -1,4 +1,3 @@
-= stylesheet 'widgets/path_selector'
 = javascript do
   :plain
     localize({

--- a/engines/bastion/app/assets/bastion/stylesheets/less/bastion.less
+++ b/engines/bastion/app/assets/bastion/stylesheets/less/bastion.less
@@ -19,6 +19,18 @@
   [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
     display: none;
   }
+
+  [class*="icon-"] {
+    &.green {
+      color: #57a81c;
+    }
+    &.yellow {
+      color: #fc3;
+    }
+    &.red {
+      color: #9e292b;
+    }
+  }
 }
 
 .maincontent {

--- a/engines/bastion/app/assets/bastion/stylesheets/scss/bastion.scss
+++ b/engines/bastion/app/assets/bastion/stylesheets/scss/bastion.scss
@@ -12,35 +12,6 @@ body {
   overflow: hidden;
 }
 
-.status_icon {
-  height: 15px;
-  width: 15px;
-  background: $status_icons_green_small;
-  //margin: 2px 1px 1px 1px;
-
-  &.green {
-    background: $status_icons_green_small;
-  }
-  &.yellow {
-    background: $status_icons_yellow_small;
-  }
-  &.red {
-    background: $status_icons_red_small;
-  }
-}
-
-[class*="icon-"] {
-  &.green {
-    color: $green2;
-  }
-  &.yellow {
-    color: $o2;
-  }
-  &.red {
-    color: $rh-red2;
-  }
-}
-
 .inline-confirmation {
   @include border-radius(5px);
   @include box-shadow(rgba(0,0,0,0.4), 2px 2px 2px);
@@ -147,10 +118,6 @@ input[type="checkbox"] {
   background: rgb(250, 250, 250);
   margin-top: 20px;
   padding: 8px;
-}
-
-.page-error {
-  color: $rh-red2 !important;
 }
 
 //used for small panes such 'copy' actions

--- a/engines/bastion/lib/bastion/engine.rb
+++ b/engines/bastion/lib/bastion/engine.rb
@@ -11,27 +11,6 @@ module Bastion
       app.config.less.paths << "#{Bastion::Engine.root}/vendor/assets/stylesheets/bastion"
 
       app.middleware.use ::ActionDispatch::Static, "#{Bastion::Engine.root}/app/assets/bastion"
-
-      app.config.assets.precompile << proc do |path|
-        full_path = Rails.application.assets.resolve(path).to_path
-        if path =~ /\.(css|js)\z/
-          if full_path.include?("bastion.js")
-            puts "Including Bastion master JS file"
-            true
-          elsif full_path.include?("bastion.scss")
-            puts "Including Bastion master SCSS file"
-            true
-          elsif full_path.include?("bastion.less")
-            puts "Including Bastion master LESS file"
-            true
-          else
-            false
-          end
-        else
-          false
-        end
-      end
-
     end
   end
 end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -27,7 +27,7 @@ module Katello
     initializer "katello.assets.paths", :group => :all do |app|
       app.config.assets.paths << "#{::UIAlchemy::Engine.root}/vendor/assets/ui_alchemy/alchemy-forms"
       app.config.assets.paths << "#{::UIAlchemy::Engine.root}/vendor/assets/ui_alchemy/alchemy-buttons"
-      app.config.sass.load_paths << "#{Bastion::Engine.root}/vendor/assets/components/font-awesome/scss"
+      #app.config.sass.load_paths << "#{Bastion::Engine.root}/vendor/assets/components/font-awesome/scss"
     end
 
     initializer "katello.paths" do |app|
@@ -50,6 +50,16 @@ module Katello
 
       app.config.logger = ::Logging.logger['app']
       app.config.active_record.logger = ::Logging.logger['sql']
+    end
+
+    initializer :register_assets do |app|
+      if Rails.env.production?
+        assets = YAML.load_file("#{Katello::Engine.root}/public/assets/manifest.yml")
+
+        assets.each_pair do |file, digest|
+          app.config.assets.digests[file] = digest
+        end
+      end
     end
 
     config.to_prepare do
@@ -82,6 +92,7 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/regenerate_repo_metadata.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/reindex.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/rubocop.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/asset_compile.rake"
     end
 
   end

--- a/lib/katello/tasks/asset_compile.rake
+++ b/lib/katello/tasks/asset_compile.rake
@@ -1,0 +1,64 @@
+desc 'Compile Katello assets'
+task 'assets:precompile:katello' => ['assets:environment'] do
+ 
+  def compile_assets(args)
+    precompile = args.fetch(:precompile, [])
+
+    _ = ActionView::Base
+    
+    target = File.join(Katello::Engine.root, 'public', 'assets')
+
+    config = Rails.application.config
+    config.assets.digests = {}
+    config.assets.manifest = File.join(target)
+    config.assets.initialize_on_precompile = false
+
+    config.assets.compile = args.fetch(:compile, true)
+    config.assets.compress = args.fetch(:compress, true)
+    config.assets.digest  = args.fetch(:digest, true)
+
+    env = Rails.application.assets
+    compiler = Sprockets::StaticCompiler.new(env,
+                                             target,
+                                             precompile,
+                                             :manifest_path => config.assets.manifest,
+                                             :digest => config.assets.digest,
+                                             :manifest => true)
+    compiler.compile
+  end
+
+  def compile_fonts
+    compile_assets(
+      precompile: [/\.(?:svg|eot|woff|ttf)$/],
+      digest: false
+    )
+  end
+
+  def compile_javascript_stylesheets
+    asset_dir = "#{Katello::Engine.root}/app/assets/javascripts/"
+
+    asset_paths = Dir[File.join(asset_dir, '**', '*') ].reject { |file| File.directory?(file) }
+    asset_paths.each do |file| 
+      file.slice!(asset_dir)
+    end
+
+    precompile = [
+      'katello/katello.css',
+      'stylesheets/less/bastion.css',
+      'stylesheets/scss/bastion.css',
+      'bastion.js',
+    ]
+
+    asset_paths.each do |asset|
+      precompile.append(asset)
+    end
+
+
+    compile_assets(
+      precompile: precompile
+    )
+  end
+
+  compile_fonts
+  compile_javascript_stylesheets
+end


### PR DESCRIPTION
This is designed to allow asset compilation of Katello assets. These assets are generated in `katello/public/assets` and made to be served up by the webserver when accessing a Katello page. To test this:

Disable Katello in the local gemfile and compile Foreman assets:

```
rake assets:precompile
```

Re-enable Katello gem and compile Katello assets from Foreman checkout:

```
rake assets:precompile:katello
```

Serve static assets with Rails server by opening `foreman/config/application.rb` and adding the following among the other config:

```
config.middleware.use ::ActionDispatch::Static, "#{Katello::Engine.root}/public"
```

Start Rails server in production:

```
rails s -e production
```
