### PR TITLE
Assets: These changes reflect required fixes for assets to properly

### DIFF
--- a/engines/bastion/lib/bastion/engine.rb
+++ b/engines/bastion/lib/bastion/engine.rb
@@ -8,6 +8,7 @@ module Bastion
                                                            'font-awesome', 'scss')
       app.config.assets.paths << Bastion::Engine.root.join('vendor', 'assets', 'fonts')
 
+      app.config.less.paths << "#{Bastion::Engine.root}/app/assets/bastion/stylesheets/less"
       app.config.less.paths << "#{Bastion::Engine.root}/vendor/assets/stylesheets/bastion"
 
       app.middleware.use ::ActionDispatch::Static, "#{Bastion::Engine.root}/app/assets/bastion"

--- a/engines/bastion/vendor/assets/javascripts/bastion/angular-gettext/angular-gettext.js
+++ b/engines/bastion/vendor/assets/javascripts/bastion/angular-gettext/angular-gettext.js
@@ -1,6 +1,8 @@
-if (typeof jQuery === 'undefined') {
-  throw new Error('Angular-gettext depends on jQuery, be sure to include it!');
-}
+// Commenting this check out as it breaks asset compilation on RHEL6
+// with the current version of therubyracer (0.11.0beta5)
+//if (typeof jQuery === 'undefined') {
+//  throw new Error('Angular-gettext depends on jQuery, be sure to include it!');
+//}
 angular.module('gettext', []);
 angular.module('gettext').factory('gettext', function () {
   return function (str) {

--- a/lib/katello/tasks/asset_compile.rake
+++ b/lib/katello/tasks/asset_compile.rake
@@ -1,6 +1,11 @@
 desc 'Compile Katello assets'
-task 'assets:precompile:katello' => ['assets:environment'] do
+task 'assets:precompile:katello' do
  
+  # Partially load the Rails environment to avoid
+  # the need of a database being setup
+  Rails.application.initialize!(:assets)
+  Sprockets::Bootstrap.new(Rails.application).run
+
   def compile_assets(args)
     precompile = args.fetch(:precompile, [])
 
@@ -11,7 +16,6 @@ task 'assets:precompile:katello' => ['assets:environment'] do
     config = Rails.application.config
     config.assets.digests = {}
     config.assets.manifest = File.join(target)
-    config.assets.initialize_on_precompile = false
 
     config.assets.compile = args.fetch(:compile, true)
     config.assets.compress = args.fetch(:compress, true)


### PR DESCRIPTION
compile on RHEL6 with the current RHSCL packages used for asset compilation.

Most notably the current versions of therubyracer (0.11.0beta5) and
uglifier (1.2.6).
