### PR TITLE
Fixes #4012: Converts sync management and sync schedule routes into reso...

### DIFF
--- a/app/views/katello/sync_management/_products.html.haml
+++ b/app/views/katello/sync_management/_products.html.haml
@@ -1,5 +1,5 @@
-= form_tag("sync", :method => :post, :remote => true, :id => 'sync_product_form') do
-  = hidden_field_tag 'sync_status_url', nil, 'data-url' => sync_management_sync_status_path
+= form_tag("sync_management/sync", :method => :post, :remote => true, :id => 'sync_product_form') do
+  = hidden_field_tag 'sync_status_url', nil, 'data-url' => sync_status_sync_management_index_path
   %table#products_table
     %thead
       %th= _("Product")

--- a/app/views/katello/sync_schedules/index.html.haml
+++ b/app/views/katello/sync_schedules/index.html.haml
@@ -9,7 +9,7 @@
 #main.container_16
   = one_panel('products', @products, @products_options)
   = one_panel('plans', @plans, @plans_options)
-  = form_tag sync_schedules_apply_path, :method => "post", :id => "sync_schedule_form" do
+  = form_tag apply_sync_schedules_path, :method => "post", :id => "sync_schedule_form" do
     = hidden_field_tag :data
     = button_to _("Apply Selected Plan to Selected Products"), {:action => "apply",
       :controller => "sync_schedules"}, :disabled => !@organization.syncable?, :method => :post, :class => 'dialogbutton fr', :id => 'apply_button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,15 +150,22 @@ Katello::Engine.routes.draw do
     end
   end
 
-  get  "sync_schedules/index"
-  post "sync_schedules/apply"
+  resources :sync_schedules do
+    collection do
+      get :index
+      post :apply
+    end
+  end
 
-  get "sync_management/manage"
-  get "sync_management/index"
-  post "sync_management/sync"
-  get  "sync_management/sync_status"
-  get  "sync_management/product_status"
-  resources :sync_management, :only => [:destroy]
+  resources :sync_management, :only => [:destroy] do
+    collection do
+      get :manage
+      get :index
+      get :sync_status
+      get :product_status
+      post :sync
+    end
+  end
 
   get "notices/note_count"
   get "notices/get_new"


### PR DESCRIPTION
...urces delcarations.

This is needed in order to fix an issue with 3.2.8 and the declaration
of menu's in lib/katello/plugin.rb against Foreman. Rails 3.2.8 is provided
by RHSCL 1.0 and the menu system fails unless a resource for the main
route is delcared via the resources method.
