### PR TITLE
1053156 - fix slowness in errata indexing

### DIFF
--- a/app/models/katello/glue/elastic_search/errata.rb
+++ b/app/models/katello/glue/elastic_search/errata.rb
@@ -54,7 +54,6 @@ module Glue::ElasticSearch::Errata
               :id           => { :type => 'string', :index => :not_analyzed},
               :errata_id    => { :type => 'string', :analyzer => :snowball},
               :errata_id_exact => { :type => 'string', :index => :not_analyzed},
-              :product_ids  => { :type => 'integer', :analyzer => :kt_name_analyzer},
               :severity     => { :type => 'string', :analyzer => :kt_name_analyzer},
               :type         => { :type => 'string', :analyzer => :kt_name_analyzer},
               :title        => { :type => 'string', :analyzer => :title_analyzer},
@@ -74,7 +73,6 @@ module Glue::ElasticSearch::Errata
           :errata_id_exact => self.errata_id,
           :errata_id_sort => self.errata_id,
           :id_title => self.errata_id + ' : ' + self.title,
-          :product_ids => self.product_ids,
           :issued => self.issued.split[0]
         }
       end
@@ -87,9 +85,9 @@ module Glue::ElasticSearch::Errata
         filter_for_errata[:repoids] = repos.collect{|r| r.pulp_id} if !repos.empty?
 
         options = { :start => 0, :page_size => 1, :filters => filter_for_errata }
-        first = self.search('', options)
+        first = self.legacy_search('', options)
         options[:page_size] = first.total
-        self.search('', options).collect{ |e| Errata.new(e.as_json) }
+        self.legacy_search('', options).collect{ |e| Errata.new(e.as_json) }
       end
 
       def self.repos_for_filter(filter)

--- a/app/models/katello/glue/pulp/errata.rb
+++ b/app/models/katello/glue/pulp/errata.rb
@@ -129,22 +129,14 @@ module Glue::Pulp::Errata
     end
 
     def products
-      products = []
-
-      self.repoids.each do |repoid|
-        # there is a problem, that Pulp in versino <= 0.0.265-1 doesn't remove
-        # repo frmo errata when deleting repository. Therefore there might be a
-        # situation that repo is not in Pulp anymore, see BZ 790356
-        if repo = Repository.where(:pulp_id => repoid)[0]
-          products << repo.product
-        end
-      end
-
-      products.uniq
+      # there is a problem, that Pulp in versino <= 0.0.265-1 doesn't remove
+      # repo frmo errata when deleting repository. Therefore there might be a
+      # situation that repo is not in Pulp anymore, see BZ 790356
+      Product.where(:id => self.product_ids)
     end
 
     def product_ids
-      products.map(&:id)
+      Repository.where(:pulp_id => self.repo_ids).pluck(:product_id).uniq
     end
 
     def product_cp_ids


### PR DESCRIPTION
product_id does not seem to be used anywhere and its fetching
was very poorly optimized and did not seem to be used as part of
a search.

Did a grep/scan of code and tested out these pages/actions:
- Dashboard
- CVD publish
- CV Refresh
- Changeset promote
- Content search
