### PR TITLE
Changes required to have katello:reset work with a dev environment.

### DIFF
--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -114,7 +114,7 @@ class HttpResource
       raise_rest_client_exception e, a_path, "POST"
     rescue Errno::ECONNREFUSED
       service = a_path.split("/").second
-      fail Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize
+      fail Katello::Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize
     end
 
     def put(a_path, payload = {}, headers = {})

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,7 +30,7 @@ fail "Foreman admin does not exist" unless user_admin
 # create a self role for user_admin, this is normally created during admin creation;
 # however, for the initial migrate/seed, it needs to be done manually
 user_admin.katello_roles.find_or_create_own_role(user_admin)
-user_admin.katello_roles << superadmin_role
+user_admin.katello_roles << superadmin_role unless user_admin.katello_roles.include?(superadmin_role)
 user_admin.remote_id = first_user_name
 user_admin.save
 fail "Unable to update admin user: #{format_errors(user_admin)}" if user_admin.errors.size > 0

--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -22,9 +22,10 @@ namespace :katello do
 
       system(service_stop.gsub("%s", tomcat))
       system("sudo /usr/share/candlepin/cpdb --drop --create")
+      # If you see errors with 'javax.crypto.BadPaddingException: Given final block not properly padded'
+      # it is due to a candlepin dev setup with a different password on the keystre
+      # than in this file.
       system("sudo /usr/share/candlepin/cpsetup -s -k `sudo cat /etc/katello/keystore_password-file`")
-      system("sudo cp /etc/#{tomcat}/server.xml.original /etc/#{tomcat}/server.xml")
-      system(service_start.gsub("%s", tomcat))
       puts "Candlepin database reset."
     end
 


### PR DESCRIPTION
I first hit namespace issues, which is fixed in the http_resource
class. I then was getting wierd candlepin errors. This was due to
the keystore (which this does not replace) in /etc/tomcat/keystore
having been generated with a password which was not stored in
/etc/katello/keystore password. This resulted in a

javax.crypto.BadPaddingException: Given final block not properly padded

exception.

Finally, the cpsetup actually restarts tomcat, so I removed the extra
commands which are not needed.
