### PR TITLE
Gemspec: Work on gem dependencies

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   # Core Dependencies
-  gem.add_dependency "rails"
+  gem.add_dependency "rails", "~> 3.2.0"
   gem.add_dependency "json"
   gem.add_dependency "oauth"
   gem.add_dependency "rest-client"


### PR DESCRIPTION
Two goals here:
1. Speed up bundle install. Jenkins has timed out a couple times during bundle install.
2. Be able to bundle in isolation.
