### PR TITLE
fixing issue with rake katello:reset every other run

### DIFF
--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -156,7 +156,7 @@ common:
     # (typically /etc/pki/tls/certs/localhost.crt) location that is needed
     # to connect to pulp over https.
     ca_cert_file:
-
+    default_login: admin
     sync_KBlimit:
     upload_chunk_size: 1048575 # upload size in bytes to pulp. see SSLRenegBufferSize in apache
 

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -132,7 +132,7 @@ Requires: %{?scl_prefix}rubygem-gettext_i18n_rails
 Requires: %{?scl_prefix}rubygem-i18n_data >= 0.2.6
 Requires: %{?scl_prefix}rubygem-apipie-rails >= 0.0.13
 Requires: %{?scl_prefix}rubygem-maruku 
-Requires: %{?scl_prefix}rubygem-runcible = 1.0.8
+Requires: %{?scl_prefix}rubygem-runcible >= 1.0.8
 Requires: %{?scl_prefix}rubygem-ruby-openid
 Requires: %{?scl_prefix}rubygem-anemone 
 Requires: %{?scl_prefix}rubygem-simple-navigation >= 3.3.4
@@ -162,7 +162,7 @@ BuildRequires: %{?scl_prefix}rubygem-gettext_i18n_rails
 BuildRequires: %{?scl_prefix}rubygem-i18n_data >= 0.2.6
 BuildRequires: %{?scl_prefix}rubygem-apipie-rails >= 0.0.13
 BuildRequires: %{?scl_prefix}rubygem-maruku 
-BuildRequires: %{?scl_prefix}rubygem-runcible = 1.0.8
+BuildRequires: %{?scl_prefix}rubygem-runcible >= 1.0.8
 BuildRequires: %{?scl_prefix}rubygem-ruby-openid
 BuildRequires: %{?scl_prefix}rubygem-anemone 
 BuildRequires: %{?scl_prefix}rubygem-simple-navigation >= 3.3.4


### PR DESCRIPTION
The initial user would attempt to be created in pulp with a blank
oauth header.  Since this is being done in the foreman seeds, there is little
we can do about it, so this forces use of the default admin user
