### PR TITLE
adding requires on the rubygem

### DIFF
--- a/deploy/katello.spec
+++ b/deploy/katello.spec
@@ -37,6 +37,7 @@ Source0:        https://fedorahosted.org/releases/k/a/katello/%{name}-%{version}
 # service-wait dependency
 Requires:       wget
 Requires:       curl
+Requires:       %{?scl_prefix}rubygem-katello
 
 BuildRequires: asciidoc
 BuildRequires: util-linux


### PR DESCRIPTION
Having katello require rubygem-katello so installs of the main katello RPM will pull in the bulk of the app
