### PR TITLE
remove unused katello-service link

### DIFF
--- a/deploy/katello.spec
+++ b/deploy/katello.spec
@@ -98,8 +98,7 @@ chmod +x %{buildroot}%{homedir}/script/*
 install -m 644 man/katello-service.8 %{buildroot}/%{_mandir}/man8
 
 %post
-#Add /etc/rc*.d links for the script
-/sbin/chkconfig --add %{name}
+#Add /etc/rc*.d links
 /sbin/chkconfig --add %{name}-jobs
 
 #Generate secret token if the file does not exist


### PR DESCRIPTION
We no longer have a init.d entry for the katello service, don't symlink
