### PR TITLE
Lock dynflow version on 0.1.0

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "tire", "~> 0.6.0"
   gem.add_dependency "logging", ">= 1.8.0"
   gem.add_dependency "hooks"
-  gem.add_dependency "dynflow", ">= 0.1.0"
+  gem.add_dependency "dynflow", "~> 0.1.0"
   gem.add_dependency "justified"
   gem.add_dependency "strong_parameters", "~> 0.2.1" # remove after we upgrade to Rails 4
 


### PR DESCRIPTION
The 0.2.0 is not backward compatbile. We're going to have the new code merged
soon, but for now, let's not break the current master.
