### PR TITLE
fixing ng-upload forms for firefox

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/new/new-gpg-key.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/new/new-gpg-key.controller.js
@@ -33,7 +33,7 @@ angular.module('Bastion.gpg-keys').controller('NewGPGKeyController',
         $scope.contentFormType = 'paste';
 
         $scope.uploadContent = function (content) {
-            if (content && (content !== "Please wait...")) {
+            if (content) {
                 if (content.errors === undefined) {
                     $scope.table.addRow(content);
                     $scope.uploadStatus = 'success';

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/repository-details-info.controller.js
@@ -77,7 +77,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
         $scope.uploadContent = function (content) {
             var returnData;
 
-            if (content !== "Please wait...") {
+            if (content) {
                 try {
                     returnData = JSON.parse(angular.element(content).html());
                 } catch (err) {

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/manifest-import.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/manifest-import.controller.js
@@ -102,8 +102,7 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
 
         $scope.uploadManifest = function (content) {
             var returnData;
-
-            if (content !== "Please wait...") {
+            if (content) {
                 try {
                     returnData = JSON.parse(angular.element(content).html());
                 } catch (err) {


### PR DESCRIPTION
under firefox ng-upload seems to trigger the callback on page load
so we can just ignore this (as was done in gpg-keys already) if there is no
content
