### PR TITLE
remove foreman and thumbslug services now that they are no longer used

### DIFF
--- a/deploy/script/katello-service
+++ b/deploy/script/katello-service
@@ -24,11 +24,7 @@ if [ -x /etc/init.d/tomcat6 -o -x /lib/systemd/system/tomcat6.service ]; then
   TOMCAT="tomcat6"
 fi
 
-if [ -x /etc/init.d/foreman -o -x /lib/systemd/system/foreman.service ]; then
-  FOREMAN="foreman"
-fi
-
-SERVICES="$TOMCAT httpd mongod qpidd thumbslug elasticsearch $FOREMAN katello-jobs"
+SERVICES="$TOMCAT httpd mongod qpidd elasticsearch katello-jobs"
 if [ -f /etc/katello/service-list ] ; then
   . /etc/katello/service-list
 fi


### PR DESCRIPTION
Remove the foreman service from the list since it is running entirely in passenger/httpd

Remove thumbslug since it is being removed as well
