### PR TITLE
More descriptive task output for package actions + action fixtures

### DIFF
--- a/app/lib/actions/helpers/pulp_packages_presenter.rb
+++ b/app/lib/actions/helpers/pulp_packages_presenter.rb
@@ -68,8 +68,8 @@ module Actions
           if errors = task_output[:result][:errors]
             ret.concat(errors)
           end
+          return ret.join("\n")
         end
-        return ret.join("\n")
       end
 
       protected

--- a/test/actions/pulp/repository/sync_test.rb
+++ b/test/actions/pulp/repository/sync_test.rb
@@ -11,8 +11,6 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 require 'katello_test_helper'
-require 'support/actions/pulp_task'
-require 'support/actions/remote_action'
 
 module Katello
   action_class = ::Actions::Pulp::Repository::Sync

--- a/test/fixtures/actions/pulp/consumer/content_install/error.yaml
+++ b/test/fixtures/actions/pulp/consumer/content_install/error.yaml
@@ -1,0 +1,42 @@
+--- 
+  pulp_task: 
+    task_group_id: 
+    exception: 
+    traceback: 
+    "_href": /pulp/api/v2/tasks/4b3c0e90-2566-4ee3-9a3a-5bded914fe2f/
+    task_id: "4b3c0e90-2566-4ee3-9a3a-5bded914fe2f"
+    call_request_tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    reasons: []
+    start_time: "2014-01-27T10:19:24Z"
+    tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    state: finished
+    finish_time: "2014-01-27T10:19:24Z"
+    dependency_failures: {}
+    schedule_id: 
+    progress: 
+      steps: 
+        - - "Refresh Repository Metadata"
+          - true
+      details: {}
+    call_request_group_id: 
+    call_request_id: "4b3c0e90-2566-4ee3-9a3a-5bded914fe2f"
+    principal_login: admin
+    response: accepted
+    result: 
+      details: 
+        rpm: 
+          details: 
+            resolved: []
+            errors: 
+              emacss: "No package(s) available to install"
+            deps: []
+          succeeded: true
+      num_changes: 0
+      succeeded: true
+      reboot: 
+        scheduled: false
+        details: {}

--- a/test/fixtures/actions/pulp/consumer/content_install/no_packages.yaml
+++ b/test/fixtures/actions/pulp/consumer/content_install/no_packages.yaml
@@ -1,0 +1,41 @@
+--- 
+  pulp_task: 
+    task_group_id: 
+    exception: 
+    traceback: 
+    "_href": /pulp/api/v2/tasks/b0636692-94af-47cd-ac36-3703882f566b/
+    task_id: b0636692-94af-47cd-ac36-3703882f566b
+    call_request_tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    reasons: []
+    start_time: "2014-01-27T10:16:03Z"
+    tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    state: finished
+    finish_time: "2014-01-27T10:16:04Z"
+    dependency_failures: {}
+    schedule_id: 
+    progress: 
+      steps: 
+        - - "Refresh Repository Metadata"
+          - true
+      details: {}
+    call_request_group_id: 
+    call_request_id: b0636692-94af-47cd-ac36-3703882f566b
+    principal_login: admin
+    response: accepted
+    result: 
+      details: 
+        rpm: 
+          details: 
+            resolved: []
+            errors: {}
+            deps: []
+          succeeded: true
+      num_changes: 0
+      succeeded: true
+      reboot: 
+        scheduled: false
+        details: {}

--- a/test/fixtures/actions/pulp/consumer/content_install/success.yaml
+++ b/test/fixtures/actions/pulp/consumer/content_install/success.yaml
@@ -1,0 +1,77 @@
+--- 
+  pulp_task: 
+    task_group_id: 
+    exception: 
+    traceback: 
+    "_href": /pulp/api/v2/tasks/a681d1ba-9211-4eb2-a2df-d3ec909d23eb/
+    task_id: a681d1ba-9211-4eb2-a2df-d3ec909d23eb
+    call_request_tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    reasons: []
+    start_time: "2014-01-27T10:07:02Z"
+    tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    state: finished
+    finish_time: "2014-01-27T10:07:15Z"
+    dependency_failures: {}
+    schedule_id: 
+    progress: 
+      steps: 
+        - - "Refresh Repository Metadata"
+          - true
+        - - "Downloading Packages"
+          - true
+        - - "Check Package Signatures"
+          - true
+        - - "Running Test Transaction"
+          - true
+        - - "Running Transaction"
+          - true
+      details: {}
+    call_request_group_id: 
+    call_request_id: a681d1ba-9211-4eb2-a2df-d3ec909d23eb
+    principal_login: admin
+    response: accepted
+    result: 
+      details: 
+        rpm: 
+          details: 
+            resolved: 
+              - name: emacs
+                qname: "1:emacs-23.1-21.el6_2.3.x86_64"
+                epoch: "1"
+                version: "23.1"
+                release: "21.el6_2.3"
+                arch: x86_64
+                repoid: eng-Server
+            errors: {}
+            deps: 
+              - name: libXmu
+                qname: libXmu-1.1.1-2.el6.x86_64
+                epoch: "0"
+                version: "1.1.1"
+                release: "2.el6"
+                arch: x86_64
+                repoid: eng-Server
+              - name: libXaw
+                qname: libXaw-1.0.11-2.el6.x86_64
+                epoch: "0"
+                version: "1.0.11"
+                release: "2.el6"
+                arch: x86_64
+                repoid: eng-Server
+              - name: libotf
+                qname: libotf-0.9.9-3.1.el6.x86_64
+                epoch: "0"
+                version: "0.9.9"
+                release: "3.1.el6"
+                arch: x86_64
+                repoid: eng-Server
+          succeeded: true
+      num_changes: 4
+      succeeded: true
+      reboot: 
+        scheduled: false
+        details: {}

--- a/test/fixtures/actions/pulp/consumer/content_uninstall/error.yaml
+++ b/test/fixtures/actions/pulp/consumer/content_uninstall/error.yaml
@@ -1,0 +1,42 @@
+--- 
+  pulp_task: 
+    task_group_id: 
+    exception: 
+    traceback: 
+    "_href": /pulp/api/v2/tasks/4b3c0e90-2566-4ee3-9a3a-5bded914fe2f/
+    task_id: "4b3c0e90-2566-4ee3-9a3a-5bded914fe2f"
+    call_request_tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    reasons: []
+    start_time: "2014-01-27T10:19:24Z"
+    tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_install"
+    state: finished
+    finish_time: "2014-01-27T10:19:24Z"
+    dependency_failures: {}
+    schedule_id: 
+    progress: 
+      steps: 
+        - - "Refresh Repository Metadata"
+          - true
+      details: {}
+    call_request_group_id: 
+    call_request_id: "4b3c0e90-2566-4ee3-9a3a-5bded914fe2f"
+    principal_login: admin
+    response: accepted
+    result: 
+      details: 
+        rpm: 
+          details: 
+            resolved: []
+            errors: 
+              emacss: "No package(s) available to install"
+            deps: []
+          succeeded: true
+      num_changes: 0
+      succeeded: true
+      reboot: 
+        scheduled: false
+        details: {}

--- a/test/fixtures/actions/pulp/consumer/content_uninstall/no_packages.yaml
+++ b/test/fixtures/actions/pulp/consumer/content_uninstall/no_packages.yaml
@@ -1,0 +1,40 @@
+--- 
+  pulp_task: 
+    task_group_id: 
+    exception: 
+    traceback: 
+    "_href": /pulp/api/v2/tasks/fb4dfe52-a9f2-4ea7-a0b5-dde74a16c192/
+    task_id: fb4dfe52-a9f2-4ea7-a0b5-dde74a16c192
+    call_request_tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_uninstall"
+    reasons: []
+    start_time: "2014-01-27T13:27:53Z"
+    tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_uninstall"
+    state: finished
+    finish_time: "2014-01-27T13:27:53Z"
+    dependency_failures: {}
+    schedule_id: 
+    progress: 
+      steps: 
+        - - "Refresh Repository Metadata"
+          - true
+      details: {}
+    call_request_group_id: 
+    call_request_id: fb4dfe52-a9f2-4ea7-a0b5-dde74a16c192
+    principal_login: admin
+    response: accepted
+    result: 
+      details: 
+        rpm: 
+          details: 
+            resolved: []
+            deps: []
+          succeeded: true
+      num_changes: 0
+      succeeded: true
+      reboot: 
+        scheduled: false
+        details: {}

--- a/test/fixtures/actions/pulp/consumer/content_uninstall/success.yaml
+++ b/test/fixtures/actions/pulp/consumer/content_uninstall/success.yaml
@@ -1,0 +1,74 @@
+--- 
+  pulp_task: 
+    task_group_id: 
+    exception: 
+    traceback: 
+    "_href": /pulp/api/v2/tasks/53212418-50ff-4e8d-8605-0bc36995e0e6/
+    task_id: "53212418-50ff-4e8d-8605-0bc36995e0e6"
+    call_request_tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_uninstall"
+    reasons: []
+    start_time: "2014-01-27T13:29:10Z"
+    tags: 
+      - "pulp:consumer:87c20448-fef4-4809-a0ca-729fdb61c8ee"
+      - "pulp:action:unit_uninstall"
+    state: finished
+    finish_time: "2014-01-27T13:29:14Z"
+    dependency_failures: {}
+    schedule_id: 
+    progress: 
+      steps: 
+        - - "Refresh Repository Metadata"
+          - true
+        - - "Downloading Packages"
+          - true
+        - - "Running Test Transaction"
+          - true
+        - - "Running Transaction"
+          - true
+      details: {}
+    call_request_group_id: 
+    call_request_id: "53212418-50ff-4e8d-8605-0bc36995e0e6"
+    principal_login: admin
+    response: accepted
+    result: 
+      details: 
+        rpm: 
+          details: 
+            resolved: 
+              - name: libXmu
+                qname: libXmu-1.1.1-2.el6.x86_64
+                epoch: "0"
+                version: "1.1.1"
+                release: "2.el6"
+                arch: x86_64
+                repoid: installed
+            deps: 
+              - name: emacs
+                qname: "1:emacs-23.1-21.el6_2.3.x86_64"
+                epoch: "1"
+                version: "23.1"
+                release: "21.el6_2.3"
+                arch: x86_64
+                repoid: installed
+              - name: libXaw
+                qname: libXaw-1.0.11-2.el6.x86_64
+                epoch: "0"
+                version: "1.0.11"
+                release: "2.el6"
+                arch: x86_64
+                repoid: installed
+              - name: libotf
+                qname: libotf-0.9.9-3.1.el6.x86_64
+                epoch: "0"
+                version: "0.9.9"
+                release: "3.1.el6"
+                arch: x86_64
+                repoid: installed
+          succeeded: true
+      num_changes: 4
+      succeeded: true
+      reboot: 
+        scheduled: false
+        details: {}

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -21,6 +21,13 @@ require 'support/auth_support'
 require 'support/controller_support'
 require 'support/search_service'
 
+require 'dynflow/testing'
+Mocha::Mock.send :include, Dynflow::Testing::Mimic
+Dynflow::Testing.logger_adapter.level = 1
+require 'support/actions/fixtures'
+require 'support/actions/pulp_task'
+require 'support/actions/remote_action'
+
 FactoryGirl.definition_file_paths = ["#{Katello::Engine.root}/test/factories"]
 FactoryGirl.find_definitions
 
@@ -208,7 +215,3 @@ def disable_glue_layers(services=[], models=[], force_reload=false)
     FactoryGirl.reload
   end
 end
-
-require 'dynflow/testing'
-Mocha::Mock.send :include, Dynflow::Testing::Mimic
-Dynflow::Testing.logger_adapter.level = 1

--- a/test/support/actions/fixtures.rb
+++ b/test/support/actions/fixtures.rb
@@ -1,0 +1,67 @@
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Support
+  module Actions
+
+    # Module for creating actions based on yaml fixtures.
+    #
+    # Usage:
+    #
+    # Given action +Actions::Pulp::Consumer::ContentInstall+
+    # and files +test/fixtures/actions/pulp/consumer/content_install/input.yaml+
+    # and +test/fixtures/actions/pulp/consumer/content_install/success.yaml+
+    # calling:
+    #
+    #     fixture_action(Actions::Pulp::Consumer::ContentInstall,
+    #                    input: :input,
+    #                    output: :success)
+    #
+    # will create new action with the data from those files. The
+    # stubbed data can be passed directly if needed.
+    #
+    #      fixture_action(Actions::Pulp::Consumer::ContentInstall,
+    #                    input: { some_input: 1 }',
+    #                    output: { some_output: 2 })
+    module Fixtures
+      include Dynflow::Testing
+
+      def fixture_action(action_class, options = {})
+        create_action(action_class).tap do |action|
+          fixture_interface(action, :input, options[:input])
+          fixture_interface(action, :output, options[:output])
+        end
+      end
+
+      def interface_fixture_file(action, variant)
+        action_path = action.action_class.name.underscore.sub('actions/','')
+        action_path << "/#{variant}.yaml"
+        fixture_file(action_path)
+      end
+
+      def fixture_interface(action, method, data)
+        if data.is_a? Symbol
+          data = fixture_data(interface_fixture_file(action, data))
+        end
+        action.stubs(method => data.with_indifferent_access)
+      end
+
+      def fixture_file(path)
+        File.join(Katello::Engine.root, 'test/fixtures/actions', path)
+      end
+
+      def fixture_data(path)
+        path = fixture_file(path) unless path =~ /\A\//
+        YAML.load_file(path).with_indifferent_access
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding more detailed task output for package actions. Also there
are now helper methods to produce actions based on yaml fixtures,
which allows easier mocking.

The ideal combination of the action fixtures is this PR in Dynflow:

https://github.com/Dynflow/dynflow/pull/90

which makes the web console to use yaml as the format for showing
inputs/outputs of actions. So one can get new fixtures as easy as
perform the action though user interface and use the Dynflow console
to copy the fixture data.
