### PR TITLE
removing non-sensical merge within TaskStatus#as_json

### DIFF
--- a/app/models/katello/task_status.rb
+++ b/app/models/katello/task_status.rb
@@ -133,7 +133,6 @@ class TaskStatus < Katello::Model
 
   def as_json(options = {})
     json = super :methods => :pending?
-    json.merge(options) if options
 
     if ('Katello::System' == task_owner_type)
       methods = [:description, :result_description, :overall_status]


### PR DESCRIPTION
this was causing an error during product rendering in the v2
controllers
