### PR TITLE
use the yum_clone distributor during CV publish

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -323,10 +323,12 @@ class ContentView < Katello::Model
       associate_contents(cloned)
     end
     update_cp_content(self.organization.library)
-    version.trigger_repository_changes
+
+    clone_overrides = self.repositories.select{|r| self.filters.applicable(r).empty?}
+    version.trigger_repository_changes(:cloned_repo_overrides => clone_overrides)
 
     Glue::Event.trigger(Katello::Actions::ContentViewPublish, self)
-    Katello::Foreman.update_foreman_content(view.organization, view.organization.library, view)
+    Katello::Foreman.update_foreman_content(self.organization, self.organization.library, self)
 
     if notify
       message = _("Successfully published content view '%s'.") % name

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -92,8 +92,9 @@ class ContentViewVersion < Katello::Model
     end
   end
 
-  def trigger_repository_changes
-    Repository.trigger_contents_changed(self.repositories, :wait => true, :reindex => true)
+  def trigger_repository_changes(options = {})
+    Repository.trigger_contents_changed(self.repositories, :wait => true, :reindex => true,
+                                        :cloned_repo_overrides => options.fetch(:cloned_repo_overrides, []))
   end
 
   private

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -688,10 +688,13 @@ module Glue::Pulp::Repo
       sync_history_item['state'] == PulpTaskStatus::Status::FINISHED.to_s
     end
 
-    def generate_metadata(force = false)
+    def generate_metadata(options = {})
+      force_regeneration = options.fetch(:force_regeneration, false)
+      cloned_repo_override = options.fetch(:cloned_repo_override, nil)
+
       tasks = []
-      clone = self.content_view_version.repositories.where(:library_instance_id => self.library_instance_id).where("id != #{self.id}").first
-      if self.environment.library? || force || clone.nil?
+      clone = cloned_repo_override || self.content_view_version.repositories.where(:library_instance_id => self.library_instance_id).where("id != #{self.id}").first
+      if force_regeneration || (self.environment.library? &&  cloned_repo_override.nil?)
         tasks << self.publish_distributor
       else
         tasks << self.publish_clone_distributor(clone)

--- a/lib/katello/tasks/regenerate_repo_metadata.rake
+++ b/lib/katello/tasks/regenerate_repo_metadata.rake
@@ -6,7 +6,7 @@ namespace :katello do
 
     Katello::Repository.all.each_with_index do |repo, i|
       puts "Regenerating #{i+1}/#{repos.count} (#{repo.pulp_id})\n"
-      Katello::PulpTaskStatus::wait_for_tasks(repo.generate_metadata(true))
+      Katello::PulpTaskStatus::wait_for_tasks(repo.generate_metadata(:force_regeneration => true))
     end
   end
 


### PR DESCRIPTION
if a repository has no filters applied, then we can just use
the yum_clone distributor for metadata generation and save a few minutes
