### PR TITLE
add back in the redhat CA file for access to the CDN

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.summary     = ""
   gem.description = ""
 
-  gem.files = Dir["{app,vendor,lib,db,config,locale}/**/*"] + ["LICENSE.txt", "README.md"]
+  gem.files = Dir["{app,vendor,lib,db,ca,config,locale}/**/*"] + ["LICENSE.txt", "README.md"]
   gem.files += Dir["engines/bastion/{app,vendor,lib}/**/*"]
   gem.files += Dir["engines/bastion/{README.md,Bastion.gemspec}"]
   gem.files += Dir["engines/fort/{app,config,db,lib}/**/*"]


### PR DESCRIPTION
adding the PEM file back in so Katello can access cdn.redhat.com.  This caused the Red Hat Repositories page to error when trying to enable/disable repos.
