### PR TITLE
fixing katello:reset when no schema exists

### DIFF
--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -30,7 +30,6 @@ namespace :katello do
     end
 
     task :elasticsearch => ['environment'] do
-      User.current = User.hidden.first
       Dir.glob(Katello::Engine.root.to_s + '/app/models/katello/*.rb').each { |file| require file }
 
       Katello::Util::Search.active_record_search_classes.each do |model|
@@ -49,7 +48,6 @@ namespace :katello do
   task :reset_backends do
     Rake::Task['katello:reset_backends:candlepin'].invoke
     Rake::Task['katello:reset_backends:pulp'].invoke
-    Rake::Task['katello:reset_backends:elasticsearch'].invoke
   end
 
   task :reset => ['environment'] do
@@ -59,6 +57,8 @@ namespace :katello do
 
     # Otherwise migration fails since it currently requires a reloaded environment
     system('rake db:migrate')
+
+    Rake::Task['katello:reset_backends:elasticsearch'].invoke
     # Load configuration needed by db:seed first
     require './config/initializers/foreman.rb'
     Rake::Task['db:seed'].invoke


### PR DESCRIPTION
otherwise you would have to manually run db:migrate by hand before
running katello:reset.  By pushing ES clearing till after db:migrate
we can safely load each model in order to clear the index
