### PR TITLE
Bastion: adding angular templates to the $templateCache.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
@@ -27,6 +27,7 @@ angular.module('Bastion', [
     'ui.bootstrap',
     'ui.bootstrap.tpls',
     'angular-blocks',
+    'Bastion.custom-info',
     'Bastion.i18n',
     'Bastion.menu',
     'Bastion.subscriptions',
@@ -42,8 +43,9 @@ angular.module('Bastion', [
     'Bastion.system-groups',
     'Bastion.gpg-keys',
     'Bastion.tasks',
-    'Bastion.custom-info',
-    'Bastion.activation-keys'
+    'Bastion.activation-keys',
+    'templates'
+
 ]);
 
 /**

--- a/engines/bastion/lib/bastion/engine.rb
+++ b/engines/bastion/lib/bastion/engine.rb
@@ -8,5 +8,9 @@ module Bastion
       app.config.less.paths << "#{Bastion::Engine.root}/vendor/assets/stylesheets/bastion"
       app.middleware.use ::ActionDispatch::Static, "#{Bastion::Engine.root}/app/assets/javascripts/bastion"
     end
+
+    initializer "angular_templates", :group => :all do |app|
+      app.config.angular_templates.ignore_prefix = '[bastion]*\/+'
+    end
   end
 end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "anemone"
 
   # UI
+  gem.add_dependency "angular-rails-templates", ">= 0.0.4"
   gem.add_dependency "simple-navigation", ">= 3.3.4"
   gem.add_dependency "less-rails"
   gem.add_dependency "sass-rails"

--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -18,6 +18,7 @@ require "anemone"
 
 require "runcible"
 
+require "angular-rails-templates"
 require "simple_navigation"
 require "haml-rails"
 require "compass-rails"

--- a/rel-eng/comps/comps-katello-foreman-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-foreman-server-fedora19.xml
@@ -27,6 +27,7 @@
 
        <packagereq type="default">foreman-installer</packagereq>
 
+       <packagereq type="default">rubygem-angular-rails-templates</packagereq>
        <packagereq type="default">rubygem-ancestry</packagereq>
        <packagereq type="default">rubygem-excon</packagereq>
        <packagereq type="default">rubygem-fog</packagereq>

--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -29,6 +29,7 @@
        <packagereq type="default">lucene3</packagereq>
        <packagereq type="default">lucene3-contrib</packagereq>
        <packagereq type="default">pulp-katello-plugins</packagereq>
+       <packagereq type="default">rubygem-angular-rails-templates</packagereq>
        <packagereq type="default">rubygem-ui_alchemy-rails</packagereq>
        <packagereq type="default">rubygem-anemone</packagereq>
        <packagereq type="default">rubygem-ansi</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -43,6 +43,7 @@
        <packagereq type="default">ruby193-ruby-augeas</packagereq>
        <packagereq type="default">ruby193-ruby-shadow</packagereq>
        <packagereq type="default">ruby193-ruby-wrapper</packagereq>
+       <packagereq type="default">ruby193-rubygem-angular-rails-templates</packagereq>
        <packagereq type="default">ruby193-rubygem-Ascii85</packagereq>
        <packagereq type="default">ruby193-rubygem-POpen4</packagereq>
        <packagereq type="default">ruby193-rubygem-Platform</packagereq>

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -106,7 +106,8 @@ Requires: postgresql
 Requires: postgresql-server
 Requires: v8
 Requires: %{?scl_prefix}rubygems
-Requires: %{?scl_prefix}rubygem-rails 
+Requires: %{?scl_prefix}rubygem-angular-rails-templates >= 0.0.4
+Requires: %{?scl_prefix}rubygem-rails
 Requires: %{?scl_prefix}rubygem-json 
 Requires: %{?scl_prefix}rubygem-oauth 
 Requires: %{?scl_prefix}rubygem-rest-client
@@ -144,6 +145,7 @@ Requires: %{?scl_prefix}rubygem-ui_alchemy-rails = 1.0.12
 Requires: %{?scl_prefix}rubygem-deface
 Requires: %{?scl_prefix}rubygem-strong_parameters
 BuildRequires: foreman >= 1.3.0
+BuildRequires: %{?scl_prefix}rubygem-angular-rails-templates >= 0.0.4
 BuildRequires: %{?scl_prefix}rubygem-net-ldap 
 BuildRequires: %{?scl_prefix}rubygem-ldap_fluff >= 0.2.2
 BuildRequires: %{?scl_prefix}rubygem-sqlite3


### PR DESCRIPTION
Three shift+reloads each, from home over VPN (hence the large numbers).
#### production mode with $templateCache:

**shift + reloads**:  23.18s,  21.61s, 19.55s

**average**:  21.45s
**median**:  21.61s
#### production mode without $templateCache:

**shift + reloads**:   32.03s, 24.51s, 23.33s

**average**:   26.62s
**median**:   24.51s
#### dev mode with $templateCache:

**shift + reloads**:   47.65s, 42.80s, 44.25s

**average**:  44.9s
**median**:  44.25s
#### dev mode without $templateCache

**shift + reloads**:  57.70s, 45.92s, 44.32s

**average**:  49.31s
**median**:  45.92s

Or an decrease in average initial page load of **5.17s** in production and **4.41s**.

In addition to these numbers successive loads of nutupane sub pages were noted as being quicker because of the lack of additional requests for templates.
