### PR TITLE
fixes for passenger in production mode

### DIFF
--- a/app/controllers/katello/api/api_controller.rb
+++ b/app/controllers/katello/api/api_controller.rb
@@ -123,7 +123,8 @@ class Api::ApiController < ::Api::BaseController
   end
 
   def client_cert_from_request
-    cert = request.env['SSL_CLIENT_CERT'] || request.env['HTTP_SSL_CLIENT_CERT']
+    cert = request.env['SSL_CLIENT_CERT'] || request.env['HTTP_SSL_CLIENT_CERT'] ||
+        ENV['SSL_CLIENT_CERT'] || ENV['HTTP_SSL_CLIENT_CERT']
     return nil if cert.blank? || cert == "(null)"
     # apache does not preserve new lines in cert file - work-around:
     if cert.include?("-----BEGIN CERTIFICATE----- ")

--- a/config/initializers/monkeys.rb
+++ b/config/initializers/monkeys.rb
@@ -1,2 +1,3 @@
 #place where monkey patches are required
 require 'monkeys/multi_json_empty_fix'
+require 'monkeys/passenger_tee_input'

--- a/lib/monkeys/passenger_tee_input.rb
+++ b/lib/monkeys/passenger_tee_input.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+# In the candlepin proxy controllers we pass the request body
+# straight from the request through to candlepin
+# This does not have a seek() method which rest client needs
+# to log properly.
+module PhusionPassenger
+  module Utils
+
+    class TeeInput
+
+      def seek(position)
+        if position == 0
+           rewind
+        else
+           fail "Seeking not supported to non zero position"
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
-  ENV is the correct place to look for headers under passenger
-  When we are proxying requests to candlepin, the request body sent
  to katello is not a StringIO anymore, it is a Passenger::Input::TeeInput.
  When RestClient tries to log the request it read the input and then calls
  seek(0) to reset the stream.  TeeInput has no seek() method, but does have a
  rewind method. This adds a monkey patch to translate the seek to a rewind
