### PR TITLE
Content Views Rework: filter updates for api consistency and to support CLI

### DIFF
--- a/app/controllers/katello/api/v2/filters_controller.rb
+++ b/app/controllers/katello/api/v2/filters_controller.rb
@@ -14,7 +14,7 @@ module Katello
 class Api::V2::FiltersController < Api::V2::ApiController
   respond_to :json
 
-  before_filter :find_content_view
+  before_filter :find_content_view, :only => [:index, :create]
   before_filter :find_filter, :except => [:index, :create]
   before_filter :authorize
 
@@ -34,7 +34,7 @@ class Api::V2::FiltersController < Api::V2::ApiController
   end
 
   api :GET, "/content_views/:content_view_id/filters", "List filters"
-  param :content_view_id, :number, :desc => "content view identifier", :required => true
+  param :content_view_id, :identifier, :desc => "content view identifier", :required => true
   def index
     options = sort_params
     options[:load_records?] = true
@@ -46,37 +46,34 @@ class Api::V2::FiltersController < Api::V2::ApiController
 
   api :POST, "/content_views/:content_view_id/filters",
       "Create a filter for a content view"
-  param :content_view_id, :number, :desc => "content view identifier", :required => true
-  param :filter, Hash, :required => true, :action_aware => true do
-    param :name, String, :desc => "name of the filter", :required => true
-    param :type, String, :desc => "type of filter (e.g. rpm, package_group, erratum, puppet_module)", :required => true
-    param :parameters, Hash, :desc => "the filter parameter rules"
-  end
+  param :content_view_id, :identifier, :desc => "content view identifier", :required => true
+  param :name, String, :desc => "name of the filter", :required => true
+  param :type, String, :desc => "type of filter (e.g. rpm, package_group, erratum, puppet_module)", :required => true
+  param :repository_ids, Array, :desc => "List of repository ids"
+  param :parameters, String, :desc => "the filter parameters rules"
   def create
     filter = Filter.create_for(params[:type], filter_params.merge(:content_view => @view))
     respond :resource => filter
   end
 
-  api :GET, "/content_views/:content_view_id/filters/:id", "Show filter info"
-  param :content_view_id, :number, :desc => "content view identifier", :required => true
-  param :id, :number, :desc => "filter identifier", :required => true
+  api :GET, "/filters/:id", "Show filter info"
+  param :id, :identifier, :desc => "filter identifier"
   def show
     respond :resource => @filter
   end
 
-  api :PUT, "/content_views/:content_view_id/filters/:id", "Update a filter"
-  param :content_view_id, :number, :desc => "Content view identifier", :required => true
-  param :id, :number, :desc => "id of the filter", :required => true
+  api :PUT, "/filters/:id", "Update a filter"
+  param :id, :identifier, :desc => "filter identifierr", :required => true
   param :name, String, :desc => "New name for the filter"
   param :repository_ids, Array, :desc => "List of repository ids"
+  param :parameters, String, :desc => "the filter parameters rules"
   def update
     @filter.update_attributes!(filter_params)
     respond :resource => @filter
   end
 
-  api :DELETE, "/content_views/:content_view_id/filters/:id", "Delete a filter"
-  param :content_view_id, :number, :desc => "content view identifier", :required => true
-  param :id, :number, :desc => "filter identifier", :required => true
+  api :DELETE, "/filters/:id", "Delete a filter"
+  param :id, :identifier, :desc => "filter identifier", :required => true
   def destroy
     @filter.destroy
     respond :resource => @filter
@@ -90,14 +87,24 @@ class Api::V2::FiltersController < Api::V2::ApiController
 
   def find_filter
     id = params[:id] || params[:filter_id]
-    @filter = Filter.where(:content_view_id => @view).find(id)
+    @filter = Filter.find(id)
+    @view = @filter.content_view
   end
 
   def filter_params
     filter_parameters = params.require(:filter).permit(:name, :repository_ids => [])
 
-    # the :parameters will be vaildated by the model layer (e.g. PackageFilter)
-    filter_parameters[:parameters] = params[:filter][:parameters].with_indifferent_access
+    # the :parameters will be validated by the model layer (e.g. PackageFilter)
+    if params.key?(:parameters)
+      filter_parameters[:parameters] = params[:filter][:parameters].with_indifferent_access
+
+      # remove 'created_at'
+      if filter_parameters[:parameters].key?(:units)
+        filter_parameters[:parameters][:units].each{ |unit| unit.delete(:created_at) }
+      end
+      filter_parameters[:parameters].delete(:created_at)
+    end
+
     filter_parameters
   end
 

--- a/app/models/katello/erratum_filter.rb
+++ b/app/models/katello/erratum_filter.rb
@@ -20,7 +20,7 @@ class ErratumFilter < Filter
                    'enhancement' => _('Enhancement'),
                    'security' => _('Security') }.with_indifferent_access
 
-  before_create :set_parameters
+  before_save :set_parameters
 
   validates_with Validators::ErratumFilterParamsValidator, :attributes => :parameters
 
@@ -109,8 +109,17 @@ class ErratumFilter < Filter
   private
 
   def set_parameters
+    # Check to see if the parameters have changed, if they have update
+    # update the created_at timestamp; otherwise, keep the old timestamp
     unless parameters.blank?
-      parameters[:created_at] = Time.zone.now
+      unless parameters_was.blank?
+        created_at = parameters_was.delete(:created_at)
+        if parameters == parameters_was
+          parameters[:created_at] = created_at
+        end
+      end
+
+      parameters[:created_at] = Time.zone.now unless parameters.key?(:created_at)
       parameters[:inclusion] = false unless parameters.key?(:inclusion)
     end
     self

--- a/app/models/katello/filter.rb
+++ b/app/models/katello/filter.rb
@@ -137,5 +137,21 @@ class Filter < Katello::Model
     validate_filter_repos(self.errors, self.content_view)
   end
 
+  def get_created_at(previous_parameters, current_unit)
+    # Check to see if the unit was previously part of the filter.
+    # If it was, return the original created_at timestamp; otherwise,
+    # return the current time
+    found_unit = nil
+    if !previous_parameters.blank? && previous_parameters.key?(:units)
+      previous_parameters[:units].each do |previous_unit|
+        created_at = previous_unit.delete(:created_at)
+        if (previous_unit == current_unit)
+          found_unit = previous_unit.merge({ :created_at => created_at })
+          break
+        end
+      end
+    end
+    found_unit.nil? ? Time.zone.now : found_unit[:created_at]
+  end
 end
 end

--- a/app/models/katello/package_filter.rb
+++ b/app/models/katello/package_filter.rb
@@ -16,7 +16,7 @@ class PackageFilter < Filter
 
   CONTENT_TYPE = Package::CONTENT_TYPE
 
-  before_create :set_parameters
+  before_save :set_parameters
 
   validates_with Validators::FilterParamsValidator, :attributes => :parameters
   validates_with Validators::FilterVersionValidator, :attributes => :parameters
@@ -60,7 +60,7 @@ class PackageFilter < Filter
 
   def set_parameters
     parameters[:units].each do |unit|
-      unit[:created_at] = Time.zone.now
+      unit[:created_at] = get_created_at(parameters_was, unit)
       unit[:inclusion] = false unless unit.key?(:inclusion)
     end if !parameters.blank? && parameters.key?(:units)
   end

--- a/app/models/katello/package_group_filter.rb
+++ b/app/models/katello/package_group_filter.rb
@@ -16,7 +16,7 @@ class PackageGroupFilter < Filter
 
   CONTENT_TYPE = PackageGroup::CONTENT_TYPE
 
-  before_create :set_parameters
+  before_save :set_parameters
 
   validates_with Validators::PackageGroupFilterParamsValidator, :attributes => :parameters
   def params_format
@@ -39,7 +39,7 @@ class PackageGroupFilter < Filter
 
   def set_parameters
     parameters[:units].each do |unit|
-      unit[:created_at] = Time.zone.now
+      unit[:created_at] = get_created_at(parameters_was, unit)
       unit[:inclusion] = false unless unit.key?(:inclusion)
     end if !parameters.blank? && parameters.key?(:units)
   end

--- a/app/models/katello/puppet_module_filter.rb
+++ b/app/models/katello/puppet_module_filter.rb
@@ -16,7 +16,7 @@ class PuppetModuleFilter < Filter
 
   CONTENT_TYPE = PuppetModule::CONTENT_TYPE
 
-  before_create :set_parameters
+  before_save :set_parameters
 
   validates_with Validators::FilterParamsValidator, :attributes => :parameters
   validates_with Validators::FilterVersionValidator, :attributes => :parameters
@@ -78,7 +78,7 @@ class PuppetModuleFilter < Filter
 
   def set_parameters
     parameters[:units].each do |unit|
-      unit[:created_at] = Time.zone.now
+      unit[:created_at] = get_created_at(parameters_was, unit)
       unit[:inclusion] = false unless unit.key?(:inclusion)
     end if !parameters.blank? && parameters.key?(:units)
   end

--- a/app/views/katello/api/v2/filters/show.json.rabl
+++ b/app/views/katello/api/v2/filters/show.json.rabl
@@ -7,7 +7,7 @@ child :content_view => :content_view do
 end
 
 child :repositories => :repositories do
-  attributes :id, :name
+  attributes :id, :name, :label
 end
 
 node(:type) { |filter| filter.type.constantize::CONTENT_TYPE }

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -26,8 +26,9 @@ Katello::Engine.routes.draw do
           post :promote
           post :refresh
         end
-        api_resources :filters, :controller => :filters
+        api_resources :filters, :only => [:index, :create], :controller => :filters
       end
+      api_resources :filters, :only => [:show, :update, :destroy], :controller => :filters
 
       api_resources :environments, :only => [:index, :show, :create, :update, :destroy] do
         api_resources :systems, :only => system_onlies do


### PR DESCRIPTION
This commit has a few minor updates to ensure api consistency, support
CLI and improve behavior such as:
- routes: use content view resource on filter index/create
- routes: do not use content view resource on filter show/update/delete
- only update filter parameter created_at if the filter have changed
- updates to docs to  support apipie bindings for hammer-cli-katello support
- ...
