### PR TITLE
Bastion: fix clash between angular-gettext and ng-if.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/products/details/partials/sync-status.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/partials/sync-status.html
@@ -4,16 +4,24 @@
 
 <div class="detail">
   <span class="info-label" translate>Sync Interval</span>
-  <span class="info-value" ng-if="product.sync_plan.interval == 'hourly'" translate>
-    Hourly at {{ product.sync_plan.sync_date | date:'m' }} minutes and {{ product.sync_plan.sync_date | date:'s' }} seconds
+  <span class="info-value" ng-if="product.sync_plan.interval == 'hourly'">
+    <span translate>
+      Hourly at {{ product.sync_plan.sync_date | date:'m' }} minutes and {{ product.sync_plan.sync_date | date:'s' }} seconds
+    </span>
   </span>
-  <span class="info-value" ng-if="product.sync_plan.interval == 'daily'" translate>
-    Daily at {{ product.sync_plan.sync_date | date:'mediumTime' }}
+  <span class="info-value" ng-if="product.sync_plan.interval == 'daily'">
+    <span translate>
+      Daily at {{ product.sync_plan.sync_date | date:'mediumTime' }}
+    </span>
   </span>
-  <span class="info-value" ng-if="product.sync_plan.interval == 'weekly'" translate>
-    Weekly on {{ product.sync_plan.sync_date | date:'EEEE' }} at {{ product.sync_plan.sync_date | date:'mediumTime' }}
+  <span class="info-value" ng-if="product.sync_plan.interval == 'weekly'">
+    <span translate>
+      Weekly on {{ product.sync_plan.sync_date | date:'EEEE' }} at {{ product.sync_plan.sync_date | date:'mediumTime' }}
+    </span>
   </span>
-  <span class="info-value" ng-hide="product.sync_plan.next_sync" translate>
-    Synced manually, no interval set.
+  <span class="info-value" ng-hide="product.sync_plan.next_sync">
+    <span translate>
+      Synced manually, no interval set.
+    </span>
   </span>
 </div>

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
@@ -24,17 +24,15 @@
 
       <button ng-if="isState('sync-plans.details.products.list')"
               class="btn btn-primary"
-              translate
               ng-disabled="productsTable.numSelected == 0 || productsTable.working"
               ng-click="removeProducts()">
-        Remove Selected
+        {{ 'Remove Selected' | translate}}
       </button>
       <button ng-if="isState('sync-plans.details.products.add')"
               class="btn btn-primary"
-              translate
               ng-disabled="productsTable.numSelected == 0 || productsTable.working"
               ng-click="addProducts()">
-        Add Selected
+        {{ 'Add Selected' | translate }}
       </button>
 
     </div>

--- a/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-groups-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-groups-table.html
@@ -26,17 +26,15 @@
 
       <button ng-if="isState('systems.details.system-groups.list')"
               class="btn btn-primary"
-              translate
               ng-disabled="systemGroupsTable.numSelected == 0 || systemGroupsTable.working"
               ng-click="removeSystemGroups()">
-        Remove Selected
+        {{ 'Remove Selected' | translate }}
       </button>
       <button ng-if="isState('systems.details.system-groups.add')"
               class="btn btn-primary"
-              translate
               ng-disabled="systemGroupsTable.numSelected == 0 || systemGroupsTable.working"
               ng-click="addSystemGroups()">
-        Add Selected
+        {{ 'Add Selected' | translate }}
       </button>
 
     </div>


### PR DESCRIPTION
Fixes the following JS error that occurs if you use the `translate` directive and `ng-if` on the same element:

```
Error: You should add a ng-if attribute whenever you add a translate attribute.
    at assert (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular-gettext/angular-gettext.js?body=1:72:21)
    at http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular-gettext/angular-gettext.js?body=1:77:11
    at nodeLinkFn (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:6227:13)
    at compositeLinkFn (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:5633:15)
    at publicLinkFn (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:5542:30)
    at boundTranscludeFn (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:5656:21)
    at controllersBoundTransclude (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:6248:18)
    at Object.ngIfWatchAction [as fn] (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:18307:15)
    at Scope.$digest (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:11809:29)
    at Scope.$apply (http://wraines-sandbox.rdu.redhat.com:3000/assets/bastion/angular/angular.js?body=1:12062:24) <!-- translate:  --> 
```
