### PR TITLE
apipie - :undef is not a valid apipie param type

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -23,7 +23,7 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
     param :name, String, :required => true
     param :label, String, :required => false
     param :product_id, :number, :required => true, :desc => "Product the repository belongs to"
-    param :url, :undef, :required => true, :desc => "repository source url"
+    param :url, String, :required => true, :desc => "repository source url"
     param :gpg_key_name, String, :desc => "name of a gpg key that will be assigned to the new repository"
     param :enabled, :bool, :desc => "flag that enables/disables the repository"
     param :content_type, String, :desc => "type of repo (either 'yum' or 'puppet', defaults to 'yum')"


### PR DESCRIPTION
it makes katello_api, hammer_cli_katello, and hammer-cli blow up with:

```
$ bundle exec hammer -v
[ INFO 2014-02-05 14:55:17 Init] Initialization of Hammer CLI (0.0.18) has started...
[ INFO 2014-02-05 14:55:17 Init] Configuration from the file /home/adprice/.foreman/cli_config.yml has been loaded
[ INFO 2014-02-05 14:55:18 Modules] Extension module hammer_cli_foreman (0.0.18) loaded
[ INFO 2014-02-05 14:55:18 HammerCLI::MainCommand] subcommand organization (HammerCLIForeman::Organization) was removed.
[ INFO 2014-02-05 14:55:18 HammerCLI::MainCommand] subcommand organization (HammerCLIKatello::Organization) was created.
[ERROR 2014-02-05 14:55:18 Modules] Error while loading module hammer_cli_katello
[ERROR 2014-02-05 14:55:18 Modules] <NoMethodError> undefined method `include?' for nil:NilClass
        /home/adprice/hammer-cli/lib/hammer_cli/apipie/options.rb:92:in `option_opts'
        /home/adprice/hammer-cli/lib/hammer_cli/apipie/options.rb:69:in `create_option'
        /home/adprice/hammer-cli/lib/hammer_cli/apipie/options.rb:59:in `block in options_for_params'
        /home/adprice/hammer-cli/lib/hammer_cli/apipie/options.rb:54:in `each'
        /home/adprice/hammer-cli/lib/hammer_cli/apipie/options.rb:54:in `options_for_params'
        /home/adprice/hammer-cli/lib/hammer_cli/apipie/options.rb:47:in `apipie_options'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello/repository.rb:13:in `<class:CreateCommand>'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello/repository.rb:7:in `<class:Repository>'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello/repository.rb:4:in `<module:HammerCLIKatello>'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello/repository.rb:2:in `<top (required)>'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello.rb:16:in `require'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello.rb:16:in `block in <module:HammerCLIKatello>'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello.rb:15:in `each'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello.rb:15:in `<module:HammerCLIKatello>'
        /home/adprice/hammer-cli-katello/lib/hammer_cli_katello.rb:9:in `<top (required)>'
        /home/adprice/hammer-cli/lib/hammer_cli/modules.rb:47:in `require'
        /home/adprice/hammer-cli/lib/hammer_cli/modules.rb:47:in `require_module'
        /home/adprice/hammer-cli/lib/hammer_cli/modules.rb:24:in `load!'
        /home/adprice/hammer-cli/lib/hammer_cli/modules.rb:41:in `load'
        /home/adprice/hammer-cli/lib/hammer_cli/modules.rb:52:in `block in load_all'
        /home/adprice/hammer-cli/lib/hammer_cli/modules.rb:51:in `each'
        /home/adprice/hammer-cli/lib/hammer_cli/modules.rb:51:in `load_all'
        /home/adprice/hammer-cli/bin/hammer:54:in `<top (required)>'
        /home/adprice/.rvm/gems/ruby-1.9.3-p484@hammer/bin/hammer:23:in `load'
        /home/adprice/.rvm/gems/ruby-1.9.3-p484@hammer/bin/hammer:23:in `<main>'
Warning: An error occured while loading module hammer_cli_katello
```

which is not helpful or indicative of the actual problem.
