### PR TITLE
add sprockets and sprockets-rails

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -57,6 +57,7 @@
        <packagereq type="default">rubygem-ruby-openid</packagereq>
        <packagereq type="default">rubygem-ruby-progressbar</packagereq>
        <packagereq type="default">rubygem-runcible</packagereq>
+       <packagereq type="default">rubygem-sprockets-rails</packagereq>
        <packagereq type="default">rubygem-tire</packagereq>
        <packagereq type="default">rubygem-yui-compressor</packagereq>
        <packagereq type="default">python-requests</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -116,6 +116,8 @@
        <packagereq type="default">ruby193-rubygem-simplecov</packagereq>
        <packagereq type="default">ruby193-rubygem-simplecov-html</packagereq>
        <packagereq type="default">ruby193-rubygem-simple-navigation</packagereq>
+       <packagereq type="default">ruby193-rubygem-sprockets</packagereq>
+       <packagereq type="default">ruby193-rubygem-sprockets-rails</packagereq>
        <packagereq type="default">ruby193-rubygem-strong_parameters</packagereq>
        <packagereq type="default">ruby193-rubygem-text-format</packagereq>
        <packagereq type="default">ruby193-rubygem-thin</packagereq>
@@ -213,6 +215,8 @@
        <packagereq type="optional">ruby193-rubygem-runcible-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-scoped_search-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-sexp_processor-doc</packagereq>
+       <packagereq type="optional">ruby193-rubygem-sprockets-doc</packagereq>
+       <packagereq type="optional">ruby193-rubygem-sprockets-rails-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-thin-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-transaction-simple-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-ttfunk-doc</packagereq>


### PR DESCRIPTION
Fedora 19 has rubygem-sprockets-2.8.2-3.fc19.noarch.rpm already.
