### PR TITLE
Bastion: Setting Jasmine dependency to prevent 2.0 from being pulled

### DIFF
--- a/engines/bastion/package.json
+++ b/engines/bastion/package.json
@@ -14,6 +14,7 @@
     "grunt-docular": ">=0.1.1",
     "karma": "~0.10",
     "karma-coverage": "0.1.0",
+    "karma-jasmine": "~0.1",
     "karma-ng-html2js-preprocessor": "~0.1",
     "grunt-htmlhint": "~0.4.0",
     "grunt-bower-task": "~0.3.4"


### PR DESCRIPTION
in and breaking tests.
