### PR TITLE
Test: Improving test performance by moving fixture loading from occuring

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -72,14 +72,15 @@ module FixtureTestCase
     self.set_fixture_class :katello_system_system_groups => "Katello::SystemSystemGroup"
     self.set_fixture_class :katello_task_statuses => "Katello::TaskStatus"
     self.set_fixture_class :katello_user_notices => "Katello::UserNotice"
+
+    load_fixtures
+    self.fixture_path = "#{Katello::Engine.root}/test/fixtures/models"
+    fixtures(:all)
   end
 
   module ClassMethods
 
     def before_suite
-      load_fixtures
-      self.fixture_path = "#{Katello::Engine.root}/test/fixtures/models"
-      fixtures(:all)
       @loaded_fixtures = load_fixtures
 
       @@admin = ::User.find(@loaded_fixtures['users']['admin']['id'])
@@ -92,7 +93,6 @@ end
 class ActionController::TestCase
   include LocaleHelperMethods
   include ControllerSupport
-  include FixtureTestCase
 
   def setup_engine_routes
     @routes = Katello::Engine.routes
@@ -156,10 +156,6 @@ class ActiveSupport::TestCase
     organization
   end
 
-end
-
-class ActionController::IntegrationTest
-  include FixtureTestCase
 end
 
 def disable_glue_layers(services=[], models=[], force_reload=false)


### PR DESCRIPTION
with every test suite to once per inclusion of the fixture test case.

Running suite localy the results are:

Previously
  Spec: 2013 sec (33.55 mins)
  Test: 543 sec (9 mins)
  Total: 44 mins

Moving fixture loading
  Spec: 626 sec (10.4 mins)
  Test: 322 sec (5.3 mins)
  Total: 20 mins
