### PR TITLE
Puppet Modules: add ability to list modules by environment

### DIFF
--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -45,7 +45,7 @@ module Authorization::Repository
     end
 
     def readable(env)
-      prod_ids = Product.readable(env.organization).collect { |p| p.id }
+      prod_ids = Katello::Product.all_readable(env.organization).collect { |p| p.id }
       where(product_id: prod_ids, :environment_id => env.id)
     end
 

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -209,6 +209,10 @@ class KTEnvironment < Katello::Model
     self.library? ? Product.in_org(self.organization) : Product.where(id: repositories.map(&:product_id))
   end
 
+  def puppet_repositories
+    Repository.readable(self).where(:content_type => Katello::Repository::PUPPET_TYPE)
+  end
+
   def as_json(options = {})
     to_ret = self.attributes
     to_ret['prior'] = self.prior &&  self.prior.name

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -48,6 +48,7 @@ Katello::Engine.routes.draw do
 
       api_resources :environments, :only => [:index, :show, :create, :update, :destroy] do
         api_resources :activation_keys, :only => [:index, :create]
+        api_resources :puppet_modules, :only => [:index]
         api_resources :systems, :only => system_onlies do
           get :report, :on => :collection
         end

--- a/test/controllers/api/v2/puppet_modules_controller_test.rb
+++ b/test/controllers/api/v2/puppet_modules_controller_test.rb
@@ -1,0 +1,95 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require "katello_test_helper"
+
+module Katello
+class Api::V2::PuppetModulesControllerTest < ActionController::TestCase
+
+  def before_suite
+    models = ["Organization", "KTEnvironment", "PuppetModule", "Repository", "Product", "Provider"]
+    services = ["Candlepin", "Pulp", "ElasticSearch"]
+    disable_glue_layers(services, models)
+    super
+  end
+
+  def models
+    @library = katello_environments(:library)
+    @repo = Repository.find(katello_repositories(:p_forge))
+  end
+
+  def permissions
+    @env_read_permission = UserPermission.new(:read_contents, :environments)
+    @prod_read_permission = UserPermission.new(:read, :providers)
+    @read_permission = @env_read_permission + @prod_read_permission
+    @unauth_perms = [NO_PERMISSION, @env_read_permission, @prod_read_permission]
+  end
+
+  def setup
+    setup_controller_defaults_api
+    @request.env['HTTP_ACCEPT'] = 'application/json'
+    @request.env['CONTENT_TYPE'] = 'application/json'
+    @fake_search_service = @controller.load_search_service(Support::SearchService::FakeSearchService.new)
+    models
+    permissions
+  end
+
+  def test_index_by_env
+    get :index, :environment_id => @library.id
+
+    assert_response :success
+    assert_template %w(katello/api/v2/puppet_modules/index)
+  end
+
+  def test_index_by_repo
+    get :index, :repository_id => @repo.id
+
+    assert_response :success
+    assert_template %w(katello/api/v2/puppet_modules/index)
+  end
+
+  def test_index_protected
+    assert_protected_action(:index, @read_permission, @unauth_perms) do
+      get :index, :repository_id => @repo.id
+    end
+  end
+
+  def test_show
+    PuppetModule.expects(:find).once.returns(mock({:repoids => [@repo.pulp_id]}))
+    get :show, :repository_id => @repo.id, :id => "abc-123"
+
+    assert_response :success
+    assert_template %w(katello/api/v2/puppet_modules/show)
+  end
+
+  def test_show_protected
+    PuppetModule.expects(:find).once.returns(mock({:repoids => [@repo.pulp_id]}))
+
+    assert_protected_action(:show, @read_permission, @unauth_perms) do
+      get :show, :repository_id => @repo.id, :id => "abc-123"
+    end
+  end
+
+  def test_show_module_not_in_repo
+    PuppetModule.expects(:find).once.returns(mock({:repoids => ['uh-oh']}))
+    get :show, :repository_id => @repo.id, :id => "abc-123"
+    assert_response 404
+  end
+
+  def test_show_module_not_found
+    PuppetModule.expects(:find).once.returns(nil)
+    get :show, :repository_id => @repo.id, :id => "abc-123"
+    assert_response 404
+  end
+
+end
+end


### PR DESCRIPTION
Currently, listing puppet modules requires the user to provide
a repository.  There are cases where a user may actually want to look
at all puppet modules in a given environment (e.g. library).  This
commit adds that support.
