### PR TITLE
Content Views Rework: APIs for available/current content

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -17,6 +17,7 @@ module Katello
     before_filter :find_content_view, :except => [:index, :create]
     before_filter :find_organization, :only => [:index, :create]
     before_filter :find_environment, :only => [:index]
+    before_filter :load_search_service, :only => [:index, :available_puppet_modules, :puppet_modules]
 
     before_filter :authorize
 
@@ -30,11 +31,13 @@ module Katello
       publish_rule = lambda { @view.publishable? }
 
       {
-        :index        => index_rule,
-        :show         => view_rule,
-        :create       => create_rule,
-        :update       => edit_rule,
-        :publish      => publish_rule
+        :index                    => index_rule,
+        :show                     => view_rule,
+        :create                   => create_rule,
+        :update                   => edit_rule,
+        :publish                  => publish_rule,
+        :available_puppet_modules => view_rule,
+        :puppet_modules           => view_rule
       }
     end
 
@@ -97,6 +100,32 @@ module Katello
     param :id, :number, :desc => "content view numeric identifier", :required => true
     def show
       respond :resource => @view
+    end
+
+    api :GET, "/content_views/:id/puppet_modules",
+        "Get puppet modules that have already been added to the content view"
+    param :id, :identifier, :desc => "content view numeric identifier", :required => true
+    def puppet_modules
+      ids = @view.content_view_puppet_modules.map(&:uuid)
+      search_filters = [:terms => { :id => ids }]
+      options = { :filters => search_filters }
+
+      respond_for_index :template => '../puppet_modules/index',
+                        :collection => item_search(PuppetModule, params, options)
+    end
+
+    api :GET, "/content_views/:id/available_puppet_modules",
+        "Get puppet modules that are available to be added to the content view"
+    param :id, :identifier, :desc => "content view numeric identifier", :required => true
+    def available_puppet_modules
+      current_ids = @view.content_view_puppet_modules.map(&:uuid)
+      repo_ids = @view.organization.library.puppet_repositories.pluck(:pulp_id)
+      search_filters = [{ :terms => { :repoids => repo_ids } },
+                        { :not => { :terms => { :id => current_ids } } }]
+      options = { :filters => search_filters }
+
+      respond_for_index :template => '../puppet_modules/index',
+                        :collection => item_search(PuppetModule, params, options)
     end
 
     private

--- a/app/controllers/katello/api/v2/filters_controller.rb
+++ b/app/controllers/katello/api/v2/filters_controller.rb
@@ -15,6 +15,8 @@ class Api::V2::FiltersController < Api::V2::ApiController
 
   before_filter :find_content_view
   before_filter :find_filter, :except => [:index, :create]
+  before_filter :load_search_service, :only => [:index, :available_errata, :errata,
+                                                :available_package_groups, :package_groups]
   before_filter :authorize
 
   wrap_parameters :include => (Filter.attribute_names + %w(repository_ids))
@@ -24,11 +26,15 @@ class Api::V2::FiltersController < Api::V2::ApiController
     view_editable = lambda { @view.editable? }
 
     {
-        :index   => view_readable,
-        :create  => view_editable,
-        :show    => view_readable,
-        :update  => view_editable,
-        :destroy => view_editable
+        :index                    => view_readable,
+        :create                   => view_editable,
+        :show                     => view_readable,
+        :update                   => view_editable,
+        :destroy                  => view_editable,
+        :available_errata         => view_readable,
+        :errata                   => view_readable,
+        :available_package_groups => view_readable,
+        :package_groups           => view_readable
     }
   end
 
@@ -67,7 +73,7 @@ class Api::V2::FiltersController < Api::V2::ApiController
   api :PUT, "/content_views/:content_view_id/filters/:id", "Update a filter"
   api :PUT, "/filters/:id", "Update a filter"
   param :content_view_id, :identifier, :desc => "content view identifier"
-  param :id, :identifier, :desc => "filter identifierr", :required => true
+  param :id, :identifier, :desc => "filter identifier", :required => true
   param :name, String, :desc => "new name for the filter"
   param :inclusion, :bool, :desc => "specifies if content should be included or excluded, default: inclusion=false"
   param :repository_ids, Array, :desc => "list of repository ids"
@@ -83,6 +89,70 @@ class Api::V2::FiltersController < Api::V2::ApiController
   def destroy
     @filter.destroy
     respond :resource => @filter
+  end
+
+  api :GET, "/content_views/:content_view_id/filters/:id",
+      "Get errata that have already been added to the filter"
+  api :GET, "/filters/:id/errata",
+      "Get errata that have already been added to the filter"
+  param :content_view_id, :identifier, :desc => "content view identifier"
+  param :id, :identifier, :desc => "filter identifier", :required => true
+  def errata
+    errata_ids = @filter.erratum_rules.map(&:errata_id)
+    search_filters = [:terms => { :errata_id_exact => errata_ids }]
+    options = { :filters => search_filters }
+
+    respond_for_index :template => '../errata/index',
+                      :collection => item_search(Errata, params, options)
+  end
+
+  api :GET, "/content_views/:content_view_id/filters/:id",
+      "Get errata that are available to be added to the filter"
+  api :GET, "/filters/:id/available_errata",
+      "Get errata that are available to be added to the filter"
+  param :content_view_id, :identifier, :desc => "content view identifier"
+  param :id, :identifier, :desc => "filter identifier", :required => true
+  def available_errata
+    current_errata_ids = @filter.erratum_rules.map(&:errata_id)
+    repo_ids = @filter.applicable_repos.pluck(:pulp_id)
+    search_filters = [{ :terms => { :repoids => repo_ids } },
+                      { :not => { :terms => { :errata_id_exact => current_errata_ids } } }]
+    options = { :filters => search_filters }
+
+    respond_for_index :template => '../errata/index',
+                      :collection => item_search(Errata, params, options)
+  end
+
+  api :GET, "/content_views/:content_view_id/filters/:id",
+      "Get package groups that have already been added to the filter"
+  api :GET, "/filters/:id/package_groups",
+      "Get package groups that have already been added to the filter"
+  param :content_view_id, :identifier, :desc => "content view identifier"
+  param :id, :identifier, :desc => "filter identifier", :required => true
+  def package_groups
+    ids = @filter.package_group_rules.map(&:name)
+    search_filters = [:terms => { :name => ids }]
+    options = { :filters => search_filters }
+
+    respond_for_index :template => '../package_groups/index',
+                      :collection => item_search(PackageGroup, params, options)
+  end
+
+  api :GET, "/content_views/:content_view_id/filters/:id",
+      "Get package groups that are available to be added to the filter"
+  api :GET, "/filters/:id/available_package_groups",
+      "Get package groups that are available to be added to the filter"
+  param :content_view_id, :identifier, :desc => "content view identifier"
+  param :id, :identifier, :desc => "filter identifier", :required => true
+  def available_package_groups
+    current_ids = @filter.package_group_rules.map(&:name)
+    repo_ids = @filter.applicable_repos.pluck(:pulp_id)
+    search_filters = [{ :terms => { :repo_id => repo_ids } },
+                      { :not => { :terms => { :name => current_ids } } }]
+    options = { :filters => search_filters }
+
+    respond_for_index :template => '../package_groups/index',
+                      :collection => item_search(PackageGroup, params, options)
   end
 
   private

--- a/app/models/katello/erratum_filter_rule.rb
+++ b/app/models/katello/erratum_filter_rule.rb
@@ -22,7 +22,7 @@ module Katello
 
     serialize :types, Array
 
-    validates :errata_id, :uniqueness => { :scope => :filter_id }
+    validates :errata_id, :uniqueness => { :scope => :filter_id }, :allow_blank => true
     validates_with Validators::ErratumFilterRuleValidator
   end
 end

--- a/app/models/katello/filter.rb
+++ b/app/models/katello/filter.rb
@@ -145,6 +145,14 @@ class Filter < Katello::Model
     repositories.collect{|r| r.product}.uniq
   end
 
+  def applicable_repos
+    if self.repositories.blank?
+      self.content_view.repositories
+    else
+      self.repositories
+    end
+  end
+
   protected
 
   def validate_repos

--- a/app/models/katello/glue/pulp/puppet_module.rb
+++ b/app/models/katello/glue/pulp/puppet_module.rb
@@ -19,10 +19,7 @@ module Glue::Pulp::PuppetModule
     base.class_eval do
       attr_accessor :_storage_path, :tag_list, :description, :license, :author,
                     :_ns, :project_page, :summary, :source, :dependencies, :version,
-                    :_content_type_id, :checksums, :_id, :types, :name, :repoids
-
-      alias_method 'id=', '_id='
-      alias_method 'id', '_id'
+                    :_content_type_id, :checksums, :id, :types, :name, :repoids
 
       def self.find(id)
         attrs = Katello.pulp_server.extensions.puppet_module.find_by_unit_id(id)
@@ -48,6 +45,7 @@ module Glue::Pulp::PuppetModule
 
   module InstanceMethods
     def initialize(params = {}, options = {})
+      params['id'] = params.delete('_id')
       params['repoids'] = params.delete(:repository_memberships) if params.key?(:repository_memberships)
       params.each_pair {|k, v| instance_variable_set("@#{k}", v) unless v.nil? }
     end

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -226,6 +226,7 @@ class Product < Katello::Model
     query = query.enabled if enabled_only
     joins(:provider).where("#{Katello::Provider.table_name}.organization_id" => env.organization).
         where("(#{Katello::Provider.table_name}.provider_type ='#{Provider::CUSTOM}') OR \
+              (#{Katello::Provider.table_name}.provider_type ='#{Provider::ANONYMOUS}') OR \
               (#{Katello::Provider.table_name}.provider_type ='#{Provider::REDHAT}' AND \
               #{Katello::Product.table_name}.id in (#{query.to_sql}))")
   end

--- a/app/views/katello/api/v2/errata/index.json.rabl
+++ b/app/views/katello/api/v2/errata/index.json.rabl
@@ -1,3 +1,12 @@
-collection @collection
+# In this index.json.rabl, we are purposely not using the
+# 'katello/api/v2/common/index' as that assumes this index
+# will only be used from the errata controller; however,
+# we'll also utilize it elsewhere (e.g. filters controller).
 
-extends 'katello/api/v2/errata/_attributes'
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends("katello/api/v2/errata/_attributes")
+end

--- a/app/views/katello/api/v2/filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/filter_rules/show.json.rabl
@@ -2,6 +2,7 @@ object @resource
 
 extends 'katello/api/v2/common/identifier'
 
+attributes :filter_id
 attributes :version, :if => lambda { |rule| rule.respond_to?(:version) && !rule.version.blank? }
 attributes :min_version, :if => lambda { |rule| rule.respond_to?(:min_version) && !rule.min_version.blank? }
 attributes :max_version, :if => lambda { |rule| rule.respond_to?(:max_version) && !rule.max_version.blank? }

--- a/app/views/katello/api/v2/package_groups/index.json.rabl
+++ b/app/views/katello/api/v2/package_groups/index.json.rabl
@@ -1,3 +1,12 @@
+# In this index.json.rabl, we are purposely not using the
+# 'katello/api/v2/common/index' as that assumes this index
+# will only be used from the package groups controller; however,
+# we'll also utilize it elsewhere (e.g. filters controller).
+
 object false
 
-extends 'katello/api/v2/common/index'
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends("katello/api/v2/package_groups/show")
+end

--- a/app/views/katello/api/v2/puppet_modules/index.json.rabl
+++ b/app/views/katello/api/v2/puppet_modules/index.json.rabl
@@ -1,3 +1,12 @@
+# In this index.json.rabl, we are purposely not using the
+# 'katello/api/v2/common/index' as that assumes this index
+# will only be used from the package groups controller; however,
+# we'll also utilize it elsewhere (e.g. content views controller).
+
 object false
 
-extends 'katello/api/v2/common/index'
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends("katello/api/v2/puppet_modules/show")
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -40,9 +40,18 @@ Katello::Engine.routes.draw do
           post :publish
           post :promote
           post :refresh
+          get :puppet_modules
+          get :available_puppet_modules
         end
         api_resources :puppet_modules, :controller => :content_view_puppet_modules
-        api_resources :filters
+        api_resources :filters do
+          member do
+            get :errata
+            get :available_errata
+            get :package_groups
+            get :available_package_groups
+          end
+        end
         api_resources :repositories, :only => [:index]
       end
 
@@ -60,6 +69,13 @@ Katello::Engine.routes.draw do
       # content view filters
       api_resources :filters do
         api_resources :rules, :controller => :filter_rules
+
+        member do
+          get :errata
+          get :available_errata
+          get :package_groups
+          get :available_package_groups
+        end
       end
 
       # content view filter rules

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -143,5 +143,38 @@ module Katello
         put :update, :id => @content_view.id, :name => "new name"
       end
     end
+
+    def test_puppet_modules
+      get :puppet_modules, :id => @content_view.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/content_views/../puppet_modules/index'
+    end
+
+    def test_puppet_modules_protected
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:puppet_modules, allowed_perms, denied_perms) do
+        get :puppet_modules, :id => @content_view.id
+      end
+    end
+
+    def test_available_puppet_modules
+      get :available_puppet_modules, :id => @content_view.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/content_views/../puppet_modules/index'
+    end
+
+    def test_available_puppet_modules_protected
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:available_puppet_modules, allowed_perms, denied_perms) do
+        get :available_puppet_modules, :id => @content_view.id
+      end
+    end
+
   end
 end

--- a/test/controllers/api/v2/filters_controller_test.rb
+++ b/test/controllers/api/v2/filters_controller_test.rb
@@ -141,5 +141,78 @@ module Katello
         delete :destroy, :content_view_id => @filter.content_view_id, :id => @filter.id
       end
     end
+
+    def test_errata
+      @filter = katello_filters(:populated_erratum_filter)
+      get :errata, :content_view_id => @filter.content_view_id, :id => @filter.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/filters/../errata/index'
+    end
+
+    def test_errata_protected
+      @filter = katello_filters(:populated_erratum_filter)
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:errata, allowed_perms, denied_perms) do
+        get :errata, :content_view_id => @filter.content_view_id, :id => @filter.id
+      end
+    end
+
+    def test_available_errata
+      @filter = katello_filters(:populated_erratum_filter)
+      get :available_errata, :content_view_id => @filter.content_view_id, :id => @filter.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/filters/../errata/index'
+    end
+
+    def test_available_errata_protected
+      @filter = katello_filters(:populated_erratum_filter)
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:available_errata, allowed_perms, denied_perms) do
+        get :available_errata, :content_view_id => @filter.content_view_id, :id => @filter.id
+      end
+    end
+
+    def test_package_groups
+      @filter = katello_filters(:populated_package_group_filter)
+      get :package_groups, :content_view_id => @filter.content_view_id, :id => @filter.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/filters/../package_groups/index'
+    end
+
+    def test_package_groups_protected
+      @filter = katello_filters(:populated_package_group_filter)
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:package_groups, allowed_perms, denied_perms) do
+        get :package_groups, :content_view_id => @filter.content_view_id, :id => @filter.id
+      end
+    end
+
+    def test_available_package_groups
+      @filter = katello_filters(:populated_package_group_filter)
+      get :available_package_groups, :content_view_id => @filter.content_view_id, :id => @filter.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/filters/../package_groups/index'
+    end
+
+    def test_available_package_groups_protected
+      @filter = katello_filters(:populated_package_group_filter)
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:available_package_groups, allowed_perms, denied_perms) do
+        get :available_package_groups, :content_view_id => @filter.content_view_id, :id => @filter.id
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This commit contains support for several additional APIs
to support the content view rework.  This includes:

ContentView - GET puppet_modules & available_puppet_modules
Filter - GET package_groups & available_package_groups
         GET errat & available_errata

It also contains a few small fixes for issues found while
working on the new APIs.
