### PR TITLE
Content Views Rework: APIs for available/current content

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -21,40 +21,46 @@ class Api::V2::ErrataController < Api::V2::ApiController
   end
 
   before_filter :find_optional_organization, :only => [:show]
-  before_filter :find_environment, :only => [:index]
   before_filter :find_repository, :only => [:index, :show]
-  before_filter :find_erratum, :only => [:show]
-  before_filter :require_repo_or_environment, :only => [:index]
+  before_filter :find_content_view, :only => [:index]
+  before_filter :find_filter, :only => [:index]
   before_filter :authorize
+  before_filter :find_erratum, :only => [:show]
 
   def rules
-    env_readable = lambda { @environment.contents_readable? }
     readable = lambda do
       (@organization && Repository.any_readable?(@organization)) ||
-      (@repo.environment.contents_readable? && @repo.product.readable?)
+      (@filter && @filter.content_view.readable?) ||
+      (@repo && @repo.environment.contents_readable? && @repo.product.readable?)
     end
-
     {
-        :index => env_readable,
+        :index => readable,
         :show  => readable,
     }
   end
 
+  api :GET, "/errata", "List errata"
+  api :GET, "/content_views/:content_view_id/filters/:filter_id/errata", "List errata"
+  api :GET, "/filters/:filter_id/errata", "List errata"
   api :GET, "/repositories/:repository_id/errata", "List errata"
-  api :GET, "/environments/:environment_id/errata", "List errata"
-  param :environment_id, :number, :desc => "The environment containing the errata."
-  param :product_id, :number, :desc => "The product which contains errata."
-  param :repository_id, :number, :desc => "The repository which contains errata."
-  param :severity, String, :desc => "Severity of errata. Usually one of: Critical, Important, Moderate, Low. Case insensitive."
-  param :type, String, :desc => "Type of errata. Usually one of: security, bugfix, enhancement. Case insensitive."
+  param :content_view_id, :identifier, :desc => "content view identifier"
+  param :filter_id, :identifier, :desc => "content view filter identifier"
+  param :repository_id, :number, :desc => "repository identifier", :required => true
   def index
-    filter = params.symbolize_keys.slice(:repository_id, :product_id, :environment_id, :type, :severity)
-    respond :collection => Errata.filter(filter)
+    collection = if @repo && !@repo.puppet?
+                   filter_by_repoids [@repo.pulp_id]
+                 elsif @filter
+                   filter_by_errata_id @filter.erratum_rules.map(&:errata_id)
+                 else
+                   filter_by_repoids
+                 end
+
+    respond(:collection => collection)
   end
 
-  api :GET, "/repositories/:repository_id/errata/:id", "Show an erratum"
   api :GET, "/errata/:id", "Show an erratum"
-  param :repository_id, :identifier, :desc => "repository identifier", :required => true
+  api :GET, "/repositories/:repository_id/errata/:id", "Show an erratum"
+  param :repository_id, :number, :desc => "repository identifier"
   param :id, String, :desc => "erratum identifier", :required => true
   def show
     respond :resource => @erratum
@@ -62,21 +68,33 @@ class Api::V2::ErrataController < Api::V2::ApiController
 
   private
 
-  def find_environment
-    if params.key?(:environment_id)
-      @environment = KTEnvironment.find(params[:environment_id])
-      fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
-      @environment
+  def filter_by_errata_id(ids)
+    options = sort_params
+    options[:filters] = [:terms => { :errata_id_exact => ids }]
+    item_search(Errata, params, options)
+  end
+
+  def filter_by_repoids(repoids = [])
+    options = sort_params
+    options[:filters] = [{ :terms => { :repoids => repoids } }]
+    item_search(Errata, params, options)
+  end
+
+  def find_content_view
+    @view = ContentView.find(params[:content_view_id]) if params[:content_view_id]
+  end
+
+  def find_filter
+    if @view
+      @filter = @view.filters.find_by_id(params[:filter_id])
+      fail HttpErrors::NotFound, _("Couldn't find Filter with id=%s") % params[:filter_id] unless @filter
+    else
+      @filter = Filter.find(params[:filter_id]) if params[:filter_id]
     end
   end
 
   def find_repository
-    if params.key?(:repository_id)
-      @repo = Repository.find(params[:repository_id])
-      fail HttpErrors::NotFound, _("Couldn't find repository '%s'") % params[:repository_id] if @repo.nil?
-      @environment ||= @repo.environment
-      @repo
-    end
+    @repo = Repository.find(params[:repository_id]) if params[:repository_id]
   end
 
   def find_erratum
@@ -85,10 +103,6 @@ class Api::V2::ErrataController < Api::V2::ApiController
     fail HttpErrors::NotFound, _("Erratum with id '%s' not found") % params[:id] if @erratum.nil?
     fail HttpErrors::NotFound, _("Erratum '%s' not found within the repository") % params[:id] unless @repo.nil? || @erratum.repoids.include?(@repo.pulp_id)
     @erratum
-  end
-
-  def require_repo_or_environment
-    fail HttpErrors::BadRequest, _("Either repository or environment is required.") % params[:id] if @repo.nil? && @environment.nil?
   end
 end
 end

--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -14,26 +14,39 @@ module Katello
 class Api::V2::PackageGroupsController < Api::V2::ApiController
 
   before_filter :find_repository
+  before_filter :find_content_view, :only => [:index]
+  before_filter :find_filter, :only => [:index]
   before_filter :authorize
   before_filter :find_package_group, :only => [:show]
 
   def rules
-    readable = lambda { @repo.environment.contents_readable? && @repo.product.readable? }
+    readable = lambda do
+      (@filter && @filter.content_view.readable?) ||
+      (@repo && @repo.environment.contents_readable? && @repo.product.readable?)
+    end
     {
-        :index  => readable,
-        :show   => readable
+        :index => readable,
+        :show  => readable
     }
   end
 
   api :GET, "/package_groups", "List package groups"
+  api :GET, "/content_views/:content_view_id/filters/:filter_id/package_groups", "List package groups"
+  api :GET, "/filters/:filter_id/package_groups", "List package groups"
   api :GET, "/repositories/:repository_id/package_groups", "List package groups"
+  param :content_view_id, :identifier, :desc => "content view identifier"
+  param :filter_id, :identifier, :desc => "content view filter identifier"
   param :repository_id, :identifier, :desc => "repository identifier", :required => true
   def index
-    options = sort_params
-    options[:filters] = [{ :term => { :repo_id => @repo.pulp_id } }]
+    collection = if @repo && !@repo.puppet?
+                   filter_by_repo_id @repo.pulp_id
+                 elsif @filter
+                   filter_by_name @filter.package_group_rules.map(&:name)
+                 else
+                   filter_by_repo_id
+                 end
 
-    @search_service.model = PackageGroup
-    respond(:collection => item_search(PackageGroup, params, options))
+    respond(:collection => collection)
   end
 
   api :GET, "/package_groups/:id", "Show a package group"
@@ -45,6 +58,31 @@ class Api::V2::PackageGroupsController < Api::V2::ApiController
   end
 
   private
+
+  def filter_by_name(names)
+    options = sort_params
+    options[:filters] = [{ :terms => { :name => names } }]
+    item_search(PackageGroup, params, options)
+  end
+
+  def filter_by_repo_id(repo_id = [])
+    options = sort_params
+    options[:filters] = [{ :term => { :repo_id => repo_id } }]
+    item_search(PackageGroup, params, options)
+  end
+
+  def find_content_view
+    @view = ContentView.find(params[:content_view_id]) if params[:content_view_id]
+  end
+
+  def find_filter
+    if @view
+      @filter = @view.filters.find_by_id(params[:filter_id])
+      fail HttpErrors::NotFound, _("Couldn't find Filter with id=%s") % params[:filter_id] unless @filter
+    else
+      @filter = Filter.find(params[:filter_id]) if params[:filter_id]
+    end
+  end
 
   def find_repository
     @repo = Repository.find(params[:repository_id]) if params[:repository_id]

--- a/app/controllers/katello/api/v2/system_groups_controller.rb
+++ b/app/controllers/katello/api/v2/system_groups_controller.rb
@@ -67,11 +67,11 @@ module Katello
     param :system_id, :identifier, :desc => "system identifier"
     def index
       subscriptions = if @system
-                        index_system
+                        filter_system
                       elsif @activation_key
-                        index_activation_key
+                        filter_activation_key
                       else
-                        index_organization
+                        filter_organization
                       end
 
       respond_for_index(:collection => subscriptions)
@@ -209,7 +209,7 @@ module Katello
 
     private
 
-    def index_system
+    def filter_system
       filters = [:terms => {:id => @system.system_groups.pluck(:id)}]
 
       options = {
@@ -219,7 +219,7 @@ module Katello
       item_search(SystemGroup, params, options)
     end
 
-    def index_activation_key
+    def filter_activation_key
       filters = [:terms => {:id => @activation_key.system_groups.pluck(:id)}]
 
       options = {
@@ -229,7 +229,7 @@ module Katello
       item_search(SystemGroup, params, options)
     end
 
-    def index_organization
+    def filter_organization
       filters = [:terms => {:id => SystemGroup.readable(@organization).pluck(:id)}]
       filters << {:term => {:name => params[:name].downcase}} if params[:name]
 

--- a/app/models/katello/erratum_filter_rule.rb
+++ b/app/models/katello/erratum_filter_rule.rb
@@ -22,7 +22,7 @@ module Katello
 
     serialize :types, Array
 
-    validates :errata_id, :uniqueness => { :scope => :filter_id }
+    validates :errata_id, :uniqueness => { :scope => :filter_id }, :allow_blank => true
     validates_with Validators::ErratumFilterRuleValidator
   end
 end

--- a/app/models/katello/filter.rb
+++ b/app/models/katello/filter.rb
@@ -145,6 +145,14 @@ class Filter < Katello::Model
     repositories.collect{|r| r.product}.uniq
   end
 
+  def applicable_repos
+    if self.repositories.blank?
+      self.content_view.repositories
+    else
+      self.repositories
+    end
+  end
+
   protected
 
   def validate_repos

--- a/app/models/katello/glue/pulp/puppet_module.rb
+++ b/app/models/katello/glue/pulp/puppet_module.rb
@@ -19,10 +19,7 @@ module Glue::Pulp::PuppetModule
     base.class_eval do
       attr_accessor :_storage_path, :tag_list, :description, :license, :author,
                     :_ns, :project_page, :summary, :source, :dependencies, :version,
-                    :_content_type_id, :checksums, :_id, :types, :name, :repoids
-
-      alias_method 'id=', '_id='
-      alias_method 'id', '_id'
+                    :_content_type_id, :checksums, :id, :types, :name, :repoids
 
       def self.find(id)
         attrs = Katello.pulp_server.extensions.puppet_module.find_by_unit_id(id)
@@ -48,6 +45,7 @@ module Glue::Pulp::PuppetModule
 
   module InstanceMethods
     def initialize(params = {}, options = {})
+      params['id'] = params.delete('_id')
       params['repoids'] = params.delete(:repository_memberships) if params.key?(:repository_memberships)
       params.each_pair {|k, v| instance_variable_set("@#{k}", v) unless v.nil? }
     end

--- a/app/views/katello/api/v2/errata/index.json.rabl
+++ b/app/views/katello/api/v2/errata/index.json.rabl
@@ -1,3 +1,7 @@
-collection @collection
+object false
 
-extends 'katello/api/v2/errata/_attributes'
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/errata/_attributes'
+end

--- a/app/views/katello/api/v2/filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/filter_rules/show.json.rabl
@@ -2,6 +2,7 @@ object @resource
 
 extends 'katello/api/v2/common/identifier'
 
+attributes :filter_id
 attributes :version, :if => lambda { |rule| rule.respond_to?(:version) && !rule.version.blank? }
 attributes :min_version, :if => lambda { |rule| rule.respond_to?(:min_version) && !rule.min_version.blank? }
 attributes :max_version, :if => lambda { |rule| rule.respond_to?(:max_version) && !rule.max_version.blank? }

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -40,9 +40,18 @@ Katello::Engine.routes.draw do
           post :publish
           post :promote
           post :refresh
+          get :available_puppet_modules
         end
-        api_resources :puppet_modules, :controller => :content_view_puppet_modules
-        api_resources :filters
+        api_resources :content_view_puppet_modules, :controller => :content_view_puppet_modules
+        api_resources :filters do
+          member do
+            get :available_errata
+            get :available_package_groups
+          end
+          api_resources :errata, :only => [:index]
+          api_resources :package_groups, :only => [:index]
+        end
+        api_resources :puppet_modules, :only => [:index]
         api_resources :repositories, :only => [:index]
         api_resources :content_view_versions, :only => [:index]
       end
@@ -59,9 +68,17 @@ Katello::Engine.routes.draw do
         end
       end
 
+      api_resources :errata, :only => [:index, :show]
+
       # content view filters
       api_resources :filters do
+        api_resources :errata, :only => [:index]
+        api_resources :package_groups, :only => [:index]
         api_resources :rules, :controller => :filter_rules
+        member do
+          get :available_errata
+          get :available_package_groups
+        end
       end
 
       # content view filter rules
@@ -358,8 +375,6 @@ Katello::Engine.routes.draw do
       api_resources :sync_plans, :only => [:show, :update, :destroy]
       api_resources :tasks, :only => [:show]
       api_resources :about, :only => [:index]
-
-      api_resources :errata, :only => [:show]
 
       # api custom information
       match '/custom_info/:informable_type/:informable_id' => 'custom_info#create', :via => :post, :as => :create_custom_info

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -143,5 +143,22 @@ module Katello
         put :update, :id => @content_view.id, :name => "new name"
       end
     end
+
+    def test_available_puppet_modules
+      get :available_puppet_modules, :id => @content_view.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/content_views/../puppet_modules/index'
+    end
+
+    def test_available_puppet_modules_protected
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:available_puppet_modules, allowed_perms, denied_perms) do
+        get :available_puppet_modules, :id => @content_view.id
+      end
+    end
+
   end
 end

--- a/test/controllers/api/v2/filters_controller_test.rb
+++ b/test/controllers/api/v2/filters_controller_test.rb
@@ -141,5 +141,42 @@ module Katello
         delete :destroy, :content_view_id => @filter.content_view_id, :id => @filter.id
       end
     end
+
+    def test_available_errata
+      @filter = katello_filters(:populated_erratum_filter)
+      get :available_errata, :content_view_id => @filter.content_view_id, :id => @filter.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/filters/../errata/index'
+    end
+
+    def test_available_errata_protected
+      @filter = katello_filters(:populated_erratum_filter)
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:available_errata, allowed_perms, denied_perms) do
+        get :available_errata, :content_view_id => @filter.content_view_id, :id => @filter.id
+      end
+    end
+
+    def test_available_package_groups
+      @filter = katello_filters(:populated_package_group_filter)
+      get :available_package_groups, :content_view_id => @filter.content_view_id, :id => @filter.id
+
+      assert_response :success
+      assert_template 'katello/api/v2/filters/../package_groups/index'
+    end
+
+    def test_available_package_groups_protected
+      @filter = katello_filters(:populated_package_group_filter)
+      allowed_perms = [@read_permission]
+      denied_perms = [@no_permission]
+
+      assert_protected_action(:available_package_groups, allowed_perms, denied_perms) do
+        get :available_package_groups, :content_view_id => @filter.content_view_id, :id => @filter.id
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This commit contains support for several additional APIs
to support the content view rework.  This includes:

ContentView - GET puppet_modules & available_puppet_modules
Filter - GET package_groups & available_package_groups
         GET errat & available_errata

It also contains a few small fixes for issues found while
working on the new APIs.
