### PR TITLE
Content Views Rework: updating publish to use the new filter models

### DIFF
--- a/app/lib/katello/util/package.rb
+++ b/app/lib/katello/util/package.rb
@@ -156,14 +156,14 @@ module Util
 
     def self.version_filter(minimum = nil, maximum = nil)
       filters = []
-      filters << PackageFilter.new(minimum, PackageFilter::GREATER_THAN).clauses if minimum
-      filters << PackageFilter.new(maximum, PackageFilter::LESS_THAN).clauses if maximum
+      filters << Util::PackageFilter.new(minimum, Util::PackageFilter::GREATER_THAN).clauses unless minimum.blank?
+      filters << Util::PackageFilter.new(maximum, Util::PackageFilter::LESS_THAN).clauses unless maximum.blank?
 
       filters
     end
 
     def self.version_eq_filter(version)
-      [PackageFilter.new(version, PackageFilter::EQUAL).clauses]
+      [Util::PackageFilter.new(version, Util::PackageFilter::EQUAL).clauses]
     end
 
     # Converts a package version to a sortable string

--- a/app/lib/katello/util/package_clause_generator.rb
+++ b/app/lib/katello/util/package_clause_generator.rb
@@ -64,7 +64,7 @@ module Util
     # output -> {"filename" => {"$in" => {"foo.el6.noarch", "..."}}} <- Packages belonging to those errata
     def package_clauses_for_errata(errata_clauses = [])
       errata_clauses = {"$or" => errata_clauses}
-      pkg_filenames = ::Errata.list_by_filter_clauses(errata_clauses).collect(&:package_filenames).flatten
+      pkg_filenames = Errata.list_by_filter_clauses(errata_clauses).collect(&:package_filenames).flatten
       {'filename' => {"$in" => pkg_filenames}} unless pkg_filenames.empty?
     end
 

--- a/app/models/katello/filter.rb
+++ b/app/models/katello/filter.rb
@@ -116,7 +116,9 @@ class Filter < Katello::Model
   end
 
   def self.applicable(repo)
-    query = %{ katello_filters.id in (select filter_id from  katello_filters_repositories where repository_id = #{repo.id}) }
+    query = %{ (katello_filters.id in (select filter_id from katello_filters_repositories where repository_id = #{repo.id})) or
+               (katello_filters.id not in (select filter_id from katello_filters_repositories))
+             }
     where(query).select("DISTINCT katello_filters.id")
   end
 

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -280,7 +280,7 @@ module Glue::Pulp::Repo
 
       #do the errata remove call
       unless errata_to_delete.empty?
-        unassociate_by_filter(FilterRule::ERRATA, {"id" => {"$in" => errata_to_delete}})
+        unassociate_by_filter(ErratumFilter::CONTENT_TYPE, { "id" => { "$in" => errata_to_delete } })
       end
 
       # Remove all  package groups with no packages
@@ -290,7 +290,7 @@ module Glue::Pulp::Repo
       package_groups_to_delete.compact!
 
       unless package_groups_to_delete.empty?
-        unassociate_by_filter(FilterRule::PACKAGE_GROUP, {"id" => {"$in" => package_groups_to_delete}})
+        unassociate_by_filter(PackageGroupFilter::CONTENT_TYPE, { "id" => { "$in" => package_groups_to_delete } })
       end
     end
 
@@ -656,7 +656,7 @@ module Glue::Pulp::Repo
       cloned_repo_override = options.fetch(:cloned_repo_override, nil)
       tasks = []
       clone = cloned_repo_override || self.content_view_version.repositories.where(:library_instance_id => self.library_instance_id).where("id != #{self.id}").first
-      if force_regeneration || self.content_view.default? || (self.content_view.nil? && !cloned_repo_override)
+      if force_regeneration || self.content_view.default? || clone.nil?
         tasks << self.publish_distributor
       else
         tasks << self.publish_clone_distributor(clone)

--- a/app/models/katello/package_filter.rb
+++ b/app/models/katello/package_filter.rb
@@ -25,28 +25,21 @@ class PackageFilter < Filter
   # @param repo [Repository] a repository containing packages to filter
   # @return [Array] an array of hashes with MongoDB conditions
   def generate_clauses(repo)
-    pkg_filenames = parameters[:units].map do |unit|
-      next if unit[:name].blank?
-
-      filter = version_filter(unit)
-      Package.search(unit[:name], 0, repo.package_count, [repo.pulp_id],
-                      [:nvrea_sort, "ASC"], :all, 'name', filter).collect(&:filename).compact
+    package_filenames = package_rules.reject{ |rule| rule.name.blank? }.flat_map do |rule|
+      filter = version_filter(rule)
+      Package.search(rule.name, 0, repo.package_count, [repo.pulp_id], [:nvrea_sort, "asc"],
+                     :all, 'name', filter).map(&:filename).compact
     end
-    pkg_filenames.flatten!
-    pkg_filenames.compact!
-
-    { 'filename' => { "$in" => pkg_filenames } } unless pkg_filenames.empty?
+    { 'filename' => { "$in" => package_filenames } } unless package_filenames.empty?
   end
 
   protected
 
-  def version_filter(unit)
-    if unit.key?(:version)
-      Util::Package.version_eq_filter(unit[:version])
-    elsif unit.key?(:min_version) || unit.key?(:max_version)
-      Util::Package.version_filter(unit[:min_version], unit[:max_version])
-    else
-      nil
+  def version_filter(rule)
+    if !rule.version.blank?
+      Util::Package.version_eq_filter(rule.version)
+    elsif !rule.min_version.blank? || !rule.max_version.blank?
+      Util::Package.version_filter(rule.min_version, rule.max_version)
     end
   end
 

--- a/app/models/katello/package_group_filter.rb
+++ b/app/models/katello/package_group_filter.rb
@@ -20,15 +20,10 @@ class PackageGroupFilter < Filter
            :class_name => "Katello::PackageGroupFilterRule"
 
   def generate_clauses(repo)
-    ids = parameters[:units].collect do |unit|
-      #{'name' => {"$regex" => unit[:name]}}
-      unless unit[:name].blank?
-        PackageGroup.legacy_search(unit[:name], 0, 0, [repo.pulp_id]).collect(&:package_group_id)
-      end
+    package_group_ids = package_group_rules.reject{ |rule| rule.name.blank? }.flat_map do |rule|
+      PackageGroup.legacy_search(rule.name, 0, 0, [repo.pulp_id]).map(&:package_group_id).compact
     end
-    ids.flatten!
-    ids.compact!
-    { "id" => { "$in" => ids } } unless ids.empty?
+    { "id" => { "$in" => package_group_ids } } unless package_group_ids.empty?
   end
 
 end


### PR DESCRIPTION
This commit contains the changes to allow the publish process
to use the new filter models for packages, package groups and
errata.

This commit does not include puppet modules.  Since those
are no longer handled as a 'filter', a separate commit
and pull request will add them.
