### PR TITLE
1057652: No longer delete derived products on import

### DIFF
--- a/spec/helpers/product_test_data.rb
+++ b/spec/helpers/product_test_data.rb
@@ -157,6 +157,14 @@ module ProductTestData
     "created" => "2011-07-11T20=>26=>26.510+0000"
   })
 
+  DERIVED_PROVIDED_PRODUCT = HashWithIndifferentAccess.new({
+      "created" => "2013-12-30T16:11:26.000+0000",
+      "id" => "8a85f987430cc341014344462dc06c38",
+      "productId" => "180",
+      "productName" => "Red Hat Beta",
+      "updated" => "2013-12-30T16:11:26.000+0000"
+  })
+
 #   PRODUCT_WITHOUT_CONTENT_ID = HashWithIndifferentAccess.new({
 #     :name => ProductTestData::PRODUCT_NAME,
 #     :id => ProductTestData::PRODUCT_ID,


### PR DESCRIPTION
Must include all derived marketing/engineering products
when determining the marketing/engineering product
mapping during manifest import, else katello thinks
that they should be deleted after an import.

Derived products are used to create a sub pool once
the subscription is attached. We can not delete them.
