### PR TITLE
fixes #4409 - rename the id used for the content menu

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -1,7 +1,7 @@
 Foreman::Plugin.register :katello do
   requires_foreman '> 1.3'
 
-  sub_menu :top_menu, :content, :caption => N_('Content'), :after => :monitor_menu do
+  sub_menu :top_menu, :content_menu, :caption => N_('Content'), :after => :monitor_menu do
     menu :top_menu,
          :environments,
          :caption => N_('Lifecycle Environments'),
@@ -27,7 +27,7 @@ Foreman::Plugin.register :katello do
                        :action => 'all'},
          :engine => Katello::Engine
 
-    divider :top_menu, :parent => :content
+    divider :top_menu, :parent => :content_menu
     menu :top_menu,
          :redhat_provider,
          :caption => N_('Red Hat Repositories'),
@@ -49,7 +49,7 @@ Foreman::Plugin.register :katello do
                        :action => 'all'},
          :engine => Katello::Engine
 
-    divider :top_menu, :parent => :content
+    divider :top_menu, :parent => :content_menu
     menu :top_menu,
          :sync_status,
          :caption => N_('Sync Status'),
@@ -64,7 +64,7 @@ Foreman::Plugin.register :katello do
                        :action => 'all'},
          :engine => Katello::Engine
 
-    divider :top_menu, :parent => :content
+    divider :top_menu, :parent => :content_menu
     menu :top_menu,
          :content_view_definitions,
          :caption => N_('Content View Definitions'),
@@ -79,7 +79,7 @@ Foreman::Plugin.register :katello do
                        :action => 'index'},
          :engine => Katello::Engine
 
-    divider :top_menu, :parent => :content
+    divider :top_menu, :parent => :content_menu
     menu :top_menu,
          :changeset_management,
          :caption => N_('Changeset Management'),


### PR DESCRIPTION
For some reason, using 'content' as the id for the Content menu
was resulting in breakage in behavior for foreman's two-pane
implementation.

Without this change, the following would occur:
- User goes to a page, clicks 'New <object>' (e.g.
  Architecture, Environment, User...)
- panel opens with form to allow user to enter
  data for the object
- User clicks submit
- At this point, the form is submitted to the server
  and the object is created; however, the form is never
  closed and the list of objects is not updated.
