### PR TITLE
fixing red hat repos page

### DIFF
--- a/app/assets/javascripts/katello/providers/provider_redhat.js
+++ b/app/assets/javascripts/katello/providers/provider_redhat.js
@@ -91,7 +91,7 @@ KT.redhat_provider_page = (function($) {
     },
     repoSetChange = function(checkbox, is_refresh) {
         var url = checkbox.data("url"),
-            disable_url = checkbox.data("disable_url"),
+            disable_url = checkbox.data("disable-url"),
             content_id = checkbox.attr("value");
         if (checkbox.attr('checked') || is_refresh) {
             refresh_repo_set(url, content_id, is_refresh);

--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -14,20 +14,43 @@ module Katello
 class ProductsController < Katello::ApplicationController
   respond_to :html, :js
 
+  before_filter :find_product, :only => [:refresh_content, :disable_content]
+  before_filter :find_provider, :only => [:refresh_content, :disable_content]
+
   before_filter :authorize
 
   def rules
     read_test = lambda {Product.any_readable?(current_organization)}
+    edit_test = lambda{@provider.editable?}
 
     {
       :index => read_test,
       :all => read_test,
-      :auto_complete =>  read_test
+      :auto_complete =>  read_test,
+      :refresh_content => edit_test,
+      :disable_content => edit_test,
     }
   end
 
   def section_id
     'contents'
+  end
+
+  def refresh_content
+    if @product.custom?
+      render_bad_parameters _('Repository sets are enabled by default for custom products.')
+    else
+      pc = @product.refresh_content(params[:content_id])
+      render :partial => 'katello/providers/redhat/repos', :locals => { :product_content => pc }
+    end
+  end
+
+  def disable_content
+    if @product.custom?
+      render_bad_parameters _('Repository sets cannot be disabled for custom products.')
+    else
+      render :json => @product.disable_content(params[:content_id])
+    end
   end
 
   def index
@@ -52,5 +75,15 @@ class ProductsController < Katello::ApplicationController
     render :json => Util::Support.array_with_total
   end
 
+  private
+
+  def find_provider
+    @provider = @product.provider if @product #don't trust the provider_id coming in if we don't need it
+    @provider ||= Provider.find(params[:provider_id])
+  end
+
+  def find_product
+    @product = Product.find(params[:id])
+  end
 end
 end

--- a/app/views/katello/providers/redhat/_repo_sets.haml
+++ b/app/views/katello/providers/redhat/_repo_sets.haml
@@ -27,7 +27,7 @@
                           :id=>"spinner_set_#{product_content.content.id}", :style=>"margin-right:1px;")
                       %input.repo_set_enable{:type=>:checkbox, :value=>product_content.content.id,
                                            :data=>{:url => refresh_content_product_path(product.id),
-                                                   :disable_url=>disable_content_product_path(product.id),
+                                                   'disable-url'=>disable_content_product_path(product.id),
                                                    :orphaned => orphaned.to_s},
                                            :disabled =>(!product_content.can_disable? || !@provider.editable? || (orphaned && !content_enabled)),
                                            :checked=>(:checked if content_enabled)}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,10 @@ Katello::Engine.routes.draw do
   end
 
   resources :products, :only => [:index] do
+    member do
+      put :refresh_content
+      put :disable_content
+    end
     collection do
       get :auto_complete
       get :all

--- a/lib/katello/tasks/test.rake
+++ b/lib/katello/tasks/test.rake
@@ -47,6 +47,7 @@ namespace :test do
           "#{Katello::Engine.root}/test/controllers/content_views_controller_test.rb",
           "#{Katello::Engine.root}/test/controllers/filter_rules_controller_test.rb",
           "#{Katello::Engine.root}/test/controllers/filters_controller_test.rb",
+          "#{Katello::Engine.root}/test/controllers/products_controller_test.rb",
           "#{Katello::Engine.root}/test/lib/repo_discovery_test.rb",
           "#{Katello::Engine.root}/test/models/authorization/*_test.rb",
           "#{Katello::Engine.root}/test/models/association_test.rb",


### PR DESCRIPTION
- product controller actions were mistakenly deleted
- routes for said actions were mistakenly deleted
- data attributes in some cases will be changed from foo_bar
  to foo-bar, so this was fixed
