### PR TITLE
Fix apipie documentation for systems

### DIFF
--- a/app/controllers/katello/api/v1/systems_controller.rb
+++ b/app/controllers/katello/api/v1/systems_controller.rb
@@ -329,7 +329,7 @@ This information is then used for computing the errata available for the system.
   DESC
   param :enabled_repos, Hash, :required => true do
     param :repos, Array, :required => true do
-      params :baseurl, Array, :description => "List of enabled repo urls for the repo (Only first is used.)", :required => false
+      param :baseurl, Array, :description => "List of enabled repo urls for the repo (Only first is used.)", :required => false
     end
   end
   def enabled_repos

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -394,7 +394,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
   DESC
   param :enabled_repos, Hash, :required => true do
     param :repos, Array, :required => true do
-      params :baseurl, Array, :description => "List of enabled repo urls for the repo (Only first is used.)", :required => false
+      param :baseurl, Array, :description => "List of enabled repo urls for the repo (Only first is used.)", :required => false
     end
   end
   param :id, String, :desc => "UUID of the system", :required => true


### PR DESCRIPTION
With update of apipie, the code that was not run before is now run in runtime,
causing troubles starting the production environmnet:

```undefined method`params' for Hash:Apipie::Validator::HashValidator
/app/controllers/katello/api/v2/systems_controller.rb:397:in `block (2 levels)
in class:SystemsController'

```
```
