### PR TITLE
rbac-actkey - allows creation of actkey permissions (does not enforce them)

### DIFF
--- a/app/controllers/katello/activation_keys_controller.rb
+++ b/app/controllers/katello/activation_keys_controller.rb
@@ -12,6 +12,9 @@
 
 module Katello
   class ActivationKeysController < Katello::ApplicationController
+
+    include Foreman::Controller::AutoCompleteSearch
+
     respond_to :html, :js
 
     before_filter :authorize
@@ -20,7 +23,8 @@ module Katello
       read_test = lambda {ActivationKey.readable?(current_organization)}
       {
         :index => read_test,
-        :all => read_test
+        :all => read_test,
+        :auto_complete_search => read_test
       }
     end
 

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -19,6 +19,7 @@ class ActivationKey < Katello::Model
   include Glue if Katello.config.use_cp
   include Authorization::ActivationKey
   include Ext::LabelFromName
+  include Authorizable
 
   belongs_to :organization, :inverse_of => :activation_keys
   belongs_to :environment, :class_name => "KTEnvironment", :inverse_of => :activation_keys
@@ -48,6 +49,9 @@ class ActivationKey < Katello::Model
     end
   end
   validates_with Validators::ContentViewEnvironmentValidator
+
+  scoped_search :on => :name, :complete_value => :true
+  scoped_search :on => :organization_id, :complete_value => :true
 
   def environment_exists
     if environment.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Katello::Engine.routes.draw do
   resources :activation_keys, :only => [:index] do
     collection do
       get :all
+      get :auto_complete_search
     end
   end
 

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -148,4 +148,25 @@ Foreman::Plugin.register :katello do
        :engine => Katello::Engine,
        :parent => :administer_menu,
        :after => :about
+
+
+  security_block :katello do
+    permission :view_activation_keys,
+               {
+                 :'katello/activation_keys' => [:all, :index],
+                 :'katello/api/v2/activation_keys' => [:index, :show]
+               }, :resource_type => 'Katello::ActivationKey'
+    permission :create_activation_keys,
+               {
+                 :'katello/api/v2/activation_keys' => [:create],
+                     }, :resource_type => 'Katello::ActivationKey'
+    permission :update_activation_keys,
+               {
+                 :'katello/api/v2/activation_keys' => [:update],
+               }, :resource_type => 'Katello::ActivationKey'
+    permission :destroy_activation_keys,
+               {
+                 :'katello/api/v2/activation_keys' => [:destroy],
+               }, :resource_type => 'Katello::ActivationKey'
+  end
 end


### PR DESCRIPTION
Adds necessary pieces to create activation keys under new RBAC system. Does not attempt to enforce them through this mechanism yet, though.
