### PR TITLE
Content View Rework: updates to support publish and promote for puppet content

### DIFF
--- a/app/models/katello/concerns/environment_extensions.rb
+++ b/app/models/katello/concerns/environment_extensions.rb
@@ -41,7 +41,13 @@ module Katello
 
         # content_view_id provides the uniqueness of the name
         def construct_name(org, env, content_view)
-          name = ["KT", org.label, env.label, content_view.label, content_view.id].reject(&:blank?).join('_')
+          name = ["KT",
+                  org.try(:label),
+                  env.try(:label),
+                  content_view.try(:label),
+                  content_view.try(:id)
+                 ].reject(&:blank?).join('_')
+
           return name.gsub('-', '_')
         end
       end

--- a/app/models/katello/content_view_puppet_environment.rb
+++ b/app/models/katello/content_view_puppet_environment.rb
@@ -1,0 +1,83 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  class ContentViewPuppetEnvironment < Katello::Model
+    self.include_root_in_json = false
+
+    include ForemanTasks::Concerns::ActionSubject
+    include Glue::Pulp::Repo if Katello.config.use_pulp
+    include Glue::ElasticSearch::ContentViewPuppetEnvironment if Katello.config.use_elasticsearch
+    include Glue if Katello.config.use_pulp
+    include AsyncOrchestration
+
+    belongs_to :environment, :class_name => "Katello::KTEnvironment",
+               :inverse_of => :content_view_puppet_environments
+    belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion",
+               :inverse_of => :content_view_puppet_environments
+
+    validates :pulp_id, :presence => true, :uniqueness => true
+    validates_with Validators::KatelloNameFormatValidator, :attributes => :name
+
+    scope :non_archived, where('environment_id is not NULL')
+    scope :archived, where('environment_id is NULL')
+
+    def content_type
+      Repository::PUPPET_TYPE
+    end
+
+    def organization
+      if self.environment
+        self.environment.organization
+      else
+        self.content_view.organization
+      end
+    end
+
+    def content_view
+      self.content_view_version.content_view
+    end
+
+    def self.in_content_view(view_id)
+      joins(:content_view_version).where(
+          "#{Katello::ContentViewVersion.table_name}.content_view_id" => view_id)
+    end
+
+    def self.in_environment(env_id)
+      where(environment_id: env_id)
+    end
+
+    def archive?
+      self.environment.nil?
+    end
+
+    def self.generate_pulp_id(organization_label, env_label, view_label, version)
+      [organization_label, env_label, view_label, version].compact.join("-").gsub(/[^-\w]/, "_")
+    end
+
+    def self.trigger_contents_changed(repos, options)
+      wait    = options.fetch(:wait, false)
+      reindex = options.fetch(:reindex, true) && Katello.config.use_elasticsearch
+      publish = options.fetch(:publish, true) && Katello.config.use_pulp
+
+      tasks = []
+      if publish
+        tasks += repos.flat_map do |repo|
+          repo.generate_metadata(:node_publish_async => true, :force_regeneration => true)
+        end
+      end
+      repos.each{|repo| repo.index_content } if reindex
+
+      PulpTaskStatus.wait_for_tasks(tasks) if wait
+    end
+  end
+end

--- a/app/models/katello/glue/elastic_search/content_view_puppet_environment.rb
+++ b/app/models/katello/glue/elastic_search/content_view_puppet_environment.rb
@@ -1,0 +1,98 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Glue::ElasticSearch::ContentViewPuppetEnvironment
+
+    # TODO: break this up into modules
+    # rubocop:disable MethodLength
+    def self.included(base)
+      base.send :include, Ext::IndexedModel
+
+      base.class_eval do
+        index_options :extended_json => :extended_index_attrs,
+                      :json => {:except => [:pulp_repo_facts, :feed_cert]}
+
+        mapping do
+          indexes :name, :type => 'string', :analyzer => :kt_name_analyzer
+          indexes :name_sort, :type => 'string', :index => :not_analyzed
+          indexes :labels, :type => 'string', :index => :not_analyzed
+        end
+
+        before_destroy :clear_content_indices
+      end
+
+      def extended_index_attrs
+        {
+            :environment => self.environment.try(:name),
+            :archive => self.archive?,
+            :environment_id => self.environment.try(:id),
+            :name_sort => self.name
+        }
+      end
+
+      def index_puppet_modules
+        Tire.index Katello::PuppetModule.index do
+          create :settings => Katello::PuppetModule.index_settings, :mappings => Katello::PuppetModule.index_mapping
+        end
+        puppet_modules = self.puppet_modules.collect{|puppet_module| puppet_module.as_json.merge(puppet_module.index_options)}
+        puppet_modules.each_slice(Katello.config.pulp.bulk_load_size) do |sublist|
+          Tire.index Katello::PuppetModule.index do
+            import sublist
+          end if !sublist.empty?
+        end
+      end
+
+      def update_puppet_modules_index
+        # for each of the puppet_modules in the repo, unassociate the repo from the module
+        puppet_modules = self.puppet_modules.collect{|puppet_module| puppet_module.as_json.merge(puppet_module.index_options)}
+        pulp_id = self.pulp_id
+
+        unless puppet_modules.empty?
+          Tire.index Katello::PuppetModule.index do
+            create :settings => Katello::PuppetModule.index_settings, :mappings => Katello::PuppetModule.index_mapping
+          end unless Tire.index(Katello::PuppetModule.index).exists?
+
+          Tire.index Katello::PuppetModule.index do
+            import puppet_modules do |documents|
+              documents.each do |document|
+                if !document["repoids"].nil? && document["repoids"].length > 1
+                  # if there is more than 1 repo associated w/ the pkg, remove this repo
+                  document["repoids"].delete(pulp_id)
+                end
+              end
+            end
+          end
+        end
+
+        # now, for any module that only had this repo asscociated with it, remove the module from the index
+        repoids = "repoids:#{pulp_id}"
+        Tire::Configuration.client.delete "#{Tire::Configuration.url}/katello_puppet_module/_query?q=#{repoids}"
+        Tire.index('katello_puppet_module').refresh
+      end
+
+      def puppet_module_count
+        results = Katello::PuppetModule.legacy_search('', :page_size => 1, :repoids => [self.pulp_id])
+        results.empty? ? 0 : results.total
+      end
+
+      def index_content
+        self.index_puppet_modules
+        true
+      end
+
+      def clear_content_indices
+        update_puppet_modules_index
+      end
+    end
+  end
+end

--- a/app/models/katello/glue/elastic_search/puppet_module.rb
+++ b/app/models/katello/glue/elastic_search/puppet_module.rb
@@ -77,7 +77,7 @@ module Glue::ElasticSearch::PuppetModule
 
     def id_search(ids)
       return Util::Support.array_with_total unless Tire.index(self.index).exists?
-      search = Tire.search self.index do
+      search = PuppetModule.search do
         fields [:id, :name, :repoids]
         query do
           all
@@ -85,11 +85,40 @@ module Glue::ElasticSearch::PuppetModule
         size ids.size
         filter :terms, :id => ids
       end
-      search.results
+      search.to_a
+    end
+
+    # Find the 'latest' version of the puppet modules provided across
+    # the list of repos provided.
+    def latest_modules_search(names_and_authors, repoids)
+      return Util::Support.array_with_total unless Tire.index(self.index).exists?
+
+      # use multi-search to perform a single request to elasticsearch which
+      # will perform N queries/searches
+      multi_search = PuppetModule.multi_search do
+        names_and_authors.each do |item|
+          search do
+            query do
+              string "name:#{ item[:name] } author:#{ item[:author] }", :default_operator => 'AND'
+            end
+            size 1
+            filter :terms, :repoids => repoids
+            sort { by :sortable_version, "desc" }
+          end
+        end
+      end
+
+      # multi_search will return a result set for each query.
+      # since each query will have a single document, return a list of those individual results
+      multi_search.reject{ |results| results[0].nil? }.map{ |results| results[0] }
     end
 
     def search(options = {}, &block)
       Tire.search(self.index, &block).results
+    end
+
+    def multi_search(options = {}, &block)
+      Tire.multi_search(self.index, &block).results
     end
 
     def mapping

--- a/app/models/katello/glue/pulp/puppet_module.rb
+++ b/app/models/katello/glue/pulp/puppet_module.rb
@@ -26,6 +26,11 @@ module Glue::Pulp::PuppetModule
         Katello::PuppetModule.new(attrs) if !attrs.nil?
       end
 
+      def self.find_by_ids(ids)
+        pulp_puppet_modules = Katello.pulp_server.extensions.puppet_module.find_all_by_unit_ids(ids)
+        pulp_puppet_modules.collect { |puppet_module| Katello::PuppetModule.new(puppet_module) }
+      end
+
       def self.generate_unit_data(filepath)
         data = parse_metadata(filepath)
 

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -75,14 +75,17 @@ module Glue::Pulp::Repo
           pre_queue.create(:name => "update pulp repo: #{self.name}", :priority => 2,
                            :action => [self, :refresh_pulp_repo, nil, nil, nil])
         end
-        if self.unprotected_changed?
-          post_queue.create(:name => "generate metadata for pulp repo #{self.name}", :priority => 3, :action => [self, :generate_metadata])
+        if self.respond_to?(:unprotected) && self.unprotected_changed?
+          post_queue.create(:name => "generate metadata for pulp repo #{self.name}", :priority => 3,
+                            :action => [self, :generate_metadata])
         end
       end
     end
 
     def pulp_update_needed?
-      (self.feed_changed? || self.unprotected_changed?) && !self.product.provider.redhat_provider?
+      ((self.respond_to?(:feed) && self.feed_changed?) ||
+       (self.respond_to?(:unprotected) && self.unprotected_changed?)) &&
+      !self.product.provider.redhat_provider?
     end
 
     def last_sync
@@ -115,7 +118,7 @@ module Glue::Pulp::Repo
     end
 
     def lookup_checksum_type
-      find_distributor['config']['checksum_type'] if self.yum? && find_distributor
+      find_distributor['config']['checksum_type'] if self.respond_to?(:yum?) && self.yum? && find_distributor
     end
 
     def create_pulp_repo
@@ -156,7 +159,9 @@ module Glue::Pulp::Repo
                                           :ssl_client_key => self.feed_key,
                                           :feed => self.feed)
       when Repository::PUPPET_TYPE
-        Runcible::Models::PuppetImporter.new(:feed => self.feed)
+        options = {}
+        options[:feed] = self.feed if self.respond_to?(:feed)
+        Runcible::Models::PuppetImporter.new(options)
       else
         fail _("Unexpected repo type %s") % self.content_type
       end
@@ -180,7 +185,7 @@ module Glue::Pulp::Repo
         [dist]
       when Repository::PUPPET_TYPE
         repo_path =  File.join(Katello.config.puppet_repo_root,
-                               Environment.construct_name(self.environment.organization,
+                               Environment.construct_name(self.organization,
                                                           self.environment,
                                                           self.content_view),
                                'modules')
@@ -656,21 +661,28 @@ module Glue::Pulp::Repo
     def generate_metadata(options = {})
       force_regeneration = options.fetch(:force_regeneration, false)
       cloned_repo_override = options.fetch(:cloned_repo_override, nil)
+
+      unless force_regeneration
+        clone = cloned_repo_override ||
+            self.content_view_version.repositories.where(:library_instance_id => self.library_instance_id).where("id != #{self.id}").first
+      end
+
       tasks = []
-      clone = cloned_repo_override || self.content_view_version.repositories.where(:library_instance_id => self.library_instance_id).where("id != #{self.id}").first
       if force_regeneration || self.content_view.default? || clone.nil?
         tasks << self.publish_distributor
       else
         tasks << self.publish_clone_distributor(clone)
       end
+
       if self.find_node_distributor
         if options[:node_publish_async]
           self.async(:organization => self.organization,
-                           :task_type => TaskStatus::TYPES[:content_view_node_publish][:type]).publish_node_distributor
+                     :task_type => TaskStatus::TYPES[:content_view_node_publish][:type]).publish_node_distributor
         else
           tasks << self.publish_node_distributor
         end
       end
+
       tasks
     end
 

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -56,6 +56,8 @@ class KTEnvironment < Katello::Model
            :dependent => :destroy, :foreign_key => :environment_id
   has_many :content_view_environments, :class_name => "Katello::ContentViewEnvironment",
            :foreign_key => :environment_id, :inverse_of => :environment, :dependent => :destroy
+  has_many :content_view_puppet_environments, :class_name => "Katello::ContentViewPuppetEnvironment",
+           :foreign_key => :environment_id, :inverse_of => :environment, :dependent => :destroy
   has_many :content_view_versions, :through => :content_view_environments, :inverse_of => :environments
   has_many :content_views, :through => :content_view_environments, :inverse_of => :environments
   has_many :content_view_histories, :class_name => "Katello::ContentViewHistory", :dependent => :destroy,

--- a/db/migrate/20140306132108_create_content_view_puppet_environments.rb
+++ b/db/migrate/20140306132108_create_content_view_puppet_environments.rb
@@ -1,0 +1,18 @@
+class CreateContentViewPuppetEnvironments < ActiveRecord::Migration
+  def change
+    create_table :katello_content_view_puppet_environments do |t|
+      t.references :content_view_version
+      t.references :environment
+      t.string     :name
+      t.string     :pulp_id, :null => false
+      t.timestamps
+    end
+
+    add_index :katello_content_view_puppet_environments, [:content_view_version_id],
+              :name => :index_cvpe_on_content_view_version_id
+    add_index :katello_content_view_puppet_environments, [:environment_id],
+              :name => :index_cvpe_on_environment_id
+    add_index :katello_content_view_puppet_environments, [:pulp_id],
+              :name => :index_cvpe_on_pulp_id
+  end
+end

--- a/spec/helpers/organization_helper_methods.rb
+++ b/spec/helpers/organization_helper_methods.rb
@@ -78,8 +78,9 @@ module OrganizationHelperMethods
   def publish_content_view(name, org, repos)
     Katello.pulp_server.extensions.repository.stubs(:create).returns({})
     Repository.any_instance.stubs(:clone_contents).returns([])
-    ContentView.any_instance.stubs(:associate_yum_types).returns([])
+    ContentView.any_instance.stubs(:associate_yum_content).returns([])
     Repository.stubs(:trigger_contents_changed).returns([])
+    Repository.stubs(:non_puppet).returns(repos)
     cv = ContentView.create!(:organization => org, :name => name)
     cv.repositories = repos
     cv.save!

--- a/test/factories/content_view_puppet_environment_factory.rb
+++ b/test/factories/content_view_puppet_environment_factory.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :katello_content_view_puppet_environment, :class => Katello::ContentViewPuppetEnvironment do
+    sequence(:name) { |n| "Content View Puppet Environment #{n}" }
+    sequence(:pulp_id) { |n| "pulp-#{n}" }
+    association :environment, :factory => :katello_k_t_environment
+    association :content_view_version, :factory => :katello_content_view_version
+
+    trait :library_content_view_puppet_environment do
+      name          "Library View Puppet Environment"
+      pulp_id       "library-view"
+    end
+  end
+end

--- a/test/models/content_view_puppet_environment_test.rb
+++ b/test/models/content_view_puppet_environment_test.rb
@@ -1,0 +1,81 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module Katello
+class ContentViewPuppetEnvironmentTest < ActiveSupport::TestCase
+
+  def self.before_suite
+    models = ["Organization", "KTEnvironment", "User", "ContentView",
+              "ContentViewEnvironment", "ContentViewPuppetEnvironment"]
+    disable_glue_layers(["Candlepin", "Pulp", "ElasticSearch"], models, true)
+  end
+
+  def setup
+    User.current = User.find(users(:admin))
+
+    @library = FactoryGirl.build(:katello_environment, :library => true)
+    @content_view_version = FactoryGirl.build(:katello_content_view_version)
+
+    @puppet_env = FactoryGirl.build(:katello_content_view_puppet_environment,
+                                    :library_content_view_puppet_environment,
+                                    :environment => @library,
+                                    :content_view_version => @content_view_version)
+  end
+
+  def test_create
+    assert        @puppet_env.save
+    refute_empty  ContentViewPuppetEnvironment.where(:id => @puppet_env.id)
+  end
+
+  def test_content_type
+    assert       @puppet_env.save
+    assert_equal "puppet", ContentViewPuppetEnvironment.find(@puppet_env.id).content_type
+  end
+
+  def test_in_content_view
+    assert       @puppet_env.save
+    refute_empty ContentViewPuppetEnvironment.in_content_view(@content_view_version.content_view)
+
+    library_dev_view = ContentView.find(katello_content_views(:library_dev_view))
+    assert_empty ContentViewPuppetEnvironment.in_content_view(library_dev_view)
+  end
+
+  def test_in_environment
+    assert       @puppet_env.save
+    refute_empty ContentViewPuppetEnvironment.in_environment(@library)
+
+    dev = KTEnvironment.find(katello_environments(:dev).id)
+    assert_empty ContentViewPuppetEnvironment.in_environment(dev)
+  end
+
+  def test_archive
+    refute @puppet_env.archive?
+
+    @puppet_env.environment = nil
+    @puppet_env.save
+    assert @puppet_env.archive?
+  end
+
+  def test_generate_pulp_id
+    assert_equal ContentViewPuppetEnvironment.generate_pulp_id("org", "env", "view", "version"),
+                 "org-env-view-version"
+
+    assert_equal ContentViewPuppetEnvironment.generate_pulp_id("org", "env", "view", nil),
+                 "org-env-view"
+
+    assert_equal ContentViewPuppetEnvironment.generate_pulp_id("org", nil, "view", "version"),
+                 "org-view-version"
+  end
+end
+end


### PR DESCRIPTION
This commit contains the changes to support publishing
and promoting content views that contain puppet content.

One key change being introduced is the 'ContentViewPuppetEnvironment',
which represents the published content. When one is created,
a pulp puppet repository is created.  It was split out to be
a separate model as it cannot be associated with a product
(since the source of the content could be multiple repositories);
however, it does share the glue/pulp/repo.rb that is used by the
Repository model.
