### PR TITLE
Require foreman-tasks ~> 0.3.6

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "tire", "~> 0.6.2"
   gem.add_dependency "logging", ">= 1.8.0"
   gem.add_dependency "hooks"
-  gem.add_dependency "foreman-tasks"
+  gem.add_dependency "foreman-tasks", "~> 0.3.6"
   gem.add_dependency "justified"
   gem.add_dependency "strong_parameters", "~> 0.2.1" # remove after we upgrade to Rails 4
 


### PR DESCRIPTION
We need it for `for_action` and `for_resource` scope definitions
