### PR TITLE
Bypass dynflow for seeding organization data in tests

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 require 'factory_girl_rails'
 require "webmock/minitest"
 require "mocha/setup"
+require 'dynflow/testing'
 
 require "#{Katello::Engine.root}/test/support/minitest/spec/shared_examples"
 require "#{Katello::Engine.root}/spec/helpers/login_helper_methods"
@@ -21,7 +22,6 @@ require "#{Katello::Engine.root}/test/support/auth_support"
 require "#{Katello::Engine.root}/test/support/controller_support"
 require "#{Katello::Engine.root}/test/support/search_service"
 
-require 'dynflow/testing'
 Mocha::Mock.send :include, Dynflow::Testing::Mimic
 Dynflow::Testing.logger_adapter.level = 1
 require "#{Katello::Engine.root}/test/support/actions/fixtures"


### PR DESCRIPTION
Use testing helpers to run the needed plan methods of dynflow actions instead: should be much faster.
