### PR TITLE
Fixes #4634: Set karma-coffee-preprocessor version to prevent newer

### DIFF
--- a/engines/bastion/package.json
+++ b/engines/bastion/package.json
@@ -16,6 +16,7 @@
     "karma-coverage": "0.1.0",
     "karma-jasmine": "~0.1",
     "karma-ng-html2js-preprocessor": "~0.1",
+    "karma-coffee-preprocessor": "~0.1.0",
     "grunt-htmlhint": "~0.4.0",
     "grunt-bower-task": "~0.3.4"
   },


### PR DESCRIPTION
version which requires Karma 0.12.0.
