### PR TITLE
Content View Rework: update content view puppet modules to always include name/author

### DIFF
--- a/app/lib/katello/validators/content_view_puppet_module_validator.rb
+++ b/app/lib/katello/validators/content_view_puppet_module_validator.rb
@@ -15,15 +15,8 @@ module Validators
   class ContentViewPuppetModuleValidator < ActiveModel::Validator
 
     def validate(record)
-      if record.name.blank? && record.uuid.blank?
-        invalid_parameters = _("Invalid puppet module parameters specified.  Either 'uuid' or 'name' must be specified.")
-        record.errors[:base] << invalid_parameters
-        return
-      end
-
-      if (!record.name.blank? || !record.author.blank?) && !record.uuid.blank?
-        invalid_parameters = _("Invalid puppet module parameters combination specified, cannot specify both " +
-                               "'uuid' and 'name' or 'author' in the same tuple.")
+      if record.name.blank? && record.author.blank? && record.uuid.blank?
+        invalid_parameters = _("Invalid puppet module parameters specified.  Either 'uuid' or 'name' and 'author' must be specified.")
         record.errors[:base] << invalid_parameters
         return
       end

--- a/app/models/katello/content_view_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_module.rb
@@ -23,5 +23,19 @@ module Katello
     validates :uuid, :uniqueness => { :scope => :content_view_id }, :allow_blank => true
 
     validates_with Validators::ContentViewPuppetModuleValidator
+
+    before_save :set_attributes
+
+    private
+
+    def set_attributes
+      if self.uuid && Katello.config.use_pulp
+        puppet_module = PuppetModule.find(self.uuid)
+        fail Errors::NotFound, _("Couldn't find Puppet Module with id=%s") % self.uuid unless puppet_module
+
+        self.name = puppet_module.name
+        self.author = puppet_module.author
+      end
+    end
   end
 end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -120,7 +120,7 @@ class ContentViewVersion < Katello::Model
 
     if options[:async]
       self.async(:organization => self.content_view.organization).promote_content(to_env, replacing_version,
-                                                                                  promote_version, history)
+                                                                                  history)
     else
       promote_content(to_env, replacing_version, history)
     end

--- a/test/lib/validators/content_view_puppet_module_validator_test.rb
+++ b/test/lib/validators/content_view_puppet_module_validator_test.rb
@@ -27,14 +27,6 @@ module Katello
       refute_empty @model.errors[:base]
     end
 
-    test "fails if both name and uuid provided" do
-      @model = OpenStruct.new(:errors => {:base => []}, :name => "module name",
-                              :author => "module author", :uuid => "3bd47a52-0847-42b5-90ff-206307b48b22")
-      @validator.validate(@model)
-
-      refute_empty @model.errors[:base]
-    end
-
     test "passes if name provided" do
       @model = OpenStruct.new(:errors => {:base => []}, :name => "module name")
       @validator.validate(@model)


### PR DESCRIPTION
A content view puppet module may consist of:
- name
- author
- uuid (optional)

With this change:
- name + author => indicates to apply the latest version of the module
  during content view publish
- uuid + name + author => indicates to apply the specific version
  associated with the uuid to the content view during publish

From a user point of view, this means the user can simply:
- on create or update, provide name+author or uuid

If the user provides uuid, the application will look up the puppet
module in pulp and assign the name + author (i.e. the user doesn't need
to provide it).
