### PR TITLE
Content Views Rework: do not publish archive repos to nodes

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -674,7 +674,9 @@ module Glue::Pulp::Repo
         tasks << self.publish_clone_distributor(clone)
       end
 
-      if self.find_node_distributor
+      # If this repository is for an 'archive', it doesn't need to be
+      # published using the node distributor.
+      if !self.archive? && self.find_node_distributor
         if options[:node_publish_async]
           self.async(:organization => self.organization,
                      :task_type => TaskStatus::TYPES[:content_view_node_publish][:type]).publish_node_distributor


### PR DESCRIPTION
This commit contains a very small change so that when an
archive repos i published, it is not published to the 'node'.

e.g /var/lib/pulp/nodes/published
