### PR TITLE
Fixes #4646: hostgroup-akeys: fix regressions with activation keys on hostgroups page

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -136,6 +136,7 @@ module Katello
 
       @environment = KTEnvironment.find(environment_id)
       fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % params[:environment_id] if @environment.nil?
+      @organization = @environment.organization
       @environment
     end
 

--- a/app/overrides/add_activation_keys_input.rb
+++ b/app/overrides/add_activation_keys_input.rb
@@ -5,7 +5,7 @@ Deface::Override.new(:virtual_path => "hostgroups/_form",
 
 Deface::Override.new(:virtual_path => "hostgroups/_form",
                      :name => "add_activation_keys_tab_pane",
-                     :insert_after => 'div.tab-content > erb[silent]:contains("show_organization_tab?") ~ erb[silent]:contains("end")',
+                     :insert_after => 'erb[loud]:contains("render"):contains("taxonomies/loc_org_tabs")',
                      :partial => '../overrides/foreman/activation_keys/host_tab_pane')
 
 Deface::Override.new(:virtual_path => "hostgroups/_form",

--- a/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
+++ b/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
@@ -44,11 +44,11 @@ $(function() {
 
                                 $.ajax({
                                     type: 'get',
-                                    url:  foreman_url('/katello/api/environments/' + ktAkeyQuery['environment_id'] + '/activation_keys'),
+                                    url:  foreman_url('/katello/api/v2/environments/' + ktAkeyQuery['environment_id'] + '/activation_keys'),
                                     data: {'content_view_id': ktAkeyQuery['content_view_id']},
                                     success: function(response) {
                                         availableActivationKeys = {};
-                                        $.each(response, function (i, key) {
+                                        $.each(response['results'], function (i, key) {
                                             availableActivationKeys[key.name] = [];
                                             $.each(key.pools, function (j, pool) {
                                                 availableActivationKeys[key.name].push(pool.productName);
@@ -231,6 +231,7 @@ $(function() {
             response($.ui.autocomplete.filter(
                 items, part));
         },
+
         focus: function() {
             // prevent value inserted on focus
             return false;
@@ -276,7 +277,7 @@ $(function() {
     </div>
 
     <p><%= _('Activation keys and subscriptions can be managed') %>
-      <b><a href="/katello/activation_keys" target="_blank"> <%= _('here') %></a></b>
+      <b><a href="/katello/activation_keys#/activation-keys" target="_blank"> <%= _('here') %></a></b>
     </p>
     <p><%= subscription_manager_configuration_url %></p>
     <p><a href="" id="ak_refresh_subscriptions"><%= _('Reload data') %></a></p>


### PR DESCRIPTION
This commit fixes a few small regressions with the activation keys
on the host groups page.
1. update so that activation keys pane will be correctly included
   within the host group page
2. update the activation keys controller to support requests by
   environment
3. update the activation keys pane to use the v2 api (since v1
   was removed)
4. update cross-linking to take the user to the nutupane
   activation keys

Note: additional changes will be needed for the products associated
with activation keys to be listed correctly.
