### PR TITLE
Content View Rework: validate that puppet module exists

### DIFF
--- a/app/lib/katello/validators/content_view_puppet_module_validator.rb
+++ b/app/lib/katello/validators/content_view_puppet_module_validator.rb
@@ -20,6 +20,18 @@ module Validators
         record.errors[:base] << invalid_parameters
         return
       end
+
+      if record.name && record.author
+        # validate that a puppet module exists with this name+author
+        unless PuppetModule.exists?(:name => record.name, :author => record.author,
+                                    :repoids => record.content_view.puppet_repos.map(&:pulp_id))
+
+          invalid_parameters = _("Puppet Module with name='%{name}' and author='%{author}' does not exist") %
+              { :name => record.name, :author => record.author }
+
+          record.errors[:base] << invalid_parameters
+        end
+      end
     end
 
   end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -165,6 +165,11 @@ class ContentView < Katello::Model
     ContentViewPuppetEnvironment.where(:id => ids).first
   end
 
+  def  puppet_repos
+    # These are the repos that may contain puppet modules that can be associated with the content view
+    self.organization.library.repositories.puppet_type
+  end
+
   def library_repos
     Repository.where(:id => library_repo_ids)
   end

--- a/app/models/katello/glue/elastic_search/puppet_module.rb
+++ b/app/models/katello/glue/elastic_search/puppet_module.rb
@@ -113,6 +113,13 @@ module Glue::ElasticSearch::PuppetModule
       multi_search.reject{ |results| results[0].nil? }.map{ |results| results[0] }
     end
 
+    def exists?(options)
+      results = PuppetModule.latest_modules_search([{ :name => options[:name],
+                                                      :author => options[:author] }],
+                                                   options[:repoids])
+      results.present?
+    end
+
     def search(options = {}, &block)
       Tire.search(self.index, &block).results
     end

--- a/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
@@ -42,6 +42,7 @@ module Katello
       @fake_search_service = @controller.load_search_service(Support::SearchService::FakeSearchService.new)
       models
       permissions
+      Katello::PuppetModule.stubs(:exists?).returns(true)
     end
 
     def test_index

--- a/test/lib/validators/content_view_puppet_module_validator_test.rb
+++ b/test/lib/validators/content_view_puppet_module_validator_test.rb
@@ -17,6 +17,8 @@ module Katello
   class ContentViewPuppetModuleValidatorTest < ActiveSupport::TestCase
 
     def setup
+      Katello::PuppetModule.stubs(:exists?).returns(true)
+      @base_record = { :errors => { :base => [] }, :content_view => OpenStruct.new({ :puppet_repos => [] }) }
       @validator = Validators::ContentViewPuppetModuleValidator.new({:attributes => [:name]})
     end
 
@@ -28,21 +30,35 @@ module Katello
     end
 
     test "passes if name provided" do
-      @model = OpenStruct.new(:errors => {:base => []}, :name => "module name")
+      @model = OpenStruct.new(@base_record.merge(:name => "module name"))
       @validator.validate(@model)
 
       assert_empty @model.errors[:base]
     end
 
     test "passes if name and author provided" do
-      @model = OpenStruct.new(:errors => {:base => []}, :name => "module name", :author => "module author")
+      @model = OpenStruct.new(@base_record.merge(:name => "module name", :author => "module author"))
+      @validator.validate(@model)
+      assert_empty @model.errors[:base]
+    end
+
+    test "passes if uuid provided" do
+      @model = OpenStruct.new(@base_record.merge(:uuid => "3bd47a52-0847-42b5-90ff-206307b48b22"))
       @validator.validate(@model)
 
       assert_empty @model.errors[:base]
     end
 
-    test "passes if uuid provided" do
-      @model = OpenStruct.new(:errors => {:base => []}, :uuid => "3bd47a52-0847-42b5-90ff-206307b48b22")
+    test "fails if module does not exists" do
+      @model = OpenStruct.new(@base_record.merge(:name => "module name", :author => "module author"))
+      Katello::PuppetModule.stubs(:exists?).returns(false)
+      @validator.validate(@model)
+
+      refute_empty @model.errors[:base]
+    end
+
+    test "passes if the module does exist" do
+      @model = OpenStruct.new(@base_record.merge(:name => "module name", :author => "module author"))
       @validator.validate(@model)
 
       assert_empty @model.errors[:base]


### PR DESCRIPTION
When creating or updating a content view puppet module that includes
name+author, validate that a module by that name is available in
puppet repos associated with that content view's organization.
