### PR TITLE
fixes 4655 - fixing registration to Library attaching to incorrect conte...

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -386,16 +386,10 @@ module Katello
       get_content_view_environment("cp_id", id)
     end
 
-    def get_content_view_environments(name = nil)
+    def get_content_view_environments(label = nil)
       environments = ContentViewEnvironment.joins(:content_view => :organization).
           where("#{Organization.table_name}.id = ?", @organization.id)
-      environments = environments.where("#{Katello::ContentViewEnvironment.table_name}.name = ?", name) if name
-
-      if environments.empty?
-        environments = ContentViewEnvironment.joins(:content_view => :organization).
-            where("#{Organization.table_name}.id = ?", @organization.id)
-        environments = environments.where("#{Katello::ContentViewEnvironment.table_name}.label = ?", name) if name
-      end
+      environments = environments.where("#{Katello::ContentViewEnvironment.table_name}.label = ?", label) if label
 
       # remove any content view environments that aren't readable
       unless @organization.readable?

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -332,8 +332,9 @@ class ContentView < Katello::Model
   # candlepin to become aware that the view is available for consumers.
   def add_environment(env)
     if self.content_view_environments.where(:environment_id => env.id).empty?
-      ContentViewEnvironment.create!(:name => env.name,
-                                     :label => self.generate_cp_environment_label(env),
+      label = self.generate_cp_environment_label(env)
+      ContentViewEnvironment.create!(:name => label,
+                                     :label => label,
                                      :cp_id => self.generate_cp_environment_id(env),
                                      :environment_id => env.id,
                                      :content_view => self)


### PR DESCRIPTION
...nt view

previously content view environment names were set to the environment name
this would result in a system subscribing to "Library" being subscribed to
a random content view in library.  This fix does two things:
-  Sets the content view environment name to be the same as the label
-  Does not use name to identify the content view environment at all
