### PR TITLE
Fixes 4654: Switches to using the Deface syntax for versions of Deface

### DIFF
--- a/app/overrides/add_activation_keys_input.rb
+++ b/app/overrides/add_activation_keys_input.rb
@@ -1,19 +1,19 @@
 Deface::Override.new(:virtual_path => "hostgroups/_form",
                      :name => "add_activation_keys_tab",
-                     :insert_after => 'ul.nav > erb[silent]:contains("show_organization_tab?") ~ erb[silent]:contains("end")',
+                     :insert_after => 'ul.nav > code[erb-silent]:contains("show_organization_tab?") ~ code[erb-silent]:contains("end")',
                      :partial => '../overrides/foreman/activation_keys/host_tab')
 
 Deface::Override.new(:virtual_path => "hostgroups/_form",
                      :name => "add_activation_keys_tab_pane",
-                     :insert_after => 'erb[loud]:contains("render"):contains("taxonomies/loc_org_tabs")',
+                     :insert_after => 'code[erb-loud]:contains("render"):contains("taxonomies/loc_org_tabs")',
                      :partial => '../overrides/foreman/activation_keys/host_tab_pane')
 
 Deface::Override.new(:virtual_path => "hostgroups/_form",
                      :name => "hostgroups_update_environments_select",
-                     :replace => 'erb[loud]:contains("select_f"):contains(":environment_id")',
+                     :replace => 'code[erb-loud]:contains("select_f"):contains(":environment_id")',
                      :partial => '../overrides/foreman/activation_keys/host_environment_select')
 
 Deface::Override.new(:virtual_path => "hosts/_form",
                      :name => "hosts_update_environments_select",
-                     :replace => 'erb[loud]:contains("select_f"):contains(":environment_id")',
+                     :replace => 'code[erb-loud]:contains("select_f"):contains(":environment_id")',
                      :partial => '../overrides/foreman/activation_keys/host_environment_select')

--- a/app/overrides/add_organization_attributes.rb
+++ b/app/overrides/add_organization_attributes.rb
@@ -1,11 +1,11 @@
 # Add organization attributes to org creation
 Deface::Override.new(:virtual_path => "taxonomies/_step1",
                      :name => "add_organization_attributes_on_create",
-                     :insert_after => 'erb[loud]:contains("text_f"):contains(":name")',
+                     :insert_after => 'code[erb-loud]:contains("text_f"):contains(":name")',
                      :partial => 'katello/organizations/step_1_override')
 
 # Add organization attributes to org edit
 Deface::Override.new(:virtual_path => "taxonomies/_form",
                      :name => "add_organization_attributes_on_edit",
-                     :insert_after => 'erb[loud]:contains("text_f"):contains(":name")',
+                     :insert_after => 'code[erb-loud]:contains("text_f"):contains(":name")',
                      :partial => 'katello/organizations/edit_override')

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "compass-960-plugin"
   gem.add_dependency "haml-rails"
   gem.add_dependency "ui_alchemy-rails", '1.0.12'
-  gem.add_dependency "deface"
+  gem.add_dependency "deface", '< 1.0.0'
 
   # Testing
   gem.add_development_dependency "rubocop", "0.17.0"

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -142,7 +142,7 @@ Requires: %{?scl_prefix}rubygem-compass-rails
 Requires: %{?scl_prefix}rubygem-compass-960-plugin 
 Requires: %{?scl_prefix}rubygem-haml-rails 
 Requires: %{?scl_prefix}rubygem-ui_alchemy-rails = 1.0.12
-Requires: %{?scl_prefix}rubygem-deface
+Requires: %{?scl_prefix}rubygem-deface < 1.0.0
 Requires: %{?scl_prefix}rubygem-strong_parameters
 BuildRequires: foreman >= 1.3.0
 BuildRequires: %{?scl_prefix}rubygem-angular-rails-templates >= 0.0.4
@@ -173,7 +173,7 @@ BuildRequires: %{?scl_prefix}rubygem-compass-rails
 BuildRequires: %{?scl_prefix}rubygem-compass-960-plugin 
 BuildRequires: %{?scl_prefix}rubygem-haml-rails 
 BuildRequires: %{?scl_prefix}rubygem-ui_alchemy-rails = 1.0.12
-BuildRequires: %{?scl_prefix}rubygem-deface
+BuildRequires: %{?scl_prefix}rubygem-deface < 1.0.0
 BuildRequires: %{?scl_prefix}rubygem(uglifier) >= 1.0.3
 BuildRequires: %{?scl_prefix}rubygem-strong_parameters
 BuildRequires: %{?scl_prefix}rubygems


### PR DESCRIPTION
less than 1.0.0 and locks down the versions avaiable for use.
