### PR TITLE
Content View Rework: update foreman puppet import

### DIFF
--- a/app/lib/katello/foreman.rb
+++ b/app/lib/katello/foreman.rb
@@ -22,16 +22,12 @@ module Katello
       # 2. environment
       # 3. puppet classes
 
-      has_puppet_content = false
-
-      content_view.repos(env).each do |repo|
-        Medium.update_media(repo)
-        has_puppet_content = true if repo.puppet?
-      end
+      content_view.repos(env).each { |repo| Medium.update_media(repo) }
 
       foreman_environment = Environment.find_or_create_by_katello_id(org, env, content_view)
 
-      if has_puppet_content && (foreman_smart_proxy = SmartProxy.find_by_name(Katello.config.host))
+      if !content_view.content_view_puppet_modules.empty? &&
+          (foreman_smart_proxy = SmartProxy.find_by_name(Katello.config.host))
         PuppetClassImporter.new(:url => foreman_smart_proxy.url).update_environment(foreman_environment)
       end
     end


### PR DESCRIPTION
With the content view rework, we no longer associate puppet repositories
with a content view.  Instead, we associate puppet modules (which
could be from any puppet repo in the library for the org).

This commit takes that in to account when determining if there
are puppet modules to import in to foreman.
