### PR TITLE
Content Views: Adding in more validations

### DIFF
--- a/app/models/katello/content_view_component.rb
+++ b/app/models/katello/content_view_component.rb
@@ -19,13 +19,17 @@ module Katello
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion",
       :inverse_of => :content_view_components
 
-    validate :content_view_composite
+    validates :content_view_version_id, :uniqueness => {:scope => :content_view_id}
+    validate :content_view_types
 
     private
 
-    def content_view_composite
+    def content_view_types
       if !content_view.composite?
         errors.add(:base, _("Cannot add component versions to a non-composite content view"))
+      end
+      if content_view_version.content_view.composite?
+        errors.add(:base, _("Cannot add composite versions to a composite content view"))
       end
     end
   end

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -19,13 +19,21 @@ module Katello
     belongs_to :repository, :inverse_of => :content_view_repositories,
       :class_name => "Katello::Repository"
 
+    validates :repository_id, :uniqueness => {:scope => :content_view_id}
     validate :content_view_composite
+    validate :non_puppet_repository
 
     private
 
     def content_view_composite
       if content_view.composite?
         errors.add(:base, _("Cannot add repositories to a composite content view"))
+      end
+    end
+
+    def non_puppet_repository
+      if repository.puppet?
+        errors.add(:base, _("Cannot add puppet repositories to a content view"))
       end
     end
   end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -266,6 +266,14 @@ class ContentViewVersion < Katello::Model
     end
   end
 
+  def archive_puppet_environment
+    content_view_puppet_environments.archived.first
+  end
+
+  def puppet_modules
+    archive_puppet_environment.puppet_modules
+  end
+
   private
 
   def remove_environment(env)

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -106,8 +106,7 @@ module Katello
 
     def test_update_repositories
       repository = Repository.find(katello_repositories(:fedora_17_x86_64).id)
-      @content_view.repositories << repository
-      @content_view.save
+      assert_includes @content_view.repositories.map(&:id), repository.id
       refute_includes @filter.repositories(true).map(&:id), repository.id
 
       put :update, :content_view_id => @filter.content_view_id, :id => @filter,

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -142,16 +142,23 @@ module Katello
       end
     end
 
-    def test_update_repositories
+    def test_update_puppet_repositories
       repository = katello_repositories(:p_forge)
       refute_includes @content_view.repositories(true).map(&:id), repository.id
-      put :update, :id => @content_view, :repository_ids => [repository.id]
+      put :update, :id => @content_view.id, :repository_ids => [repository.id]
+      assert_response 422 # cannot add puppet repos to cv
+    end
 
+    def test_update_repositories
+      repository = katello_repositories(:fedora_17_unpublished)
+      refute_includes @content_view.repositories(true).map(&:id), repository.id
+      put :update, :id => @content_view.id, :repository_ids => [repository.id]
       assert_response :success
       assert_includes @content_view.repositories(true).map(&:id), repository.id
     end
 
     def test_update_components
+      ContentViewVersion.any_instance.stubs(:puppet_modules).returns([])
       version = @content_view.versions.first
       composite = ContentView.find(katello_content_views(:composite_view))
       refute_includes composite.components(true).map(&:id), version.id

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -179,7 +179,24 @@ class ContentViewTest < ActiveSupport::TestCase
     refute component.save
   end
 
+  def test_composite_views_with_composite_versions
+    ContentViewVersion.any_instance.stubs(:puppet_modules).returns([])
+    ContentViewVersion.any_instance.stubs(:content_view).returns(stub(:composite? => true))
+    composite = ContentView.find(katello_content_views(:composite_view))
+    v1 = ContentViewVersion.find(katello_content_view_versions(:library_view_version_1))
+    assert_raises(ActiveRecord::RecordInvalid) do
+      composite.update_attributes(:component_ids => [v1.id])
+    end
+
+    component = ContentViewComponent.new(:content_view => composite,
+                                         :content_view_version => v1
+                                        )
+    refute component.valid?
+    refute component.save
+  end
+
   def test_repositories_to_publish
+    ContentViewVersion.any_instance.stubs(:puppet_modules).returns([])
     composite = ContentView.find(katello_content_views(:composite_view))
     v1 = ContentViewVersion.find(katello_content_view_versions(:library_view_version_1))
     composite.update_attributes(:component_ids => [v1.id])
@@ -191,6 +208,7 @@ class ContentViewTest < ActiveSupport::TestCase
   end
 
   def test_repo_conflicts
+    ContentViewVersion.any_instance.stubs(:puppet_modules).returns([])
     composite = ContentView.find(katello_content_views(:composite_view))
     v1 = ContentViewVersion.find(katello_content_view_versions(:library_view_version_1))
     v2 = ContentViewVersion.find(katello_content_view_versions(:library_view_version_2))
@@ -201,6 +219,31 @@ class ContentViewTest < ActiveSupport::TestCase
 
     assert_raises(RuntimeError) do
       composite.components << v1
+    end
+  end
+
+  def test_puppet_module_conflicts
+    composite = ContentView.find(katello_content_views(:composite_view))
+    view = create(:katello_content_view)
+    versions = 2.times.map do |i|
+      create(:katello_content_view_version, :content_view => view)
+    end
+    ContentViewVersion.any_instance.stubs(:puppet_modules).returns([stub(:name => "httpd")]).times(4)
+
+    refute composite.update_attributes(component_ids: versions.map(&:id))
+    assert_equal 1, composite.errors.count
+    assert composite.errors.full_messages.first =~ /^Puppet module conflict/
+
+    assert_raises(RuntimeError) do
+      composite.components << versions.first
+    end
+  end
+
+  def test_puppet_repos
+    @p_forge = Repository.find(katello_repositories(:p_forge))
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      @library_view.repositories << @p_forge
     end
   end
 


### PR DESCRIPTION
- Validating that composite puppet module don't conflict
- Validating that content views don't have puppet repos
- Validating that composites don't have composite versions
