### PR TITLE
Support for repo content uploads 

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -11,14 +11,92 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Katello
-class Api::V2::ContentUploadsController < Api::V1::ContentUploadsController
+class Api::V2::ContentUploadsController < Api::V2::ApiController
+  respond_to :json
+  before_filter :find_repository
+  before_filter :authorize
 
-  include Api::V2::Rendering
+  def rules
+    upload_test = lambda { @repo.product.editable? }
 
-  resource_description do
-    api_version 'v2'
-    api_base_url "#{Katello.config.url_prefix}/api"
+    {
+      :create => upload_test,
+      :upload_bits => upload_test,
+      :destroy => upload_test,
+      :import_into_repo => upload_test,
+      :upload_file => upload_test
+    }
   end
 
+  api :POST, "/repositories/:repo_id/content_uploads", "Create an upload request"
+  param :repo_id, :identifier, :required => true, :desc => "repository id"
+  def create
+    respond :resource => pulp_content.create_upload_request
+  end
+
+  api :PUT, "/repositories/:repo_id/content_uploads/:id/upload_bits", "Upload bits"
+  param :repo_id, :identifier, :required => true, :desc => "repository id"
+  param :id, :identifier, :required => true, :desc => "upload request id"
+  param :offset, :number, :required => true, :desc => "the offset at which Pulp will store the file contents"
+  param :content, File, :required => true, :desc => "file contents"
+  def upload_bits
+    pulp_content.upload_bits(params[:id], params[:offset], params[:content])
+    render :nothing => true
+  end
+
+  api :DELETE, "/repositories/:repo_id/content_uploads/:id", "Delete an upload request"
+  param :repo_id, :identifier, :required => true, :desc => "repository id"
+  param :id, :identifier, :required => true, :desc => "upload request id"
+  def destroy
+    pulp_content.delete_upload_request(params[:id])
+    render :nothing => true
+  end
+
+  api :POST, "/repositories/:repo_id/content_uploads/import_into_repo", "Import into a repository"
+  param :repo_id, :identifier, :required => true, :desc => "repository id"
+  param :uploads, Array, :required => true, :desc => "array of uploads to import"
+  def import_into_repo
+    params[:uploads].each do |upload|
+      pulp_content.import_into_repo(@repo.pulp_id, @repo.unit_type_id,
+        upload[:id], upload[:unit_key], {:unit_metadata => upload[:metadata]})
+    end
+
+    unit_keys = params[:uploads].map { |upload| upload[:unit_key] }
+    @repo.trigger_contents_changed(:wait => false, :index_units => unit_keys, :reindex => false)
+    render :nothing => true
+  end
+
+  api :POST, "/repositories/:id/content_uploads/file", "Upload content into the repository"
+  param :id, :identifier, :required => true
+  param :content, File, :required => true, :desc => "file contents"
+  def upload_file
+    filepath = params.try(:[], :content).try(:path)
+
+    if filepath
+      @repo.upload_content(filepath)
+      render :json => {:status => "success"}
+    else
+      fail HttpErrors::BadRequest, _("No file uploaded")
+    end
+
+  rescue Katello::Errors::InvalidPuppetModuleError => error
+    respond_for_exception(
+      error,
+      :status => :unprocessable_entity,
+      :text => error.message,
+      :errors => [error.message],
+      :with_logging => true
+    )
+  end
+
+  private
+
+  def pulp_content
+    Katello.pulp_server.resources.content
+  end
+
+  def find_repository
+    @repo = Repository.find(params[:repository_id])
+  end
 end
 end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -318,6 +318,16 @@ Katello::Engine.routes.draw do
         api_resources :puppet_modules, :only => [:index, :show] do
           get :search, :on => :collection
         end
+
+        api_resources :content_uploads, :controller => :content_uploads, :only => [:create, :destroy] do
+          member do
+            put :upload_bits
+          end
+          collection do
+            post :file, :to => 'content_uploads#upload_file'
+            post :import_into_repo
+          end
+        end
         member do
           get :package_groups
           get :package_group_categories

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -1,0 +1,143 @@
+# encoding: utf-8
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::ContentUploadsControllerTest < ActionController::TestCase
+
+    def self.before_suite
+      models = ["Organization", "KTEnvironment", "Repository", "Product", "Provider", "Package"]
+      services = ["Candlepin", "Pulp", "ElasticSearch"]
+      disable_glue_layers(services, models)
+      super
+    end
+
+    def models
+      @repo = Repository.find(katello_repositories(:fedora_17_x86_64))
+      @org = get_organization
+      @environment = katello_environments(:library)
+    end
+
+    def permissions    
+      @edit_permission = UserPermission.new(:update, :providers)
+      @read_permission = UserPermission.new(:read, :providers)
+      @no_permission = NO_PERMISSION
+    end
+
+    def setup
+      setup_controller_defaults_api
+      login_user(User.find(users(:admin)))
+      @fake_search_service = @controller.load_search_service(Support::SearchService::FakeSearchService.new)
+      models
+      permissions
+    end
+
+    def test_create_upload_request
+      mock_pulp_server(:create_upload_request => [])
+      post :create, :repository_id => @repo.id
+
+      assert_response :success
+    end
+  
+    def test_create_upload_request_protected
+      allowed_perms = [@edit_permission]
+      denied_perms = [@read_permission, @no_permission]
+
+      assert_protected_action(:create, allowed_perms, denied_perms) do
+        post :create, :repository_id => @repo.id 
+      end
+    end
+
+    def test_upload_bits
+      mock_pulp_server(:upload_bits => true)
+      put :upload_bits, :id => "1" , :offset => "0", :content => "/tmp/my_file.rpm", :repository_id => @repo.id
+   
+      assert_response :success
+    end
+  
+    def test_upload_bits_protected
+      allowed_perms = [@edit_permission]
+      denied_perms = [@read_permission, @no_permission]
+
+      assert_protected_action(:upload_bits, allowed_perms, denied_perms) do
+        put :upload_bits, :id => "1" , :offset => "0", :content => "/tmp/my_file.rpm", :repository_id => @repo.id
+      end	
+    end
+
+    def test_import_into_repo
+      mock_pulp_server(:import_into_repo => true)
+      Repository.any_instance.expects(:trigger_contents_changed).returns([])
+      Repository.any_instance.expects(:unit_type_id).returns("rpm")
+   
+      post :import_into_repo, :id => "1", :repository_id => @repo.id, 
+           :uploads => [{:unit_type_id => "rpm", :unit_key => {}, :unit_metadata => {}}]
+
+      assert_response :success
+    end
+
+    def test_import_into_repo_protected
+      allowed_perms = [@edit_permission]
+      denied_perms = [@read_permission, @no_permission]
+
+      assert_protected_action(:import_into_repo, allowed_perms, denied_perms) do
+        post :import_into_repo, :id => "1", :unit_type_id => "rpm", :unit_key => {}, :unit_metadata => {},
+             :repository_id => @repo.id 
+      end
+    end
+
+    def test_delete_request
+      mock_pulp_server(:delete_upload_request  => true)
+      delete :destroy, :id => "1", :repository_id => @repo.id
+
+      assert_response :success
+    end
+
+    def test_delete_request_protected
+      allowed_perms = [@edit_permission]
+      denied_perms = [@no_permission, @read_permission]
+
+      assert_protected_action(:destroy, allowed_perms, denied_perms) do
+        delete :destroy, :id => "1", :repository_id => @repo.id
+      end
+    end
+
+    def test_upload_file
+      test_document = File.join(Engine.root, "test", "fixtures", "files", "puppet_module.tar.gz")
+      puppet_module = Rack::Test::UploadedFile.new(test_document, '')
+      Repository.any_instance.stubs(:upload_content)
+   
+      post :upload_file, :id => "1", :repository_id => @repo.id, :content => puppet_module
+
+      assert_response :success
+    end
+ 
+    def test_upload_file_protected
+      allowed_perms = [@edit_permission]
+      denied_perms = [@read_permission, @no_permission]
+
+      assert_protected_action(:upload_file, allowed_perms, denied_perms) do
+        post :upload_file, :repository_id => @repo.id 
+      end
+    end
+
+    private
+
+    def mock_pulp_server(content_hash)
+      content = mock(content_hash)
+      resources = mock(:content => content)
+      pulp_server = mock(:resources => resources)
+      Katello.expects(:pulp_server).returns(pulp_server)
+    end
+  end
+end


### PR DESCRIPTION
Support repo content uploads in hammer-cli-katello. 
Code to be updated when Katello brings in Pulp 2.4.
