### PR TITLE
Defer garbage collection for 10s to speed up tests

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -164,6 +164,27 @@ class ActiveSupport::TestCase
     organization
   end
 
+  # defer garbage collection to speed up tests
+  setup :begin_gc_deferment
+  teardown :reconsider_gc_deferment
+
+  DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 10.0).to_f
+
+  @@last_gc_run = Time.now
+
+  def begin_gc_deferment
+    GC.disable if DEFERRED_GC_THRESHOLD > 0
+  end
+
+  def reconsider_gc_deferment
+    if DEFERRED_GC_THRESHOLD > 0 && Time.now - @@last_gc_run >= DEFERRED_GC_THRESHOLD
+      GC.enable
+      GC.start
+      GC.disable
+
+      @@last_gc_run = Time.now
+    end
+  end
 end
 
 def disable_glue_layers(services=[], models=[], force_reload=false)


### PR DESCRIPTION
**DO NOT MERGE**. Testing this in Jenkins.

**Before**

```
Finished tests in 104.873295s, 1.3349 tests/s, 4.3672 assertions/s.
```

**After**

```
Finished tests in 89.776439s, 1.5594 tests/s, 5.1016 assertions/s.
```
