### PR TITLE
Fixes 4663: Available releases version will not properly populate the AP...

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -547,9 +547,9 @@ class Api::V2::SystemsController < Api::V2::ApiController
       :release_ver => :releaseVer,
       :service_level => :serviceLevel,
       :last_checkin => :lastCheckin }.each do |snake, camel|
-      if params[:system][snake]
+      if params[snake]
         system_params[camel] = params[snake]
-      elsif params[:system][camel]
+      elsif params[camel]
         system_params[camel] = params[camel]
       end
     end

--- a/app/models/katello/glue/candlepin/consumer.rb
+++ b/app/models/katello/glue/candlepin/consumer.rb
@@ -27,7 +27,7 @@ module Glue::Candlepin::Consumer
 
       as_json_hook :consumer_as_json
 
-      attr_accessible :cp_type, :owner, :serviceLevel, :installedProducts, :facts, :guestIds
+      attr_accessible :cp_type, :owner, :serviceLevel, :installedProducts, :facts, :guestIds, :releaseVer
 
       lazy_accessor :href, :facts, :cp_type, :href, :idCert, :owner, :lastCheckin, :created, :guestIds,
                     :installedProducts, :autoheal, :releaseVer, :serviceLevel, :capabilities, :entitlementStatus,

--- a/app/views/katello/api/v2/systems/releases.json.rabl
+++ b/app/views/katello/api/v2/systems/releases.json.rabl
@@ -2,8 +2,6 @@ object false
 
 extends "katello/api/v2/common/metadata"
 
-child @collection[:results] => :results do
-  @collection[:releases].map do |release|
-    release
-  end
+node :results do
+  @collection[:results]
 end

--- a/app/views/katello/api/v2/systems/show.json.rabl
+++ b/app/views/katello/api/v2/systems/show.json.rabl
@@ -32,7 +32,7 @@ attributes :installedProducts
 
 
 
-node :releaseVer do |sys|
+node :release_ver do |sys|
   sys.releaseVer.is_a?(Hash) ? sys.releaseVer[:releaseVer] : sys.releaseVer
 end
 

--- a/engines/bastion/app/assets/javascripts/bastion/incubator/alch-edit.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/incubator/alch-edit.directive.js
@@ -50,8 +50,12 @@ angular.module('alchemy')
 
                 if (options !== undefined) {
                     if (options.hasOwnProperty('then')) {
+                        $scope.workingMode = true;
+                        $scope.editMode = false;
                         options.then(function (data) {
                             $scope.options = data;
+                            $scope.workingMode = false;
+                            $scope.editMode = true;
 
                             if ($scope.options.length === 0) {
                                 $scope.disableSave = true;

--- a/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-info.html
@@ -186,9 +186,9 @@
       <div class="detail">
         <span class="info-label" translate>Release Version</span>
         <span class="info-value"
-              alch-edit-select="system.releaseVer"
+              alch-edit-select="system.release_ver"
               readonly="system.readonly"
-              selector="system.releaseVer"
+              selector="system.release_ver"
               options="releaseVersions()"
               options-format="option for option in options"
               on-save="save(system)">


### PR DESCRIPTION
...I

and UI data. Further, systems can now have their release version updated from
the UI correctly.
