### PR TITLE
Removing traces of unused cdn_import_success code

### DIFF
--- a/app/lib/katello/util/cdn_var_substitutor.rb
+++ b/app/lib/katello/util/cdn_var_substitutor.rb
@@ -21,6 +21,7 @@ module Util
     def initialize(cdn_resource)
       @resource = cdn_resource
       @substitutions = Thread.current[:cdn_var_substitutor_cache] || {}
+      @status = true
     end
 
     # using substitutor from whithin the block makes sure that every
@@ -124,7 +125,7 @@ module Util
       @resource.get(File.join(base_path, "listing")).split("\n")
     rescue Errors::NotFound => e # some of listing file points to not existing content
       @resource.log :error, e.message
-      @resource.product.try(:repositories_cdn_import_failed!)
+      @status = false
       [] # return no substitution for unreachable listings
     end
 

--- a/app/models/katello/candlepin/product_content.rb
+++ b/app/models/katello/candlepin/product_content.rb
@@ -78,7 +78,6 @@ class Candlepin::ProductContent
       cdn_var_substitutor.precalculate([content_url])
     rescue Errors::SecurityViolation => e
       # in case we cannot access CDN server to obtain repository URLS we note down error
-      self.repositories_cdn_import_failed!
       Rails.logger.error("\nproduct #{product.name} repositories import: " <<
                                    'SecurityViolation occurred when contacting CDN to fetch ' <<
                                    "listing files\n" + e.backtrace.join("\n"))
@@ -138,7 +137,6 @@ class Candlepin::ProductContent
           #Temporarily running task here until entire repo set enable is dynflowed
           sync_task(::Actions::Katello::Repository::Create, repo)
         end
-        product.repositories_cdn_import_passed! unless product.cdn_import_success?
         @repos = nil #reset repo cache
       rescue RestClient::InternalServerError => e
         if e.message.include? "Architecture must be one of"

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -258,16 +258,6 @@ module Glue::Provider
       Resources::Candlepin::Owner.imports self.organization.label
     end
 
-    # All products that had problem with repository creation in pulp
-    def failed_products
-      self.products.repositories_cdn_import_failed
-    end
-
-    # Returns text representation of failed products status
-    def failed_products_status
-      (s = failed_products.size) > 0 ? (_('%d products may have missing repositories') % s) : _('OK')
-    end
-
     # TODO: break up method
     # rubocop:disable MethodLength
     def queue_import_manifest(options)
@@ -320,17 +310,6 @@ module Glue::Provider
                       _("Subscription manifest uploaded successfully for provider '%s'.")
                     end
           values = [self.name]
-          if self.failed_products.present?
-            message << _("There are %d products having repositories that could not be created.")
-            builder = Object.new.extend(ActionView::Helpers::UrlHelper, ActionView::Helpers::TagHelper)
-            path    = Katello.config.url_prefix + '/' + Rails.application.routes.url_helpers.refresh_products_providers_path(:id => self)
-            link    = builder.link_to(_('repository refresh'),
-                                      path,
-                                      :method => :put,
-                                      :remote => true)
-            message << _("You can run %s action to fix this. Note that it can take some time to complete." % link)
-            values.push self.failed_products.size
-          end
           Notify.success message % values,
                          :request_type => 'providers__update_redhat_provider',
                          :organization => self.organization,

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -318,20 +318,6 @@ module Glue::Pulp::Repos
       end
     end
 
-    def repositories_cdn_import_failed!
-      set_repositories_cdn_import false
-    end
-
-    def repositories_cdn_import_passed!
-      set_repositories_cdn_import true
-    end
-
-    # update flag skipping all callbacks (hence orchestration)
-    # after upgrade to >= 3.1.0 we could use #update_column
-    def set_repositories_cdn_import(value)
-      self.class.where(:id => self.id).update_all(:cdn_import_success => value)
-    end
-
     def del_repos
       #destroy all repos in all environments
       Rails.logger.debug "deleting all repositories in product #{self.label}"

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -179,8 +179,6 @@ class Product < Katello::Model
 
   scope :all_in_org, lambda{|org| Product.joins(:provider).where("#{Katello::Provider.table_name}.organization_id = ?", org.id)}
 
-  scope :repositories_cdn_import_failed, where(:cdn_import_success => false)
-
   def assign_unique_label
     self.label = Util::Model.labelize(self.name) if self.label.blank?
 

--- a/app/views/katello/providers/redhat/show.html.haml
+++ b/app/views/katello/providers/redhat/show.html.haml
@@ -11,13 +11,6 @@
       #provider
         %h4 #{_("Enable Red Hat Repositories")}
 
-  -#.grid_16
-    -#= _("Current status: %s") % @provider.failed_products_status
-    -#%br
-    -#= _("You can use this link to %s to products." % link_to(_('add missing repositories'),
-    -#  refresh_products_providers_path(:id => @provider), :method => :put, :remote => true))
-    -#= _("You can encounter missing repositories because of errors during manifest import or new content was uploaded to CDN.")
-    -#= _("Note that this action can take some time to complete.")
   - if @provider.products.empty?
     = (_("No Red Hat products currently exist, please import a manifest <a href='%s'>here</a> to receive Red Hat content.") % subscriptions_path).html_safe
   - else

--- a/db/migrate/20140318174203_drop_cdn_import_success_column.rb
+++ b/db/migrate/20140318174203_drop_cdn_import_success_column.rb
@@ -1,0 +1,9 @@
+class DropCdnImportSuccessColumn < ActiveRecord::Migration
+  def up
+    remove_column :katello_products, :cdn_import_success
+  end
+
+  def down
+    add_column :katello_products,  "cdn_import_success", :boolean, :default => true, :null => false
+  end
+end

--- a/spec/lib/cdn_spec.rb
+++ b/spec/lib/cdn_spec.rb
@@ -20,7 +20,7 @@ describe Resources::CDN::CdnResource do
   let(:another_path_with_variables) { "/content/dist/rhel/server/6/$releasever/$basearch/os" }
   let(:connect_options) do
     {:ssl_client_cert => "456",:ssl_ca_file => "fake-ca.pem", :ssl_client_key => "123",
-    :product => OpenStruct.new(:repositories_cdn_import_failed! => true)}
+    :product => OpenStruct.new}
   end
 
   before do
@@ -68,12 +68,6 @@ describe Resources::CDN::CdnResource do
       subject.precalculate([path_with_variables])
       subject.expects(:for_each_substitute_of_next_var).never # doesn't calculate results
       substitutions_with_urls = subject.substitute_vars(path_with_variables)
-    end
-
-    it "should describe why it failed when some listing unavailable" do
-      Net::HTTP.any_instance.stubs(:start).raises(RestClient::ResourceNotFound)
-      connect_options[:product].expects(:repositories_cdn_import_failed!).once
-      subject.precalculate([path_with_variables]).wont_be_nil
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -445,17 +445,6 @@ describe Provider do
 
   end
 
-  describe "#failed_products" do
-    before do
-      @provider = Provider.create(:name => 'test')
-      @provider.products.expects(:repositories_cdn_import_failed).once
-    end
-
-    it "should ask products for repositories_cdn_import_failed" do
-      @provider.failed_products
-    end
-  end
-
   it 'should be destroyable' do
     disable_product_orchestration
     provider = create(:katello_provider, organization: @organization)


### PR DESCRIPTION
This db column is left over legacy code that was being used from the days
when importing manifest also created repositories in pulp and candlepin.

After we moved to the better way of importing reposets this code became
dead code. Nothing was referring to this, so removing this.
