### PR TITLE
Fixes #4723: Adds an explicit restart of tomcat to the reset script

### DIFF
--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -26,6 +26,7 @@ namespace :katello do
       # it is due to a candlepin dev setup with a different password on the keystre
       # than in this file.
       system("sudo /usr/share/candlepin/cpsetup -s -k `sudo cat /etc/katello/keystore_password-file`")
+      system(service_start.gsub("%s", tomcat))
       puts "Candlepin database reset."
     end
 


### PR DESCRIPTION
to ensure that tomcat is restarted before db:seed is run.
