### PR TITLE
Fixes #4705: Updates repository bulk deletion to delete via dynflow

### DIFF
--- a/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
@@ -32,7 +32,10 @@ module Katello
     def destroy_repositories
       display_messages = []
 
-      @repositories.each{ |repository| repository.destroy }
+      @repositories.each do |repository|
+        trigger(::Actions::Katello::Repository::Destroy, repository)
+      end
+
       display_messages << _("Successfully removed %s repositories") % @repositories.length
       respond_for_show :template => 'bulk_action', :resource => { 'displayMessages' => display_messages }
     end


### PR DESCRIPTION
actions and properly remove the repository from Katello and Pulp. This
prevented the ability to create a repository with the same name after deleting
it.
