### PR TITLE
Fixes #4713 - don't store results for copy/remove content actions

### DIFF
--- a/app/lib/actions/pulp/repository/abstract_copy_content.rb
+++ b/app/lib/actions/pulp/repository/abstract_copy_content.rb
@@ -40,6 +40,10 @@ module Actions
           end
         end
 
+        def external_task=(external_task_data)
+          super(external_task_data.except('result'))
+        end
+
       end
     end
   end

--- a/app/lib/actions/pulp/repository/abstract_remove_content.rb
+++ b/app/lib/actions/pulp/repository/abstract_remove_content.rb
@@ -35,6 +35,10 @@ module Actions
           { type_ids: [content_extension.content_type], filters: {unit: input[:clauses] } }
         end
 
+        def external_task=(external_task_data)
+          super(external_task_data.except('result'))
+        end
+
       end
     end
   end


### PR DESCRIPTION
The data are not used in the code so no need to consume storage/memory on
that, as there might be quite a lot of data for large repos.
