### PR TITLE
Fixes #4688: Prevents ugly indentation of row headers on Firefox, adds

### DIFF
--- a/app/assets/stylesheets/katello/content_search.scss
+++ b/app/assets/stylesheets/katello/content_search.scss
@@ -432,7 +432,7 @@ table.changelog {
       }
 
       .row_height_2 {
-        height: 32px;
+        height: 44px;
         padding: 6px 3px;
       }
       .row_height_3 {

--- a/app/assets/stylesheets/katello/katello.scss
+++ b/app/assets/stylesheets/katello/katello.scss
@@ -50,7 +50,7 @@ body {
 pre  { text-indent: 18px; }
 a { outline: 0 none;}
 strong { font-weight: bold; }
-ul { -webkit-padding-start: 0; }
+ul { -webkit-padding-start: 0; -moz-padding-start: 0; }
 .clear { clear: both; }
 .clearfloat { /* this class can be placed on a <br /> or empty div as the final element following the last floated div (within the #container) if the overflow:hidden on the .container is removed */
   clear:both;

--- a/app/views/katello/content_search/_grid.html.haml
+++ b/app/views/katello/content_search/_grid.html.haml
@@ -43,7 +43,7 @@
           .slide_trigger
           %span.right_arrow_icon-black
         #column_selector
-          %span.path_button.selector_icon-black
+          %span.path_button.icon-plus
         #column_headers_window
           %ul#column_headers
   %section


### PR DESCRIPTION
back the missing environment selector icon, and sets the proper header
row height.
