### PR TITLE
fixes #4726 - update hostgroup activation keys to support katello v2 apis

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -42,13 +42,20 @@ module Katello
     end
 
     api :GET, "/activation_keys", "List activation keys"
+    api :GET, "/environments/:environment_id/activation_keys"
     api :GET, "/organizations/:organization_id/activation_keys"
     param :organization_id, :identifier, :desc => "organization identifier", :required => true
+    param :environment_id, :identifier, :desc => "environment identifier"
+    param :content_view_id, :identifier, :desc => "content view identifier"
     param :name, String, :desc => "activation key name to filter by"
     param_group :search, Api::V2::ApiController
     def index
-      filters = [:terms => {:id => ActivationKey.readable(@organization).pluck(:id)}]
-      filters << {:term => {:name => params[:name].downcase}} if params[:name]
+      query_string = ActivationKey.readable(@organization)
+      query_string = query_string.where(:environment_id => params[:environment_id]) if params[:environment_id]
+      query_string = query_string.where(:content_view_id => params[:content_view_id]) if params[:content_view_id]
+
+      filters = [:terms => { :id => query_string.pluck(:id) }]
+      filters << {:term => { :name => params[:name].downcase} } if params[:name]
 
       options = {
           :filters       => filters,

--- a/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
+++ b/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
@@ -16,54 +16,24 @@ $(function() {
         $("#ak-subscriptions-info").hide();
         $("#ak-subscriptions-spinner").show();
 
-        var ktOrgLabel = selectedOrgEnvCv[0],
-            ktEnvLabel = selectedOrgEnvCv[1],
-            ktCvLabel = selectedOrgEnvCv[2],
-            ktAkeyQuery = {};
+        var selectedEnvId = $("#kt_environment_id option:selected").data('katello-env-id'),
+            selectedCvId = $("#hostgroup_environment_id").val();
 
-        // Retrieve the activation keys.  In order to do this, need to
-        // first retrieve content view & environment and then use the
-        // ids from the results to retrieve the keys.  In the future,
-        // we can simplify this logic; however, currently porting of
-        // logic from existing foreman-katello-engine.
+        // Retrieve the activation keys associated with the current
+        // environment & content view.
         $.ajax({
             type: 'get',
-            url:  foreman_url('/katello/api/organizations/' + ktOrgLabel + '/content_views'),
-            data: {'label': ktCvLabel},
+            url:  foreman_url('/katello/api/v2/environments/' + selectedEnvId + '/activation_keys'),
+            data: {'content_view_id': selectedCvId},
             success: function(response) {
-                if (response[0]) {
-                    ktAkeyQuery['content_view_id'] = response[0].id;
-
-                    $.ajax({
-                        type: 'get',
-                        url:  foreman_url('/katello/api/organizations/' + ktOrgLabel + '/environments'),
-                        data: {'label': ktEnvLabel},
-                        success: function(response) {
-                            if (response[0]) {
-                                ktAkeyQuery['environment_id'] = response[0].id;
-
-                                $.ajax({
-                                    type: 'get',
-                                    url:  foreman_url('/katello/api/v2/environments/' + ktAkeyQuery['environment_id'] + '/activation_keys'),
-                                    data: {'content_view_id': ktAkeyQuery['content_view_id']},
-                                    success: function(response) {
-                                        availableActivationKeys = {};
-                                        $.each(response['results'], function (i, key) {
-                                            availableActivationKeys[key.name] = [];
-                                            $.each(key.pools, function (j, pool) {
-                                                availableActivationKeys[key.name].push(pool.productName);
-                                            });
-                                        });
-                                        ktAkUpdateSubscriptionsInfo();
-                                    },
-                                    error: ktErrorLoadingActivationKeys
-                                });
-
-                            }
-                        },
-                        error: ktErrorLoadingActivationKeys
+                availableActivationKeys = {};
+                $.each(response['results'], function (i, key) {
+                    availableActivationKeys[key.name] = [];
+                    $.each(key.pools, function (j, pool) {
+                        availableActivationKeys[key.name].push(pool.productName);
                     });
-                }
+                });
+                ktAkUpdateSubscriptionsInfo();
             },
             error: ktErrorLoadingActivationKeys
         });


### PR DESCRIPTION
When a user selects a lifecycle environment & content view,
a request is sent to the server to retrieve the activation
keys associated with the selected env+view.  This allows the user
to choose from those via the Activation Keys pane.

This commit is to fix the behavior which previously
performed multiple requests to the server to retrieve
environment, content view and then keys.  This alters
that behavior to perform a single request for the keys.
