### PR TITLE
fixes #4725 - fixes deletion of puppet environments with no modules

### DIFF
--- a/app/lib/katello/foreman.rb
+++ b/app/lib/katello/foreman.rb
@@ -26,8 +26,7 @@ module Katello
 
       foreman_environment = Environment.find_or_create_by_katello_id(org, env, content_view)
 
-      if !content_view.content_view_puppet_modules.empty? &&
-          (foreman_smart_proxy = SmartProxy.find_by_name(Katello.config.host))
+      if (foreman_smart_proxy = SmartProxy.find_by_name(Katello.config.host))
         PuppetClassImporter.new(:url => foreman_smart_proxy.url).update_environment(foreman_environment)
       end
     end

--- a/app/services/katello/puppet_class_importer_extensions.rb
+++ b/app/services/katello/puppet_class_importer_extensions.rb
@@ -25,6 +25,12 @@ module Katello
             changed[kind].slice!(environment.name) unless changed[kind].empty?
           end
 
+          #prevent the puppet environment from being deleted, by removing special '_destroy_' String
+          if changed['obsolete'][environment.name]
+            changed['obsolete'][environment.name] =
+              changed['obsolete'][environment.name].select{|klass| klass != '_destroy_'}
+          end
+
           # PuppetClassImporter expects [kind][env] to be in json format
           change_types.each do |kind|
             unless (envs = changed[kind]).empty?


### PR DESCRIPTION
Without this change, puppet environment would be deleted if for some reason the modules
did not exist on the puppet master in /etc/puppet/environments/

Also new content view versions without puppet modules would not have their environment
changed on the file system to reflect the modules actually in the the repo (none)
