### PR TITLE
fixes #4754 - BZ-1075189 - subscription-manager register w/ activation keys

### DIFF
--- a/app/lib/actions/candlepin/consumer/create.rb
+++ b/app/lib/actions/candlepin/consumer/create.rb
@@ -25,6 +25,7 @@ module Actions
           param :release_ver
           param :service_level
           param :capabilities
+          param :activation_keys
         end
 
         def run
@@ -39,7 +40,8 @@ module Actions
                      input[:release_ver],
                      input[:service_level],
                      "",
-                     input[:capabilities])
+                     input[:capabilities],
+                     input[:activation_keys])
         end
       end
     end

--- a/app/lib/actions/katello/system/create.rb
+++ b/app/lib/actions/katello/system/create.rb
@@ -17,7 +17,7 @@ module Actions
 
         middleware.use ::Actions::Middleware::RemoteAction
 
-        def plan(system)
+        def plan(system, activation_keys = [])
           system.disable_auto_reindex!
           cp_create = plan_action(Candlepin::Consumer::Create,
                                   cp_environment_id:   system.cp_environment_id,
@@ -29,7 +29,8 @@ module Actions
                                   autoheal:            system.autoheal,
                                   release_ver:         system.release,
                                   service_level:       system.serviceLevel,
-                                  capabiliteis:        system.capabilities)
+                                  capabilities:        system.capabilities,
+                                  activation_keys:     activation_keys)
           system.save!
           action_subject system, uuid: cp_create.output[:response][:uuid]
           plan_self

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -112,8 +112,12 @@ module Resources
 
 # rubocop:disable ParameterLists
         def create(env_id, key, name, type, facts, installed_products, autoheal = true, release_ver = nil,
-                   service_level = "", uuid = "", capabilities = nil)
+                   service_level = "", uuid = "", capabilities = nil, activation_keys = [])
 # rubocop:enable ParameterLists
+
+          activation_key_ids = activation_keys.collect do |activation_key|
+            activation_key['label']
+          end
 
           url = "/candlepin/environments/#{url_encode(env_id)}/consumers/"
           attrs = {:name => name,
@@ -125,6 +129,7 @@ module Resources
                    :serviceLevel => service_level,
                    :uuid => uuid,
                    :capabilities => capabilities}
+          url += "?activation_keys=" + activation_key_ids.join(",") if activation_key_ids.length > 0
           response = self.post(url, attrs.to_json, self.default_headers).body
           JSON.parse(response).with_indifferent_access
         end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -222,6 +222,7 @@ Katello::Engine.routes.draw do
       scope :constraints => Katello::RegisterWithActivationKeyContraint.new do
         match '/consumers' => 'candlepin_proxies#consumer_activate', :via => :post
       end
+      match '/consumers' => 'candlepin_proxies#consumer_create', :via => :post
       match '/hypervisors' => 'candlepin_proxies#hypervisors_update', :via => :post
       match '/owners/:organization_id/environments' => 'candlepin_proxies#rhsm_index', :via => :get
       match '/owners/:organization_id/pools' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_pools_path

--- a/test/actions/katello/system_test.rb
+++ b/test/actions/katello/system_test.rb
@@ -41,7 +41,7 @@ module ::Actions::Katello::System
         params[:uuid].must_be_kind_of Dynflow::ExecutionPlan::OutputReference
         params[:uuid].subkeys.must_equal %w[response uuid]
       end
-      plan_action(action, system)
+      plan_action(action, system, [])
       assert_action_planed(action, ::Actions::Candlepin::Consumer::Create)
       assert_action_planed_with(action, ::Actions::ElasticSearch::Reindex, system)
       assert_action_planed_with(action, ::Actions::Pulp::Consumer::Create) do |params, *_|


### PR DESCRIPTION
Fixes
- sub-mgr register to org w/ single environment
- sub-mgr register to org w/ multiple environments
- sub-mgr register w/ one activation key
- sub-mgr register w/ multiple activation key
