### PR TITLE
Fixes #4758: Adds client authentication to enabled repos call.

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -13,10 +13,10 @@
 module Katello
   class Api::V1::CandlepinProxiesController < Api::V1::ApiController
 
-    include Katello::Authentication::RhsmClientAuthentication
+    include Katello::Authentication::RhsmAuthentication
 
     skip_before_filter :authorize
-    before_filter :authorize_client, :except => [:consumer_activate]
+    before_filter :authorize_rhsm, :except => [:consumer_activate]
     before_filter :add_candlepin_version_header
 
     before_filter :proxy_request_path, :proxy_request_body

--- a/app/controllers/katello/api/v1/systems_controller.rb
+++ b/app/controllers/katello/api/v1/systems_controller.rb
@@ -15,6 +15,8 @@ module Katello
 class Api::V1::SystemsController < Api::V1::ApiController
   respond_to :json
 
+  include Katello::Authentication::ClientAuthentication
+
   skip_before_filter :set_default_response_format, :only => :report
 
   before_filter :find_default_organization_and_or_environment, :only => [:create, :index, :activate]
@@ -30,7 +32,8 @@ class Api::V1::SystemsController < Api::V1::ApiController
                                         :subscription_status]
   before_filter :find_content_view, :only => [:create, :update]
 
-  before_filter :authorize, :except => [:activate]
+  before_filter :authorize, :except => [:activate, :enabled_repos]
+  before_filter :authorize_client, :only => [:enabled_repos]
 
   def organization_id_keys
     [:organization_id, :owner]

--- a/app/services/client/cert.rb
+++ b/app/services/client/cert.rb
@@ -13,7 +13,7 @@
 require 'openssl'
 require 'base64'
 
-module Rhsm
+module Client
   class Cert
 
     attr_accessor :cert

--- a/app/services/katello/authentication/client_authentication.rb
+++ b/app/services/katello/authentication/client_authentication.rb
@@ -1,0 +1,57 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'active_support'
+require File.expand_path('../../../client/cert.rb', __FILE__)
+
+module Katello
+  module Authentication
+    module ClientAuthentication
+      extend ActiveSupport::Concern
+
+      included do
+
+        def authorize_client
+          if cert_present?
+            set_client_user
+          else
+            deny_access
+          end
+        end
+
+        def set_client_user
+          client_cert = Client::Cert.new(cert_from_request)
+          uuid = client_cert.uuid
+          User.current = CpConsumerUser.new(:uuid => uuid, :login => uuid, :remote_id => uuid)
+        end
+
+        def cert_present?
+          ssl_client_cert = cert_from_request
+          !ssl_client_cert.nil? && !ssl_client_cert.empty? && ssl_client_cert != "(null)"
+        end
+
+        def cert_from_request
+          request.env['SSL_CLIENT_CERT'] ||
+          request.env['HTTP_SSL_CLIENT_CERT'] ||
+          ENV['SSL_CLIENT_CERT'] ||
+          ENV['HTTP_SSL_CLIENT_CERT']
+        end
+
+        def add_candlepin_version_header
+          response.headers["X-CANDLEPIN-VERSION"] = "katello/#{Katello.config.katello_version}"
+        end
+
+      end
+
+    end
+  end
+end

--- a/app/services/katello/authentication/rhsm_authentication.rb
+++ b/app/services/katello/authentication/rhsm_authentication.rb
@@ -10,34 +10,22 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-require 'rhsm/cert'
-
 module Katello
   module Authentication
-    module RhsmClientAuthentication
+    module RhsmAuthentication
       extend ActiveSupport::Concern
 
       included do
+        include ClientAuthentication
 
-        def authorize_client
-          ssl_client_cert = cert_from_request
-
-          if ssl_client_cert.present? && ssl_client_cert != "(null)"
-            rhsm_cert = Rhsm::Cert.new(cert_from_request)
-            uuid = rhsm_cert.uuid
-            User.current = CpConsumerUser.new(:uuid => uuid, :login => uuid, :remote_id => uuid)
+        def authorize_rhsm
+          if cert_present?
+            set_client_user
           elsif authenticate
             User.current
           else
             deny_access
           end
-        end
-
-        def cert_from_request
-          request.env['SSL_CLIENT_CERT'] ||
-          request.env['HTTP_SSL_CLIENT_CERT'] ||
-          ENV['SSL_CLIENT_CERT'] ||
-          ENV['HTTP_SSL_CLIENT_CERT']
         end
 
         def add_candlepin_version_header

--- a/test/services/client/cert_test.rb
+++ b/test/services/client/cert_test.rb
@@ -11,9 +11,9 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 require 'minitest/autorun'
-require File.expand_path('../../../../app/services/rhsm/cert.rb', __FILE__)
+require File.expand_path('../../../../app/services/client/cert.rb', __FILE__)
 
-module Rhsm
+module Client
   class CertTest < MiniTest::Unit::TestCase
 
     CERT = '
@@ -45,19 +45,19 @@ module Rhsm
       -----END CERTIFICATE-----'
 
     def test_uuid
-      rhsm_cert = Rhsm::Cert.new(CERT)
+      rhsm_cert = Client::Cert.new(CERT)
       assert_equal rhsm_cert.uuid, '14e98155-731a-4cae-b151-5c504cc30e1a'
     end
 
     def test_empty_cert
       assert_raises RuntimeError do
-        Rhsm::Cert.new('')
+        Cert.new('')
       end
     end
 
     def test_bad_cert
       assert_raises OpenSSL::X509::CertificateError do
-        Rhsm::Cert.new('This is not a real cert string.')
+        Cert.new('This is not a real cert string.')
       end
     end
 


### PR DESCRIPTION
After moving the client authentication solely to the Candlepin proxies
controller, the enabled repos call from katello agent could no longer
complete successfully. This slightly re-factor the client cert to be
generic to any client providing an SSL cert and includes this authentication
method for the enabled repos call in the V1 systems controller.
