### PR TITLE
fixes #4773 - Content Views: fix issue which did not allow for multiple errata ids per filter

### DIFF
--- a/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
+++ b/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
@@ -43,7 +43,7 @@ module Validators
         end
 
       else
-        unless record.filter.erratum_rules.with_date_or_type.empty?
+        if record.filter_has_date_or_type_rule?
           invalid_parameters = _("May not add an id rule to a filter that has an existing type or date range rule.")
           record.errors[:base] << invalid_parameters
         end

--- a/app/models/katello/content_view_erratum_filter_rule.rb
+++ b/app/models/katello/content_view_erratum_filter_rule.rb
@@ -26,6 +26,8 @@ module Katello
     validates :errata_id, :uniqueness => { :scope => :content_view_filter_id }, :allow_blank => true
     validates_with Validators::ContentViewErratumFilterRuleValidator
 
-    scope :with_date_or_type, where('start_date is not NULL or end_date is not NULL or types is not NULL')
+    def filter_has_date_or_type_rule?
+      filter.erratum_rules.any?{ |rule| rule.start_date || rule.end_date || !rule.types.blank? }
+    end
   end
 end

--- a/test/lib/validators/content_view_erratum_filter_rule_validator_test.rb
+++ b/test/lib/validators/content_view_erratum_filter_rule_validator_test.rb
@@ -53,8 +53,7 @@ module Katello
     end
 
     test "fails with errata_id, if already has a date range" do
-      Katello::ContentViewErratumFilter.any_instance.stubs(:erratum_rules).
-          returns(stub(:with_date_or_type => ["not empty"]))
+      Katello::ContentViewErratumFilterRule.any_instance.stubs(:filter_has_date_or_type_rule?).returns(true)
       model = ContentViewErratumFilterRule.new(:content_view_filter_id => @filter.id, :errata_id => "RHSA-2014:1234")
       @validator.validate(model)
       refute_empty model.errors[:base]


### PR DESCRIPTION
The erratum filter rule 'types' is a serialized array.  The scope
that was placed on the model was incorrectly looking for 'nil';
however, with a serialized type, we really need to fetch the records
to look at the value of 'types', as the value for an existing
rule will not be 'nil', even when types is not specified.
