### PR TITLE
fixes #4778 - Content View Version: package/errata counts are incorrect for latest version

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -262,7 +262,7 @@ class ContentViewVersion < Katello::Model
   end
 
   def packages
-    repositories.flat_map(&:packages)
+    repositories.archived.flat_map(&:packages)
   end
 
   def package_count
@@ -270,7 +270,7 @@ class ContentViewVersion < Katello::Model
   end
 
   def errata
-    repositories.flat_map(&:errata)
+    repositories.archived.flat_map(&:errata)
   end
 
   def errata_count


### PR DESCRIPTION
When counting the packages and errata for a content view version, it should be sufficient to count based on the 'achived' (i.e.versioned) repos.
