### PR TITLE
fixes #4782 - speeding up CV Version content count methods

### DIFF
--- a/app/controllers/katello/api/v1/packages_controller.rb
+++ b/app/controllers/katello/api/v1/packages_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::PackagesController < Api::V1::ApiController
   param :repository_id, :number, :desc => "environment numeric identifier"
   param :search, String, :desc => "search expression"
   def search
-    packages = Package.search(params[:search], 0, 0, [@repo.pulp_id])
+    packages = Package.legacy_search(params[:search], 0, 0, [@repo.pulp_id])
     respond_for_index :collection => packages.to_a
   end
 

--- a/app/controllers/katello/content_search_controller.rb
+++ b/app/controllers/katello/content_search_controller.rb
@@ -290,7 +290,7 @@ class ContentSearchController < Katello::ApplicationController
 
   def repo_packages
     offset = params[:offset] || 0
-    packages = Package.search('', offset, current_user.page_size, [@repo.pulp_id])
+    packages = Package.legacy_search('', offset, current_user.page_size, [@repo.pulp_id])
 
     rows = packages.collect do |pack|
       { :name => package_display(pack),
@@ -397,7 +397,7 @@ class ContentSearchController < Katello::ApplicationController
 
     units = case unit_type
             when :package
-              Package.search('', offset, current_user.page_size,
+              Package.legacy_search('', offset, current_user.page_size,
                              repo_map.keys, [:nvrea_sort, "ASC"], process_search_mode)
             when :errata
               Errata.legacy_search('', :start => offset, :page_size => current_user.page_size,

--- a/app/lib/katello/content_search/content_view_comparison.rb
+++ b/app/lib/katello/content_search/content_view_comparison.rb
@@ -137,7 +137,7 @@ module ContentSearch
         # build the rows
         units = case unit_type
                 when :package
-                  Package.search('', offset, page_size, view_repos.map(&:pulp_id),
+                  Package.legacy_search('', offset, page_size, view_repos.map(&:pulp_id),
                                  [:nvrea_sort, "ASC"], search_mode)
                 when :errata
                   Errata.legacy_search('', :start => offset, :page_size => page_size,

--- a/app/models/katello/content_view_package_filter.rb
+++ b/app/models/katello/content_view_package_filter.rb
@@ -27,7 +27,7 @@ class ContentViewPackageFilter < ContentViewFilter
   def generate_clauses(repo)
     package_filenames = package_rules.reject{ |rule| rule.name.blank? }.flat_map do |rule|
       filter = version_filter(rule)
-      Package.search(rule.name, 0, repo.package_count, [repo.pulp_id], [:nvrea_sort, "asc"],
+      Package.legacy_search(rule.name, 0, repo.package_count, [repo.pulp_id], [:nvrea_sort, "asc"],
                      :all, 'name', filter).map(&:filename).compact
     end
     { 'filename' => { "$in" => package_filenames } } unless package_filenames.empty?

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -266,20 +266,20 @@ class ContentViewVersion < Katello::Model
   end
 
   def package_count
-    packages.count
+    Package.package_count(self.repositories.archived)
   end
 
   def errata
     repositories.archived.flat_map(&:errata)
   end
 
-  def errata_count
-    errata.count
+  def errata_count(errata_type = nil)
+    Errata.errata_count(self.repositories.archived, errata_type)
   end
 
   def errata_type_counts
     Errata::TYPES.each_with_object({}) do |type, counts|
-      counts[type] = errata.select { |err| err.type == type }.count
+      counts[type] = errata_count(type)
     end
   end
 

--- a/app/models/katello/glue/elastic_search/content_view.rb
+++ b/app/models/katello/glue/elastic_search/content_view.rb
@@ -42,7 +42,7 @@ module Glue::ElasticSearch::ContentView
 
     def total_package_count(env)
       repoids = self.repos(env).collect{|r| r.pulp_id}
-      result = Katello::Package.search('*', 0, 1, repoids)
+      result = Katello::Package.legacy_search('*', 0, 1, repoids)
       result.length > 0 ? result.total : 0
     end
 

--- a/app/models/katello/glue/elastic_search/errata.rb
+++ b/app/models/katello/glue/elastic_search/errata.rb
@@ -82,6 +82,20 @@ module Glue::ElasticSearch::Errata
         }
       end
 
+      def self.errata_count(repos, errata_type = nil)
+        repo_ids = repos.map(&:pulp_id)
+        search = Errata.search do
+          query do
+            all
+          end
+          fields [:id]
+          size 1
+          filter :terms, :repoids => repo_ids
+          filter :term, :type => errata_type  if errata_type
+        end
+        search.total
+      end
+
       def self.filter(filter)
         filter_for_repo = filter.slice(:repository_id, :repoid, :environment_id, :product_id)
         filter_for_errata = filter.except(*filter_for_repo.keys)

--- a/app/models/katello/glue/elastic_search/package.rb
+++ b/app/models/katello/glue/elastic_search/package.rb
@@ -130,9 +130,30 @@ module Glue::ElasticSearch::Package
         search.results
       end
 
+      def self.package_count(repos)
+        repo_ids = repos.map(&:pulp_id)
+        search = Package.search do
+          query do
+            all
+          end
+          fields [:id]
+          size 1
+          filter :terms, :repoids => repo_ids
+        end
+        search.total
+      end
+
+      def self.mapping
+        Tire.index(self.index).mapping
+      end
+
+      def self.search(options = {}, &block)
+        Tire.search(self.index, &block).results
+      end
+
       # TODO: break up method
       # rubocop:disable MethodLength
-      def self.search(query, start = 0, page_size = 15, repoids = nil, sort = [:nvrea_sort, "asc"],
+      def self.legacy_search(query, start = 0, page_size = 15, repoids = nil, sort = [:nvrea_sort, "asc"],
                       search_mode = :all, default_field = 'nvrea', filters = [])
         if !Tire.index(self.index).exists? || (repoids && repoids.empty?)
           return Util::Support.array_with_total

--- a/app/models/katello/glue/elastic_search/product.rb
+++ b/app/models/katello/glue/elastic_search/product.rb
@@ -46,7 +46,7 @@ module Glue::ElasticSearch::Product
 
   def total_package_count(env, view)
     repo_ids = view.repos(env).in_product(self).collect{ |r| r.pulp_id }
-    result = Katello::Package.search('*', 0, 1, repo_ids)
+    result = Katello::Package.legacy_search('*', 0, 1, repo_ids)
     result.length > 0 ? result.total : 0
   end
 

--- a/app/models/katello/glue/elastic_search/repository.rb
+++ b/app/models/katello/glue/elastic_search/repository.rb
@@ -240,7 +240,7 @@ module Glue::ElasticSearch::Repository
     end
 
     def package_count
-      results = Katello::Package.search('', 0, 1, :repoids => [self.pulp_id])
+      results = Katello::Package.legacy_search('', 0, 1, :repoids => [self.pulp_id])
       results.empty? ? 0 : results.total
     end
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
@@ -47,8 +47,8 @@
             {{ version.errata_count || 0 }} Errata
             <span>(</span>
             <span><i class="icon-warning-sign inline-icon"></i>{{ version.errata_counts.security || 0 }}</span>
-            <span><i class="icon-bug inline-icon"></i>{{ version.errata_counts.bugs || 0 }}</span>
-            <span><i class="icon-plus-sign-alt inline-icon"></i>{{ version.errata_counts.enhancements || 0 }}</span>
+            <span><i class="icon-bug inline-icon"></i>{{ version.errata_counts.bugfix || 0 }}</span>
+            <span><i class="icon-plus-sign-alt inline-icon"></i>{{ version.errata_counts.enhancement || 0 }}</span>
             <span>)</span>
           </div>
         </td>

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -42,6 +42,8 @@ module Katello
       setup_controller_defaults_api
       models
       permissions
+      ContentViewVersion.any_instance.stubs(:package_count).returns(0)
+      ContentViewVersion.any_instance.stubs(:errata_count).returns(0)
     end
 
     def test_index

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -42,6 +42,9 @@ module Katello
       @request.env['CONTENT_TYPE'] = 'application/json'
       @fake_search_service = @controller.load_search_service(Support::SearchService::FakeSearchService.new)
       ContentView.any_instance.stubs(:reindex_on_association_change).returns(true)
+      ContentViewVersion.any_instance.stubs(:package_count).returns(0)
+      ContentViewVersion.any_instance.stubs(:errata_count).returns(0)
+
       models
       permissions
     end

--- a/test/glue/elasticsearch/package_test.rb
+++ b/test/glue/elasticsearch/package_test.rb
@@ -100,7 +100,7 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   def filter_search(filters)
-    Package.search("*", 0, @packages.length, [@repo.pulp_id], [:id, "ASC"], :all,
+    Package.legacy_search("*", 0, @packages.length, [@repo.pulp_id], [:id, "ASC"], :all,
                    'name', filters)
   end
 end


### PR DESCRIPTION
Also adapting Package to use normal tire search and moving old
search method to legacy_search.  Should be the last non-AR object to 
need this.
