### PR TITLE
fixes #4780 - fixing link to system errata details

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/systems/content/system-errata.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/systems/content/system-errata.controller.js
@@ -39,7 +39,7 @@ angular.module('Bastion.systems').controller('SystemErrataController',
                 item.title.indexOf(searchText) >= 0;
         };
 
-        $scope.errataTable.transitionToErratum = function (erratum) {
+        $scope.transitionToErratum = function (erratum) {
             loadErratum(erratum.errata_id);
             $scope.transitionTo('systems.details.errata.details', {errataId: erratum.errata_id});
         };


### PR DESCRIPTION
I believe this was caused with the upgrade to angular which
broke the way we were using isolate scope
