### PR TITLE
fixes #4776 - session - extend session timeout when api controllers are hit

### DIFF
--- a/app/controllers/katello/api/api_controller.rb
+++ b/app/controllers/katello/api/api_controller.rb
@@ -19,11 +19,16 @@ class Api::ApiController < ::Api::BaseController
   respond_to :json
   before_filter :verify_ldap
   before_filter :turn_off_strong_params
+  before_filter :update_activity_time
 
   # override warden current_user (returns nil because there is no user in that scope)
   def current_user
     # get the logged user from the correct scope
     User.current
+  end
+
+  def update_activity_time
+    session[:expires_at] = Setting[:idle_timeout].minutes.from_now.utc
   end
 
   def load_search_service(service = nil)


### PR DESCRIPTION
The Katello UI uses it's API controllers heavily; however,
the Foreman core only extends the session when a UI controller
is hit.  As a result, a user that is primarily using the Katello
UI can experience more frequent timeouts, if they stay on the same
page to perform several actions.

This commit will update the base Katello API controller to extend
the session without impacting the behavior of the core.
