### PR TITLE
fixes #4746 - removing non-existant CV History User relationship

### DIFF
--- a/app/models/katello/concerns/user_extensions.rb
+++ b/app/models/katello/concerns/user_extensions.rb
@@ -54,7 +54,6 @@ module Katello
         has_many :search_favorites, :dependent => :destroy, :class_name => "Katello::SearchFavorite"
         has_many :search_histories, :dependent => :destroy, :class_name => "Katello::SearchHistory"
         has_many :activation_keys, :dependent => :destroy, :class_name => "Katello::ActivationKey"
-        has_many :content_view_histories, :dependent => :nullify, :class_name => "Katello::ContentViewHistory"
         belongs_to :default_environment, :class_name => "Katello::KTEnvironment", :inverse_of => :users
         serialize :preferences, Hash
 


### PR DESCRIPTION
CV History doesn't actually have a relationship to user,
it just stores its user login, so no need for AR association
