### PR TITLE
Proxy requests to candlepin for guest ids and content overrides API calls

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -58,8 +58,7 @@ module Katello
           (User.consumer? || @organization.readable?)
         when "api_proxy_consumer_certificates_path", "api_proxy_consumer_releases_path", "api_proxy_certificate_serials_path",
             "api_proxy_consumer_entitlements_path", "api_proxy_consumer_entitlements_post_path", "api_proxy_consumer_entitlements_delete_path",
-            "api_proxy_consumer_dryrun_path", "api_proxy_consumer_owners_path", "api_proxy_consumer_compliance_path",
-            "api_proxy_consumer_content_overrides_path"
+            "api_proxy_consumer_dryrun_path", "api_proxy_consumer_owners_path", "api_proxy_consumer_compliance_path"
           User.consumer? && current_user.uuid == params[:id]
         when "api_proxy_consumer_certificates_delete_path"
           User.consumer? && current_user.uuid == params[:consumer_id]
@@ -69,6 +68,15 @@ module Katello
           User.consumer?
         when "api_proxy_subscriptions_post_path"
           User.consumer? && current_user.uuid == params[:consumer_uuid]
+        when "api_proxy_consumer_content_overrides_path", "api_proxy_consumer_content_overrides_put_path",
+             "api_proxy_consumer_content_overrides_delete_path"
+          # These queries are restricted in Candlepin
+          User.consumer?
+        when "api_proxy_consumer_guestids_path", "api_proxy_consumer_guestids_get_guestid_path",
+             "api_proxy_consumer_guestids_put_path", "api_proxy_consumer_guestids_put_guestid_path",
+             "api_proxy_consumer_guestids_delete_guestid_path"
+          # These queries are restricted in Candlepin
+          User.consumer?
         when "api_proxy_deleted_consumers_path"
           current_user.has_superadmin_role?
         else
@@ -142,13 +150,19 @@ module Katello
     end
 
     def delete
-      r = Resources::Candlepin::Proxy.delete(@request_path)
+      r = Resources::Candlepin::Proxy.delete(@request_path, @request_body)
       logger.debug r
       render :json => r
     end
 
     def post
       r = Resources::Candlepin::Proxy.post(@request_path, @request_body)
+      logger.debug r
+      render :json => r
+    end
+
+    def put
+      r = Resources::Candlepin::Proxy.put(@request_path, @request_body)
       logger.debug r
       render :json => r
     end

--- a/app/controllers/katello/api/v1/root_controller.rb
+++ b/app/controllers/katello/api/v1/root_controller.rb
@@ -33,6 +33,8 @@ class Api::V1::RootController < Api::V1::ApiController
     # provide some fake paths that does not exist (but rhsm is checking it's existance)
     api_root_routes << { :href => '/api/packages/', :rel => 'packages' }
     api_root_routes << { :href => '/api/status/', :rel => 'status' }
+    api_root_routes << { :href => '/api/guestids', :rel => 'guestids'}
+    api_root_routes << { :href => '/api/content_overrides', :rel => 'content_overrides'}
 
     # katello only APIs
     katello_only = ["/api/templates/",

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -29,9 +29,11 @@ module Resources
         client.post body, {:accept => :json, :content_type => :json}.merge(User.cp_oauth_header)
       end
 
-      def self.delete(path)
+      def self.delete(path, body = nil)
         logger.debug "Sending DELETE request to Candlepin: #{path}"
         client = CandlepinResource.rest_client(Net::HTTP::Delete, :delete, path_with_cp_prefix(path))
+        # Some candlepin calls will set the body in DELETE requests.
+        client.options[:payload] = body unless body.nil?
         client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
       end
 
@@ -39,6 +41,12 @@ module Resources
         logger.debug "Sending GET request to Candlepin: #{path}"
         client = CandlepinResource.rest_client(Net::HTTP::Get, :get, path_with_cp_prefix(path))
         client.get({:accept => :json}.merge(User.cp_oauth_header))
+      end
+
+      def self.put(path, body)
+        logger.debug "Sending PUT request to Candlepin: #{path}"
+        client = CandlepinResource.rest_client(Net::HTTP::Put, :put, path_with_cp_prefix(path))
+        client.put body, {:accept => :json, :content_type => :json}.merge(User.cp_oauth_header)
       end
 
       def self.path_with_cp_prefix(path)

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -248,11 +248,18 @@ Katello::Engine.routes.draw do
       match '/deleted_consumers' => 'candlepin_proxies#get', :via => :get, :as => :proxy_deleted_consumers_path
       match '/entitlements/:id' => 'candlepin_proxies#get', :via => :get, :as => :proxy_entitlements_path
       match '/subscriptions' => 'candlepin_proxies#post', :via => :post, :as => :proxy_subscriptions_post_path
-      match '/consumers/:id/content_overrides' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_content_overrides_path
       match '/consumers/:id/profile/' => 'candlepin_proxies#upload_package_profile', :via => :put
       match '/consumers/:id/packages/' => 'candlepin_proxies#upload_package_profile', :via => :put
       match '/consumers/:id/checkin/' => 'candlepin_proxies#checkin', :via => :put
       match '/consumers/:id' => 'candlepin_proxies#facts', :via => :put
+      match '/consumers/:id/guestids/' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_guestids_path
+      match '/consumers/:id/guestids/:guest_id' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_guestids_get_guestid_path
+      match '/consumers/:id/guestids/' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_guestids_put_path
+      match '/consumers/:id/guestids/:guest_id' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_guestids_put_guestid_path
+      match '/consumers/:id/guestids/:guest_id' => 'candlepin_proxies#delete', :via => :delete, :as => :proxy_consumer_guestids_delete_guestid_path
+      match '/consumers/:id/content_overrides/' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_content_overrides_path
+      match '/consumers/:id/content_overrides/' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_content_overrides_put_path
+      match '/consumers/:id/content_overrides/' => 'candlepin_proxies#delete', :via => :delete, :as => :proxy_consumer_content_overrides_delete_path
 
       # development / debugging support
       if Rails.env == "development"

--- a/spec/routing/api/v1/consumers_routing_spec.rb
+++ b/spec/routing/api/v1/consumers_routing_spec.rb
@@ -37,6 +37,14 @@ module Katello
         ({:controller => proxies_controller, :action => "get", :id => "1", :api_version => "v1"}).must_recognize({ :method => "get", :path => "/api/entitlements/1" })
         ({:controller => proxies_controller, :action => "post", :api_version => "v1"}).must_recognize({ :method => "post", :path => "/api/subscriptions" })
         {:controller => proxies_controller, :action => "upload_package_profile", :id => "1", :api_version => "v1"}.must_recognize({ :method => "put", :path => "/api/consumers/1/profile/" })
+        {:controller => proxies_controller, :action => "get", :id => "1", :api_version => "v1"}.must_recognize({ :method => "get", :path => "/api/consumers/1/guestids/" })
+        {:controller => proxies_controller, :action => "get", :id => "1", :guest_id => "1", :api_version => "v1"}.must_recognize({ :method => "get", :path => "/api/consumers/1/guestids/1" })
+        {:controller => proxies_controller, :action => "put", :id => "1", :api_version => "v1"}.must_recognize({ :method => "put", :path => "/api/consumers/1/guestids/" })
+        {:controller => proxies_controller, :action => "put", :id => "1", :guest_id => "1", :api_version => "v1"}.must_recognize({ :method => "put", :path => "/api/consumers/1/guestids/1" })
+        {:controller => proxies_controller, :action => "delete", :id => "1", :guest_id => "1", :api_version => "v1"}.must_recognize({ :method => "delete", :path => "/api/consumers/1/guestids/1" })
+        {:controller => proxies_controller, :action => "get", :id => "1", :api_version => "v1"}.must_recognize({ :method => "get", :path => "/api/consumers/1/content_overrides/" })
+        {:controller => proxies_controller, :action => "put", :id => "1", :api_version => "v1"}.must_recognize({ :method => "put", :path => "/api/consumers/1/content_overrides/" })
+        {:controller => proxies_controller, :action => "delete", :id => "1", :api_version => "v1"}.must_recognize({ :method => "delete", :path => "/api/consumers/1/content_overrides/" })
       end
 
     end


### PR DESCRIPTION
- Add support for proxing PUT requests to candlepin
- Allow proxying DELETE request with body to candlepin
- Proxy calls to /api/consumer/:id/guestids/\* directly to candlepin
  - Add fake root path for guestids allowing client tooling to check support
  - Proxy GET /consumers/:id/guestids to candlepin
  - Proxy GET /consumers/:id/guestids/:guest_id to candlepin
  - Proxy PUT /consumers/:id/guestids to candlepin
  - Proxy PUT /consumers/:id/guestids/:guest_id to candlepin
  - Proxy DELETE /consumers/:id/guestids/:guest_id to candlepin
- Proxy requests to candlepin's content_overrides
  - Added fake root path that is checked by rhsm (unlocks adding extra
    guest data support in python-rhsm)
  - GET /api/consumers/:id/content_overrides
  - PUT /api/consumers/:id/content_overrides
  - DELETE /api/consumers/:id/content_overrides
