### PR TITLE
Fixes #4853: Prevents 500 error loading subscription details from API.

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -16,11 +16,14 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
 
   before_filter :find_activation_key
   before_filter :find_system
-  before_filter :find_optional_organization, :only => [:index, :available]
+  before_filter :find_optional_organization, :only => [:index, :available, :show]
   before_filter :find_organization, :only => [:upload, :delete_manifest, :refresh_manifest]
-  before_filter :find_subscription, :only => [:show]
   before_filter :find_provider
+
+  # Authorize must be before find_subscription since find_subscription reaches out to Candlepin
+  # and needs a current user set
   before_filter :authorize
+  before_filter :find_subscription, :only => [:show]
 
   before_filter :load_search_service, :only => [:index, :available]
 


### PR DESCRIPTION
Previous changes to ensure the use of Foreman's authentication and authorization
call resulted in the subscriptions details breaking. The find_subscriptions
method makes a call out to Candlepin which requires a current user. Thus,
the authorize method was moved higher in the filter stack and the entities
required to do authorization such as the provider, and organization were
placed prior to the authorization check.
