### PR TITLE
fixes #4874 - content view filter: display validation error to user

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/new-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/new-filter.controller.js
@@ -46,7 +46,10 @@ angular.module('Bastion.content-views').controller('NewFilterController',
         }
 
         function failure(response) {
-            $scope.errorMessages = [response.data.displayMessage];
+            angular.forEach(response.data.errors, function (errors, field) {
+                $scope.filterForm[field].$setValidity('server', false);
+                $scope.filterForm[field].$error.messages = errors;
+            });
         }
 
         function transitionToDetails(filter) {

--- a/engines/bastion/test/content-views/details/filters/new-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/new-filter.controller.test.js
@@ -26,6 +26,7 @@ describe('Controller: NewFilterController', function() {
         $scope = $injector.get('$rootScope').$new();
 
         $scope.contentView = {id: 1};
+        $scope.filterForm = $injector.get('MockForm');
 
         $controller('NewFilterController', {
             $scope: $scope,
@@ -90,5 +91,14 @@ describe('Controller: NewFilterController', function() {
         )
     });
 
+    it('should fail to save a new filter resource', function() {
+        $scope.filter.failed = true;
+        spyOn($scope.filter, '$save').andCallThrough();
+        $scope.save($scope.filter, $scope.contentView);
+
+        expect($scope.filter.$save).toHaveBeenCalled();
+        expect($scope.filterForm['name'].$invalid).toBe(true);
+        expect($scope.filterForm['name'].$error.messages).toBeDefined();
+    });
 });
 


### PR DESCRIPTION
This commit is to ensure that validation errors when
creating a new filter are displayed to the user.  The
approach used is similar/same as what is done with
creating a new content view, in that the validation
will be inlined in the form, such that the user may
correct the error and resubmit.
