### PR TITLE
Refs #4883: Disables SMAPs from showing up in the UI menu.

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -14,12 +14,14 @@ Foreman::Plugin.register :katello do
          :url_hash => {:controller => 'katello/subscriptions',
                        :action => 'all'},
          :engine => Katello::Engine
-    menu :top_menu,
-         :subscription_manager_applications,
-         :caption => N_('Subscription Manager Applications'),
-         :url_hash => {:controller => 'katello/distributors',
-                       :action => 'index'},
-         :engine => Katello::Engine
+   # TODO
+   # Refs http://projects.theforeman.org/issues/4883
+   # menu :top_menu,
+   #      :subscription_manager_applications,
+   #      :caption => N_('Subscription Manager Applications'),
+   #      :url_hash => {:controller => 'katello/distributors',
+   #                    :action => 'index'},
+   #      :engine => Katello::Engine
     menu :top_menu,
          :activation_keys,
          :caption => N_('Activation Keys'),


### PR DESCRIPTION
With the recent UI updates to Nutupane, and styling introductions of
Patternfly and Boostrap 3 (post enginification) as well as the backend
updates to the code base in favor of DynFlow, the Subscription Manager
Applications page is essentially non-functional. This temporary solution
is to remove the menu item for Subscription Manager Applications so as
not to give users a false sense of an existing feature.
