### PR TITLE
fixes #4890 - content view filter: unable to add package groups

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-package-group-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-package-group-filter.controller.js
@@ -42,11 +42,16 @@ angular.module('Bastion.content-views').controller('AvailablePackageGroupFilterC
             var packageGroupNames = nutupane.getAllSelectedResults('name').included.ids;
 
             angular.forEach(packageGroupNames, function (name) {
-                var rule = new Rule({name: name, 'filter_id': filter.id});
-
-                rule.$save(success, failure);
+                var rule = new Rule({name: name});
+                saveRule(rule, filter);
             });
         };
+
+        function saveRule(rule, filter) {
+            var params = {filterId: filter.id};
+
+            rule.$save(params, success, failure);
+        }
 
         function success(rule) {
             nutupane.removeRow(rule.name, 'name');

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter.html
@@ -4,7 +4,7 @@
   <nav>
     <ul class="nav nav-tabs">
       <li ng-class="{active: isState('content-views.details.filters.details.package_group.list')}">
-        <a ui-sref="content-views.details.filters.details.package_group.list">
+        <a ui-sref="content-views.details.filters.details.package_group.list({filterId: filter.id})">
         <span translate>
           List/Remove
         </span>
@@ -13,7 +13,7 @@
 
       <li ng-class="{active: isState('content-views.details.filters.details.package_group.available')}"
           ng-show="!contentView.permissions.editable">
-        <a ui-sref="content-views.details.filters.details.package_group.available">
+        <a ui-sref="content-views.details.filters.details.package_group.available({filterId: filter.id})">
         <span translate>
           Add
         </span>


### PR DESCRIPTION
This commit actually fixes 2 issues:
1. unable to add package groups to a package group filters
2. clicking on Remove/List or Add will generate an invalid
   request to the server (i.e. missing filter id)
