### PR TITLE
fixes #4875 - ignore errors on applicability regeneration

### DIFF
--- a/app/lib/actions/pulp/repository/regenerate_applicability.rb
+++ b/app/lib/actions/pulp/repository/regenerate_applicability.rb
@@ -23,6 +23,11 @@ module Actions
           pulp_extensions.repository.regenerate_applicability_by_ids([input[:pulp_id]])
         end
 
+        def external_task=(external_task_data)
+          #ignore errors, see issue #4875
+          output[:pulp_task] = external_task_data
+        end
+
       end
     end
   end


### PR DESCRIPTION
due to pulp bz1080647 applicability generation may fail
for reasons beyond our control, so ignore any errors
