### PR TITLE
fixes #4892 - content view filters & rules api - return object on DELETE

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -87,7 +87,7 @@ module Katello
     param :id, :identifier, :desc => "rule identifier", :required => true
     def destroy
       @rule.destroy
-      respond :resource => @rule
+      respond_for_show :resource => @rule
     end
 
     private

--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -85,7 +85,7 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   param :id, :identifier, :desc => "filter identifier", :required => true
   def destroy
     @filter.destroy
-    respond :resource => @filter
+    respond_for_show :resource => @filter
   end
 
   api :GET, "/content_views/:content_view_id/filters/:id/available_errata",

--- a/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
@@ -118,6 +118,10 @@ module Katello
     def test_destroy
       delete :destroy, :content_view_filter_id => @filter.id, :id => @rule.id
 
+      results = JSON.parse(response.body)
+      refute results.blank?
+      assert_equal results['id'], @rule.id
+
       assert_response :success
       assert_nil ContentViewPackageFilterRule.find_by_id(@rule.id)
     end

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -128,6 +128,10 @@ module Katello
     def test_destroy
       delete :destroy, :content_view_id => @filter.content_view_id, :id => @filter.id
 
+      results = JSON.parse(response.body)
+      refute results.blank?
+      assert_equal results['id'], @filter.id
+
       assert_response :success
       assert_nil ContentViewFilter.find_by_id(@filter.id)
     end


### PR DESCRIPTION
When a content view filter or rule is deleted with the API, return
the object that is being deleted.

This is correct behavior according to the API documentation and
is assumed behavior for the UI to properly update lists during
a deletion.
