### PR TITLE
fixes #4904 - erratum rule filter validator: fix for updating a date/type rule

### DIFF
--- a/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
+++ b/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
@@ -37,7 +37,8 @@ module Validators
 
     def _check_single_date_range(record)
       if record.start_date || record.end_date || !record.types.empty?
-        unless record.filter.erratum_rules.empty?
+        if !record.filter.erratum_rules.empty? &&
+           !record.filter.erratum_rules.any?{ |rule| rule.id == record.id }
           invalid_parameters = _("May not add a type or date range rule to a filter that has existing rules.")
           record.errors[:base] << invalid_parameters
         end

--- a/test/lib/validators/content_view_erratum_filter_rule_validator_test.rb
+++ b/test/lib/validators/content_view_erratum_filter_rule_validator_test.rb
@@ -42,7 +42,9 @@ module Katello
     end
 
     test "fails with start_date or end_date, if already has a rule" do
-      Katello::ContentViewErratumFilter.any_instance.stubs(:erratum_rules).returns(["not empty"])
+      rule1 = FactoryGirl.create(:katello_content_view_erratum_filter_rule)
+      Katello::ContentViewErratumFilter.any_instance.stubs(:erratum_rules).returns([rule1])
+
       model = ContentViewErratumFilterRule.new(:content_view_filter_id => @filter.id, :start_date => '2014/01/20')
       @validator.validate(model)
       refute_empty model.errors[:base]


### PR DESCRIPTION
This commit fixes an issue that would not allow the user
to update an existing content view erratum date/type filter rule.
