### PR TITLE
fixes #4905 - content views - add 'working' mode to couple of the Save buttons

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
@@ -58,6 +58,7 @@ angular.module('Bastion.content-views').controller('DateTypeErrataFilterControll
         }
 
         function failure(response) {
+            $scope.rule.working = false;
             $scope.errorMessages = [response.data.displayMessage];
         }
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/new-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/new-filter.controller.js
@@ -26,6 +26,7 @@ angular.module('Bastion.content-views').controller('NewFilterController',
         var filterType;
 
         $scope.filter = new Filter();
+        $scope.working = false;
 
         $scope.save = function (filter, contentView) {
             filterType = filter.type;
@@ -46,6 +47,7 @@ angular.module('Bastion.content-views').controller('NewFilterController',
         }
 
         function failure(response) {
+            $scope.working = false;
             angular.forEach(response.data.errors, function (errors, field) {
                 $scope.filterForm[field].$setValidity('server', false);
                 $scope.filterForm[field].$error.messages = errors;

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/date-type-errata-filter.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/date-type-errata-filter.html
@@ -4,7 +4,8 @@
 
   <div alch-form-buttons
        on-cancel="transitionTo('content-views.details.filters.list', {contentViewId: contentView.id})"
-       on-save="save(rule, filter)">
+       on-save="save(rule, filter)"
+       working="rule.working">
   </div>
 
 </form>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/new-filter.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/new-filter.html
@@ -54,7 +54,8 @@
 
     <div alch-form-buttons
          on-cancel="transitionTo('content-views.details.filters.list', {contentViewId: contentView.id})"
-         on-save="save(filter, contentView)">
+         on-save="save(filter, contentView)"
+         working="working">
     </div>
   </form>
 


### PR DESCRIPTION
This commit is a minor change to transition the Save
button to 'Saving...' when clicked. This is to be
consistent with other forms.
