### PR TITLE
fixes #4915 - content view publish - resolve method undefined errors

### DIFF
--- a/app/lib/katello/util/package_clause_generator.rb
+++ b/app/lib/katello/util/package_clause_generator.rb
@@ -64,7 +64,7 @@ module Util
     # output -> {"filename" => {"$in" => {"foo.el6.noarch", "..."}}} <- Packages belonging to those errata
     def package_clauses_for_errata(errata_clauses = [])
       errata_clauses = {"$or" => errata_clauses}
-      pkg_filenames = Errata.list_by_filter_clauses(errata_clauses).collect(&:package_filenames).flatten
+      pkg_filenames = Katello::Errata.list_by_filter_clauses(errata_clauses).collect(&:package_filenames).flatten
       {'filename' => {"$in" => pkg_filenames}} unless pkg_filenames.empty?
     end
 
@@ -72,7 +72,7 @@ module Util
     # output -> {"names" => {"$in" => {"foo", "..."}}}  <- packages belonging to those packages
     def package_clauses_for_group(group_clauses = [])
       group_clauses = {"$or" => group_clauses}
-      pkg_names = PackageGroup.list_by_filter_clauses(group_clauses).collect(&:package_names).flatten
+      pkg_names = Katello::PackageGroup.list_by_filter_clauses(group_clauses).collect(&:package_names).flatten
       {'name' => {"$in" => pkg_names}} unless pkg_names.empty?
     end
 

--- a/app/models/katello/content_view_erratum_filter.rb
+++ b/app/models/katello/content_view_erratum_filter.rb
@@ -24,6 +24,7 @@ class ContentViewErratumFilter < ContentViewFilter
            :class_name => "Katello::ContentViewErratumFilterRule"
 
   def generate_clauses(repo)
+    return if erratum_rules.blank?
 
     if filter_by_id?
       errata_ids = erratum_rules.map(&:errata_id)


### PR DESCRIPTION
This commit addresses a couple of undefined method errors that
have been observed.
- package_clause_generator - observed error in production configuration
  when filter contained errata; however, same should occur for package
  groups
- content_view_erratum_filter - observed error if the errata id filter
  was empty (ie. no rules/ids)
