### PR TITLE
fixes #4931 - content view errata by date/type rule - default types to false

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter.controller.js
@@ -35,9 +35,9 @@ angular.module('Bastion.content-views').controller('ErrataFilterController',
         };
 
         $scope.types = {
-            enhancement: true,
-            bugfix: true,
-            security: true
+            enhancement: false,
+            bugfix: false,
+            security: false
         };
 
         $scope.errataFilter = function (errata) {

--- a/engines/bastion/test/content-views/details/filters/errata-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/errata-filter.controller.test.js
@@ -38,9 +38,9 @@ describe('Controller: ErrataFilterController', function() {
 
     it("adds types to the scope", function() {
         expect($scope.types).toBeDefined();
-        expect($scope.types.enhancement).toBe(true);
-        expect($scope.types.bugfix).toBe(true);
-        expect($scope.types.security).toBe(true);
+        expect($scope.types.enhancement).toBe(false);
+        expect($scope.types.bugfix).toBe(false);
+        expect($scope.types.security).toBe(false);
     });
 
     it("adds a method to open the start date picker", function() {
@@ -62,17 +62,20 @@ describe('Controller: ErrataFilterController', function() {
             type: 'security'
         };
 
+        $scope.types = {'security': true};
         expect($scope.errataFilter(errata)).toBe(true);
 
-        $scope.types = ['bugfix'];
+        $scope.types = {'bugfix': false};
         expect($scope.errataFilter(errata)).toBe(false);
     });
 
-    it("should provider a method to filter errata that were issued after a particular date", function () {
+    it("should provide a method to filter errata that were issued after a particular date", function () {
         var errata = {
             type: 'security',
             issued: new Date('1/1/2012')
         };
+
+        $scope.types = {'security': true};
 
         $scope.rule['start_date'] = new Date('1/1/2012');
         expect($scope.errataFilter(errata)).toBe(true);
@@ -81,11 +84,13 @@ describe('Controller: ErrataFilterController', function() {
         expect($scope.errataFilter(errata)).toBe(false);
     });
 
-    it("should provider a method to filter errata that were issued before a particular date", function () {
+    it("should provide a method to filter errata that were issued before a particular date", function () {
         var errata = {
             type: 'security',
             issued: new Date('1/2/2012')
         };
+
+        $scope.types = {'security': true};
 
         $scope.rule['end_date'] = new Date('1/1/2012');
         expect($scope.errataFilter(errata)).toBe(false);


### PR DESCRIPTION
This minor change is so that the UI will not always show the
types (enhancement, security, bugfix) as selected/checked.
In other words, the default value is unselected and then overriden
based on the types retrieved from the server.
