### PR TITLE
Fixes #4924 - dynflow migration for product create

### DIFF
--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -70,9 +70,9 @@ module Katello
     param :label, String, :required => false
     def create
       params[:product][:label] = labelize_params(product_params) if product_params
-      product = Product.create!(product_params) do |prod|
-        prod.provider =  @organization.anonymous_provider
-      end
+      product = Product.new(product_params)
+
+      sync_task(::Actions::Katello::Product::Create, product, @organization)
       respond(:resource => product)
     end
 

--- a/app/lib/actions/candlepin/product/create.rb
+++ b/app/lib/actions/candlepin/product/create.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Candlepin
+    module Product
+      class Create < Candlepin::Abstract
+        input_format do
+          param :name, String
+          param :multiplier
+          param :attributes
+        end
+
+        def run
+          output[:response] = ::Katello::Resources::Candlepin::Product.create(:name => input[:name],
+                                                                              :multiplier => input[:multiplier],
+                                                                              :attributes => input[:attributes])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/candlepin/product/create_unlimited_supscription.rb
+++ b/app/lib/actions/candlepin/product/create_unlimited_supscription.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Candlepin
+    module Product
+      class CreateUnlimitedSubscription < Candlepin::Abstract
+
+        input_format do
+          param :owner_key, String
+          param :product_id, String
+        end
+
+        def run
+          output[:response] = ::Katello::Resources::Candlepin::Product.create_unlimited_subscription(input[:owner_key],
+                                                                                                     input[:product_id])
+        end
+
+      end
+
+    end
+  end
+end

--- a/app/lib/actions/katello/product/create.rb
+++ b/app/lib/actions/katello/product/create.rb
@@ -1,0 +1,53 @@
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module Product
+
+      class Create < Actions::EntryAction
+        def plan(product, organization)
+          product.disable_auto_reindex!
+          product.provider = organization.anonymous_provider
+
+          cp_create = plan_action(::Actions::Candlepin::Product::Create,
+                                  :name => product.name,
+                                  :multiplier => 1,
+                                  :attributes => [{:name => "arch", :value => "ALL"}])
+
+          cp_id = cp_create.output[:response][:id]
+
+          plan_action(::Actions::Candlepin::Product::CreateUnlimitedSubscription,
+                      :owner_key => organization.label,
+                      :product_id => cp_id)
+          product.save!
+          action_subject product, :cp_id => cp_id
+
+          plan_self
+          plan_action ElasticSearch::Reindex, product
+        end
+
+        def finalize
+          product = ::Katello::Product.find(input[:product][:id])
+          product.disable_auto_reindex!
+          product.cp_id = input[:cp_id]
+          product.save!
+        end
+
+        def humanized_name
+          _("Create")
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -50,48 +50,6 @@ describe Product, :katello => true do
     ProductTestData::PRODUCT_WITH_CP_CONTENT.merge!({:provider => @provider})
   end
 
-  describe "create product" do
-
-    describe "new product" do
-      before(:each) { @p = Product.new({}) }
-      specify { @p.productContent.must_equal([]) }
-    end
-
-    describe "with valid parameters" do
-      before(:each) do
-        disable_product_orchestration
-        @p = Product.create!(ProductTestData::SIMPLE_PRODUCT)
-      end
-
-      specify { @p.name.must_equal(ProductTestData::SIMPLE_PRODUCT['name']) }
-      specify { @p.created_at.wont_be_nil }
-      specify { @p.library.must_equal(@organization.library) }
-    end
-
-    describe "candlepin orchestration" do
-      before do
-        Resources::Candlepin::Product.stubs(:certificate).returns("")
-        Resources::Candlepin::Product.stubs(:key).returns("")
-      end
-
-      describe "with attributes" do
-        it "should create product in katello" do
-
-          expected_product = {
-              :attributes => ProductTestData::PRODUCT_WITH_ATTRS[:attrs],
-              :multiplier => ProductTestData::PRODUCT_WITH_ATTRS[:multiplier],
-              :name => ProductTestData::PRODUCT_WITH_ATTRS[:name]
-          }
-
-          Resources::Candlepin::Product.expects(:create).once.with(expected_product).returns({:id => '1'})
-          product = Product.create!(ProductTestData::PRODUCT_WITH_ATTRS)
-          product.organization.wont_be_nil
-        end
-      end
-
-    end
-  end
-
   describe "lazily-loaded attributes" do
     before(:each) do
       Resources::Candlepin::Product.stubs(:get).returns([ProductTestData::SIMPLE_PRODUCT.merge(:attributes => [])])

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -74,6 +74,13 @@ class Api::V2::ProductsControllerTest < ActionController::TestCase
       :name => 'fedora product',
       :description => 'this is my cool new product.'
     }
+    Api::V2::ProductsController.any_instance.expects(:sync_task).with do |action_class, prod, org|
+      action_class.must_equal ::Actions::Katello::Product::Create
+      prod.must_be_kind_of(Product)
+      org.must_equal @organization
+      prod.provider = @provider
+    end
+
     post :create, :product => product_params, :organization_id => @organization.label
 
     assert_response :success


### PR DESCRIPTION
Fixes #4924 - dynflow migration for product create
dynflow migration of product creation
unit tests for product create
removed old product create unit test
fixed other unit tests
