### PR TITLE
Fixes #4936 - Updated repo info to enable cli ops

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -161,6 +161,10 @@ class Repository < Katello::Model
     end
   end
 
+  def product_type
+    redhat? ? "redhat" : "custom"
+  end
+
   def redhat?
     product.redhat?
   end

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -13,6 +13,7 @@ attributes :feed,
 attributes :major, :minor
 attributes :gpg_key_id
 attributes :content_id, :content_view_version_id, :library_instance_id
+attributes :product_type
 
 node :content_counts do |repo|
   if repo.respond_to?(:pulp_repo_facts)
@@ -24,6 +25,11 @@ node :permissions do |repo|
   {
     :deletable => repo.deletable?
   }
+end
+
+child :gpg_key do |gpg|
+  attribute :name
+  attribute :id
 end
 
 child :product do |product|


### PR DESCRIPTION
Added a product_type flag to repo to determine if its a redhat product
or custom.
Updated the documentation for "update" method of repo controllers.
Updated the json rabl to give more information needed by the cli.
