### PR TITLE
fixes #4956 - content view errata by id filter - list available errata

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
@@ -20,13 +20,18 @@
  * @requires Rule
  *
  * @description
- *   Handles creating an errata filter that allows specification of a stare date, end date and/or
+ *   Handles creating an errata filter that allows specification of a start date, end date and/or
  *   set of errata types by which to dynamically filter.
  */
 angular.module('Bastion.content-views').controller('DateTypeErrataFilterController',
     ['$scope', 'translate', 'Rule', function ($scope, translate, Rule) {
 
         $scope.filter.$promise.then(function (filter) {
+            $scope.types = {
+                enhancement: false,
+                bugfix: false,
+                security: false
+            };
             $scope.rule = new Rule(filter.rules[0]);
 
             angular.forEach($scope.types, function (value, type) {

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter.controller.js
@@ -31,13 +31,13 @@ angular.module('Bastion.content-views').controller('ErrataFilterController',
 
         $scope.date = {
             startOpen: false,
-            endOpen: false,
+            endOpen: false
         };
 
         $scope.types = {
-            enhancement: false,
-            bugfix: false,
-            security: false
+            enhancement: true,
+            bugfix: true,
+            security: true
         };
 
         $scope.errataFilter = function (errata) {
@@ -74,6 +74,5 @@ angular.module('Bastion.content-views').controller('ErrataFilterController',
             $scope.date.startOpen = true;
             $scope.date.endOpen = false;
         };
-
     }]
 );

--- a/engines/bastion/test/content-views/details/filters/errata-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/errata-filter.controller.test.js
@@ -38,9 +38,9 @@ describe('Controller: ErrataFilterController', function() {
 
     it("adds types to the scope", function() {
         expect($scope.types).toBeDefined();
-        expect($scope.types.enhancement).toBe(false);
-        expect($scope.types.bugfix).toBe(false);
-        expect($scope.types.security).toBe(false);
+        expect($scope.types.enhancement).toBe(true);
+        expect($scope.types.bugfix).toBe(true);
+        expect($scope.types.security).toBe(true);
     });
 
     it("adds a method to open the start date picker", function() {


### PR DESCRIPTION
This is a fix so that available errata are listed in
the UI.  This is fixing a regression that I introduced with
17f9b25871460e59cee62bd54484806398d2b330 :(
