### PR TITLE
fixes #4985 - nutupane - add padding-right to the nutupane-bar

### DIFF
--- a/engines/bastion/app/assets/stylesheets/bastion/nutupane.less
+++ b/engines/bastion/app/assets/stylesheets/bastion/nutupane.less
@@ -102,7 +102,7 @@ td.row-select {
 
 .nutupane-bar {
   background: rgb(250, 250, 250);
-  padding: 10px 0;
+  padding: 10px 15px 10px 0;
   border-bottom: 1px solid rgb(230, 230, 230);
   overflow: auto;
 


### PR DESCRIPTION
This commit is to add some padding to the right of the nutupane-bar.
This will fix an issue where buttons are being cut-off.

This PR is to address the issue in the near-term; however, it is possible
that as the patternfly changes are introduced, this is no longer necessary.
(Reference: https://github.com/Katello/katello/pull/3898)
