### PR TITLE
fixes #5013 - host groups - fix retrieval of activation keys

### DIFF
--- a/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
+++ b/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
@@ -17,7 +17,7 @@ $(function() {
         $("#ak-subscriptions-spinner").show();
 
         var selectedEnvId = $("#kt_environment_id option:selected").data('katello-env-id'),
-            selectedCvId = $("#hostgroup_environment_id").val();
+            selectedCvId = $("#hostgroup_environment_id option:selected").data('content_view-id');
 
         // Retrieve the activation keys associated with the current
         // environment & content view.
@@ -29,9 +29,6 @@ $(function() {
                 availableActivationKeys = {};
                 $.each(response['results'], function (i, key) {
                     availableActivationKeys[key.name] = [];
-                    $.each(key.pools, function (j, pool) {
-                        availableActivationKeys[key.name].push(pool.productName);
-                    });
                 });
                 ktAkUpdateSubscriptionsInfo();
             },


### PR DESCRIPTION
This commit fixes the behavior of hostgroup create/edit,
where the user selects a lifecycle environment and
content view and in turn the list of available activation
keys is return from the server.

The main issue prior to this commit was that the
logic was using the foreman puppet environment id
where it should have been using the katello
content view id.
