### PR TITLE
fixes #5036 BZ1075238 - specify table name explicitly in pluck

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -107,8 +107,8 @@ module Katello
     param_group :search, Api::V2::ApiController
     param :name, String, :desc => "system group name to filter by"
     def available_system_groups
-      filters = [:terms => {:id => SystemGroup.readable(@activation_key.organization).pluck(:id) -
-                   @activation_key.system_groups.pluck(:id)}]
+      filters = [:terms => {:id => SystemGroup.readable(@activation_key.organization).pluck("#{Katello::SystemGroup.table_name}.id") -
+                   @activation_key.system_groups.pluck("#{Katello::SystemGroup.table_name}.id")}]
       filters << {:term => {:name => params[:name].downcase}} if params[:name]
 
       options = {

--- a/app/controllers/katello/api/v2/system_groups_controller.rb
+++ b/app/controllers/katello/api/v2/system_groups_controller.rb
@@ -210,7 +210,7 @@ module Katello
     private
 
     def filter_system
-      filters = [:terms => {:id => @system.system_groups.pluck(:id)}]
+      filters = [:terms => {:id => @system.system_groups.pluck("#{Katello::SystemGroup.table_name}.id")}]
 
       options = {
           :filters       => filters,
@@ -220,7 +220,7 @@ module Katello
     end
 
     def filter_activation_key
-      filters = [:terms => {:id => @activation_key.system_groups.pluck(:id)}]
+      filters = [:terms => {:id => @activation_key.system_groups.pluck("#{Katello::SystemGroup.table_name}.id")}]
 
       options = {
           :filters       => filters,
@@ -230,7 +230,7 @@ module Katello
     end
 
     def filter_organization
-      filters = [:terms => {:id => SystemGroup.readable(@organization).pluck(:id)}]
+      filters = [:terms => {:id => SystemGroup.readable(@organization).pluck("#{Katello::SystemGroup.table_name}.id")}]
       filters << {:term => {:name => params[:name].downcase}} if params[:name]
 
       options = {

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -197,7 +197,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
   param_group :search, Api::V2::ApiController
   param :name, String, :desc => "system group name to filter by"
   def available_system_groups
-    filters = [:terms => {:id => SystemGroup.readable(@system.organization).pluck(:id) - @system.system_group_ids}]
+    filters = [:terms => {:id => SystemGroup.readable(@system.organization).pluck("#{Katello::SystemGroup.table_name}.id") - @system.system_group_ids}]
     filters << {:term => {:name => params[:name].downcase}} if params[:name]
 
     options = {


### PR DESCRIPTION
On rails-3.2.8 some psql generated inner joins which pluck needs to have explicit table name for "id".
