### PR TITLE
Fixes #5044, fix link to subscriptions.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -69,7 +69,7 @@
         <tbody>
           <tr alch-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
             <td alch-table-cell colspan="8">
-              <a ui-sref="subscriptions.details.info({subscriptionId: name})">
+              <a href='subscriptions#/subscriptions?search=productName:"{{ name }}"'>
                 {{ name }}
               </a>
             </td>

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -68,7 +68,7 @@
         <tbody>
           <tr alch-table-row  ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
             <td alch-table-cell colspan="8">
-              <a ui-sref="subscriptions.details.info({subscriptionId: name})">
+              <a href='subscriptions#/subscriptions?search=productName:"{{ name }}"'>
                 {{ name }}
               </a>
             </td>

--- a/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-add-subscriptions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-add-subscriptions.html
@@ -67,7 +67,7 @@
         <tbody>
           <tr alch-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
             <td alch-table-cell colspan="8">
-              <a ui-sref="subscriptions.details.info({subscriptionId: name})">
+              <a href='subscriptions#/subscriptions?search=productName:"{{ name }}"'>
                 {{ name }}
               </a>
             </td>

--- a/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/systems/details/views/system-subscriptions-list.html
@@ -66,7 +66,7 @@
         <tbody>
           <tr alch-table-row  ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
             <td alch-table-cell colspan="8">
-              <a ui-sref="subscriptions.details.info({subscriptionId: name})">
+              <a href='subscriptions#/subscriptions?search=productName:"{{ name }}"'>
                 {{ name }}
               </a>
             </td>


### PR DESCRIPTION
The link to subscriptions was using the name of the subscription
instead of the ID.  This resulted in a broken link.  Fixed the link
to do a search for the subscription name instead.
