### PR TITLE
Fixes #4482: Adds manual bootstrapping and modules specification for the...

### DIFF
--- a/engines/bastion/.jshintrc
+++ b/engines/bastion/.jshintrc
@@ -9,7 +9,8 @@
     "globals": {
         "angular": false,
         "KT": true,
-		"_": true
+	"_": true,
+	"BASTION_MODULES": true
     },
     "immed": true,
     "indent": 4,

--- a/engines/bastion/README.md
+++ b/engines/bastion/README.md
@@ -105,6 +105,14 @@ version of a component has been bumped.
 - `npm install`
 - `grunt bower:dev`
 
+## Adding a Custom Module ##
+
+If creating a plugin that you would like to hook into and take advantage of the Bastion setup, your custom module can be added to the list of modules that are imported at application bootstrap. Adding a custom module requires two steps: ensuring your assets are included on the page and declaring the inclusion of your module. The former can be achieved through various methods and depends on your setup. To declare the inclusion of your module, ensure the following is defined somewhere within your JavaScript (we recommend adding it to the top of your mymodulename.module.js file or in a separate mymodulename-bootstrap.js file):
+
+```
+BASTION_MODULES.push('myModuleName');
+```
+
 ## Testing ##
 
 The Bastion JavaScript test suite requires the use of nodejs to be run. Nodejs is currently available for Fedora 18, Fedora 19 and EPEL. See here for more information - https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#fedora

--- a/engines/bastion/app/assets/javascripts/bastion/bastion-bootstrap.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion-bootstrap.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+angular.element(document).ready(function () {
+    angular.bootstrap(document, BASTION_MODULES);
+});
+
+BASTION_MODULES = [
+    'Bastion',
+    'alchemy',
+    'alchemy.format',
+    'alch-templates',
+    'angular-blocks',
+    'ngAnimate',
+    'ngSanitize',
+    'templates',
+    'ui.bootstrap',
+    'ui.bootstrap.tpls',
+    'Bastion.activation-keys',
+    'Bastion.content-views',
+    'Bastion.content-views.versions',
+    'Bastion.custom-info',
+    'Bastion.environments',
+    'Bastion.gpg-keys',
+    'Bastion.i18n',
+    'Bastion.menu',
+    'Bastion.nodes',
+    'Bastion.organizations',
+    'Bastion.products',
+    'Bastion.providers',
+    'Bastion.repositories',
+    'Bastion.subscriptions',
+    'Bastion.sync-plans',
+    'Bastion.system-groups',
+    'Bastion.systems',
+    'Bastion.tasks',
+    'Bastion.widgets'
+];

--- a/engines/bastion/app/assets/javascripts/bastion/bastion.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.js
@@ -103,3 +103,5 @@
 
 //= require "bastion/activation-keys/activation-keys.module.js"
 //= require_tree "./activation-keys"
+
+//= require "bastion/bastion-bootstrap"

--- a/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
@@ -20,34 +20,7 @@
  *   modules used by the application.
  */
 angular.module('Bastion', [
-    'alchemy',
-    'alchemy.format',
-    'alch-templates',
-    'angular-blocks',
-    'ngAnimate',
-    'ngSanitize',
-    'templates',
-    'ui.bootstrap',
-    'ui.bootstrap.tpls',
-    'Bastion.activation-keys',
-    'Bastion.content-views',
-    'Bastion.content-views.versions',
-    'Bastion.custom-info',
-    'Bastion.environments',
-    'Bastion.gpg-keys',
-    'Bastion.i18n',
-    'Bastion.menu',
-    'Bastion.nodes',
-    'Bastion.organizations',
-    'Bastion.products',
-    'Bastion.providers',
-    'Bastion.repositories',
-    'Bastion.subscriptions',
-    'Bastion.sync-plans',
-    'Bastion.system-groups',
-    'Bastion.systems',
-    'Bastion.tasks',
-    'Bastion.widgets'
+    'ui.router'
 ]);
 
 /**

--- a/engines/bastion/app/views/bastion/layouts/application.html.haml
+++ b/engines/bastion/app/views/bastion/layouts/application.html.haml
@@ -6,7 +6,7 @@
   Katello
 
 = content_for(:content) do
-  %article.maincontent.rcue-styles{'ng-app' => "Bastion"}
+  %article.maincontent.rcue-styles
     %section.container-fluid{'ui-view' => ''}
 
 = content_for(:javascripts) do
@@ -20,5 +20,6 @@
           consumerCertRPM: "#{Katello.config.consumer_cert_rpm}",
           markTranslated: #{SETTINGS[:mark_translated] || false}
       });
+  = yield :bastion_javascripts
 
 = render :file => "layouts/base"

--- a/engines/bastion/karma.conf.js
+++ b/engines/bastion/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function(config) {
             '.tmp/bower_components/angular-mocks/angular-mocks.js',
             'vendor/assets/javascripts/bastion/angular-sanitize/angular-sanitize.js',
             'vendor/assets/javascripts/bastion/angular-resource/angular-resource.js',
+            'vendor/assets/javascripts/bastion/**/*.js',
             'vendor/assets/javascripts/bastion/alchemy/alchemy.js',
             'vendor/assets/javascripts/bastion/underscore/underscore.js',
             'vendor/assets/javascripts/bastion/angular-ui-router/angular-ui-router.js',
@@ -27,9 +28,15 @@ module.exports = function(config) {
             '../../app/assets/javascripts/katello/common/notices.js',
             '../../app/assets/javascripts/katello/common/experimental/katello-globals.module.js',
 
-            // Must load modules first
+            // Load Bastion module first
+            'app/assets/javascripts/bastion/bastion.module.js',
+
+            // Load Bastion test constants
+            'test/bastion/test-constants.js',
+
+            // Load modules first
             'app/assets/javascripts/bastion/**/*.module.js',
-            'app/assets/javascripts/bastion/**/*.js ',
+            'app/assets/javascripts/bastion/**/*.js',
             'app/assets/javascripts/bastion/**/*.html',
 
             'test/test-mocks.module.js',

--- a/engines/bastion/test/bastion/test-constants.js
+++ b/engines/bastion/test/bastion/test-constants.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+angular.module('Bastion').value('currentLocale', 'Here');
+angular.module('Bastion').value('CurrentOrganization', "ACME");
+angular.module('Bastion').value('CurrentUser', "User");
+angular.module('Bastion').constant('BastionConfig', {
+    consumerCertRPM: "consumer_cert_rpm",
+    markTranslated: false
+});
+
+angular.module('templates', []);


### PR DESCRIPTION
... Angular app.

Given the boostrap process can only occur once, declaring all our module
requirements in an array and manually bootstrapping provides the ability
to dynamically add modules for inclusion. This in turn will allow secondary
or plugin modules to declare themselves and be included within the greater
application. This can be achived by the following:

BASTION_MODULES.push('myModuleName')

This should not place any requirements on when the JavaScript containing the
module declaration is loaded as long as it is prior to the DOM content being
loaded.
