### PR TITLE
fixes 5039 - update bulk actions before_filters to fix 403 forbidden issue

### DIFF
--- a/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
@@ -14,17 +14,17 @@ module Katello
 class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
 
   before_filter :find_organization
-  before_filter :load_search_service
+  before_filter :find_groups, :only => [:bulk_add_system_groups, :bulk_remove_system_groups]
+  before_filter :find_environment, :only => [:environment_content_view]
+  before_filter :find_content_view, :only => [:environment_content_view]
+  before_filter :authorize
+
   before_filter :find_editable_systems, :except => [:destroy_systems, :applicable_errata]
   before_filter :find_deletable_systems, :only => [:destroy_systems]
   before_filter :find_readable_systems, :only => [:applicable_errata]
 
-  before_filter :find_environment, :only => [:environment_content_view]
-  before_filter :find_content_view, :only => [:environment_content_view]
-
-  before_filter :find_groups, :only => [:bulk_add_system_groups, :bulk_remove_system_groups]
   before_filter :validate_content_action, :only => [:install_content, :update_content, :remove_content]
-  before_filter :authorize
+  before_filter :load_search_service
 
   PARAM_ACTIONS = {
       :install_content => {


### PR DESCRIPTION
Prior to this commit the system bulk actions for 'errata' would
fail with a 403 forbidden indicating that the user was not set.
The root cause is that User.current is currently set as
part of 'authenticate' (which is performed by the 'authorize' filter);
however, authorize was being executed after some of the filters that
required access to User.current.

This commit reorders the filters so that User.current
will be set before it is needed by other filters.
