### PR TITLE
Fixes #4967 - use http instead of https for bootstrap rpm in kickstart

### DIFF
--- a/app/helpers/katello/katello_urls_helper.rb
+++ b/app/helpers/katello/katello_urls_helper.rb
@@ -18,7 +18,7 @@ module Katello
     end
 
     def subscription_manager_configuration_url
-      "#{Setting['foreman_url']}/pub/#{Katello.config.consumer_cert_rpm}"
+      "#{Setting['foreman_url']}/pub/#{Katello.config.consumer_cert_rpm}".sub(/\Ahttps/, 'http')
     end
   end
 end


### PR DESCRIPTION
We don't have the certificate installed yet, so the verification fails.
