### PR TITLE
Fixes #4966 - add subscription_manager_configuration_url to ALLOWED_HELPERS

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -139,4 +139,6 @@ Foreman::Plugin.register :katello do
   Foreman::AccessControl.permission(:edit_organizations).actions << 'organizations/download_debug_certificate'
   Foreman::AccessControl.permission(:edit_organizations).actions << 'organizations/repo_discover'
   Foreman::AccessControl.permission(:edit_organizations).actions << 'organizations/cancel_repo_discover'
+
+  allowed_template_helpers :subscription_manager_configuration_url
 end


### PR DESCRIPTION
This allows rendering the template in safe mode
