### PR TITLE
fixes #5079 - fixing error on puppet module upload

### DIFF
--- a/app/models/katello/glue/elastic_search/puppet_module.rb
+++ b/app/models/katello/glue/elastic_search/puppet_module.rb
@@ -15,6 +15,9 @@ module Glue::ElasticSearch::PuppetModule
   extend ActiveSupport::Concern
 
   included do
+
+    include Glue::ElasticSearch::BackendIndexedModel
+
     def index_options
       {
         "_type"             => :puppet_module,


### PR DESCRIPTION
undefined local variable or method create_index for Katello::PuppetModule:Class
