### PR TITLE
fixes #5080 - invalid puppet module names would show to add to CV

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -89,7 +89,7 @@ module Katello
       @search_service.model =  item_class
       options[:per_page] = 1
       options[:facets] = {facet_name => term}
-      options[:facet_filters] =  options[:filters]
+      options[:facet_filters] =  {:and => options[:filters]}
 
       @search_service.retrieve('', 0, options)
 


### PR DESCRIPTION
due to the way facet filters work, you need to specify :and between all the filters
unlike in a normal search where you can specify multiple filter lines
and tire will :and them together
