### PR TITLE
fixes #5100 - updates to how/when foreman content is created

### DIFF
--- a/app/lib/actions/katello/content_view/update_environment.rb
+++ b/app/lib/actions/katello/content_view/update_environment.rb
@@ -26,7 +26,10 @@ module Actions
           plan_action(Candlepin::Environment::SetContent,
                       cp_environment_id: view_env.cp_id,
                       content_ids:       content_ids)
-          plan_action(Katello::Foreman::ContentUpdate, environment, content_view)
+
+          unless content_view.default?
+            plan_action(Katello::Foreman::ContentUpdate, environment, content_view)
+          end
         end
 
       end

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -44,7 +44,8 @@ module Actions
             unless clone
               unless repository.product.redhat?
                 content_create = plan_action(Katello::Product::ContentCreate, repository)
-                plan_action(ContentView::UpdateEnvironment, org.default_content_view, org.library, content_create.input[:content_id])
+                plan_action(ContentView::UpdateEnvironment, org.default_content_view,
+                            org.library, content_create.input[:content_id])
               end
               plan_action(Katello::Repository::MetadataGenerate, repository) unless repository.puppet?
               plan_action(ElasticSearch::Reindex, repository)


### PR DESCRIPTION
This commit addresses 2 issues:
1. Do not create foreman content (install media, OS...etc) when creating a repo in the default content view (i.e. Library)
2. Do not blindly create install media, if it already exists (e.g. rather than Medium.create! do Medium.find_or_create_medium)
