### PR TITLE
Fixes #5098: Table select all checkboxes no longer trigger one another.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/incubator/alch-table.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/incubator/alch-table.directive.js
@@ -22,10 +22,12 @@ angular.module('alchemy')
     }])
     .controller('AlchTableController', ['$scope', function ($scope) {
         var rows = $scope.rows = [],
-            headers = $scope.headers = [];
+            headers = $scope.headers = [],
+            self = this;
+
+        this.selection = {allSelected: false, selectAllDisabled: false};
 
         $scope.table.numSelected = 0;
-        $scope.table.allSelected = false;
         $scope.table.chosenRow = null;
 
         $scope.table.getSelected = function () {
@@ -39,6 +41,18 @@ angular.module('alchemy')
         };
 
         $scope.table.selectAllDisabled = false;
+
+        this.disableSelectAll = $scope.table.disableSelectAll = function () {
+            self.selection.selectAllDisabled = true;
+        };
+
+        this.enableSelectAll = $scope.table.enableSelectAll = function () {
+            self.selection.selectAllDisabled = false;
+        };
+
+        $scope.table.allSelected = function () {
+            return self.selection.allSelected;
+        };
 
         this.addRow = function (row) {
             rows.push(row);
@@ -58,7 +72,7 @@ angular.module('alchemy')
 
         this.itemSelected = function (row) {
             $scope.table.numSelected += row.selected ? 1 : -1;
-            $scope.table.allSelected = false;
+            self.selection.allSelected = false;
         };
 
         this.itemChosen = function (row) {
@@ -68,12 +82,12 @@ angular.module('alchemy')
         this.selectAll = $scope.table.selectAll = function (selected) {
             var table = $scope.table;
 
-            table.allSelected = selected;
+            self.selection.allSelected = selected;
 
-            $scope.table.numSelected = table.allSelected ? table.rows.length : 0;
+            $scope.table.numSelected = self.selection.allSelected ? table.rows.length : 0;
 
             angular.forEach(table.rows, function (row) {
-                row.selected = table.allSelected;
+                row.selected = self.selection.allSelected;
             });
         };
 
@@ -82,9 +96,9 @@ angular.module('alchemy')
         var rowSelectTemplate = function () {
             return '<th class="row-select">' +
                       '<input type="checkbox"' +
-                              'ng-model="table.allSelected"' +
-                              'ng-disabled="table.selectAllDisabled"' +
-                              'ng-change="allSelected(table)">' +
+                              'ng-model="selection.allSelected"' +
+                              'ng-disabled="selection.selectAllDisabled"' +
+                              'ng-change="allSelected()">' +
                     '</th>';
         }, rowChoiceTemplate = function () {
             return '<th translate class="row-select"></th>';
@@ -111,8 +125,10 @@ angular.module('alchemy')
 
                     alchTableController.addHeader(scope.header);
 
-                    scope.allSelected = function (table) {
-                        alchTableController.selectAll(table.allSelected);
+                    scope.selection = alchTableController.selection;
+
+                    scope.allSelected = function () {
+                        alchTableController.selectAll(scope.selection.allSelected);
                     };
                 };
             }

--- a/engines/bastion/app/assets/javascripts/bastion/layouts/select-all-results.html
+++ b/engines/bastion/app/assets/javascripts/bastion/layouts/select-all-results.html
@@ -1,4 +1,4 @@
-<div class="nutupane-select-all" ng-show="table.selectAllResultsEnabled && table.allSelected && !table.allResultsSelected">
+<div class="nutupane-select-all" ng-show="table.selectAllResultsEnabled && table.allSelected() && !table.allResultsSelected">
   <span translate>All {{ table.rows.length }} items on this page are selected.</span>
   <a ng-click="table.selectAllResults(true)" translate>Select all {{ table.resource.subtotal }}.</a>
 </div>

--- a/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
@@ -267,14 +267,19 @@ angular.module('Bastion.widgets').factory('Nutupane',
             // Otherwise provides expanded functionality
 
             self.table.selectAllResults = function (selectAll) {
-                if (self.table.selectAll) {
+                if (self.table.allSelected()) {
                     self.table.selectAll(selectAll);
                 } else {
                     self.table.initialSelectAll = true;
                 }
 
                 if (self.table.selectAllResultsEnabled) {
-                    self.table.selectAllDisabled = selectAll;
+                    if (selectAll) {
+                        self.table.disableSelectAll();
+                    } else {
+                        self.table.enableSelectAll();
+                    }
+
                     self.table.allResultsSelected = selectAll;
                     self.table.numSelected = selectAll ? self.table.resource.subtotal : 0;
                 }

--- a/engines/bastion/test/incubator/alch-table.directive.test.js
+++ b/engines/bastion/test/incubator/alch-table.directive.test.js
@@ -112,14 +112,14 @@ describe('Directive: alchTable', function() {
             tableController.itemSelected(row);
 
             expect(scope.table.numSelected).toEqual(1);
-            expect(scope.table.allSelected).toEqual(false);
+            expect(scope.table.allSelected()).toEqual(false);
         });
 
         it("should select all rows", function() {
             tableController.selectAll(true);
 
             expect(scope.table.numSelected).toEqual(2);
-            expect(scope.table.allSelected).toEqual(true);
+            expect(scope.table.allSelected()).toEqual(true);
             expect(scope.table.rows[0].selected).toEqual(true);
         });
 
@@ -127,7 +127,7 @@ describe('Directive: alchTable', function() {
             tableController.selectAll(false);
 
             expect(scope.table.numSelected).toEqual(0);
-            expect(scope.table.allSelected).toEqual(false);
+            expect(scope.table.allSelected()).toEqual(false);
             expect(scope.table.rows[0].selected).toEqual(false);
         });
 
@@ -137,6 +137,17 @@ describe('Directive: alchTable', function() {
             tableController.itemChosen(row);
 
             expect(scope.table.chosenRow).toBe(row);
+        });
+
+        it("should disable select all", function() {
+            tableController.disableSelectAll(true);
+
+            expect(tableController.selection.selectAllDisabled).toBe(true);
+        });
+
+        it("should provide a method to check if all are selected", function() {
+            scope.table.selectAll(true);
+            expect(scope.table.allSelected()).toBe(true);
         });
 
     });

--- a/engines/bastion/test/incubator/nutupane.factory.test.js
+++ b/engines/bastion/test/incubator/nutupane.factory.test.js
@@ -55,6 +55,9 @@ describe('Factory: Nutupane', function() {
             nutupane.table.working = false;
             nutupane.table.selectAll = function() {};
             nutupane.table.getSelected = function() {};
+            nutupane.table.disableSelectAll = function () { };
+            nutupane.table.enableSelectAll = function () { };
+            nutupane.table.allSelected = function () { return true; };
             nutupane.table.rows = [{id: 0, value: "value0"}, {id:1, value: "value1"}];
             nutupane.table.resource = Resource;
         });
@@ -178,11 +181,12 @@ describe('Factory: Nutupane', function() {
         it("provides a way to select all results", function() {
             nutupane.enableSelectAllResults();
             spyOn(nutupane.table, 'selectAll');
+            spyOn(nutupane.table, 'disableSelectAll');
 
             nutupane.table.selectAllResults(true);
 
             expect(nutupane.table.selectAll).toHaveBeenCalledWith(true);
-            expect(nutupane.table.selectAllDisabled).toBe(true);
+            expect(nutupane.table.disableSelectAll).toHaveBeenCalled();
             expect(nutupane.table.allResultsSelected).toBe(true);
             expect(nutupane.table.numSelected).toBe(nutupane.table.resource.subtotal);
         });
@@ -191,10 +195,11 @@ describe('Factory: Nutupane', function() {
             nutupane.enableSelectAllResults();
             nutupane.table.numSelected = 0;
             spyOn(nutupane.table, 'selectAll');
+            spyOn(nutupane.table, 'enableSelectAll');
             nutupane.table.selectAllResults(false);
 
             expect(nutupane.table.selectAll).toHaveBeenCalledWith(false);
-            expect(nutupane.table.selectAllDisabled).toBe(false);
+            expect(nutupane.table.enableSelectAll).toHaveBeenCalled();
             expect(nutupane.table.allResultsSelected).toBe(false);
             expect(nutupane.table.numSelected).toBe(0);
         });


### PR DESCRIPTION
Previously, the select all functionality was tied to the assumption that a
table variable existed attached to the scope; however, this use of a table
variable reflected that created by an outside controller and not the internal
scope of the directive.

Changes the handling of select all internally within alch table by
introducing a private variable that belongs to each instance of alch-table.
Methods were introduced to wrap the internal variable to enforce the internal
nature of the variable.
