### PR TITLE
fixes #5142 - fixing error on repo create with empty string

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -102,6 +102,7 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
   param_group :repo
   def create
     params[:label] = labelize_params(params)
+    params[:url] = nil if params[:url].blank?
     gpg_key = @product.gpg_key
     unless params[:gpg_key_id].blank?
       gpg_key = @gpg_key
@@ -133,7 +134,9 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
   param :unprotected, :bool, :desc => "true if this repository can be published via HTTP"
   param :url, String, :desc => "the feed url of the original repository "
   def update
-    @repository.update_attributes!(repository_params)
+    repo_params = repository_params
+    repo_params[:url] = nil if repository_params[:url].blank?
+    @repository.update_attributes!(repo_params)
     respond_for_show(:resource => @repository)
   end
 

--- a/app/lib/katello/validators/katello_url_format_validator.rb
+++ b/app/lib/katello/validators/katello_url_format_validator.rb
@@ -16,11 +16,11 @@ module Validators
     include KatelloUrlHelper
 
     def validate_each(record, attribute, value)
-      if options[:blank_allowed]
-        if options[:blank_allowed].respond_to?(:call)
-          return if value.blank? && options[:blank_allowed].call(record)
+      if options[:nil_allowed]
+        if options[:nil_allowed].respond_to?(:call)
+          return if value.nil? && options[:nil_allowed].call(record)
         else
-          return if value.blank?
+          return if value.nil?
         end
       end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -68,7 +68,7 @@ class Repository < Katello::Model
   validates_with Validators::RepoDisablementValidator, :attributes => :enabled, :on => :update
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates_with Validators::KatelloUrlFormatValidator,
-    :attributes => :feed, :blank_allowed => proc { |o| o.custom? }, :field_name => :url,
+    :attributes => :feed, :nil_allowed => proc { |o| o.custom? }, :field_name => :url,
     :if => proc { |o| o.in_default_view? }
   validates :content_type, :inclusion => {
       :in => TYPES,

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -198,19 +198,34 @@ class RepositoryInstanceTest < RepositoryTestBase
     assert_equal "/content_views/composite_view/1/library/fedora_17_label", relative_path
   end
 
-  def test_blank_feed_url
+  def new_custom_repo
     new_custom_repo = @fedora_17_x86_64.clone
     new_custom_repo.name = "new_custom_repo"
     new_custom_repo.label = "new_custom_repo"
     new_custom_repo.pulp_id = "new_custom_repo"
-    new_custom_repo.feed = ""
-    assert new_custom_repo.save
-    assert new_custom_repo.persisted?
-    assert_equal "", new_custom_repo.reload.feed
-    refute new_custom_repo.feed?
+    new_custom_repo
+  end
 
+  def test_nil_feed_url
+    new_repo = new_custom_repo
+    new_repo.feed = nil
+    assert new_repo.save
+    assert new_repo.persisted?
+    assert_equal nil, new_repo.reload.feed
+    refute new_repo.feed?
+  end
+
+  def test_blank_feed_url
+    new_repo = new_custom_repo
+    new_repo.feed = ""
+    refute new_repo.save
+    refute new_repo.errors.empty?
+    assert_equal nil, new_repo.reload.feed
+  end
+
+  def test_nil_rhel_url
     rhel = Repository.find(katello_repositories(:rhel_6_x86_64))
-    rhel.feed = ""
+    rhel.feed = nil
     refute rhel.valid?
     refute rhel.save
     refute_empty rhel.errors


### PR DESCRIPTION
pulp does not treat empty string for feed urls the same as
nil.  As a result repo creation would fail.  This fixes the issue by doing 2 things:

a) convert empty string to nil at repo creation time
b) explicitly do not accept empty string in the url validator
