### PR TITLE
Fixes #5160, BZ1082163 - limit content view descriptions to 255 chars.

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -60,6 +60,7 @@ class ContentView < Katello::Model
   validates :label, :uniqueness => {:scope => :organization_id},
                     :presence => true
   validates :name, :presence => true, :uniqueness => {:scope => :organization_id}
+  validates :description, :length => {:maximum => 255}
   validates :organization_id, :presence => true
   validate :check_repo_conflicts
   validate :check_puppet_conflicts

--- a/db/migrate/20140411134235_update_content_view_description_type.rb
+++ b/db/migrate/20140411134235_update_content_view_description_type.rb
@@ -1,0 +1,9 @@
+class UpdateContentViewDescriptionType < ActiveRecord::Migration
+  def up
+    change_column :katello_content_views, :description, :string, :limit => 255
+  end
+
+  def down
+    change_column :katello_content_views, :description, :text
+  end
+end


### PR DESCRIPTION
http://projects.theforeman.org/issues/5160
https://bugzilla.redhat.com/show_bug.cgi?id=1082163

Note that you may need to `katello:reset` if you have content views with a description of greater than 255 chars or remove the offending row(s).
