### PR TITLE
Fixes #5154 - CSRF related ng upload issue

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-info.html
@@ -13,7 +13,8 @@
         <form role="form"
               action="{{ uploadURL }}"
               ng-upload="uploadContent(content)"
-              upload-options-enable-controls>
+              upload-options-enable-controls
+              upload-options-enable-rails-csrf>
 
           <div class="control-group">
               <input type="file" name="content"/>

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/new/views/gpg-key-new.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/new/views/gpg-key-new.html
@@ -19,7 +19,8 @@
 
     <form name="gpgKeyForm" class="form form-horizontal" novalidate role="form"
           action="{{ uploadURL }}"
-          ng-upload="uploadContent(content)">
+          ng-upload="uploadContent(content)"
+          upload-options-enable-rails-csrf>
 
       <div alch-form-group label="{{ 'Name' | translate }}">
         <input id="name"

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
@@ -173,7 +173,8 @@
     <form role="form"
           action="{{ uploadURL }}"
           ng-upload="uploadContent(content)"
-          upload-options-enable-controls>
+          upload-options-enable-controls
+          upload-options-enable-rails-csrf>
 
       <div class="control-group">
         <div class="input">

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/views/manifest-import.html
@@ -49,7 +49,8 @@
   <form role="form"
         action="{{ uploadURL }}"
         ng-upload="uploadManifest(content, completed)"
-        upload-options-enable-controls>
+        upload-options-enable-controls
+        upload-options-enable-rails-csrf>
 
     <div class="control-group">
       <div class="input">


### PR DESCRIPTION
Fixes the following cases
1) Manifest Import
2) Repository Info puppet module upload
3) Gpg key upload
After the following change in foreman https://github.com/theforeman/foreman/commit/73f99b5c79de3d2a6b65e8833c6be72117ca1257
the upload code would stop working because csrf tokens were not
being sent as a part of the session.
This commit fixes that issue
