### PR TITLE
Fixes #5194: Properly loads Bastion UI after session timeout and subsequ...

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/activation-keys.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/activation-keys.module.js
@@ -34,7 +34,7 @@ angular.module('Bastion.activation-keys').config(['$stateProvider', function ($s
         templateUrl: 'activation-keys/views/activation-keys.html'
     })
     .state('activation-keys.index', {
-        url: '/activation-keys',
+        url: '/activation_keys',
         views: {
             'table': {
                 templateUrl: 'activation-keys/views/activation-keys-table-full.html'
@@ -42,7 +42,7 @@ angular.module('Bastion.activation-keys').config(['$stateProvider', function ($s
         }
     })
     .state('activation-keys.new', {
-        url: '/activation-keys/new',
+        url: '/activation_keys/new',
         collapsed: true,
         views: {
             'table': {
@@ -57,7 +57,7 @@ angular.module('Bastion.activation-keys').config(['$stateProvider', function ($s
 
     $stateProvider.state("activation-keys.details", {
         abstract: true,
-        url: '/activation-keys/:activationKeyId',
+        url: '/activation_keys/:activationKeyId',
         collapsed: true,
         views: {
             'table': {

--- a/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
@@ -99,6 +99,16 @@ angular.module('Bastion').config(
 
         $httpProvider.interceptors.push('PrefixInterceptor');
         $httpProvider.interceptors.push('UnauthorizedInterceptor');
+
+        $urlRouterProvider.when('/', ['$location', '$window', function ($location, $window) {
+            var path = $window.location.pathname;
+
+            path = path.replace('/katello', '');
+
+            if (path.indexOf('.html') === -1) {
+                $location.path(path);
+            }
+        }]);
     }]
 );
 

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/sync-plans.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/sync-plans.module.js
@@ -40,7 +40,7 @@ angular.module('Bastion.sync-plans').config(['$stateProvider', function ($stateP
         templateUrl: 'sync-plans/views/sync-plans.html'
     })
     .state('sync-plans.index', {
-        url: '/sync-plans',
+        url: '/sync_plans',
         views: {
             'table': {
                 templateUrl: 'sync-plans/views/sync-plans-table-full.html'
@@ -65,7 +65,7 @@ angular.module('Bastion.sync-plans').config(['$stateProvider', function ($stateP
 
     .state("sync-plans.details", {
         abstract: true,
-        url: '/sync-plans/:syncPlanId',
+        url: '/sync_plans/:syncPlanId',
         collapsed: true,
         views: {
             'table': {

--- a/engines/bastion/app/assets/javascripts/bastion/system-groups/system-groups.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/system-groups/system-groups.module.js
@@ -32,7 +32,7 @@ angular.module('Bastion.system-groups').config(['$stateProvider', function ($sta
         templateUrl: 'system-groups/views/system-groups.html'
     })
     .state('system-groups.index', {
-        url: '/system-groups',
+        url: '/system_groups',
         views: {
             'table': {
                 templateUrl: 'system-groups/views/system-groups-table-full.html'
@@ -53,7 +53,7 @@ angular.module('Bastion.system-groups').config(['$stateProvider', function ($sta
         }
     })
     .state('system-groups.new.form', {
-        url: '/system-groups/new',
+        url: '/system_groups/new',
         collapsed: true,
         controller: 'SystemGroupFormController',
         templateUrl: 'system-groups/new/views/system-group-new-form.html'
@@ -61,7 +61,7 @@ angular.module('Bastion.system-groups').config(['$stateProvider', function ($sta
 
     $stateProvider.state("system-groups.details", {
         abstract: true,
-        url: '/system-groups/:systemGroupId',
+        url: '/system_groups/:systemGroupId',
         collapsed: true,
         views: {
             'table': {


### PR DESCRIPTION
...ent redirect.

Bastion pages are driven off routes attached to the HTML anchor. The
anchor is not passed down to the web server, thus whenever a session
timeout occurs the user is redirected to the proper page but lacks
the anchor which tells our angular routing what to load. Since all of our
pages include the base route, this adds a check if the hash-path is empty
to inspect the full url, extract the current entity page and add that
to the hash-path. This assumes that the structure of our pages is
'/katello/entity#/entity'.
