### PR TITLE
Fixes #5236 - Speed up content view publish

### DIFF
--- a/app/models/katello/glue/elastic_search/backend_indexed_model.rb
+++ b/app/models/katello/glue/elastic_search/backend_indexed_model.rb
@@ -11,6 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 module Katello
 module Glue::ElasticSearch::BackendIndexedModel
+  UPDATE_BATCH_SIZE = 200
 
   def self.included(base)
     base.send :include, InstanceMethods
@@ -40,7 +41,9 @@ module Glue::ElasticSearch::BackendIndexedModel
           :script => script
         }
       end
-      Tire.index(obj_class.index).bulk_update(documents)
+      documents.in_groups_of(UPDATE_BATCH_SIZE, false) do |docs|
+        Tire.index(obj_class.index).bulk_update(docs)
+      end
       Tire.index(self.index).refresh
     end
 


### PR DESCRIPTION
Sped up indexing content for a RHEL content view from 20 min to 30-40 seconds.
