### PR TITLE
fixes #5234 - content dashboard - fix system group links

### DIFF
--- a/app/views/katello/dashboard/_system_group_item.html.haml
+++ b/app/views/katello/dashboard/_system_group_item.html.haml
@@ -2,17 +2,17 @@
 
   .col_1
     - if updates == :critical
-      %a{:href => "#{generate_url(system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Critical')}"}
+      %a{:href => "#{system_groups_path}#/system-groups/#{group.id}/actions", :title => "#{_('Critical')}"}
         .status_icon.red
     - elsif updates == :warning
-      %a{:href => "#{generate_url(system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Warning')}"}
+      %a{:href => "#{system_groups_path}#/system-groups/#{group.id}/actions", :title => "#{_('Warning')}"}
         .status_icon.yellow
     - else
-      %a{:href => "#{generate_url(system_groups_path, {:id => group.id, :panel_page => "errata"}, "system_group")}", :title => "#{_('Up to date')}"}
+      %a{:href => "#{system_groups_path}#/system-groups/#{group.id}/actions", :title => "#{_('Up to date')}"}
         .status_icon.green
 
   .col_2.one-line-ellipsis
-    = link_to(group.name, generate_url(system_groups_path, {:id => group.id, :panel_page => "edit"}, "system_group"))
+    = link_to(group.name, "#{system_groups_path}#/system-groups/#{group.id}/info")
 
   .col_3.one-line-ellipsis
-    = link_to(group.systems.length, generate_url(system_groups_path, {:id => group.id, :panel_page => "systems"}, "system_group"))
+    = link_to(group.systems.length, "#{system_groups_path}#/system-groups/#{group.id}/systems")


### PR DESCRIPTION
Updating the system group widget to point to the nutupane system
groups page.
