### PR TITLE
fixes 5233 - System Groups UI - fix cross-linking to the systems page

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/system-groups/details/views/system-group-add-content-hosts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/system-groups/details/views/system-group-add-content-hosts.html
@@ -69,7 +69,7 @@
                      ng-change="itemSelected(contentHost)"/>
             </td>
             <td alch-table-cell>
-              <a ui-sref="content-hosts.details.info({contentHostId: contentHost.id})">
+              <a ui-sref="content-hosts.details.info({contentHostId: contentHost.uuid})">
                 {{ contentHost.name }}
               </a>
             </td>

--- a/engines/bastion/app/assets/javascripts/bastion/system-groups/details/views/system-group-content-hosts-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/system-groups/details/views/system-group-content-hosts-list.html
@@ -64,7 +64,7 @@
         <tbody>
           <tr alch-table-row ng-repeat="contentHost in contentHostsTable.rows" row-select="contentHost">
             <td alch-table-cell >
-              <a ui-sref="content-hosts.details.info({contentHostId: contentHost.id})">
+              <a ui-sref="content-hosts.details.info({contentHostId: contentHost.uuid})">
                 {{ contentHost.name}}
               </a>
             </td>


### PR DESCRIPTION
The cross-linking is using the active record id; however, the systems
page expects the system uuid to be used.
