### PR TITLE
fixes #5232 - System Groups UI - fix link from system count to the group's System list.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/system-groups/views/system-groups-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/system-groups/views/system-groups-table-full.html
@@ -16,7 +16,7 @@
         <i class="icon-chevron-right selected-icon" ng-show="group.selected"></i>
       </td>
       <td alch-table-cell>
-        <a ui-sref="system-groups.details.content-hosts({systemGroupId: group.id})">
+        <a ui-sref="system-groups.details.content-hosts.list({systemGroupId: group.id})">
           {{ group.total_systems }}
         </a>
       </td>


### PR DESCRIPTION
Minor change so that clicking on the system count from the System Groups
list will take the user to the group's System list.
