### PR TITLE
fixes #5257 - UI - fix product create and manifest import

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/products/new/product-form.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/products/new/product-form.controller.js
@@ -13,12 +13,11 @@
 
 /**
  * @ngdoc object
- * @name  Bastion.products.controller:ProducFormController
+ * @name  Bastion.products.controller:ProductFormController
  *
  * @requires $scope
  * @requires $q
  * @requires Product
- * @requires Provider
  * @requires GPGKey
  * @requires SyncPlan
  * @requires FormUtils
@@ -29,14 +28,8 @@
  *   within the table.
  */
 angular.module('Bastion.products').controller('ProductFormController',
-    ['$scope', '$q', 'Product', 'Provider', 'GPGKey', 'SyncPlan', 'FormUtils',
-    function ($scope, $q, Product, Provider, GPGKey, SyncPlan, FormUtils) {
-
-        function fetchProviders() {
-            Provider.queryUnpaged(function (providers) {
-                $scope.providers = providers.results;
-            });
-        }
+    ['$scope', '$q', 'Product', 'GPGKey', 'SyncPlan', 'FormUtils',
+    function ($scope, $q, Product, GPGKey, SyncPlan, FormUtils) {
 
         function fetchGpgKeys() {
             GPGKey.queryUnpaged(function (gpgKeys) {
@@ -53,13 +46,12 @@ angular.module('Bastion.products').controller('ProductFormController',
         function populateSelects() {
             var deferred = $q.defer();
 
-            $scope.$watch("providers && gpgKeys && syncPlans", function (value) {
+            $scope.$watch("gpgKeys && syncPlans", function (value) {
                 if (value !== undefined) {
                     deferred.resolve(true);
                 }
             });
 
-            fetchProviders();
             fetchGpgKeys();
             fetchSyncPlans();
 

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/subscriptions.controller.js
@@ -79,7 +79,7 @@ angular.module('Bastion.subscriptions').controller('SubscriptionsController',
             }
         };
 
-        $scope.providers = Provider.queryUnpaged({ 'provider_type': 'Red Hat' }, function (response) {
+        $scope.providers = Provider.queryUnpaged({ 'organization_id': CurrentOrganization, 'provider_type': 'Red Hat' }, function (response) {
             $scope.provider = _.first(response.results);
         });
 


### PR DESCRIPTION
Recently some changes went in to ensure consistency in the UI for
paged and non-paged queries.  In the process, a couple of issues
arose.  This commit addresses those 2 items:
1. manifest import - update the query sent to server to include organization_id
2. product create - remove unnecessary provider requests to the server
