### PR TITLE
Fixes #5418 - Migration for adding anonymous providers

### DIFF
--- a/db/migrate/20140423191446_add_anonymous_providers_to_orgs.rb
+++ b/db/migrate/20140423191446_add_anonymous_providers_to_orgs.rb
@@ -1,0 +1,9 @@
+class AddAnonymousProvidersToOrgs < ActiveRecord::Migration
+  def up
+    Organization.all.each do |org|
+      if org.anonymous_provider.nil?
+        Katello::Provider.create!(:name => Katello::Provider::ANONYMOUS, :provider_type => Katello::Provider::ANONYMOUS, :organization => org)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need every org to have an anonymous provider.
THis case has been covered for new orgs,
The migration script will update the orgs
that were created before the 'Centralized Provider'
commit.
