### PR TITLE
fixes #5411 - precreating backend object search indexes

### DIFF
--- a/app/lib/katello/util/search.rb
+++ b/app/lib/katello/util/search.rb
@@ -62,6 +62,14 @@ module Util
       initial_list + subclass_list
     end
 
+    def self.backend_search_classes
+      [Katello::Package,
+       Katello::Errata,
+       Katello::Pool,
+       Katello::PuppetModule,
+       Katello::PackageGroup]
+    end
+
     def self.get_subclasses(obj_class)
       classes = obj_class.subclasses
       subs = classes.collect {|c| get_subclasses(c) }.flatten

--- a/app/models/katello/glue/elastic_search/backend_indexed_model.rb
+++ b/app/models/katello/glue/elastic_search/backend_indexed_model.rb
@@ -47,6 +47,10 @@ module Glue::ElasticSearch::BackendIndexedModel
       Tire.index(self.index).refresh
     end
 
+    def delete_index
+      Tire.index(self.index).delete
+    end
+
     def create_index
       unless index_exists?
         class_obj = self

--- a/app/models/katello/glue/elastic_search/pool.rb
+++ b/app/models/katello/glue/elastic_search/pool.rb
@@ -18,6 +18,17 @@ module Glue::ElasticSearch::Pool
   def self.included(base)
 
     base.class_eval do
+
+      include Glue::ElasticSearch::BackendIndexedModel
+
+      def self.search_type
+        :pool
+      end
+
+      def self.index
+        "#{Katello.config.elastic_index}_pool"
+      end
+
       # Most ActiveRecord models that need to be indexed do so through including IndexedModel. Since not all Pool
       # objects are persisted, this could lead to confusion and unnecessary overhead. (Only Pools referenced by
       # ActivationKeys are stored.) The methods below are the infrastructure for indexing the Pool objects.
@@ -153,10 +164,6 @@ module Glue::ElasticSearch::Pool
                 }
             }
         }
-      end
-
-      def self.index
-        "#{Katello.config.elastic_index}_pool"
       end
 
       def self.expiration_filter(filter_name)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,3 +78,5 @@ ConfigTemplate.where(:name => "Katello Kickstart Default for RHEL").first_or_cre
 ConfigTemplate.where(:name => "subscription_manager_registration").first_or_create!(
     :snippet  => true,
     :template => File.read("#{Katello::Engine.root}/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb"))
+
+Katello::Util::Search.backend_search_classes.each{|c| c.create_index}

--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -37,11 +37,7 @@ namespace :katello do
         Tire.index(model.index.name).delete
       end
 
-      Tire.index(Katello::Package.index).delete
-      Tire.index(Katello::Errata.index).delete
-      Tire.index(Katello::PackageGroup.index).delete
-      Tire.index(Katello::PuppetModule.index).delete
-      Tire.index(Katello::Pool.index).delete
+      Katello::Util::Search.backend_search_classes.each{|c| c.delete_index}
       puts "Elasticsearch Indices cleared."
     end
   end


### PR DESCRIPTION
 As part of this, updated the pool object to include BackendIndexedModel
