### PR TITLE
Fixes #5186, #5189 - Content Host - show provisioning details and cross-link to foreman host

### DIFF
--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -33,6 +33,7 @@ class System < Katello::Model
   after_rollback :rollback_on_create, :on => :create
 
   belongs_to :environment, :class_name => "Katello::KTEnvironment", :inverse_of => :systems
+  belongs_to :foreman_host, :class_name => "Host::Managed", :foreign_key => :host_id
 
   has_many :task_statuses, :class_name => "Katello::TaskStatus", :as => :task_owner, :dependent => :destroy
   has_many :system_activation_keys, :class_name => "Katello::SystemActivationKey", :dependent => :destroy

--- a/app/views/katello/api/v2/systems/show.json.rabl
+++ b/app/views/katello/api/v2/systems/show.json.rabl
@@ -7,6 +7,25 @@ attributes :name, :description
 attributes :location
 attributes :content_view, :content_view_id
 
+child :foreman_host => :host do
+  attributes :id, :name
+  attributes :host_status => :status
+  attributes :last_report
+
+  child :environment => :puppet_environment do
+    attributes :id, :name
+  end
+  child :operatingsystem do
+    attributes :id, :name, :description
+  end
+  child :model do
+    attributes :id, :name
+  end
+  child :hostgroup do
+    attributes :id, :name
+  end
+end
+
 child :system_groups => :systemGroups do
   attributes :id, :name, :description, :max_systems, :total_systems
 end

--- a/db/migrate/20140425155126_add_host_id_to_system.rb
+++ b/db/migrate/20140425155126_add_host_id_to_system.rb
@@ -1,0 +1,13 @@
+class AddHostIdToSystem < ActiveRecord::Migration
+  def up
+    add_column :katello_systems, :host_id, :integer
+    add_index :katello_systems, :host_id
+    add_foreign_key 'katello_systems', 'hosts', :name => 'katello_systems_host_id', :column => 'host_id'
+  end
+
+  def down
+    remove_foreign_key 'katello_systems', :name => :katello_systems_host_id
+    remove_index :katello_systems, :host_id
+    remove_column :katello_systems, :host_id
+  end
+end

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts-helper.service.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts-helper.service.js
@@ -21,6 +21,18 @@
 angular.module('Bastion.content-hosts').service('ContentHostsHelper',
     function () {
 
+        // The color mapping used here is based upon the mapping utilized by when it displays Host status
+        var hostStatusColorMap = {
+            'Pending Installation': 'light-blue',
+            'Alerts disabled': 'gray',
+            'No reports': 'gray',
+            'Out of sync': 'orange',
+            'Error': 'red',
+            'Active': 'light-blue',
+            'Pending': 'orange',
+            'No Change': 'green'
+        };
+
         this.getStatusColor = function (status) {
             var colors = {
                     'valid': 'green',
@@ -31,5 +43,14 @@ angular.module('Bastion.content-hosts').service('ContentHostsHelper',
             return colors[status] ? colors[status] : 'red';
         };
 
+        this.getProvisioningStatusColor = function (status) {
+            var  color;
+            if (status !== undefined) {
+                if ((color = hostStatusColorMap[status]) === undefined) {
+                    throw "Unknown status = " + status;
+                }
+            }
+            return color;
+        };
     }
 );

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.controller.js
@@ -54,6 +54,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
         }
 
         $scope.contentHostTable.getStatusColor = ContentHostsHelper.getStatusColor;
+        $scope.contentHostTable.getProvisioningStatusColor = ContentHostsHelper.getProvisioningStatusColor;
 
         $scope.contentHostTable.closeItem = function () {
             $scope.transitionTo('content-hosts.index');

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
@@ -89,6 +89,11 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
         collapsed: true,
         controller: 'ContentHostDetailsInfoController',
         templateUrl: 'content-hosts/details/views/content-host-info.html'
+    })
+    .state('content-hosts.details.provisioning', {
+        url: '/provisioning',
+        collapsed: true,
+        templateUrl: 'content-hosts/details/views/content-host-provisioning-info.html'
     });
 
     $stateProvider.state('content-hosts.details.tasks', {

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-details.html
@@ -32,6 +32,12 @@
           Details
         </a>
       </li>
+      <li ng-class="{active: isState('content-hosts.details.provisioning')}">
+        <a translate
+           ui-sref="content-hosts.details.provisioning">
+          Provisioning Details
+        </a>
+      </li>
       <li ng-class="{active: isState('content-hosts.details.subscriptions.list')}">
         <a translate
            ui-sref="content-hosts.details.subscriptions.list">

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-provisioning-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-provisioning-info.html
@@ -1,0 +1,62 @@
+<span page-title ng-model="contentHost">{{ 'Content Host' | translate }} {{ contentHost.name }}</span>
+
+<section>
+  <div class="details fl">
+
+    <section ng-show="!contentHost.host">
+      <div translate>No provisioning details are available for this content host.</div>
+    </section>
+
+    <section ng-hide="!contentHost.host">
+
+      <h4 translate>Provisioning Host Details</h4>
+
+      <div class="detail">
+        <span class="info-label" translate>Name</span>
+        <span class="info-value">
+          <a href="/hosts/{{ contentHost.host.name }}">
+            {{ contentHost.host.name }}
+          </a>
+        </span>
+      </div>
+
+      <div class="detail">
+        <span class="info-label" translate>Status</span>
+        <span class="info-value">
+          <i class="icon-circle provisioning-status" ng-class="contentHostTable.getProvisioningStatusColor(contentHost.host.status)"></i>
+          {{ contentHost.host.status | translate }}
+        </span>
+      </div>
+
+      <div class="detail">
+        <span class="info-label" translate>Operating System</span>
+        <span class="info-value">{{ contentHost.host.operatingsystem.description }}</span>
+      </div>
+
+      <div class="detail">
+        <span class="info-label" translate>Puppet Environment</span>
+        <span class="info-value">{{ contentHost.host.puppet_environment.name }}</span>
+      </div>
+
+      <div class="detail">
+        <span class="info-label" translate>Last Puppet Report</span>
+        <span class="info-value">{{ contentHost.host.last_report | date:'short' }}</span>
+      </div>
+
+      <div class="detail">
+        <span class="info-label" translate>Model</span>
+        <span class="info-value">{{ contentHost.host.model.name }}</span>
+      </div>
+
+      <div class="detail">
+        <span class="info-label" translate>Host Group</span>
+        <span class="info-value">
+          <a href="/hostgroups/{{ contentHost.host.hostgroup.id }}-{{ contentHost.host.hostgroup.name }}/edit">
+            {{ contentHost.host.hostgroup.name }}
+          </a>
+        </span>
+      </div>
+
+    </section>
+  </div>
+</section>

--- a/engines/bastion/app/assets/stylesheets/bastion/bastion.less
+++ b/engines/bastion/app/assets/stylesheets/bastion/bastion.less
@@ -50,6 +50,15 @@
     &.red {
       color: #9e292b;
     }
+    &.light-blue {
+      color: @brand-info;
+    }
+    &.gray {
+      color: @gray-light;
+    }
+    &.orange {
+      color: @brand-warning;
+    }
   }
 
   .leading-icon {

--- a/engines/bastion/test/content-hosts/content-hosts-helper.service.test.js
+++ b/engines/bastion/test/content-hosts/content-hosts-helper.service.test.js
@@ -25,4 +25,15 @@ describe('Controller: ContentHostsController', function() {
         expect(ContentHostsHelper.getStatusColor("partial")).toBe("yellow");
         expect(ContentHostsHelper.getStatusColor("error")).toBe("red");
     });
+
+    it("provides a way to get the status color for the provisioning host.", function() {
+        expect(ContentHostsHelper.getProvisioningStatusColor("Pending Installation")).toBe("light-blue");
+        expect(ContentHostsHelper.getProvisioningStatusColor("Alerts disabled")).toBe("gray");
+        expect(ContentHostsHelper.getProvisioningStatusColor("No reports")).toBe("gray");
+        expect(ContentHostsHelper.getProvisioningStatusColor("Out of sync")).toBe("orange");
+        expect(ContentHostsHelper.getProvisioningStatusColor("Error")).toBe("red");
+        expect(ContentHostsHelper.getProvisioningStatusColor("Active")).toBe("light-blue");
+        expect(ContentHostsHelper.getProvisioningStatusColor("Pending")).toBe("orange");
+    });
+
 });


### PR DESCRIPTION
This commit contains a few basic changes, including:
1. Add a foreign key to katello's system to enable associating it to a foreman host
2. Add a 'Provisioning Details' tab to a katello content host
3. Add high-level information from foreman to the provisioning details.  At this time,
   this includes the information that is currently shown from foreman host list,
   such as name, status, OS, puppet environment, last puppet report, model & host group.
4. Provide cross-linking (where possible) from the katello content host to the foreman host.
   This currently supports linking to the host as well as hostgroup.

This commit does not include the logic to actually associate the katello content host
to the foreman host.  That work will be done separately.  To test this, the association
was manually done using rails console.

![provision-details-none-available](https://cloud.githubusercontent.com/assets/1319246/2830836/d411aad0-cfb2-11e3-943b-e44564d4c8d6.png)

![provisioning-details](https://cloud.githubusercontent.com/assets/1319246/2830839/da1c218a-cfb2-11e3-995c-bb8c10eba23e.png)
