### PR TITLE
Fixes #5008 Manifest History not updated on import

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -16,7 +16,9 @@ module Katello
     include Api::V2::Rendering
     include ForemanTasks::Triggers
 
-    before_filter :local_find_taxonomy, :only => %w{repo_discover cancel_repo_discover download_debug_certificate redhat_provider update}
+    before_filter :local_find_taxonomy, :only => %w{repo_discover cancel_repo_discover
+                                                    download_debug_certificate
+                                                    redhat_provider update}
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -17,7 +17,8 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
   before_filter :find_activation_key
   before_filter :find_system
   before_filter :find_optional_organization, :only => [:index, :available, :show]
-  before_filter :find_organization, :only => [:upload, :delete_manifest, :refresh_manifest]
+  before_filter :find_organization, :only => [:upload, :delete_manifest,
+                                              :refresh_manifest, :manifest_history]
   before_filter :find_provider
 
   # Authorize must be before find_subscription since find_subscription reaches out to Candlepin
@@ -56,7 +57,8 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
       :available => available_test,
       :upload => edit_test,
       :delete_manifest => edit_test,
-      :refresh_manifest => edit_test
+      :refresh_manifest => edit_test,
+      :manifest_history => read_test
     }
   end
 
@@ -205,6 +207,13 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
   def delete_manifest
     task = async_task(::Actions::Katello::Provider::ManifestDelete, @provider)
     respond_for_async :resource => task
+  end
+
+  api :GET, "/organizations/:organization_id/subscriptions/manifest_history", "obtain manifest history for subscriptions"
+  param :organization_id, :identifier, :desc => "Organization ID", :required => true
+  def manifest_history
+    @manifest_history = @organization.manifest_history
+    respond_with_template_collection(params[:action], "subscriptions", {collection: @manifest_history})
   end
 
   protected

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -120,6 +120,10 @@ module Katello
           self.providers.anonymous.first
         end
 
+        def manifest_history
+          imports.map{ |i| OpenStruct.new(i) }
+        end
+
         def repo_discovery_task
           self.task_statuses.where(:task_type => :repo_discovery).order('created_at DESC').first
         end

--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -129,6 +129,9 @@ module Glue::Candlepin::Owner
       Resources::Candlepin::Owner.auto_attach(self.label)
     end
 
+    def imports
+      Resources::Candlepin::Owner.imports(self.label)
+    end
   end
 
 end

--- a/app/views/katello/api/v2/subscriptions/manifest_history.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/manifest_history.json.rabl
@@ -1,0 +1,2 @@
+collection @manifest_history
+attributes :statusMessage, :status, :created

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -102,6 +102,7 @@ Katello::Engine.routes.draw do
           end
         end
         member do
+          get :manifest_history
           post :repo_discover
           post :cancel_repo_discover
           post :autoattach_subscriptions
@@ -112,6 +113,7 @@ Katello::Engine.routes.draw do
         api_resources :subscriptions, :only => [:index] do
           collection do
             match '/available' => 'subscriptions#available', :via => :get
+            get :manifest_history
           end
         end
         api_resources :system_groups, :only => [:index, :create]

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/manifest-history.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/manifest-history.controller.js
@@ -21,8 +21,11 @@
  *   Controls the import of a manifest.
  */
 angular.module('Bastion.subscriptions').controller('ManifestHistoryController',
-    ['$scope', function ($scope) {
-        $scope.manifestStatuses = $scope.manifestHistory();
-        $scope.panel.loading = false;
+    ['$scope', 'Subscription', function ($scope, Subscription) {
+        $scope.histories = Subscription.manifestHistory();
+        $scope.histories.$promise.then(function (result) {
+            $scope.statuses = result;
+            $scope.panel.loading = false;
+        });
     }]
 );

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/manifest.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/manifest.controller.js
@@ -17,31 +17,13 @@
  *
  * @requires $scope
  * @requires translate
+ * @requires ManifestHistoryService
  *
  * @description
  *   Controls the managment of manifests for use by sub-controllers.
  */
 angular.module('Bastion.subscriptions').controller('ManifestController',
-    ['$scope', 'translate',
-    function ($scope, translate) {
-
+    ['$scope', function ($scope) {
         $scope.panel = {loading: true};
-
-        $scope.manifestHistory = function () {
-            var statuses = [];
-
-            angular.forEach($scope.redhatProvider['owner_imports'], function (value) {
-                statuses.push(value);
-
-                if (value['webAppPrefix'] !== undefined) {
-                    var message = translate("Manifest from %s.").replace('%s', value['upstreamName']);
-                    statuses.push({statusMessage: message, created: value.created});
-                }
-
-            });
-
-            return statuses;
-        };
-
     }]
 );

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/views/manifest-import-history.html
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/views/manifest-import-history.html
@@ -6,12 +6,12 @@
     </tr>
   </thead>
   <tbody>
-    <tr ng-repeat="status in manifestStatuses">
-      <td>
-        <span ng-class="status.status == 'FAILURE' ? 'icon-warning-sign' : 'icon-ok'" />
-        {{ status.statusMessage }}
-      </td>
-      <td>{{ status.created | date:"short" }}</td>
+    <tr ng-repeat="status in statuses track by $index">
+        <td>
+          <i ng-class="status.status == 'FAILURE' ? 'icon-warning-sign' : 'icon-ok'" />
+          {{ status.statusMessage }}
+        </td>
+        <td>{{ status.created | date:"short" }}</td>
     </tr>
   </tbody>
 </table>

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/subscriptions.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/subscriptions.factory.js
@@ -36,6 +36,13 @@ angular.module('Bastion.subscriptions').factory('Subscription', ['BastionResourc
                     method: 'PUT',
                     url: '/api/v2/organizations/:org/subscriptions/refresh_manifest',
                     params: {'org': CurrentOrganization}
+                },
+
+                manifestHistory: {
+                    method: 'GET',
+                    url:  '/api/v2/organizations/:org/subscriptions/:action',
+                    params: {action: 'manifest_history'},
+                    isArray: true
                 }
             });
     }]

--- a/engines/bastion/test/subscriptions/manifest/manifest-import.controller.test.js
+++ b/engines/bastion/test/subscriptions/manifest/manifest-import.controller.test.js
@@ -47,17 +47,17 @@ describe('Controller: ManifestImportController', function() {
             translate;
         Organization = $injector.get('Organization');
         Subscription = $injector.get('Subscription');
+        $httpBackend.expectGET('/api/organization/ACME/subscriptions/manifest_history').respond([]);
+        $httpBackend.expectGET('/api/v2/organizations/ACME/redhat_provider').respond({name: "Red Hat"});
         $httpBackend.expectGET('/api/organization/ACME').respond(organization);
         $httpBackend.expectGET('/api/v2/organizations/ACME/redhat_provider').respond({name: "Red Hat"});
 
         $scope = $injector.get('$rootScope').$new();
         $q = $injector.get('$q');
         $scope.redhatProvider = Organization.redhatProvider();
+        $scope.histories = Subscription.manifestHistory();
 
         Task = {registerSearch: function() {}};
-
-        // stub out manifestHistory since it's being tested elsewhere
-        $scope.manifestHistory = function(prov) { return history; };
 
         translate = function(a) { return a };
 
@@ -137,10 +137,15 @@ describe('Controller: ManifestImportController', function() {
         });
     });
 
-    it('should refresh organization info when requested', function() {
+    it('should refresh organization info when requested', function () {
         spyOn(Organization, 'get').andCallThrough();
         $scope.refreshOrganizationInfo();
         expect(Organization.get).toHaveBeenCalled();
-    })
+    });
 
+    it('should truncate the histories', function () {
+        var histories = [{}, {}, {}, {}, {}];
+        var result = $scope.truncateHistories($scope.histories);
+        expect(result.length).toBeLessThan(histories.length);
+    });
 });

--- a/engines/bastion/test/subscriptions/manifest/manifest.controller.test.js
+++ b/engines/bastion/test/subscriptions/manifest/manifest.controller.test.js
@@ -21,47 +21,11 @@ describe('Controller: ManifestController', function() {
 
         translate = function(a) { return a };
         $scope = $rootScope.$new();
+        Subscription = $injector.get('Subscription');
         $controller('ManifestController', {
             $scope: $scope,
             translate: translate,
-
+            Subscription: Subscription
         });
     }));
-
-
-    it("should provide a method to get history for a provider", function() {
-        var provider,
-            history;
-
-        provider = {
-            name: "Red Hat",
-            id: 1,
-            owner_imports: [
-                {
-                    statusMessage: "metamorphosis by kafka",
-                    created: "1915-10-25"
-                },
-                {
-                    webAppPrefix: "dickens",
-                    upstreamName: "bleakhouse",
-                    created: "1852-03-03"
-                }
-            ]
-        };
-
-        history = provider.owner_imports.slice(0);
-        history.push({
-            statusMessage: "Manifest from bleakhouse.",
-            created: "1852-03-03"
-        });
-
-        $scope.redhatProvider = provider;
-
-        expect($scope.manifestHistory(provider)).toEqual(history);
-        expect($scope.manifestHistory(provider).length).toBe(3);
-        expect($scope.manifestHistory(provider)[0]).toBe(history[0]);
-        expect($scope.manifestHistory(provider)[1]).toBe(history[1]);
-        expect($scope.manifestHistory(provider)[2].statusMessage).toBe(history[2].statusMessage);
-        expect($scope.manifestHistory(provider)[2].created).toBe(history[2].created);
-    });
 });

--- a/engines/bastion/test/subscriptions/subscriptions.factory.test.js
+++ b/engines/bastion/test/subscriptions/subscriptions.factory.test.js
@@ -59,4 +59,10 @@ describe('Factory: Subscription', function() {
         });
     });
 
+    it('provides a way to get a manifest history', function() {
+        $httpBackend.expectGET('/api/v2/organizations/ACME/subscriptions/manifest_history?').respond([]);
+        Subscription.manifestHistory(function(result){
+            expect(result).not.toBeUndefined();
+        });
+    });
 });

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -183,7 +183,14 @@ describe Organization do
        lambda{Organization.find(@organization.id)}.must_raise(ActiveRecord::RecordNotFound)
        KTEnvironment.where(:name =>'Dev-34343').size.must_equal(0)
     end
+  end
 
+  describe "it can retrieve manifest history" do
+    test 'test manifest history should be successful' do 
+      @organization = @organization.reload
+      @organization.expects(:imports).returns([{'foo' => 'bar' },{'foo' => 'bar'}])
+      assert @organization.manifest_history[0].foo == 'bar'
+    end
   end
 end
 end

--- a/test/controllers/api/v2/subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/subscriptions_controller_test.rb
@@ -173,5 +173,20 @@ class Api::V2::SubscriptionsControllerTest < ActionController::TestCase
       post :delete_manifest, :organization_id => @organization.label
     end
   end
+
+  def test_manifest_history
+    Organization.any_instance.stubs(:manifest_history).returns(OpenStruct.new({status: 'FAILED', statusMessage: 'failed to create'}))
+    get :manifest_history, :organization_id => @organization.label
+    assert_response :success
+  end
+
+  def test_manifest_history_protected
+    allowed_perms = [@read_permission]
+    denied_perms = [@no_permission]
+
+    assert_protected_action(:manifest_history, allowed_perms, denied_perms) do
+      get :manifest_history, :organization_id => @organization.label
+    end
+  end
 end
 end


### PR DESCRIPTION
- BZ1077893
- updates manifest file history on import/delete
- exposes import history from the organization and subscription
