### PR TITLE
Fixes #5515, adding Bastion config directory to whitelist for RPMs.

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.description = ""
 
   gem.files = Dir["{app,vendor,lib,db,ca,config,locale}/**/*"] + ["LICENSE.txt", "README.md"]
-  gem.files += Dir["engines/bastion/{app,vendor,lib}/**/*"]
+  gem.files += Dir["engines/bastion/{app,vendor,lib,config}/**/*"]
   gem.files += Dir["engines/bastion/{README.md,Bastion.gemspec}"]
   gem.files += Dir["engines/fort/{app,config,db,lib}/**/*"]
   gem.files += Dir["engines/bastion/{README.md,fort.gemspec}"]


### PR DESCRIPTION
http://projects.theforeman.org/issues/5515
