### PR TITLE
Fixes #5548 - Add gemnasium to tell us about outdated gem requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Katello [![Build Status](https://travis-ci.org/Katello/katello.png?branch=master)](https://travis-ci.org/Katello/katello)
+# Katello [![Dependency Status](https://gemnasium.com/Katello/katello.svg)](https://gemnasium.com/Katello/katello)
 
 Full documentation is at http://katello.github.io/katello
 


### PR DESCRIPTION
Gemnasium will tell us if our gems are outdated. Most importantly, it also notifies us if there are security patches (with a red badge). Also, I'm removing the old Travis badge.
