### PR TITLE
Fixes #5514 Subscription Link missing in Content Host Subscriptions

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
@@ -73,7 +73,11 @@
           </tr>
           <tr alch-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
             <td alch-table-cell>{{ subscription | subscriptionAttachAmountFilter }}</td>
-            <td alch-table-cell>{{ subscription | subscriptionConsumedFilter }}</td>
+            <td alch-table-cell>
+              <a ui-sref="subscriptions.details.info({subscriptionId: subscription.subscription_id})">
+                {{ subscription | subscriptionConsumedFilter }}
+              </a>
+            </td>
             <td alch-table-cell>{{ subscription.start_date | date:"shortDate" }}</td>
             <td alch-table-cell>{{ subscription.end_date | date:"shortDate" }}</td>
             <td alch-table-cell>{{ subscription.service_level }}</td>


### PR DESCRIPTION
- bz995940
- adds links to Content Host's Subscriptions to view the details of each Subscription
