### PR TITLE
fixes #5596 - fixing errors on system registration

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -30,7 +30,7 @@ module Katello
     before_filter :find_system, :only => [:consumer_show, :consumer_destroy, :consumer_checkin,
                                           :upload_package_profile, :regenerate_identity_certificates, :facts]
     before_filter :find_user_by_login, :only => [:list_owners]
-    before_filter :authorize, :except => [:consumer_activate, :upload_package_profile]
+    before_filter :authorize, :except => [:consumer_activate]
 
     # TODO: break up method
     # rubocop:disable MethodLength
@@ -393,11 +393,6 @@ module Katello
       if value
         cve = ContentViewEnvironment.where(key => value).first
         fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % value unless cve
-        if @organization.nil? || !@organization.readable?
-          unless cve.content_view.readable? || User.consumer?
-            fail Errors::SecurityViolation, _("Could not access content view in environment '%s'") % value
-          end
-        end
       end
       cve
     end


### PR DESCRIPTION
a readable? call was occuring prior to authorized being called
Since readable? is not even the correct permission, and the
consumer_create actions handles its own permissions checking
registerable?.

The only other action that uses it is hypervisors_update,
but since this is using consumer auth, it was ignoring the
check completely
