### PR TITLE
Fixes #5613 Fixes problem with hammer only returning Bad Access when sys...

### DIFF
--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -26,6 +26,8 @@ module Api
         rescue_from ActiveRecord::RecordInvalid, :with => :rescue_from_record_invalid
         rescue_from ActiveRecord::RecordNotFound, :with => :rescue_from_record_not_found
 
+        rescue_from HttpErrors::BadRequest, :with => :rescue_from_unsupported_action_exception
+        rescue_from HttpErrors::NotFound, :with => :rescue_from_not_found
         rescue_from Errors::NotFound, :with => :rescue_from_not_found
         rescue_from Errors::SecurityViolation, :with => :rescue_from_security_violation
         rescue_from Errors::ConflictException, :with => :rescue_from_conflict_exception


### PR DESCRIPTION
...tem id is invalid

Hammer didn't know display the errors rendered after raising a HttpErrors::NotFound. 
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1084722
