### PR TITLE
Refs #4478 - Add support for localized API docs

### DIFF
--- a/app/controllers/katello/api/v1/about_controller.rb
+++ b/app/controllers/katello/api/v1/about_controller.rb
@@ -20,8 +20,8 @@ class Api::V1::AboutController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/about", "Shows status of system and it's subcomponents"
-  description "This service is only available for authenticated users"
+  api :GET, "/about", N_("Shows status of system and it's subcomponents")
+  description N_("This service is only available for authenticated users")
   def index
     @packages = Ping.packages
     @system_info = {  "Application" => Katello.config.app_name,

--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -165,13 +165,13 @@ module Katello
       render :json => r
     end
 
-    #api :GET, "/consumers/:id", "Show a system"
-    #param :id, String, :desc => "UUID of the consumer", :required => true
+    #api :GET, "/consumers/:id", N_("Show a system")
+    #param :id, String, :desc => N_("UUID of the consumer"), :required => true
     def consumer_show
       render :json => Resources::Candlepin::Consumer.get(@system.uuid)
     end
 
-    #api :GET, "/owners/:organization_id/environments", "List environments for RHSM"
+    #api :GET, "/owners/:organization_id/environments", N_("List environments for RHSM")
     def rhsm_index
       @all_environments = get_content_view_environments(query_params[:name]).collect do |env|
         {
@@ -185,23 +185,23 @@ module Katello
       respond_for_index :collection => @all_environments
     end
 
-    #api :POST, "/hypervisors", "Update the hypervisors information for environment"
+    #api :POST, "/hypervisors", N_("Update the hypervisors information for environment")
     #desc 'See virt-who tool for more details.'
     def hypervisors_update
       cp_response, _ = System.register_hypervisors(@environment, @content_view, params.except(:controller, :action, :format))
       render :json => cp_response
     end
 
-    #api :PUT, "/consumers/:id/checkin/", "Update consumer check-in time"
-    #param :date, String, :desc => "check-in time"
+    #api :PUT, "/consumers/:id/checkin/", N_("Update consumer check-in time")
+    #param :date, String, :desc => N_("check-in time")
     def consumer_checkin
       @system.checkin(params[:date])
       render :json => Resources::Candlepin::Consumer.get(@system.uuid)
     end
 
-    #api :PUT, "/consumers/:id/packages", "Update installed packages"
-    #api :PUT, "/consumers/:id/profile", "Update installed packages"
-    #param :id, String, :desc => "UUID of the consumer", :required => true
+    #api :PUT, "/consumers/:id/packages", N_("Update installed packages")
+    #api :PUT, "/consumers/:id/profile", N_("Update installed packages")
+    #param :id, String, :desc => N_("UUID of the consumer"), :required => true
     def upload_package_profile
       allowed = rules[:upload_package_profile].call
       if allowed
@@ -221,15 +221,15 @@ module Katello
       respond_for_index :collection => orgs.map { |o| { :key => o.label, :displayName => o.name } }
     end
 
-    #api :POST, "/consumers/:id", "Regenerate consumer identity"
-    #param :id, String, :desc => "UUID of the consumer"
+    #api :POST, "/consumers/:id", N_("Regenerate consumer identity")
+    #param :id, String, :desc => N_("UUID of the consumer")
     #desc 'Schedules the consumer identity certificate regeneration'
     def regenerate_identity_certificates
       @system.regenerate_identity_certificates
       render :json => Resources::Candlepin::Consumer.get(@system.uuid)
     end
 
-    #api :POST, "/environments/:environment_id/consumers", "Register a consumer in environment"
+    #api :POST, "/environments/:environment_id/consumers", N_("Register a consumer in environment")
     def consumer_create
       @system = System.new(system_params.merge(:environment  => @environment,
                                                :content_view => @content_view,
@@ -239,15 +239,15 @@ module Katello
       render :json => Resources::Candlepin::Consumer.get(@system.uuid)
     end
 
-    #api :DELETE, "/consumers/:id", "Unregister a consumer"
-    #param :id, String, :desc => "UUID of the consumer", :required => true
+    #api :DELETE, "/consumers/:id", N_("Unregister a consumer")
+    #param :id, String, :desc => N_("UUID of the consumer"), :required => true
     def consumer_destroy
       @system.destroy
       render :text => _("Deleted consumer '%s'") % params[:id], :status => 204
     end
 
     # used for registering with activation keys
-    #api :POST, "/consumers", "Register a system with activation key (compatibility)"
+    #api :POST, "/consumers", N_("Register a system with activation key (compatibility)")
     #param :activation_keys, String, :required => true
     def consumer_activate
       # Activation keys are userless by definition so use the internal generic user

--- a/app/controllers/katello/api/v1/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v1/content_uploads_controller.rb
@@ -28,33 +28,33 @@ class Api::V1::ContentUploadsController < Api::V1::ApiController
     }
   end
 
-  api :POST, "/repositories/:repo_id/content_uploads", "Create an upload request"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
+  api :POST, "/repositories/:repo_id/content_uploads", N_("Create an upload request")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
   def create
     respond :resource => Katello.pulp_server.resources.content.create_upload_request
   end
 
-  api :PUT, "/repositories/:repo_id/content_uploads/:id/upload_bits", "Upload bits"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
-  param :id, :identifier, :required => true, :desc => "upload request id"
-  param :offset, :number, :required => true, :desc => "the offset at which Pulp will store the file contents"
-  param :content, File, :required => true, :desc => "file contents"
+  api :PUT, "/repositories/:repo_id/content_uploads/:id/upload_bits", N_("Upload bits")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
+  param :id, :identifier, :required => true, :desc => N_("upload request id")
+  param :offset, :number, :required => true, :desc => N_("the offset at which Pulp will store the file contents")
+  param :content, File, :required => true, :desc => N_("file contents")
   def upload_bits
     Katello.pulp_server.resources.content.upload_bits(params[:id], params[:offset], params[:content])
     render :nothing => true
   end
 
-  api :DELETE, "/repositories/:repo_id/content_uploads/:id", "Delete an upload request"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
-  param :id, :identifier, :required => true, :desc => "upload request id"
+  api :DELETE, "/repositories/:repo_id/content_uploads/:id", N_("Delete an upload request")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
+  param :id, :identifier, :required => true, :desc => N_("upload request id")
   def destroy
     Katello.pulp_server.resources.content.delete_upload_request(params[:id])
     render :nothing => true
   end
 
-  api :POST, "/repositories/:repo_id/content_uploads/import_into_repo", "Import into a repository"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
-  param :uploads, Array, :required => true, :desc => "array of uploads to import"
+  api :POST, "/repositories/:repo_id/content_uploads/import_into_repo", N_("Import into a repository")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
+  param :uploads, Array, :required => true, :desc => N_("array of uploads to import")
   def import_into_repo
     params[:uploads].each do |upload|
       Katello.pulp_server.resources.content.import_into_repo(@repo.pulp_id, @repo.unit_type_id,
@@ -66,9 +66,9 @@ class Api::V1::ContentUploadsController < Api::V1::ApiController
     render :nothing => true
   end
 
-  api :POST, "/repositories/:id/content_uploads/file", "Upload content into the repository"
+  api :POST, "/repositories/:id/content_uploads/file", N_("Upload content into the repository")
   param :id, :identifier, :required => true
-  param :content, File, :required => true, :desc => "file contents"
+  param :content, File, :required => true, :desc => N_("file contents")
   def upload_file
     filepaths = params.try(:[], :content).try(:map, &:path)
 

--- a/app/controllers/katello/api/v1/crls_controller.rb
+++ b/app/controllers/katello/api/v1/crls_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::CrlsController < Api::V1::ApiController
     { :index => superadmin_test }
   end
 
-  api :GET, "/crls", "Regenerate X.509 CRL immediately and return them"
+  api :GET, "/crls", N_("Regenerate X.509 CRL immediately and return them")
   def index
     render :text => Resources::Candlepin::Proxy.get('/crl')
   end

--- a/app/controllers/katello/api/v1/custom_info_controller.rb
+++ b/app/controllers/katello/api/v1/custom_info_controller.rb
@@ -32,11 +32,11 @@ class Api::V1::CustomInfoController < Api::V1::ApiController
   end
 
   def_param_group :informable_identifier do
-    param :informable_type, String, :desc => "name of the resource", :required => true
-    param :informable_id, :identifier, :desc => "resource identifier", :required => true
+    param :informable_type, String, :desc => N_("name of the resource"), :required => true
+    param :informable_id, :identifier, :desc => N_("resource identifier"), :required => true
   end
 
-  api :POST, "/custom_info/:informable_type/:informable_id", "Create custom info"
+  api :POST, "/custom_info/:informable_type/:informable_id", N_("Create custom info")
   param_group :informable_identifier
   param :keyname, String, :required => true
   param :value, String, :required => true
@@ -44,22 +44,22 @@ class Api::V1::CustomInfoController < Api::V1::ApiController
     respond :resource => @informable.custom_info.create!(package_args(params))
   end
 
-  api :GET, "/custom_info/:informable_type/:informable_id", "List custom info"
+  api :GET, "/custom_info/:informable_type/:informable_id", N_("List custom info")
   param_group :informable_identifier
   def index
     respond :collection => @informable.custom_info
   end
 
-  api :GET, "/custom_info/:informable_type/:informable_id/:keyname", "Show custom info"
+  api :GET, "/custom_info/:informable_type/:informable_id/:keyname", N_("Show custom info")
   param_group :informable_identifier
-  param :keyname, String, :desc => "Custom info key", :required => true
+  param :keyname, String, :desc => N_("Custom info key"), :required => true
   def show
     respond :resource => @single_custom_info
   end
 
-  api :PUT, "/custom_info/:informable_type/:informable_id/:keyname", "Update custom info"
+  api :PUT, "/custom_info/:informable_type/:informable_id/:keyname", N_("Update custom info")
   param_group :informable_identifier
-  param :keyname, String, :desc => "Custom info key", :required => true
+  param :keyname, String, :desc => N_("Custom info key"), :required => true
   param :value, String, :required => true
   def update
     value = params[:value]
@@ -69,9 +69,9 @@ class Api::V1::CustomInfoController < Api::V1::ApiController
     respond :resource => @single_custom_info.value
   end
 
-  api :DELETE, "/custom_info/:informable_type/:informable_id/:keyname", "Delete custom info"
+  api :DELETE, "/custom_info/:informable_type/:informable_id/:keyname", N_("Delete custom info")
   param_group :informable_identifier
-  param :keyname, String, :desc => "Custom info key", :required => true
+  param :keyname, String, :desc => N_("Custom info key"), :required => true
   def destroy
     @single_custom_info.destroy
     respond :message => _("Deleted custom info '%s'") % params[:keyname], :resource => @single_custom_info

--- a/app/controllers/katello/api/v1/distributions_controller.rb
+++ b/app/controllers/katello/api/v1/distributions_controller.rb
@@ -26,13 +26,13 @@ class Api::V1::DistributionsController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/repositories/:repository_id/distributions", "List distributions"
+  api :GET, "/repositories/:repository_id/distributions", N_("List distributions")
   def index
     respond :collection => @repo.distributions
   end
 
-  api :GET, "/repositories/:repository_id/distributions/:id", "Show a distribution"
-  param :repository_id, :number, :desc => "repository numeric id"
+  api :GET, "/repositories/:repository_id/distributions/:id", N_("Show a distribution")
+  param :repository_id, :number, :desc => N_("repository numeric id")
   def show
     dist = Distribution.find(params[:id])
     respond :resource => dist

--- a/app/controllers/katello/api/v1/distributors_controller.rb
+++ b/app/controllers/katello/api/v1/distributors_controller.rb
@@ -59,23 +59,23 @@ class Api::V1::DistributorsController < Api::V1::ApiController
 
   def_param_group :distributors do
     param :distributor, Hash, :required => true, :action_aware => true do
-      param :name, String, :desc => "Name of the distributor", :required => true, :action_aware => true
-      param :facts, Hash, :desc => "Key-value hash of distributor-specific facts"
-      param :installedProducts, Array, :desc => "List of products installed on the distributor"
-      param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT"
-      param :releaseVer, String, :desc => "Release of the os. The $releasever variable in repo url will be replaced with this value"
-      param :location, String, :desc => "Physical of the distributor"
-      param :capabilities, Array, :desc => "List of subscription capabilities"
+      param :name, String, :desc => N_("Name of the distributor"), :required => true, :action_aware => true
+      param :facts, Hash, :desc => N_("Key-value hash of distributor-specific facts")
+      param :installedProducts, Array, :desc => N_("List of products installed on the distributor")
+      param :serviceLevel, String, :allow_nil => true, :desc => N_("A service level for auto-healing process, e.g. SELF-SUPPORT")
+      param :releaseVer, String, :desc => N_("Release of the os. The $releasever variable in repo url will be replaced with this value")
+      param :location, String, :desc => N_("Physical of the distributor")
+      param :capabilities, Array, :desc => N_("List of subscription capabilities")
     end
   end
 
   # this method is called from katello cli client and it does not work with activation keys
   # for activation keys there is method activate (see custom routes)
-  api :POST, "/environments/:environment_id/distributors", "Register a distributor in environment"
+  api :POST, "/environments/:environment_id/distributors", N_("Register a distributor in environment")
   param_group :distributors
   param :distributor, Hash, :required => true, :action_aware => true do
-    param :type, String, :desc => "Type of the distributor, it should always be 'distributor'", :required => true
-    param :version, String, :desc => "Version of the distributor. Defaults to the latest if not given."
+    param :type, String, :desc => N_("Type of the distributor, it should always be 'distributor'"), :required => true
+    param :version, String, :desc => N_("Version of the distributor. Defaults to the latest if not given.")
   end
   def create
     distributor_params = params[:distributor]
@@ -88,9 +88,9 @@ class Api::V1::DistributorsController < Api::V1::ApiController
     respond
   end
 
-  api :PUT, "/distributors/:id", "Update distributor information"
+  api :PUT, "/distributors/:id", N_("Update distributor information")
   param_group :distributors
-  param :capabilities, Array, :desc => "For backwards capability with Red Hat hosted candlepin - List of subscription capabilities"
+  param :capabilities, Array, :desc => N_("For backwards capability with Red Hat hosted candlepin - List of subscription capabilities")
   def update
     distributor_params = params[:distributor]
     distributor_params = params.slice(:capabilities) if distributor_params.nil?
@@ -100,10 +100,10 @@ class Api::V1::DistributorsController < Api::V1::ApiController
     respond
   end
 
-  api :GET, "/environments/:environment_id/distributors", "List distributors in environment"
-  api :GET, "/organizations/:organization_id/distributors", "List distributors in organization"
-  param :name, String, :desc => "Filter distributors by name"
-  param :pool_id, String, :desc => "Filter distributors by subscribed pool"
+  api :GET, "/environments/:environment_id/distributors", N_("List distributors in environment")
+  api :GET, "/organizations/:organization_id/distributors", N_("List distributors in organization")
+  param :name, String, :desc => N_("Filter distributors by name")
+  param :pool_id, String, :desc => N_("Filter distributors by subscribed pool")
   def index
     # expected parameters
     expected_params = params.slice(:name, :uuid)
@@ -115,14 +115,14 @@ class Api::V1::DistributorsController < Api::V1::ApiController
     respond
   end
 
-  api :GET, "/distributors/:id", "Show a distributor"
-  param :id, String, :desc => "UUID of the distributor", :required => true
+  api :GET, "/distributors/:id", N_("Show a distributor")
+  param :id, String, :desc => N_("UUID of the distributor"), :required => true
   def show
     respond
   end
 
-  api :GET, "/distributors/:id/export", "Export distributor's manifest"
-  param :id, String, :desc => "UUID of the distributor", :required => true
+  api :GET, "/distributors/:id/export", N_("Export distributor's manifest")
+  param :id, String, :desc => N_("UUID of the distributor"), :required => true
   def export
     filename = params[:filename]
     filename = 'manifest.zip' if filename.nil? || filename == ''
@@ -133,15 +133,15 @@ class Api::V1::DistributorsController < Api::V1::ApiController
               :type     => 'application/xml'
   end
 
-  api :DELETE, "/distributors/:id", "Unregister a distributor"
-  param :id, String, :desc => "UUID of the distributor", :required => true
+  api :DELETE, "/distributors/:id", N_("Unregister a distributor")
+  param :id, String, :desc => N_("UUID of the distributor"), :required => true
   def destroy
     @distributor.destroy
     respond :message => _("Deleted distributor '%s'") % params[:id]
   end
 
-  api :GET, "/distributors/:id/pools", "List pools a distributor is subscribed to"
-  param :id, String, :desc => "UUID of the distributor", :required => true
+  api :GET, "/distributors/:id/pools", N_("List pools a distributor is subscribed to")
+  param :id, String, :desc => N_("UUID of the distributor"), :required => true
   def pools
     match_distributor = params.key?(:match_distributor) ? params[:match_distributor].to_bool : false
     match_installed   = params.key?(:match_installed) ? params[:match_installed].to_bool : false
@@ -152,9 +152,9 @@ class Api::V1::DistributorsController < Api::V1::ApiController
     respond_for_index :collection => { :pools => cp_pools }
   end
 
-  api :GET, "/organizations/:organization_id/distributors/tasks", "List async tasks for the distributor"
-  param :distributor_name, String, :desc => "Name of the distributor"
-  param :distributor_uuid, String, :desc => "UUID of the distributor"
+  api :GET, "/organizations/:organization_id/distributors/tasks", N_("List async tasks for the distributor")
+  param :distributor_name, String, :desc => N_("Name of the distributor")
+  param :distributor_uuid, String, :desc => N_("UUID of the distributor")
   def tasks
     query = TaskStatus.joins(:distributor).where(:"task_statuses.organization_id" => @organization.id)
     if @environment
@@ -173,14 +173,14 @@ class Api::V1::DistributorsController < Api::V1::ApiController
     respond_for_index :collection => @tasks
   end
 
-  api :GET, "/distributors/tasks/:id", "Show details of the async task"
-  param :id, String, :desc => "UUID of the task", :required => true
+  api :GET, "/distributors/tasks/:id", N_("Show details of the async task")
+  param :id, String, :desc => N_("UUID of the task"), :required => true
   def task_show
     @task.refresh
     respond_for_show :resource => @task
   end
 
-  api :GET, "/distributor_versions", "Show the list of available distributor versions"
+  api :GET, "/distributor_versions", N_("Show the list of available distributor versions")
   def versions
     respond_for_index :collection => Distributor.available_versions
   end

--- a/app/controllers/katello/api/v1/environments_controller.rb
+++ b/app/controllers/katello/api/v1/environments_controller.rb
@@ -85,19 +85,19 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
   end
 
   def_param_group :search_params do
-    param :organization_id, :number, :desc => "organization identifier"
-    param :library, :bool, :desc => "set true if you want to see only library environment"
-    param :name, :identifier, :desc => "filter only environments with this identifier"
+    param :organization_id, :number, :desc => N_("organization identifier")
+    param :library, :bool, :desc => N_("set true if you want to see only library environment")
+    param :name, :identifier, :desc => N_("filter only environments with this identifier")
   end
 
   def_param_group :environment do
     param :environment, Hash, :required => true, :action_aware => true do
-      param :name, :identifier, :desc => "name of the environment (identifier)", :required => true
+      param :name, :identifier, :desc => N_("name of the environment (identifier)"), :required => true
       param :description, String
     end
   end
 
-  api :GET, "/organizations/:organization_id/environments", "List environments in an organization"
+  api :GET, "/organizations/:organization_id/environments", N_("List environments in an organization")
   param_group :search_params
   def index
     query_params.delete(:environment)
@@ -122,16 +122,16 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
     respond
   end
 
-  api :GET, "/environments/:id", "Show an environment"
-  api :GET, "/organizations/:organization_id/environments/:id", "Show an environment"
-  param :id, :identifier, :desc => "environment identifier"
-  param :organization_id, :number, :desc => "organization identifier"
+  api :GET, "/environments/:id", N_("Show an environment")
+  api :GET, "/organizations/:organization_id/environments/:id", N_("Show an environment")
+  param :id, :identifier, :desc => N_("environment identifier")
+  param :organization_id, :number, :desc => N_("organization identifier")
   def show
     respond
   end
 
-  api :POST, "/organizations/:organization_id/environments", "Create an environment in an organization"
-  param :organization_id, :number, :desc => "organization identifier"
+  api :POST, "/organizations/:organization_id/environments", N_("Create an environment in an organization")
+  param :organization_id, :number, :desc => N_("organization identifier")
   param_group :environment
   param :environment, Hash, :required => true do
     param :prior, :identifier, :required => true, :desc => <<-DESC
@@ -149,8 +149,8 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
     respond
   end
 
-  api :PUT, "/environments/:id", "Update an environment"
-  api :PUT, "/organizations/:organization_id/environments/:id", "Update an environment in an organization"
+  api :PUT, "/environments/:id", N_("Update an environment")
+  api :PUT, "/organizations/:organization_id/environments/:id", N_("Update an environment in an organization")
   param_group :environment
   def update
     fail HttpErrors::BadRequest, _("Can't update the '%s' environment") % "Library" if @environment.library?
@@ -158,10 +158,10 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
     respond
   end
 
-  api :DELETE, "/environments/:id", "Destroy an environment"
-  api :DELETE, "/organizations/:organization_id/environments/:id", "Destroy an environment in an organization"
-  param :id, :identifier, :desc => "environment identifier"
-  param :organization_id, :number, :desc => "organization identifier"
+  api :DELETE, "/environments/:id", N_("Destroy an environment")
+  api :DELETE, "/organizations/:organization_id/environments/:id", N_("Destroy an environment in an organization")
+  param :id, :identifier, :desc => N_("environment identifier")
+  param :organization_id, :number, :desc => N_("organization identifier")
   def destroy
     if @environment.is_deletable?
       @environment.destroy
@@ -172,10 +172,10 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
     end
   end
 
-  api :GET, "/organizations/:organization_id/environments/:id/repositories", "List repositories available in the environment"
-  param :id, :identifier, :desc => "environment identifier"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :content_view_id, :identifier, :desc => "content view identifier", :required => false
+  api :GET, "/organizations/:organization_id/environments/:id/repositories", N_("List repositories available in the environment")
+  param :id, :identifier, :desc => N_("environment identifier")
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => false
   def repositories
     if !@environment.library? && @content_view.nil?
       fail HttpErrors::BadRequest,
@@ -188,8 +188,8 @@ class Api::V1::EnvironmentsController < Api::V1::ApiController
     respond_for_index :collection => @repositories
   end
 
-  api :GET, "/environments/:id/releases", "List available releases for given environment"
-  param :id, :identifier, :desc => "environment identifier"
+  api :GET, "/environments/:id/releases", N_("List available releases for given environment")
+  param :id, :identifier, :desc => N_("environment identifier")
   def releases
     respond_for_index :collection => { :releases => @environment.available_releases }
   end

--- a/app/controllers/katello/api/v1/errata_controller.rb
+++ b/app/controllers/katello/api/v1/errata_controller.rb
@@ -15,8 +15,8 @@ class Api::V1::ErrataController < Api::V1::ApiController
   respond_to :json
 
   resource_description do
-    error :code => 401, :desc => "Unauthorized"
-    error :code => 404, :desc => "Not found"
+    error :code => 401, :desc => N_("Unauthorized")
+    error :code => 404, :desc => N_("Not found")
 
     api_version 'v1'
   end
@@ -35,15 +35,15 @@ class Api::V1::ErrataController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/errata", "List errata"
-  api :GET, "/repositories/:repository_id/errata", "List errata"
-  description "Either :repoid or :product_id is required."
-  error :code => 400, :desc => "Repo id or environment must be provided"
-  param :environment_id, :number, :desc => "Id of environment containing the errata."
-  param :product_id, :number, :desc => "The product which contains the errata."
-  param :repoid, :number, :desc => "Id of repository containing the errata."
-  param :severity, String, :desc => "Severity of errata. Usually one of: Critical, Important, Moderate, Low. Case insensitive."
-  param :type, String, :desc => "Type of errata. Usually one of: security, bugfix, enhancement. Case insensitive."
+  api :GET, "/errata", N_("List errata")
+  api :GET, "/repositories/:repository_id/errata", N_("List errata")
+  description N_("Either :repoid or :product_id is required.")
+  error :code => 400, :desc => N_("Repo id or environment must be provided")
+  param :environment_id, :number, :desc => N_("Id of environment containing the errata.")
+  param :product_id, :number, :desc => N_("The product which contains the errata.")
+  param :repoid, :number, :desc => N_("Id of repository containing the errata.")
+  param :severity, String, :desc => N_("Severity of errata. Usually one of: Critical, Important, Moderate, Low. Case insensitive.")
+  param :type, String, :desc => N_("Type of errata. Usually one of: security, bugfix, enhancement. Case insensitive.")
   def index
     filter = params.symbolize_keys.slice(:repoid, :repository_id, :product_id, :environment_id, :type, :severity)
     unless filter[:repoid] || filter[:repository_id] || filter[:environment_id]
@@ -52,7 +52,7 @@ class Api::V1::ErrataController < Api::V1::ApiController
     render :json => Errata.filter(filter)
   end
 
-  api :GET, "/repositories/:repository_id/errata/:id", "Show an erratum"
+  api :GET, "/repositories/:repository_id/errata/:id", N_("Show an erratum")
   def show
     render :json => @erratum
   end

--- a/app/controllers/katello/api/v1/host_collection_errata_controller.rb
+++ b/app/controllers/katello/api/v1/host_collection_errata_controller.rb
@@ -17,8 +17,8 @@ class Api::V1::HostCollectionErrataController < Api::V1::ApiController
       methods for handling erratas on host collection level
     DOC
 
-    param :organization_id, :number, :desc => "oranization identifier", :required => true
-    param :host_collection_id, :identifier, :desc => "host_collection identifier", :required => true
+    param :organization_id, :number, :desc => N_("oranization identifier"), :required => true
+    param :host_collection_id, :identifier, :desc => N_("host_collection identifier"), :required => true
 
     api_version 'v1'
     api_version 'v2'
@@ -39,8 +39,8 @@ class Api::V1::HostCollectionErrataController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/organizations/:organization_id/host_collections/:host_collection_id/errata", "Get list of errata associated with the host collection"
-  param :type, %w(bugfix enhancement security), :desc => "Filter errata by type", :required => false
+  api :GET, "/organizations/:organization_id/host_collections/:host_collection_id/errata", N_("Get list of errata associated with the host collection")
+  param :type, %w(bugfix enhancement security), :desc => N_("Filter errata by type"), :required => false
   # TODO: when errata are enabled there has to be created rabl template for errata
   def index
     filter_type = params[:filter_type]
@@ -66,8 +66,8 @@ class Api::V1::HostCollectionErrataController < Api::V1::ApiController
     respond :collection => errata
   end
 
-  api :POST, "/organizations/:organization_id/host_collections/:host_collection_id/errata", "Install errata remotely"
-  param :errata_ids, Array, :desc => "List of errata ids to install", :required => true
+  api :POST, "/organizations/:organization_id/host_collections/:host_collection_id/errata", N_("Install errata remotely")
+  param :errata_ids, Array, :desc => N_("List of errata ids to install"), :required => true
   def create
     if params[:errata_ids]
       job = @host_collection.install_errata(params[:errata_ids])

--- a/app/controllers/katello/api/v1/host_collection_packages_controller.rb
+++ b/app/controllers/katello/api/v1/host_collection_packages_controller.rb
@@ -16,8 +16,8 @@ class Api::V1::HostCollectionPackagesController < Api::V1::ApiController
       methods for handling packages on host collection level
     DOC
 
-    param :organization_id, :number, :desc => "oranization identifier", :required => true
-    param :host_collection_id, :identifier, :desc => "host_collection identifier", :required => true
+    param :organization_id, :number, :desc => N_("oranization identifier"), :required => true
+    param :host_collection_id, :identifier, :desc => N_("host_collection identifier"), :required => true
 
     api_version 'v1'
     api_version 'v2'
@@ -39,7 +39,7 @@ class Api::V1::HostCollectionPackagesController < Api::V1::ApiController
     }
   end
 
-  api :POST, "/organizations/:organization_id/host_collections/:host_collection_id/packages", "Install packages remotely"
+  api :POST, "/organizations/:organization_id/host_collections/:host_collection_id/packages", N_("Install packages remotely")
   param_group :packages_or_groups, Api::V1::SystemPackagesController
   def create
     if params[:packages]
@@ -55,7 +55,7 @@ class Api::V1::HostCollectionPackagesController < Api::V1::ApiController
     end
   end
 
-  api :PUT, "/organizations/:organization_id/host_collections/:host_collection_id/packages", "Update packages remotely"
+  api :PUT, "/organizations/:organization_id/host_collections/:host_collection_id/packages", N_("Update packages remotely")
   param_group :packages_or_groups, Api::V1::SystemPackagesController
   def update
     if params[:packages]
@@ -72,7 +72,7 @@ class Api::V1::HostCollectionPackagesController < Api::V1::ApiController
     end
   end
 
-  api :DELETE, "/organizations/:organization_id/host_collections/:host_collection_id/packages", "Uninstall packages remotely"
+  api :DELETE, "/organizations/:organization_id/host_collections/:host_collection_id/packages", N_("Uninstall packages remotely")
   param_group :packages_or_groups, Api::V1::SystemPackagesController
   def destroy
     if params[:packages]

--- a/app/controllers/katello/api/v1/host_collections_controller.rb
+++ b/app/controllers/katello/api/v1/host_collections_controller.rb
@@ -59,15 +59,15 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
 
   def_param_group :host_collection do
     param :host_collection, Hash, :required => true, :action_aware => true do
-      param :name, String, :required => true, :desc => "Host collection name"
+      param :name, String, :required => true, :desc => N_("Host collection name")
       param :description, String
-      param :max_content_hosts, Integer, :desc => "Maximum number of content hosts in the host collection"
+      param :max_content_hosts, Integer, :desc => N_("Maximum number of content hosts in the host collection")
     end
   end
 
-  api :GET, "/organizations/:organization_id/host_collections", "List host collections"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :name, String, :desc => "Host collection name to filter by"
+  api :GET, "/organizations/:organization_id/host_collections", N_("List host collections")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :name, String, :desc => N_("Host collection name to filter by")
   def index
     query_string = params[:search]
 
@@ -98,16 +98,16 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
     respond :collection => host_collections
   end
 
-  api :GET, "/organizations/:organization_id/host_collections/:id", "Show a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :GET, "/organizations/:organization_id/host_collections/:id", N_("Show a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   def show
     respond
   end
 
-  api :PUT, "/organizations/:organization_id/host_collections/:id", "Update a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :PUT, "/organizations/:organization_id/host_collections/:id", N_("Update a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   param_group :host_collection
   def update
     host_collection_param = params[:host_collection]
@@ -119,18 +119,18 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
     respond
   end
 
-  api :GET, "/organizations/:organization_id/host_collections/:id/content_hosts", "List content hosts in the host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :GET, "/organizations/:organization_id/host_collections/:id/content_hosts", N_("List content hosts in the host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   def content_hosts
     respond_for_index :collection => @host_collection.systems.collect { |sys| { :id => sys.uuid, :name => sys.name } }
   end
 
-  api :POST, "/organizations/:organization_id/host_collections/:id/add_content_hosts", "Add content hosts to the host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :POST, "/organizations/:organization_id/host_collections/:id/add_content_hosts", N_("Add content hosts to the host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   param :host_collection, Hash, :required => true do
-    param :system_ids, Array, :desc => "Array of content host ids"
+    param :system_ids, Array, :desc => N_("Array of content host ids")
   end
 
   def add_content_hosts
@@ -141,11 +141,11 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
     systems
   end
 
-  api :POST, "/organizations/:organization_id/host_collections/:id/remove_content_hosts", "Remove content hosts from the host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :POST, "/organizations/:organization_id/host_collections/:id/remove_content_hosts", N_("Remove content hosts from the host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   param :host_collection, Hash, :required => true do
-    param :system_ids, Array, :desc => "Array of system ids"
+    param :system_ids, Array, :desc => N_("Array of system ids")
   end
   def remove_content_hosts
     ids                         = system_uuids_to_ids(params[:host_collection][:system_ids])
@@ -155,25 +155,25 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
     systems
   end
 
-  api :GET, "/organizations/:organization_id/host_collections/:id/history", "History of jobs performed on a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :GET, "/organizations/:organization_id/host_collections/:id/history", N_("History of jobs performed on a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   def history
     jobs = @host_collection.refreshed_jobs
     respond_for_index :collection => jobs
   end
 
-  api :GET, "/organizations/:organization_id/host_collections/:id/history", "History of a job performed on a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
-  param :job_id, :identifier, :desc => "Id of a job for filtering"
+  api :GET, "/organizations/:organization_id/host_collections/:id/history", N_("History of a job performed on a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
+  param :job_id, :identifier, :desc => N_("Id of a job for filtering")
   def history_show
     job = @host_collection.refreshed_jobs.where(:id => params[:job_id]).first
     respond_for_show :resource => job
   end
 
-  api :POST, "/organizations/:organization_id/host_collections", "Create a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
+  api :POST, "/organizations/:organization_id/host_collections", N_("Create a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
   param_group :host_collection
   def create
     host_collection_param = params[:host_collection]
@@ -186,13 +186,13 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
     respond
   end
 
-  api :POST, "/organizations/:organization_id/host_collections/:id/copy", "Make copy of a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :POST, "/organizations/:organization_id/host_collections/:id/copy", N_("Make copy of a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   param :host_collection, Hash, :required => true, :action_aware => true do
-    param :new_name, String, :required => true, :desc => "Host collection name"
+    param :new_name, String, :required => true, :desc => N_("Host collection name")
     param :description, String
-    param :max_content_hosts, Integer, :desc => "Maximum number of content hosts in the host collection"
+    param :max_content_hosts, Integer, :desc => N_("Maximum number of content hosts in the host collection")
   end
   def copy
     if @organization.id != @host_collection.organization.id
@@ -222,18 +222,18 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
     respond_for_create :resource => new_host_collection
   end
 
-  api :DELETE, "/organizations/:organization_id/host_collections/:id", "Destroy a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+  api :DELETE, "/organizations/:organization_id/host_collections/:id", N_("Destroy a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   def destroy
     @host_collection.destroy
     respond :message => _("Deleted host collection '%s'") % params[:id]
   end
 
   api :DELETE, "/organizations/:organization_id/host_collections/:id/destroy_content_hosts",
-      "Destroy a host collection and its systems"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+      N_("Destroy a host collection and its systems")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   def destroy_content_hosts
     # this will destroy both the systems contained within the host collection as well as the host collection itself
     system_names = []
@@ -248,12 +248,12 @@ class Api::V1::HostCollectionsController < Api::V1::ApiController
   end
 
   api :PUT, "/organizations/:organization_id/host_collections/:id/update_content_hosts",
-      "Update systems within a host collection"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :id, :identifier, :desc => "Id of the host collection", :required => true
+      N_("Update systems within a host collection")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
   param :host_collection, Hash do
-    param :content_view_id, :identifier, "id of the content view to set systems to"
-    param :environment_id, :identifier, "id of the enviornment to set systems to"
+    param :content_view_id, :identifier, N_("id of the content view to set systems to")
+    param :environment_id, :identifier, N_("id of the enviornment to set systems to")
   end
   def update_content_hosts
     unless params[:host_collection].blank?

--- a/app/controllers/katello/api/v1/organization_default_info_controller.rb
+++ b/app/controllers/katello/api/v1/organization_default_info_controller.rb
@@ -33,11 +33,11 @@ class Api::V1::OrganizationDefaultInfoController < Api::V1::ApiController
   end
 
   def_param_group :informable_identifier do
-    param :informable_type, String, :desc => "name of the resource", :required => true
-    param :informable_id, :identifier, :desc => "resource identifier", :required => true
+    param :informable_type, String, :desc => N_("name of the resource"), :required => true
+    param :informable_id, :identifier, :desc => N_("resource identifier"), :required => true
   end
 
-  api :POST, '/organizations/:organization_id/default_info/:informable_type', "Create default info"
+  api :POST, '/organizations/:organization_id/default_info/:informable_type', N_("Create default info")
   param_group :informable_identifier
   param :keyname, String, :required => true
   def create
@@ -56,9 +56,9 @@ class Api::V1::OrganizationDefaultInfoController < Api::V1::ApiController
     }.to_json
   end
 
-  api :DELETE, "/organizations/:organization_id/default_info/:informable_type/:informable_id/:keyname", "Delete default info"
+  api :DELETE, "/organizations/:organization_id/default_info/:informable_type/:informable_id/:keyname", N_("Delete default info")
   param_group :informable_identifier
-  param :keyname, String, :desc => "Custom info key", :required => true
+  param :keyname, String, :desc => N_("Custom info key"), :required => true
   def destroy
     inf_type = params[:informable_type]
     @organization.default_info[inf_type].delete(params[:keyname])
@@ -70,9 +70,9 @@ class Api::V1::OrganizationDefaultInfoController < Api::V1::ApiController
     }.to_json
   end
 
-  api :POST, '/organizations/:organization_id/default_info/:informable_type/apply', "Apply existing default info on all informable resources"
+  api :POST, '/organizations/:organization_id/default_info/:informable_type/apply', N_("Apply existing default info on all informable resources")
   param_group :informable_identifier
-  param :async, :bool, :required => false, :desc => "directive to run this asynchronously or not"
+  param :async, :bool, :required => false, :desc => N_("directive to run this asynchronously or not")
   def apply_to_all
     params[:async] = true if params[:async].nil?
 

--- a/app/controllers/katello/api/v1/packages_controller.rb
+++ b/app/controllers/katello/api/v1/packages_controller.rb
@@ -27,23 +27,23 @@ class Api::V1::PackagesController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/repositories/:repository_id/packages", "List packages"
-  param :repository_id, :number, :desc => "environment numeric identifier"
+  api :GET, "/repositories/:repository_id/packages", N_("List packages")
+  param :repository_id, :number, :desc => N_("environment numeric identifier")
   def index
     respond :collection => @repo.packages
   end
 
   api :GET, "/repositories/:repository_id/packages/search"
-  param :repository_id, :number, :desc => "environment numeric identifier"
-  param :search, String, :desc => "search expression"
+  param :repository_id, :number, :desc => N_("environment numeric identifier")
+  param :search, String, :desc => N_("search expression")
   def search
     packages = Package.legacy_search(params[:search], 0, 0, [@repo.pulp_id])
     respond_for_index :collection => packages.to_a
   end
 
-  api :GET, "/repositories/:repository_id/packages/:id", "Show a package"
-  param :repository_id, :number, :desc => "environment numeric identifier"
-  param :id, String, :desc => "package id"
+  api :GET, "/repositories/:repository_id/packages/:id", N_("Show a package")
+  param :repository_id, :number, :desc => N_("environment numeric identifier")
+  param :id, String, :desc => N_("package id")
   def show
     respond
   end

--- a/app/controllers/katello/api/v1/permissions_controller.rb
+++ b/app/controllers/katello/api/v1/permissions_controller.rb
@@ -41,30 +41,30 @@ class Api::V1::PermissionsController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/roles/:role_id/permissions", "List permissions for a role"
-  param :name, String, :desc => "filter by name"
-  param :description, String, :desc => "filter by description"
-  param :all_verbs, :bool, :desc => "filter by all_verbs flag"
-  param :all_tags, :bool, :desc => "filter by all_flags flag"
+  api :GET, "/roles/:role_id/permissions", N_("List permissions for a role")
+  param :name, String, :desc => N_("filter by name")
+  param :description, String, :desc => N_("filter by description")
+  param :all_verbs, :bool, :desc => N_("filter by all_verbs flag")
+  param :all_tags, :bool, :desc => N_("filter by all_flags flag")
   def index
     queries = query_params.empty? ? {} : {:permissions => query_params}
     respond :collection => @role.permissions.where(queries)
   end
 
-  api :GET, "/roles/:role_id/permissions/:id", "Show a permission"
+  api :GET, "/roles/:role_id/permissions/:id", N_("Show a permission")
   def show
     respond
   end
 
-  api :POST, "/roles/:role_id/permissions", "Create a roles permission"
+  api :POST, "/roles/:role_id/permissions", N_("Create a roles permission")
   param :description, String, :allow_nil => true
   param :name, String, :required => true
   param :organization_id, :identifier
-  param :tags, Array, :desc => "array of tag ids"
-  param :type, String, :desc => "name of a resource or 'all'", :required => true
-  param :verbs, Array, :desc => "array of permission verbs"
-  param :all_tags, :bool, :desc => "True if the permission should use all tags"
-  param :all_verbs, :bool, :desc => "True if the permission should use all verbs"
+  param :tags, Array, :desc => N_("array of tag ids")
+  param :type, String, :desc => N_("name of a resource or 'all'"), :required => true
+  param :verbs, Array, :desc => N_("array of permission verbs")
+  param :all_tags, :bool, :desc => N_("True if the permission should use all tags")
+  param :all_verbs, :bool, :desc => N_("True if the permission should use all verbs")
   def create
     new_params = {
         :name         => params[:name],
@@ -89,7 +89,7 @@ class Api::V1::PermissionsController < Api::V1::ApiController
     render :json => @permission.to_json
   end
 
-  api :DELETE, "/roles/:role_id/permissions/:id", "Destroy a roles permission"
+  api :DELETE, "/roles/:role_id/permissions/:id", N_("Destroy a roles permission")
   def destroy
     @permission.destroy
     respond :message => _("Deleted permission '%s'") % params[:id]

--- a/app/controllers/katello/api/v1/ping_controller.rb
+++ b/app/controllers/katello/api/v1/ping_controller.rb
@@ -16,8 +16,8 @@ module Katello
     skip_before_filter :authorize # ok - anyone authenticated can ask for status
     skip_before_filter :require_user, :only => [:server_status]
 
-    api :GET, "/ping", "Shows status of system and it's subcomponents"
-    description "This service is only available for authenticated users"
+    api :GET, "/ping", N_("Shows status of system and it's subcomponents")
+    description N_("This service is only available for authenticated users")
     def index
       resource = Hash[Ping.ping.collect { |k, v| [{:status => :result, :services => :status}[k], v] }]
       resource[:status].each_key do |key|
@@ -26,8 +26,8 @@ module Katello
       respond_for_show :resource => resource
     end
 
-    api :GET, "/status", "Shows version information"
-    description "This service is also available for unauthenticated users"
+    api :GET, "/status", N_("Shows version information")
+    description N_("This service is also available for unauthenticated users")
     def server_status
       # rubocop:disable SymbolName
       status = { :release    => Katello.config.app_name,
@@ -38,8 +38,8 @@ module Katello
       respond_for_show :resource => status
     end
 
-    api :GET, "/version", "Shows name and version information"
-    description "This service is only available for authenticated users"
+    api :GET, "/version", N_("Shows name and version information")
+    description N_("This service is only available for authenticated users")
     def version
       respond_for_show :resource => { :name => Katello.config.app_mode, :version => Katello.config.katello_version }
     end

--- a/app/controllers/katello/api/v1/products_controller.rb
+++ b/app/controllers/katello/api/v1/products_controller.rb
@@ -49,24 +49,24 @@ class Api::V1::ProductsController < Api::V1::ApiController
 
   def_param_group :product do
     param :product, Hash, :required => true, :action_aware => true do
-      param :gpg_key_name, :identifier, :desc => "identifier of the gpg key"
-      param :description, String, :desc => "Product description"
+      param :gpg_key_name, :identifier, :desc => N_("identifier of the gpg key")
+      param :description, String, :desc => N_("Product description")
     end
   end
 
-  api :GET, "/organizations/:organization_id/products/:id", "Show a product"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :id, :number, :desc => "product numeric identifier"
+  api :GET, "/organizations/:organization_id/products/:id", N_("Show a product")
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :id, :number, :desc => N_("product numeric identifier")
   def show
     respond
   end
 
-  api :PUT, "/organizations/:organization_id/products/:id", "Update a product"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :id, :number, :desc => "product numeric identifier"
+  api :PUT, "/organizations/:organization_id/products/:id", N_("Update a product")
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :id, :number, :desc => N_("product numeric identifier")
   param_group :product
   param :product, Hash do
-    param :recursive, :bool, :desc => "set to true to recursive update gpg key"
+    param :recursive, :bool, :desc => N_("set to true to recursive update gpg key")
   end
   def update
     fail HttpErrors::BadRequest, _("Red Hat products cannot be updated.") if @product.redhat?
@@ -78,11 +78,11 @@ class Api::V1::ProductsController < Api::V1::ApiController
     respond
   end
 
-  api :GET, "/environments/:environment_id/products", "List products in an environment"
-  api :GET, "/organizations/:organization_id/products", "List all products in an organization"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :name, :identifier, :desc => "product identifier"
-  param :include_marketing, :bool, :desc => "include marketing products in results"
+  api :GET, "/environments/:environment_id/products", N_("List products in an environment")
+  api :GET, "/organizations/:organization_id/products", N_("List all products in an organization")
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :name, :identifier, :desc => N_("product identifier")
+  param :include_marketing, :bool, :desc => N_("include marketing products in results")
   def index
     query_params.delete(:organization_id)
     query_params.delete(:environment_id)
@@ -92,9 +92,9 @@ class Api::V1::ProductsController < Api::V1::ApiController
     respond :collection => products.select("products.*, providers.name AS provider_name").joins(:provider).where(query_params).all
   end
 
-  api :DELETE, "/organizations/:organization_id/products/:id", "Destroy a product"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :id, :number, :desc => "product numeric identifier"
+  api :DELETE, "/organizations/:organization_id/products/:id", N_("Destroy a product")
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :id, :number, :desc => N_("product numeric identifier")
   def destroy
     @product.destroy
     respond :message => _("Deleted product '%s'") % params[:id]
@@ -103,11 +103,11 @@ class Api::V1::ProductsController < Api::V1::ApiController
   api :GET, "/environments/:environment_id/products/:id/repositories"
   api :GET, "/organizations/:organization_id/products/:id/repositories"
   api :GET, "/organizations/:organization_id/products/:id/repositories"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :environment_id, :identifier, :desc => "environment identifier"
-  param :id, :number, :desc => "product numeric identifier"
-  param :name, :identifier, :desc => "repository identifier"
-  param :content_view_id, :identifier, :desc => "find repos in content view instead of default content view"
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :environment_id, :identifier, :desc => N_("environment identifier")
+  param :id, :number, :desc => N_("product numeric identifier")
+  param :name, :identifier, :desc => N_("repository identifier")
+  param :content_view_id, :identifier, :desc => N_("find repos in content view instead of default content view")
   def repositories
     if !@environment.library? && @content_view.nil?
       fail HttpErrors::BadRequest,
@@ -118,20 +118,20 @@ class Api::V1::ProductsController < Api::V1::ApiController
         where(query_params.slice(:name))
   end
 
-  api :POST, "/organizations/:organization_id/products/:id/sync_plan", "Assign sync plan to product"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :id, :number, :desc => "product numeric identifier"
-  param :plan_id, :number, :desc => "Plan numeric identifier"
+  api :POST, "/organizations/:organization_id/products/:id/sync_plan", N_("Assign sync plan to product")
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :id, :number, :desc => N_("product numeric identifier")
+  param :plan_id, :number, :desc => N_("Plan numeric identifier")
   def set_sync_plan
     @product.sync_plan = SyncPlan.find(params[:plan_id])
     @product.save!
     respond_for_status :message => _("Synchronization plan assigned.")
   end
 
-  api :DELETE, "/organizations/:organization_id/products/:id/sync_plan", "Delete assignment sync plan and product"
-  param :organization_id, :number, :desc => "organization identifier"
-  param :id, :number, :desc => "product numeric identifier"
-  param :plan_id, :number, :desc => "Plan numeric identifier"
+  api :DELETE, "/organizations/:organization_id/products/:id/sync_plan", N_("Delete assignment sync plan and product")
+  param :organization_id, :number, :desc => N_("organization identifier")
+  param :id, :number, :desc => N_("product numeric identifier")
+  param :plan_id, :number, :desc => N_("Plan numeric identifier")
   def remove_sync_plan
     @product.sync_plan = nil
     @product.save!

--- a/app/controllers/katello/api/v1/puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v1/puppet_modules_controller.rb
@@ -28,15 +28,15 @@ class Api::V1::PuppetModulesController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/repositories/:repository_id/puppet_modules", "List puppet modules"
-  param :repository_id, :number, :desc => "repository numeric identifier"
+  api :GET, "/repositories/:repository_id/puppet_modules", N_("List puppet modules")
+  param :repository_id, :number, :desc => N_("repository numeric identifier")
   def index
     respond :collection => @repo.puppet_modules
   end
 
   api :GET, "/repositories/:repository_id/puppet_modules/search"
-  param :repository_id, :number, :desc => "repository numeric identifier"
-  param :search, String, :desc => "search expression"
+  param :repository_id, :number, :desc => N_("repository numeric identifier")
+  param :search, String, :desc => N_("search expression")
   def search
     puppet_modules = PuppetModule.search(params[:search],
                                          :repoids => @repo.pulp_id,
@@ -46,9 +46,9 @@ class Api::V1::PuppetModulesController < Api::V1::ApiController
     respond_for_index :collection => puppet_modules.to_a
   end
 
-  api :GET, "/repositories/:repository_id/puppet_modules/:id", "Show a puppet module"
-  param :repository_id, :number, :desc => "repository numeric identifier"
-  param :id, String, :desc => "puppet module id"
+  api :GET, "/repositories/:repository_id/puppet_modules/:id", N_("Show a puppet module")
+  param :repository_id, :number, :desc => N_("repository numeric identifier")
+  param :id, String, :desc => N_("puppet module id")
   def show
     respond
   end

--- a/app/controllers/katello/api/v1/repositories_controller.rb
+++ b/app/controllers/katello/api/v1/repositories_controller.rb
@@ -49,13 +49,13 @@ class Api::V1::RepositoriesController < Api::V1::ApiController
     }
   end
 
-  api :POST, "/repositories", "Create a repository"
+  api :POST, "/repositories", N_("Create a repository")
   param :name, String, :required => true
-  param :organization_id, :number, :required => true, :desc => "id of an organization the repository will be contained in"
-  param :product_id, :number, :required => true, :desc => "id of a product the repository will be contained in"
-  param :url, :undef, :required => true, :desc => "repository source url"
-  param :gpg_key_name, String, :desc => "name of a gpg key that will be assigned to the new repository"
-  param :content_type, String, :desc => "type of repo (either 'yum' or 'puppet', defaults to 'yum')"
+  param :organization_id, :number, :required => true, :desc => N_("id of an organization the repository will be contained in")
+  param :product_id, :number, :required => true, :desc => N_("id of a product the repository will be contained in")
+  param :url, :undef, :required => true, :desc => N_("repository source url")
+  param :gpg_key_name, String, :desc => N_("name of a gpg key that will be assigned to the new repository")
+  param :content_type, String, :desc => N_("type of repo (either 'yum' or 'puppet', defaults to 'yum')")
   see "v1#gpg_keys#index"
   def create
     fail HttpErrors::BadRequest, _("Repository can be only created for custom provider.") unless @product.custom?
@@ -71,17 +71,17 @@ class Api::V1::RepositoriesController < Api::V1::ApiController
     respond :resource => content
   end
 
-  api :GET, "/repositories/:id", "Show a repository"
-  param :id, :identifier, :required => true, :desc => "repository id"
+  api :GET, "/repositories/:id", N_("Show a repository")
+  param :id, :identifier, :required => true, :desc => N_("repository id")
   def show
     respond
   end
 
-  api :PUT, "/repositories/:id", "Update a repository"
-  param :id, :identifier, :required => true, :desc => "repository id"
+  api :PUT, "/repositories/:id", N_("Update a repository")
+  param :id, :identifier, :required => true, :desc => N_("repository id")
   param :repository, Hash, :required => true do
-    param :gpg_key_name, String, :desc => "name of a gpg key that will be assigned to the repository"
-    param :url, String, :desc => "repository source url"
+    param :gpg_key_name, String, :desc => N_("name of a gpg key that will be assigned to the repository")
+    param :url, String, :desc => N_("repository source url")
   end
   def update
     fail HttpErrors::BadRequest, _("A Red Hat repository cannot be updated.") if @repository.redhat?
@@ -91,7 +91,7 @@ class Api::V1::RepositoriesController < Api::V1::ApiController
     respond
   end
 
-  api :DELETE, "/repositories/:id", "Destroy a repository"
+  api :DELETE, "/repositories/:id", N_("Destroy a repository")
   param :id, :identifier, :required => true
   def destroy
     #
@@ -106,7 +106,7 @@ class Api::V1::RepositoriesController < Api::V1::ApiController
     end
   end
 
-  api :GET, "/repositories/:id/package_groups", "List all package groups in a repository"
+  api :GET, "/repositories/:id/package_groups", N_("List all package groups in a repository")
   param :id, :identifier, :required => true
   def package_groups
     #translate group_id to id in search params (conflict with repo id used for routing)
@@ -116,7 +116,7 @@ class Api::V1::RepositoriesController < Api::V1::ApiController
     respond_for_index :collection => @repository.package_groups_search(search_attrs)
   end
 
-  api :GET, "/repositories/:id/package_group_categories", "List all package group categories in a repository"
+  api :GET, "/repositories/:id/package_group_categories", N_("List all package group categories in a repository")
   param :id, :identifier, :required => true
   def package_group_categories
     #translate category_id to id in search params (conflict with repo id used for routing)
@@ -129,7 +129,7 @@ class Api::V1::RepositoriesController < Api::V1::ApiController
   # returns the content of a repo gpg key, used directly by yum
   # we don't want to authenticate, authorize etc, trying to distinquse between a yum request and normal api request
   # might not always be 100% bullet proof, and its more important that yum can fetch the key.
-  api :GET, "/repositories/:id/gpg_key_content", "Return the content of a repo gpg key, used directly by yum"
+  api :GET, "/repositories/:id/gpg_key_content", N_("Return the content of a repo gpg key, used directly by yum")
   param :id, :identifier, :required => true
   def gpg_key_content
     if @repository.gpg_key && @repository.gpg_key.content.present?

--- a/app/controllers/katello/api/v1/role_ldap_groups_controller.rb
+++ b/app/controllers/katello/api/v1/role_ldap_groups_controller.rb
@@ -26,23 +26,23 @@ class Api::V1::RoleLdapGroupsController < Api::V1::ApiController
     }
   end
 
-  api :POST, "/roles/:role_id/ldap_groups", "Add group to list of LDAP groups associated with the role"
-  param :name, String, :desc => "name of the LDAP group"
+  api :POST, "/roles/:role_id/ldap_groups", N_("Add group to list of LDAP groups associated with the role")
+  param :name, String, :desc => N_("name of the LDAP group")
   def create
     @role.add_ldap_group(params[:name])
     respond_for_status :message => _("Added LDAP group '%s'") % params[:name], :format => :text
   end
 
-  api :DELETE, "/roles/:role_id/ldap_groups/:id", "Remove group from the list of LDAP groups associated with the role"
-  param :role_id, :identifier, :desc => "role identifier"
-  param :id, String, :desc => "ldap group (name)"
+  api :DELETE, "/roles/:role_id/ldap_groups/:id", N_("Remove group from the list of LDAP groups associated with the role")
+  param :role_id, :identifier, :desc => N_("role identifier")
+  param :id, String, :desc => N_("ldap group (name)")
   def destroy
     @role.remove_ldap_group(params[:id])
     respond :message => _("Removed LDAP group '%s'") % params[:id], :resource => false
   end
 
-  api :GET, "/roles/:role_id/ldap_groups", "List LDAP groups associated with the role"
-  param :role_id, :identifier, :desc => "role identifier"
+  api :GET, "/roles/:role_id/ldap_groups", N_("List LDAP groups associated with the role")
+  param :role_id, :identifier, :desc => N_("role identifier")
   def index
     respond :collection => @role.ldap_group_roles.where(query_params)
   end

--- a/app/controllers/katello/api/v1/roles_controller.rb
+++ b/app/controllers/katello/api/v1/roles_controller.rb
@@ -49,24 +49,24 @@ class Api::V1::RolesController < Api::V1::ApiController
     end
   end
 
-  api :GET, "/roles", "List roles"
+  api :GET, "/roles", N_("List roles")
   param :name, String
   def index
     respond :collection => (Role.readable.non_self.where query_params)
   end
 
-  api :GET, "/roles/:id", "Show a role"
+  api :GET, "/roles/:id", N_("Show a role")
   def show
     respond
   end
 
-  api :POST, "/roles", "Create a role"
+  api :POST, "/roles", N_("Create a role")
   param_group :role
   def create
     respond :resource => Role.create!(params[:role])
   end
 
-  api :PUT, "/roles/:id", "Update a role"
+  api :PUT, "/roles/:id", N_("Update a role")
   param_group :role
   def update
     @role.update_attributes!(params[:role])
@@ -74,14 +74,14 @@ class Api::V1::RolesController < Api::V1::ApiController
     respond
   end
 
-  api :DELETE, "/roles/:id", "Destroy a role"
+  api :DELETE, "/roles/:id", N_("Destroy a role")
   def destroy
     @role.destroy
     respond :message => _("Deleted role '%s'") % params[:id]
   end
 
-  api :GET, "/roles/available_verbs", "List all available verbs that can be set to roles"
-  param :organization_id, :number, :desc => "With this option specified the listed tags are scoped to the organization."
+  api :GET, "/roles/available_verbs", N_("List all available verbs that can be set to roles")
+  param :organization_id, :number, :desc => N_("With this option specified the listed tags are scoped to the organization.")
   def available_verbs
     details = {}
 

--- a/app/controllers/katello/api/v1/status_controller.rb
+++ b/app/controllers/katello/api/v1/status_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::StatusController < Api::V1::ApiController
   skip_before_filter :require_user
   skip_before_filter :authorize # ok - authenticated users are able to call this
 
-  api :GET, "/status/memory", "Counts objects in memory for debug purposes. Can take a while!"
+  api :GET, "/status/memory", N_("Counts objects in memory for debug purposes. Can take a while!")
   def memory
     User.as :admin do
       objs = Hash.new(0)

--- a/app/controllers/katello/api/v1/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v1/subscriptions_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::SubscriptionsController < Api::V1::ApiController
 
   def_param_group :system do
     description "Systems subscriptions management."
-    param :system_id, :identifier, :desc => "System uuid", :required => true
+    param :system_id, :identifier, :desc => N_("System uuid"), :required => true
 
     api_version 'v1'
     api_version 'v2'
@@ -41,14 +41,14 @@ class Api::V1::SubscriptionsController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/systems/:system_id/subscriptions", "List subscriptions"
+  api :GET, "/systems/:system_id/subscriptions", N_("List subscriptions")
   param_group :system
   def index
     respond :collection => { :entitlements => @system.consumed_entitlements }
   end
 
-  api :GET, "/subscriptions", "List subscriptions"
-  #params :search, String, :desc => "Filter subscriptions by advanced search query"
+  api :GET, "/subscriptions", N_("List subscriptions")
+  #params :search, String, :desc => N_("Filter subscriptions by advanced search query")
   def organization_index
 
     query_string = params[:search]
@@ -91,10 +91,10 @@ class Api::V1::SubscriptionsController < Api::V1::ApiController
     respond_for_index(:collection => subscriptions)
   end
 
-  api :POST, "/systems/:system_id/subscriptions", "Create a subscription"
+  api :POST, "/systems/:system_id/subscriptions", N_("Create a subscription")
   param_group :system
-  param :pool, String, :desc => "Subscription Pool uuid", :required => true
-  param :quantity, :number, :desc => "Number of subscription to use", :required => true
+  param :pool, String, :desc => N_("Subscription Pool uuid"), :required => true
+  param :quantity, :number, :desc => N_("Number of subscription to use"), :required => true
   def create
     expected_params = params.with_indifferent_access.slice(:pool, :quantity)
     fail HttpErrors::BadRequest, _("Please provide pool and quantity") if expected_params.count != 2
@@ -102,8 +102,8 @@ class Api::V1::SubscriptionsController < Api::V1::ApiController
     respond :resource => @system
   end
 
-  api :DELETE, "/systems/:system_id/subscriptions/:id", "Delete a subscription"
-  param :id, :number, :desc => "Entitlement id"
+  api :DELETE, "/systems/:system_id/subscriptions/:id", N_("Delete a subscription")
+  param :id, :number, :desc => N_("Entitlement id")
   param_group :system
   def destroy
     expected_params = params.with_indifferent_access.slice(:id)
@@ -112,15 +112,15 @@ class Api::V1::SubscriptionsController < Api::V1::ApiController
     respond_for_show :resource => @system
   end
 
-  api :DELETE, "/systems/:system_id/subscriptions", "Delete all system subscriptions"
+  api :DELETE, "/systems/:system_id/subscriptions", N_("Delete all system subscriptions")
   param_group :system
   def destroy_all
     @system.unsubscribe_all
     respond_for_show :resource => @system
   end
 
-  api :DELETE, "/systems/:system_id/subscriptions/serials/:serial_id", "Delete a subscription by serial id"
-  param :serial_id, String, :desc => "Subscription serial id"
+  api :DELETE, "/systems/:system_id/subscriptions/serials/:serial_id", N_("Delete a subscription by serial id")
+  param :serial_id, String, :desc => N_("Subscription serial id")
   param_group :system
   def destroy_by_serial
     expected_params = params.with_indifferent_access.slice(:serial_id)

--- a/app/controllers/katello/api/v1/sync_controller.rb
+++ b/app/controllers/katello/api/v1/sync_controller.rb
@@ -19,10 +19,10 @@ class Api::V1::SyncController < Api::V1::ApiController
       individualy by id, by product or by provider
     DOC
 
-    param :organization_id, :number, :desc => "oranization identifier", :required => true
-    param :product_id, :identifier, :desc => "product identifier", :required => true
-    param :provider_id, :identifier, :desc => "provider identifier", :required => true
-    param :repository_id, :identifier, :desc => "repository identifier", :required => true
+    param :organization_id, :number, :desc => N_("oranization identifier"), :required => true
+    param :product_id, :identifier, :desc => N_("product identifier"), :required => true
+    param :provider_id, :identifier, :desc => N_("provider identifier"), :required => true
+    param :repository_id, :identifier, :desc => N_("repository identifier"), :required => true
 
     api_version 'v1'
     api_version 'v2'
@@ -45,23 +45,23 @@ class Api::V1::SyncController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/providers/:provider_id/sync", "Get status of repo synchronisation for given provider"
-  api :GET, "/organizations/:organization_id/products/:product_id/sync", "Get status of repo synchronisation for given product"
-  api :GET, "/repositories/:repository_id/sync", "Get status of synchronisation for given repository"
+  api :GET, "/providers/:provider_id/sync", N_("Get status of repo synchronisation for given provider")
+  api :GET, "/organizations/:organization_id/products/:product_id/sync", N_("Get status of repo synchronisation for given product")
+  api :GET, "/repositories/:repository_id/sync", N_("Get status of synchronisation for given repository")
   def index
     respond_for_show :resource => @obj.sync_status
   end
 
-  api :POST, "/providers/:provider_id/sync", "Synchronize all provider's repositories"
-  api :POST, "organizations/:organization_id/products/:product_id/sync", "Synchronise all repositories for given product"
-  api :POST, "/repositories/:repository_id/sync", "Synchronise repository"
+  api :POST, "/providers/:provider_id/sync", N_("Synchronize all provider's repositories")
+  api :POST, "organizations/:organization_id/products/:product_id/sync", N_("Synchronise all repositories for given product")
+  api :POST, "/repositories/:repository_id/sync", N_("Synchronise repository")
   def create
     respond_for_index :collection => @obj.sync, :status => 202
   end
 
-  api :DELETE, "/providers/:provider_id/sync", "Cancel running synchronisation for given provider"
-  api :DELETE, "/organizations/:organization_id/products/:product_id/sync", "Cancel running synchronisations for given product"
-  api :DELETE, "/repositories/:repository_id/sync", "Cancel running synchronisation"
+  api :DELETE, "/providers/:provider_id/sync", N_("Cancel running synchronisation for given provider")
+  api :DELETE, "/organizations/:organization_id/products/:product_id/sync", N_("Cancel running synchronisations for given product")
+  api :DELETE, "/repositories/:repository_id/sync", N_("Cancel running synchronisation")
   def cancel
     if @obj.sync_state.to_s == PulpSyncStatus::Status::RUNNING.to_s
       @obj.cancel_sync

--- a/app/controllers/katello/api/v1/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v1/sync_plans_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::SyncPlansController < Api::V1::ApiController
       synchronization of the repository with the upstream.
     DOC
 
-    param :organization_id, :number, :desc => "oranization identifier", :required => true
+    param :organization_id, :number, :desc => N_("oranization identifier"), :required => true
 
     api_version 'v1'
     api_version 'v2'
@@ -51,29 +51,29 @@ class Api::V1::SyncPlansController < Api::V1::ApiController
 
   def_param_group :sync_plan do
     param :sync_plan, Hash, :required => true, :action_aware => true do
-      param :name, String, :desc => "sync plan name", :required => true
-      param :interval, SyncPlan::TYPES, :desc => "how often synchronization should run"
-      param :sync_date, String, :desc => "start datetime of synchronization"
-      param :description, String, :desc => "sync plan description"
+      param :name, String, :desc => N_("sync plan name"), :required => true
+      param :interval, SyncPlan::TYPES, :desc => N_("how often synchronization should run")
+      param :sync_date, String, :desc => N_("start datetime of synchronization")
+      param :description, String, :desc => N_("sync plan description")
     end
   end
 
-  api :GET, "/organizations/:organization_id/sync_plans", "List sync plans"
-  param :name, String, :desc => "filter by name"
-  param :sync_date, String, :desc => "filter by sync date"
-  param :interval, SyncPlan::TYPES, :desc => "filter by interval"
+  api :GET, "/organizations/:organization_id/sync_plans", N_("List sync plans")
+  param :name, String, :desc => N_("filter by name")
+  param :sync_date, String, :desc => N_("filter by sync date")
+  param :interval, SyncPlan::TYPES, :desc => N_("filter by interval")
   def index
     query_params.delete :organization_id
     respond :collection => @organization.sync_plans.where(query_params)
   end
 
-  api :GET, "/organizations/:organization_id/sync_plans/:id", "Show a sync plan"
-  param :id, :number, :desc => "sync plan numeric identifier", :required => true
+  api :GET, "/organizations/:organization_id/sync_plans/:id", N_("Show a sync plan")
+  param :id, :number, :desc => N_("sync plan numeric identifier"), :required => true
   def show
     respond :resource => @plan
   end
 
-  api :POST, "/organizations/:organization_id/sync_plans", "Create a sync plan"
+  api :POST, "/organizations/:organization_id/sync_plans", N_("Create a sync plan")
   param_group :sync_plan
   def create
     sync_date = params[:sync_plan][:sync_date].to_time
@@ -86,8 +86,8 @@ class Api::V1::SyncPlansController < Api::V1::ApiController
     respond :resource => SyncPlan.create!(params[:sync_plan])
   end
 
-  api :PUT, "/organizations/:organization_id/sync_plans/:id", "Update a sync plan"
-  param :id, :number, :desc => "sync plan numeric identifier", :required => true
+  api :PUT, "/organizations/:organization_id/sync_plans/:id", N_("Update a sync plan")
+  param :id, :number, :desc => N_("sync plan numeric identifier"), :required => true
   param_group :sync_plan
   def update
     sync_date = params[:sync_plan].try(:[], :sync_date).try(:to_time)
@@ -102,8 +102,8 @@ class Api::V1::SyncPlansController < Api::V1::ApiController
     respond :resource => @plan
   end
 
-  api :DELETE, "/organizations/:organization_id/sync_plans/:id", "Destroy a sync plan"
-  param :id, :number, :desc => "sync plan numeric identifier"
+  api :DELETE, "/organizations/:organization_id/sync_plans/:id", N_("Destroy a sync plan")
+  param :id, :number, :desc => N_("sync plan numeric identifier")
   def destroy
     @plan.destroy
     respond :message => _("Deleted sync plan '%s'") % params[:id], :resource => @plan

--- a/app/controllers/katello/api/v1/system_packages_controller.rb
+++ b/app/controllers/katello/api/v1/system_packages_controller.rb
@@ -13,7 +13,7 @@ module Katello
 class Api::V1::SystemPackagesController < Api::V1::ApiController
 
   resource_description do
-    param :system_id, :identifier, :desc => "system identifier", :required => true
+    param :system_id, :identifier, :desc => N_("system identifier"), :required => true
 
     api_version 'v1'
     api_version 'v2'
@@ -37,12 +37,12 @@ class Api::V1::SystemPackagesController < Api::V1::ApiController
   end
 
   def_param_group :packages_or_groups do
-    param :packages, Array, :desc => "List of package names", :required => false
-    param :groups, Array, :desc => "List of package group names", :required => false
+    param :packages, Array, :desc => N_("List of package names"), :required => false
+    param :groups, Array, :desc => N_("List of package group names"), :required => false
   end
 
   # install packages remotely
-  api :POST, "/systems/:system_id/packages", "Install packages remotely"
+  api :POST, "/systems/:system_id/packages", N_("Install packages remotely")
   param_group :packages_or_groups
   def create
     if params[:packages]
@@ -59,8 +59,8 @@ class Api::V1::SystemPackagesController < Api::V1::ApiController
   end
 
   # update packages remotely
-  api :PUT, "/systems/:system_id/packages", "Update packages remotely"
-  param :packages, Array, :desc => "list of packages names"
+  api :PUT, "/systems/:system_id/packages", N_("Update packages remotely")
+  param :packages, Array, :desc => N_("list of packages names")
   def update
     if params[:packages]
       params[:packages] = [] if params[:packages] == 'all'
@@ -71,7 +71,7 @@ class Api::V1::SystemPackagesController < Api::V1::ApiController
   end
 
   # uninstall packages remotely
-  api :DELETE, "/systems/:system_id/packages", "Uninstall packages remotely"
+  api :DELETE, "/systems/:system_id/packages", N_("Uninstall packages remotely")
   param_group :packages_or_groups
   def destroy
     if params[:packages]

--- a/app/controllers/katello/api/v1/systems_controller.rb
+++ b/app/controllers/katello/api/v1/systems_controller.rb
@@ -82,19 +82,19 @@ class Api::V1::SystemsController < Api::V1::ApiController
   end
 
   def_param_group :system do
-    param :facts, Hash, :desc => "Key-value hash of system-specific facts", :action_aware => true
-    param :installedProducts, Array, :desc => "List of products installed on the system", :action_aware => true
-    param :name, String, :desc => "Name of the system", :required => true, :action_aware => true
-    param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true, :action_aware => true
-    param :serviceLevel, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT", :action_aware => true
-    param :location, String, :desc => "Physical of the system"
+    param :facts, Hash, :desc => N_("Key-value hash of system-specific facts"), :action_aware => true
+    param :installedProducts, Array, :desc => N_("List of products installed on the system"), :action_aware => true
+    param :name, String, :desc => N_("Name of the system"), :required => true, :action_aware => true
+    param :type, String, :desc => N_("Type of the system, it should always be 'system'"), :required => true, :action_aware => true
+    param :serviceLevel, String, :allow_nil => true, :desc => N_("A service level for auto-healing process, e.g. SELF-SUPPORT"), :action_aware => true
+    param :location, String, :desc => N_("Physical of the system")
     param :content_view_id, :identifier
     param :environment_id, :identifier
   end
 
   # this method is called from katello cli client and it does not work with activation keys
   # for activation keys there is method activate (see custom routes)
-  api :POST, "/environments/:environment_id/systems", "Register a system in environment"
+  api :POST, "/environments/:environment_id/systems", N_("Register a system in environment")
   param_group :system
   def create
     @system = System.create!(system_params.merge(:environment  => @environment,
@@ -103,7 +103,7 @@ class Api::V1::SystemsController < Api::V1::ApiController
     respond_for_create
   end
 
-  api :POST, "/hypervisors", "Update the hypervisors information for environment"
+  api :POST, "/hypervisors", N_("Update the hypervisors information for environment")
   desc <<DESC
 Takes a hash representing the mapping: host system having geust systems, e.g.:
 
@@ -118,7 +118,7 @@ DESC
   end
 
   # used for registering with activation keys
-  api :POST, "/organizations/:organization_id/systems", "Register a system with activation key"
+  api :POST, "/organizations/:organization_id/systems", N_("Register a system with activation key")
   param :activation_keys, String, :required => true
   param_group :system, :as => :create
   def activate
@@ -147,7 +147,7 @@ DESC
     end
   end
 
-  api :PUT, "/systems/:id", "Update system information"
+  api :PUT, "/systems/:id", N_("Update system information")
   param_group :system
   def update
     attrs = params.clone
@@ -169,19 +169,19 @@ DESC
     respond
   end
 
-  api :PUT, "/systems/:id/checkin", "Update system check-in time"
-  param :date, String, :desc => "check-in time"
+  api :PUT, "/systems/:id/checkin", N_("Update system check-in time")
+  param :date, String, :desc => N_("check-in time")
   def checkin
     @system.checkin(params[:date])
     respond_for_show
   end
 
-  api :GET, "/environments/:environment_id/systems", "List systems in environment"
-  api :GET, "/organizations/:organization_id/systems", "List systems in organization"
-  param :name, String, :desc => "Filter systems by name"
-  param :pool_id, String, :desc => "Filter systems by subscribed pool"
-  param :search, String, :desc => "Filter systems by advanced search query"
-  param :uuid, String, :desc => "Filter systems by uuid"
+  api :GET, "/environments/:environment_id/systems", N_("List systems in environment")
+  api :GET, "/organizations/:organization_id/systems", N_("List systems in organization")
+  param :name, String, :desc => N_("Filter systems by name")
+  param :pool_id, String, :desc => N_("Filter systems by subscribed pool")
+  param :search, String, :desc => N_("Filter systems by advanced search query")
+  param :uuid, String, :desc => N_("Filter systems by uuid")
   def index
     query_string = params[:name] ? "name:#{params[:name]}" : params[:search]
     filters      = []
@@ -222,27 +222,27 @@ DESC
     respond(:collection => systems)
   end
 
-  api :GET, "/systems/:id", "Show a system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id", N_("Show a system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def show
     respond
   end
 
-  api :DELETE, "/systems/:id", "Unregister a system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :DELETE, "/systems/:id", N_("Unregister a system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def destroy
     @system.destroy
     respond :message => _("Deleted system '%s'") % params[:id], :status => 204
   end
 
-  api :GET, "/systems/:id/subscription_status", "Show status of subscriptions on the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/subscription_status", N_("Show status of subscriptions on the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def subscription_status
     respond_for_index :collection => @system.compliance
   end
 
-  api :GET, "/systems/:id/pools", "List pools a system is subscribed to"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/pools", N_("List pools a system is subscribed to")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def pools
     match_system    = params.key?(:match_system) ? params[:match_system].to_bool : false
     match_installed = params.key?(:match_installed) ? params[:match_installed].to_bool : false
@@ -253,8 +253,8 @@ DESC
     respond_for_index :collection => { :pools => cp_pools }
   end
 
-  api :GET, "/systems/:id/releases", "Show releases available for the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/releases", N_("Show releases available for the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   desc <<-DESC
 A hint for choosing the right value for the releaseVer param
   DESC
@@ -262,21 +262,21 @@ A hint for choosing the right value for the releaseVer param
     respond_for_index :collection => { :releases => @system.available_releases }
   end
 
-  api :GET, "/systems/:id/packages", "List packages installed on the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/packages", N_("List packages installed on the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def package_profile
     respond_for_index :collection => @system.simple_packages.sort { |a, b| a.name.downcase <=> b.name.downcase }
   end
 
-  api :GET, "/systems/:id/errata", "List errata available for the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/errata", N_("List errata available for the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def errata
     respond_for_index :collection => @system.errata
   end
 
   # TODO: break this mehtod up
-  api :GET, "/environments/:environment_id/systems/report", "Get system reports for the environment"
-  api :GET, "/organizations/:organization_id/systems/report", "Get system reports for the organization"
+  api :GET, "/environments/:environment_id/systems/report", N_("Get system reports for the environment")
+  api :GET, "/organizations/:organization_id/systems/report", N_("Get system reports for the organization")
   def report # rubocop:disable MethodLength
     data = @environment.nil? ? @organization.systems.readable(@organization) : @environment.systems.readable(@organization)
 
@@ -306,9 +306,9 @@ A hint for choosing the right value for the releaseVer param
     end
   end
 
-  api :GET, "/organizations/:organization_id/systems/tasks", "List async tasks for the system"
-  param :system_name, String, :desc => "Name of the system"
-  param :system_uuid, String, :desc => "UUID of the system"
+  api :GET, "/organizations/:organization_id/systems/tasks", N_("List async tasks for the system")
+  param :system_name, String, :desc => N_("Name of the system")
+  param :system_uuid, String, :desc => N_("UUID of the system")
   def tasks
     if params[:system_name]
       @tasks = System.where(:name => params[:system_name]).first.tasks
@@ -319,14 +319,14 @@ A hint for choosing the right value for the releaseVer param
     respond_for_index :collection => @tasks
   end
 
-  api :PUT, "/systems/:id/enabled_repos", "Update the information about enabled repositories"
+  api :PUT, "/systems/:id/enabled_repos", N_("Update the information about enabled repositories")
   desc <<-DESC
 Used by katello-agent to keep the information about enabled repositories up to date.
 This information is then used for computing the errata available for the system.
   DESC
   param :enabled_repos, Hash, :required => true do
     param :repos, Array, :required => true do
-      param :baseurl, Array, :description => "List of enabled repo urls for the repo (Only first is used.)", :required => false
+      param :baseurl, Array, :desc => N_("List of enabled repo urls for the repo (Only first is used.)"), :required => false
     end
   end
   def enabled_repos
@@ -368,9 +368,9 @@ This information is then used for computing the errata available for the system.
     respond_for_show :resource => result
   end
 
-  api :POST, "/systems/:id/host_collections", "Add a system to host collections"
+  api :POST, "/systems/:id/host_collections", N_("Add a system to host collections")
   param :system, Hash, :required => true do
-    param :host_collection_ids, Array, :desc => "List of host collection ids to add the system to", :required => true
+    param :host_collection_ids, Array, :desc => N_("List of host collection ids to add the system to"), :required => true
   end
   def add_host_collections
     ids                         = params[:system][:host_collection_ids]
@@ -379,9 +379,9 @@ This information is then used for computing the errata available for the system.
     respond_for_create
   end
 
-  api :DELETE, "/systems/:id/host_collections", "Remove a system from host collections"
+  api :DELETE, "/systems/:id/host_collections", N_("Remove a system from host collections")
   param :system, Hash, :required => true do
-    param :host_collection_ids, Array, :desc => "List of host collection ids to add the system to", :required => true
+    param :host_collection_ids, Array, :desc => N_("List of host collection ids to add the system to"), :required => true
   end
   def remove_host_collections
     ids                         = params[:system][:host_collection_ids].map(&:to_i)
@@ -390,8 +390,8 @@ This information is then used for computing the errata available for the system.
     respond_for_show
   end
 
-  api :PUT, "/systems/:id/refresh_subscriptions", "Trigger a refresh of subscriptions, auto-attaching if enabled"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :PUT, "/systems/:id/refresh_subscriptions", N_("Trigger a refresh of subscriptions, auto-attaching if enabled")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def refresh_subscriptions
     @system.refresh_subscriptions
     respond_for_show

--- a/app/controllers/katello/api/v1/tasks_controller.rb
+++ b/app/controllers/katello/api/v1/tasks_controller.rb
@@ -37,9 +37,9 @@ class Api::V1::TasksController < Api::V1::ApiController
     }
   end
 
-  api :GET, "/organizations/:organization_id/tasks", "List tasks of given organization"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
-  param :status, String, :desc => "Filter tasks by status"
+  api :GET, "/organizations/:organization_id/tasks", N_("List tasks of given organization")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+  param :status, String, :desc => N_("Filter tasks by status")
   def index
     query_string = params[:status] ? "status:#{params[:status]}" : ''
 
@@ -69,8 +69,8 @@ class Api::V1::TasksController < Api::V1::ApiController
     respond(:collection => tasks)
   end
 
-  api :GET, "/tasks/:id", "Show a task info"
-  param :id, :identifier, :desc => "task identifier", :required => true
+  api :GET, "/tasks/:id", N_("Show a task info")
+  param :id, :identifier, :desc => N_("task identifier"), :required => true
   def show
     @task.refresh
     respond

--- a/app/controllers/katello/api/v1/uebercerts_controller.rb
+++ b/app/controllers/katello/api/v1/uebercerts_controller.rb
@@ -21,8 +21,8 @@ class Api::V1::UebercertsController < Api::V1::ApiController
     { :show => read_test }
   end
 
-  api :GET, "/organizations/:organization_id/uebercert", "Show an ueber certificate for an organization"
-  param :regenerate, :bool, :desc => "When set to 'True' certificate will be re-issued"
+  api :GET, "/organizations/:organization_id/uebercert", N_("Show an ueber certificate for an organization")
+  param :regenerate, :bool, :desc => N_("When set to 'True' certificate will be re-issued")
   def show
     @organization.generate_debug_cert if (params[:regenerate] || '').downcase == 'true'
     respond :resource => @organization.debug_cert

--- a/app/controllers/katello/api/v1/users_controller.rb
+++ b/app/controllers/katello/api/v1/users_controller.rb
@@ -53,22 +53,22 @@ class Api::V1::UsersController < Api::V1::ApiController
     param :disabled, :bool, :action_aware => true
   end
 
-  api :GET, "/users", "List users"
-  param :email, String, :desc => "filter by email"
-  param :disabled, :bool, :desc => "filter by disabled flag"
-  param :login, String, :desc => "filter by login"
+  api :GET, "/users", N_("List users")
+  param :email, String, :desc => N_("filter by email")
+  param :disabled, :bool, :desc => N_("filter by disabled flag")
+  param :login, String, :desc => N_("filter by login")
   def index
     respond :collection => User.readable.where(query_params)
   end
 
-  api :GET, "/users/:id", "Show a user"
+  api :GET, "/users/:id", N_("Show a user")
   def show
     @user[:allowed_organizations] = @user.allowed_organizations
     @user[:roles] = @user.katello_roles
     respond
   end
 
-  api :POST, "/users", "Create an user"
+  api :POST, "/users", N_("Create an user")
   param :login, String, :required => true
   param_group :user
   def create
@@ -90,7 +90,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     respond
   end
 
-  api :PUT, "/users/:id", "Update an user"
+  api :PUT, "/users/:id", N_("Update an user")
   param_group :user
   def update
     user_params = params[:user].reject { |k, _| k == 'default_organization_id' }
@@ -117,26 +117,26 @@ class Api::V1::UsersController < Api::V1::ApiController
     respond
   end
 
-  api :DELETE, "/users/:id", "Destroy an user"
+  api :DELETE, "/users/:id", N_("Destroy an user")
   def destroy
     @user.destroy
     respond :message => _("Deleted user '%s'") % params[:id]
   end
 
-  api :GET, "/users/:user_id/roles", "List roles assigned to a user"
+  api :GET, "/users/:user_id/roles", N_("List roles assigned to a user")
   #TODO: create rabl
   def list_roles
     @user.set_ldap_roles if Katello.config.ldap_roles
     respond_for_index :collection => @user.roles.non_self
   end
 
-  api :GET, "/users/sync_ldap_roles", "Synchronises roles for all users with LDAP groups"
+  api :GET, "/users/sync_ldap_roles", N_("Synchronises roles for all users with LDAP groups")
   def sync_ldap_roles
     User.all.each { |user| user.set_ldap_roles }
     respond_for_status :message => _("Roles for all users were synchronised with LDAP groups")
   end
 
-  api :POST, "/users/:user_id/roles", "Assign a role to a user"
+  api :POST, "/users/:user_id/roles", N_("Assign a role to a user")
   param :role_id, Integer
   def add_role
     role = Role.find(params[:role_id])
@@ -145,7 +145,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     respond_for_status :message => _("User '%{login}' assigned to role '%{rolename}'") % { :login => @user.login, :rolename => role.name }
   end
 
-  api :DELETE, "/users/:user_id/roles/:id", "Remove user's role"
+  api :DELETE, "/users/:user_id/roles/:id", N_("Remove user's role")
   def remove_role
     role = Role.find(params[:id])
     @user.roles.delete(role)

--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -45,13 +45,13 @@ module Katello
       }
     end
 
-    api :GET, "/activation_keys", "List activation keys"
+    api :GET, "/activation_keys", N_("List activation keys")
     api :GET, "/environments/:environment_id/activation_keys"
     api :GET, "/organizations/:organization_id/activation_keys"
-    param :organization_id, :number, :desc => "organization identifier", :required => true
-    param :environment_id, :identifier, :desc => "environment identifier"
-    param :content_view_id, :identifier, :desc => "content view identifier"
-    param :name, String, :desc => "activation key name to filter by"
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+    param :environment_id, :identifier, :desc => N_("environment identifier")
+    param :content_view_id, :identifier, :desc => N_("content view identifier")
+    param :name, String, :desc => N_("activation key name to filter by")
     param_group :search, Api::V2::ApiController
     def index
       query_string = ActivationKey.readable(@organization)
@@ -68,15 +68,15 @@ module Katello
       respond_for_index(:collection => item_search(ActivationKey, params, options))
     end
 
-    api :POST, "/activation_keys", "Create an activation key"
-    param :organization_id, :number, :desc => "organization identifier", :required => true
-    param :name, String, :desc => "name", :required => true
-    param :label, String, :desc => "unique label"
-    param :description, String, :desc => "description"
-    param :environment, Hash, :desc => "environment"
-    param :environment_id, :identifier, :desc => "environment id"
-    param :content_view_id, :identifier, :desc => "content view id"
-    param :usage_limit, :number, :desc => "maximum number of registered content hosts, or 'unlimited'"
+    api :POST, "/activation_keys", N_("Create an activation key")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+    param :name, String, :desc => N_("name"), :required => true
+    param :label, String, :desc => N_("unique label")
+    param :description, String, :desc => N_("description")
+    param :environment, Hash, :desc => N_("environment")
+    param :environment_id, :identifier, :desc => N_("environment id")
+    param :content_view_id, :identifier, :desc => N_("content view id")
+    param :usage_limit, :number, :desc => N_("maximum number of registered content hosts, or 'unlimited'")
     def create
       @activation_key = ActivationKey.create!(activation_key_params) do |activation_key|
         activation_key.environment = @environment if @environment
@@ -86,37 +86,37 @@ module Katello
       respond
     end
 
-    api :PUT, "/activation_keys/:id", "Update an activation key"
-    param :id, :identifier, :desc => "ID of the activation key", :required => true
-    param :organization_id, :number, :desc => "organization identifier", :required => true
-    param :name, String, :desc => "name", :required => true
-    param :description, String, :desc => "description"
-    param :environment_id, :identifier, :desc => "environment id", :required => true
-    param :content_view_id, :identifier, :desc => "content view id", :required => true
-    param :usage_limit, :number, :desc => "maximum number of registered content hosts, or 'unlimited'"
-    param :release_version, String, :desc => "content release version"
-    param :service_level, String, :desc => "service level"
+    api :PUT, "/activation_keys/:id", N_("Update an activation key")
+    param :id, :identifier, :desc => N_("ID of the activation key"), :required => true
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+    param :name, String, :desc => N_("name"), :required => true
+    param :description, String, :desc => N_("description")
+    param :environment_id, :identifier, :desc => N_("environment id"), :required => true
+    param :content_view_id, :identifier, :desc => N_("content view id"), :required => true
+    param :usage_limit, :number, :desc => N_("maximum number of registered content hosts, or 'unlimited'")
+    param :release_version, String, :desc => N_("content release version")
+    param :service_level, String, :desc => N_("service level")
     def update
       @activation_key.update_attributes(activation_key_params)
       respond
     end
 
-    api :DELETE, "/activation_keys/:id", "Destroy an activation key"
-    param :id, :identifier, :desc => "ID of the activation key", :required => true
+    api :DELETE, "/activation_keys/:id", N_("Destroy an activation key")
+    param :id, :identifier, :desc => N_("ID of the activation key"), :required => true
     def destroy
       @activation_key.destroy
       respond
     end
 
-    api :GET, "/activation_keys/:id", "Show an activation key"
-    param :id, :identifier, :desc => "ID of the activation key", :required => true
+    api :GET, "/activation_keys/:id", N_("Show an activation key")
+    param :id, :identifier, :desc => N_("ID of the activation key"), :required => true
     def show
       respond
     end
 
-    api :GET, "/activation_keys/:id/host_collections/available", "List host collections the system does not belong to"
+    api :GET, "/activation_keys/:id/host_collections/available", N_("List host collections the system does not belong to")
     param_group :search, Api::V2::ApiController
-    param :name, String, :desc => "host collection name to filter by"
+    param :name, String, :desc => N_("host collection name to filter by")
     def available_host_collections
       filters = [:terms => {:id => HostCollection.readable(@activation_key.organization).pluck("#{Katello::HostCollection.table_name}.id") -
                    @activation_key.host_collections.pluck("#{Katello::HostCollection.table_name}.id")}]
@@ -130,8 +130,8 @@ module Katello
       respond_for_index(:collection => item_search(HostCollection, params, options))
     end
 
-    api :GET, "/activation_keys/:id/releases", "Show release versions available for an activation key"
-    param :id, String, :desc => "ID of the activation key", :required => true
+    api :GET, "/activation_keys/:id/releases", N_("Show release versions available for an activation key")
+    param :id, String, :desc => N_("ID of the activation key"), :required => true
     def available_releases
       response = {
           :results => @activation_key.available_releases,
@@ -142,7 +142,7 @@ module Katello
     end
 
     api :PUT, "/activation_keys/:id/host_collections"
-    param :id, :identifier, :desc => "ID of the activation key", :required => true
+    param :id, :identifier, :desc => N_("ID of the activation key"), :required => true
     def add_host_collections
       ids = activation_key_params[:host_collection_ids]
       @activation_key.host_collection_ids = (@activation_key.host_collection_ids + ids).uniq

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -34,19 +34,19 @@ module Katello
     end
 
     def_param_group :search do
-      param :search, String, :desc => "Search string"
-      param :page, :number, :desc => "Page number, starting at 1"
-      param :per_page,  :number, :desc => "Number of results per page to return"
-      param :order, String, :desc => "Sort field and order, eg. 'name DESC'"
-      param :full_results, :bool, :desc => "Whether or not to show all results"
-      param :sort, Hash, :desc => "Hash version of 'order' param" do
-        param :by, String, :desc => "Field to sort the results on"
-        param :order, String, :desc => "How to order the sorted results (e.g. ASC for ascending)"
+      param :search, String, :desc => N_("Search string")
+      param :page, :number, :desc => N_("Page number, starting at 1")
+      param :per_page,  :number, :desc => N_("Number of results per page to return")
+      param :order, String, :desc => N_("Sort field and order, eg. 'name DESC'")
+      param :full_results, :bool, :desc => N_("Whether or not to show all results")
+      param :sort, Hash, :desc => N_("Hash version of 'order' param") do
+        param :by, String, :desc => N_("Field to sort the results on")
+        param :order, String, :desc => N_("How to order the sorted results (e.g. ASC for ascending)")
       end
     end
 
-    param :object_root, String, :desc => "root-node of single-resource responses (optional)"
-    param :root_name, String, :desc => "root-node of collection contained in responses (default: 'results')"
+    param :object_root, String, :desc => N_("root-node of single-resource responses (optional)")
+    param :root_name, String, :desc => N_("root-node of collection contained in responses (default: 'results')")
 
     def item_search(item_class, params, options)
       fail "@search_service search not defined" if @search_service.nil?

--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -28,33 +28,33 @@ class Api::V2::ContentUploadsController < Api::V2::ApiController
     }
   end
 
-  api :POST, "/repositories/:repo_id/content_uploads", "Create an upload request"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
+  api :POST, "/repositories/:repo_id/content_uploads", N_("Create an upload request")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
   def create
     respond :resource => pulp_content.create_upload_request
   end
 
-  api :PUT, "/repositories/:repo_id/content_uploads/:id/upload_bits", "Upload bits"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
-  param :id, :identifier, :required => true, :desc => "upload request id"
-  param :offset, :number, :required => true, :desc => "the offset at which Pulp will store the file contents"
-  param :content, File, :required => true, :desc => "file contents"
+  api :PUT, "/repositories/:repo_id/content_uploads/:id/upload_bits", N_("Upload bits")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
+  param :id, :identifier, :required => true, :desc => N_("upload request id")
+  param :offset, :number, :required => true, :desc => N_("the offset at which Pulp will store the file contents")
+  param :content, File, :required => true, :desc => N_("file contents")
   def upload_bits
     pulp_content.upload_bits(params[:id], params[:offset], params[:content])
     render :nothing => true
   end
 
-  api :DELETE, "/repositories/:repo_id/content_uploads/:id", "Delete an upload request"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
-  param :id, :identifier, :required => true, :desc => "upload request id"
+  api :DELETE, "/repositories/:repo_id/content_uploads/:id", N_("Delete an upload request")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
+  param :id, :identifier, :required => true, :desc => N_("upload request id")
   def destroy
     pulp_content.delete_upload_request(params[:id])
     render :nothing => true
   end
 
-  api :POST, "/repositories/:repo_id/content_uploads/import_into_repo", "Import into a repository"
-  param :repo_id, :identifier, :required => true, :desc => "repository id"
-  param :uploads, Array, :required => true, :desc => "array of uploads to import"
+  api :POST, "/repositories/:repo_id/content_uploads/import_into_repo", N_("Import into a repository")
+  param :repo_id, :identifier, :required => true, :desc => N_("repository id")
+  param :uploads, Array, :required => true, :desc => N_("array of uploads to import")
   def import_into_repo
     params[:uploads].each do |upload|
       pulp_content.import_into_repo(@repo.pulp_id, @repo.unit_type_id,
@@ -66,9 +66,9 @@ class Api::V2::ContentUploadsController < Api::V2::ApiController
     render :nothing => true
   end
 
-  api :POST, "/repositories/:id/content_uploads/file", "Upload content into the repository"
+  api :POST, "/repositories/:id/content_uploads/file", N_("Upload content into the repository")
   param :id, :identifier, :required => true
-  param :content, File, :required => true, :desc => "file contents"
+  param :content, File, :required => true, :desc => N_("file contents")
   def upload_file
     filepaths = params.try(:[], :content).try(:map, &:path)
 

--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -30,8 +30,8 @@ module Katello
       }
     end
 
-    api :GET, "/content_view_filters/:content_view_filter_id/rules", "List filter rules"
-    param :content_view_filter_id, :identifier, :desc => "filter identifier", :required => true
+    api :GET, "/content_view_filters/:content_view_filter_id/rules", N_("List filter rules")
+    param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
     def index
       options = sort_params
       options[:load_records?] = true
@@ -42,49 +42,49 @@ module Katello
     end
 
     api :POST, "/content_view_filters/:content_view_filter_id/rules",
-        "Create a filter rule. The parameters included should be based upon the filter type."
-    param :content_view_filter_id, :identifier, :desc => "filter identifier", :required => true
-    param :name, String, :desc => "package or package group: name"
-    param :version, String, :desc => "package: version"
-    param :min_version, String, :desc => "package: minimum version"
-    param :max_version, String, :desc => "package: maximum version"
-    param :errata_id, String, :desc => "erratum: id"
-    param :start_date, String, :desc => "erratum: start date (YYYY-MM-DD)"
-    param :end_date, String, :desc => "erratum: end date (YYYY-MM-DD)"
-    param :types, Array, :desc => "erratum: types (enhancement, bugfix, security)"
+        N_("Create a filter rule. The parameters included should be based upon the filter type.")
+    param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
+    param :name, String, :desc => N_("package or package group: name")
+    param :version, String, :desc => N_("package: version")
+    param :min_version, String, :desc => N_("package: minimum version")
+    param :max_version, String, :desc => N_("package: maximum version")
+    param :errata_id, String, :desc => N_("erratum: id")
+    param :start_date, String, :desc => N_("erratum: start date (YYYY-MM-DD)")
+    param :end_date, String, :desc => N_("erratum: end date (YYYY-MM-DD)")
+    param :types, Array, :desc => N_("erratum: types (enhancement, bugfix, security)")
     def create
       rule_clazz = ContentViewFilter.rule_class_for(@filter)
       rule = rule_clazz.create!(rule_params.merge(:filter => @filter))
       respond :resource => rule
     end
 
-    api :GET, "/content_view_filters/:content_view_filter_id/rules/:id", "Show filter rule info"
-    param :content_view_filter_id, :identifier, :desc => "filter identifier", :required => true
-    param :id, :identifier, :desc => "rule identifier", :required => true
+    api :GET, "/content_view_filters/:content_view_filter_id/rules/:id", N_("Show filter rule info")
+    param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
+    param :id, :identifier, :desc => N_("rule identifier"), :required => true
     def show
       respond :resource => @rule
     end
 
     api :PUT, "/content_view_filters/:content_view_filter_id/rules/:id",
-        "Update a filter rule. The parameters included should be based upon the filter type."
-    param :content_view_filter_id, :identifier, :desc => "filter identifier", :required => true
-    param :id, :identifier, :desc => "rule identifier", :required => true
-    param :name, String, :desc => "package or package group: name"
-    param :version, String, :desc => "package: version"
-    param :min_version, String, :desc => "package: minimum version"
-    param :max_version, String, :desc => "package: maximum version"
-    param :errata_id, String, :desc => "erratum: id"
-    param :start_date, String, :desc => "erratum: start date (YYYY-MM-DD)"
-    param :end_date, String, :desc => "erratum: end date (YYYY-MM-DD)"
-    param :types, Array, :desc => "erratum: types (enhancement, bugfix, security)"
+        N_("Update a filter rule. The parameters included should be based upon the filter type.")
+    param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
+    param :id, :identifier, :desc => N_("rule identifier"), :required => true
+    param :name, String, :desc => N_("package or package group: name")
+    param :version, String, :desc => N_("package: version")
+    param :min_version, String, :desc => N_("package: minimum version")
+    param :max_version, String, :desc => N_("package: maximum version")
+    param :errata_id, String, :desc => N_("erratum: id")
+    param :start_date, String, :desc => N_("erratum: start date (YYYY-MM-DD)")
+    param :end_date, String, :desc => N_("erratum: end date (YYYY-MM-DD)")
+    param :types, Array, :desc => N_("erratum: types (enhancement, bugfix, security)")
     def update
       @rule.update_attributes!(rule_params)
       respond :resource => @rule
     end
 
-    api :DELETE, "/content_view_filters/:content_view_filter_id/rules/:id", "Delete a filter rule"
-    param :content_view_filter_id, :identifier, :desc => "filter identifier", :required => true
-    param :id, :identifier, :desc => "rule identifier", :required => true
+    api :DELETE, "/content_view_filters/:content_view_filter_id/rules/:id", N_("Delete a filter rule")
+    param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
+    param :id, :identifier, :desc => N_("rule identifier"), :required => true
     def destroy
       @rule.destroy
       respond_for_show :resource => @rule

--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -35,9 +35,9 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/content_views/:content_view_id/filters", "List filters"
-  api :GET, "/content_view_filters", "List filters"
-  param :content_view_id, :identifier, :desc => "content view identifier", :required => true
+  api :GET, "/content_views/:content_view_id/filters", N_("List filters")
+  api :GET, "/content_view_filters", N_("List filters")
+  param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
   def index
     options = sort_params
     options[:load_records?] = true
@@ -47,53 +47,53 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
     respond(:collection => item_search(ContentViewFilter, params, options))
   end
 
-  api :POST, "/content_views/:content_view_id/filters", "Create a filter for a content view"
-  api :POST, "/content_view_filters", "Create a filter for a content view"
-  param :content_view_id, :identifier, :desc => "content view identifier", :required => true
-  param :name, String, :desc => "name of the filter", :required => true
-  param :type, String, :desc => "type of filter (e.g. rpm, package_group, erratum)", :required => true
-  param :inclusion, :bool, :desc => "specifies if content should be included or excluded, default: inclusion=false"
-  param :repository_ids, Array, :desc => "list of repository ids"
+  api :POST, "/content_views/:content_view_id/filters", N_("Create a filter for a content view")
+  api :POST, "/content_view_filters", N_("Create a filter for a content view")
+  param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
+  param :name, String, :desc => N_("name of the filter"), :required => true
+  param :type, String, :desc => N_("type of filter (e.g. rpm, package_group, erratum)"), :required => true
+  param :inclusion, :bool, :desc => N_("specifies if content should be included or excluded, default: inclusion=false")
+  param :repository_ids, Array, :desc => N_("list of repository ids")
   def create
     filter = ContentViewFilter.create_for(params[:type], filter_params.merge(:content_view => @view))
     respond :resource => filter
   end
 
-  api :GET, "/content_views/:content_view_id/filters/:id", "Show filter info"
-  api :GET, "/content_view_filters/:id", "Show filter info"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :id, :identifier, :desc => "filter identifier", :required => true
+  api :GET, "/content_views/:content_view_id/filters/:id", N_("Show filter info")
+  api :GET, "/content_view_filters/:id", N_("Show filter info")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :id, :identifier, :desc => N_("filter identifier"), :required => true
   def show
     respond :resource => @filter
   end
 
-  api :PUT, "/content_views/:content_view_id/filters/:id", "Update a filter"
-  api :PUT, "/content_view_filters/:id", "Update a filter"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :id, :identifier, :desc => "filter identifier", :required => true
-  param :name, String, :desc => "new name for the filter"
-  param :inclusion, :bool, :desc => "specifies if content should be included or excluded, default: inclusion=false"
-  param :repository_ids, Array, :desc => "list of repository ids"
+  api :PUT, "/content_views/:content_view_id/filters/:id", N_("Update a filter")
+  api :PUT, "/content_view_filters/:id", N_("Update a filter")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :id, :identifier, :desc => N_("filter identifier"), :required => true
+  param :name, String, :desc => N_("new name for the filter")
+  param :inclusion, :bool, :desc => N_("specifies if content should be included or excluded, default: inclusion=false")
+  param :repository_ids, Array, :desc => N_("list of repository ids")
   def update
     @filter.update_attributes!(filter_params)
     respond :resource => @filter
   end
 
-  api :DELETE, "/content_views/:content_view_id/filters/:id", "Delete a filter"
-  api :DELETE, "/content_view_filters/:id", "Delete a filter"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :id, :identifier, :desc => "filter identifier", :required => true
+  api :DELETE, "/content_views/:content_view_id/filters/:id", N_("Delete a filter")
+  api :DELETE, "/content_view_filters/:id", N_("Delete a filter")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :id, :identifier, :desc => N_("filter identifier"), :required => true
   def destroy
     @filter.destroy
     respond_for_show :resource => @filter
   end
 
   api :GET, "/content_views/:content_view_id/filters/:id/available_errata",
-      "Get errata that are available to be added to the filter"
+      N_("Get errata that are available to be added to the filter")
   api :GET, "/content_view_filters/:id/available_errata",
-      "Get errata that are available to be added to the filter"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :id, :identifier, :desc => "filter identifier", :required => true
+      N_("Get errata that are available to be added to the filter")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :id, :identifier, :desc => N_("filter identifier"), :required => true
   def available_errata
     current_errata_ids = @filter.erratum_rules.map(&:errata_id)
     repo_ids = @filter.applicable_repos.pluck(:pulp_id)
@@ -113,11 +113,11 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   end
 
   api :GET, "/content_views/:content_view_id/filters/:id/available_package_groups",
-      "Get package groups that are available to be added to the filter"
+      N_("Get package groups that are available to be added to the filter")
   api :GET, "/content_view_filters/:id/available_package_groups",
-      "Get package groups that are available to be added to the filter"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :id, :identifier, :desc => "filter identifier", :required => true
+      N_("Get package groups that are available to be added to the filter")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :id, :identifier, :desc => N_("filter identifier"), :required => true
   def available_package_groups
     current_ids = @filter.package_group_rules.map(&:name)
     repo_ids = @filter.applicable_repos.pluck(:pulp_id)

--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -29,8 +29,8 @@ module Katello
       }
     end
 
-    api :GET, "/content_views/:content_view_id/content_view_puppet_modules", "List content view puppet modules"
-    param :content_view_id, :identifier, :desc => "content view identifier", :required => true
+    api :GET, "/content_views/:content_view_id/content_view_puppet_modules", N_("List content view puppet modules")
+    param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
     def index
       options = sort_params
       options[:load_records?] = true
@@ -41,11 +41,11 @@ module Katello
     end
 
     api :POST, "/content_views/:content_view_id/content_view_puppet_modules",
-        "Add a puppet module to the content view"
-    param :content_view_id, :identifier, :desc => "content view identifier", :required => true
-    param :name, String, :desc => "name of the puppet module"
-    param :author, String, :desc => "author of the puppet module"
-    param :uuid, String, :desc => "the uuid of the puppet module to associate"
+        N_("Add a puppet module to the content view")
+    param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
+    param :name, String, :desc => N_("name of the puppet module")
+    param :author, String, :desc => N_("author of the puppet module")
+    param :uuid, String, :desc => N_("the uuid of the puppet module to associate")
     def create
       @puppet_module = ContentViewPuppetModule.create!(puppet_module_params) do |puppet_module|
         puppet_module.content_view = @view
@@ -54,28 +54,28 @@ module Katello
       respond :resource => @puppet_module
     end
 
-    api :GET, "/content_views/:content_view_id/content_view_puppet_modules/:id", "Show a content view puppet module"
-    param :content_view_id, :number, :desc => "content view numeric identifier", :required => true
+    api :GET, "/content_views/:content_view_id/content_view_puppet_modules/:id", N_("Show a content view puppet module")
+    param :content_view_id, :number, :desc => N_("content view numeric identifier"), :required => true
     def show
       respond :resource => @puppet_module
     end
 
     api :PUT, "/content_views/:content_view_id/content_view_puppet_modules/:id",
-        "Update a puppet module associated with the content view"
-    param :content_view_id, :identifier, :desc => "content view identifier", :required => true
-    param :id, :identifier, :desc => "puppet module identifier", :required => true
-    param :name, String, :desc => "name of the puppet module"
-    param :author, String, :desc => "author of the puppet module"
-    param :uuid, String, :desc => "the uuid of the puppet module to associate"
+        N_("Update a puppet module associated with the content view")
+    param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
+    param :id, :identifier, :desc => N_("puppet module identifier"), :required => true
+    param :name, String, :desc => N_("name of the puppet module")
+    param :author, String, :desc => N_("author of the puppet module")
+    param :uuid, String, :desc => N_("the uuid of the puppet module to associate")
     def update
       @puppet_module.update_attributes!(puppet_module_params)
       respond :resource => @puppet_module
     end
 
     api :DELETE, "/content_views/:content_view_id/content_view_puppet_modules/:id",
-        "Remove a puppet module from the content view"
-    param :content_view_id, :identifier, :desc => "content view identifier", :required => true
-    param :id, :identifier, :desc => "puppet module identifierr", :required => true
+        N_("Remove a puppet module from the content view")
+    param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
+    param :id, :identifier, :desc => N_("puppet module identifierr"), :required => true
     def destroy
       @puppet_module.destroy
       respond :resource => @puppet_module

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -29,9 +29,9 @@ module Katello
       }
     end
 
-    api :GET, "/content_view_versions", "List content view versions"
-    api :GET, "/content_views/:content_view_id/content_view_versions", "List content view versions"
-    param :content_view_id, :identifier, :desc => "Content view identifier", :required => true
+    api :GET, "/content_view_versions", N_("List content view versions")
+    api :GET, "/content_views/:content_view_id/content_view_versions", N_("List content view versions")
+    param :content_view_id, :identifier, :desc => N_("Content view identifier"), :required => true
     def index
       collection = {:results  => @view.versions.order('version desc'),
                     :subtotal => @view.versions.count,
@@ -40,22 +40,22 @@ module Katello
       respond(:collection => collection)
     end
 
-    api :GET, "/content_view_versions/:id", "Show content view version"
-    param :id, :identifier, :desc => "Content view version identifier", :required => true
+    api :GET, "/content_view_versions/:id", N_("Show content view version")
+    param :id, :identifier, :desc => N_("Content view version identifier"), :required => true
     def show
       respond :resource => @version
     end
 
-    api :POST, "/content_view_versions/:id/promote", "Promote a content view version"
-    param :id, :identifier, :desc => "Content view version identifier", :required => true
+    api :POST, "/content_view_versions/:id/promote", N_("Promote a content view version")
+    param :id, :identifier, :desc => N_("Content view version identifier"), :required => true
     param :environment_id, :identifier
     def promote
       task = async_task(::Actions::Katello::ContentView::Promote, @version, @environment)
       respond_for_async :resource => task
     end
 
-    api :DELETE, "/content_view_versions/:id", "Remove content view version"
-    param :id, :identifier, :desc => "Content view version identifier", :required => true
+    api :DELETE, "/content_view_versions/:id", N_("Remove content view version")
+    param :id, :identifier, :desc => N_("Content view version identifier"), :required => true
     def destroy
       task = async_task(::Actions::Katello::ContentViewVersion::Destroy, @version)
       respond_for_async :resource => task

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -26,9 +26,9 @@ module Katello
     end
 
     def_param_group :content_view do
-      param :description, String, :desc => "Description for the content view"
-      param :repository_ids, Array, :desc => "List of repository ids"
-      param :component_ids, Array, :desc => "List of component content view version ids for composite views"
+      param :description, String, :desc => N_("Description for the content view")
+      param :repository_ids, Array, :desc => N_("List of repository ids")
+      param :component_ids, Array, :desc => N_("List of component content view version ids for composite views")
     end
 
     def rules
@@ -54,11 +54,11 @@ module Katello
       }
     end
 
-    api :GET, "/organizations/:organization_id/content_views", "List content views"
-    api :GET, "/content_views", "List content views"
-    param :organization_id, :number, :desc => "organization identifier", :required => true
-    param :environment_id, :identifier, :desc => "environment identifier"
-    param :nondefault, :bool, :desc => "Filter out default content views"
+    api :GET, "/organizations/:organization_id/content_views", N_("List content views")
+    api :GET, "/content_views", N_("List content views")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+    param :environment_id, :identifier, :desc => N_("environment identifier")
+    param :nondefault, :bool, :desc => N_("Filter out default content views")
     def index
       options = sort_params
       options[:load_records?] = true
@@ -76,12 +76,12 @@ module Katello
       respond(:collection => item_search(ContentView, params, options))
     end
 
-    api :POST, "/organizations/:organization_id/content_views", "Create a content view"
-    api :POST, "/content_views", "Create a content view"
-    param :organization_id, :number, :desc => "Organization identifier", :required => true
-    param :name, String, :desc => "Name of the content view", :required => true
-    param :label, String, :desc => "Content view label"
-    param :composite, :bool, :desc => "Composite content view"
+    api :POST, "/organizations/:organization_id/content_views", N_("Create a content view")
+    api :POST, "/content_views", N_("Create a content view")
+    param :organization_id, :number, :desc => N_("Organization identifier"), :required => true
+    param :name, String, :desc => N_("Name of the content view"), :required => true
+    param :label, String, :desc => N_("Content view label")
+    param :composite, :bool, :desc => N_("Composite content view")
     param_group :content_view
     def create
       @view = ContentView.create!(view_params) do |view|
@@ -92,9 +92,9 @@ module Katello
       respond :resource => @view
     end
 
-    api :PUT, "/content_views/:id", "Update a content view"
-    param :id, :number, :desc => "Content view identifier", :required => true
-    param :name, String, :desc => "New name for the content view"
+    api :PUT, "/content_views/:id", N_("Update a content view")
+    param :id, :number, :desc => N_("Content view identifier"), :required => true
+    param :name, String, :desc => N_("New name for the content view")
     param_group :content_view
     def update
       @view.update_attributes!(view_params)
@@ -102,23 +102,23 @@ module Katello
       respond :resource => @view
     end
 
-    api :POST, "/content_views/:id/publish", "Publish a content view"
-    param :id, :identifier, :desc => "Content view identifier", :required => true
+    api :POST, "/content_views/:id/publish", N_("Publish a content view")
+    param :id, :identifier, :desc => N_("Content view identifier"), :required => true
     def publish
       task = async_task(::Actions::Katello::ContentView::Publish, @view)
       respond_for_async :resource => task
     end
 
-    api :GET, "/content_views/:id", "Show a content view"
-    param :id, :number, :desc => "content view numeric identifier", :required => true
+    api :GET, "/content_views/:id", N_("Show a content view")
+    param :id, :number, :desc => N_("content view numeric identifier"), :required => true
     def show
       respond :resource => @view
     end
 
     api :GET, "/content_views/:id/available_puppet_modules",
-        "Get puppet modules that are available to be added to the content view"
-    param :id, :identifier, :desc => "content view numeric identifier", :required => true
-    param :name, String, :desc => "module name to restrict modules for", :required => false
+        N_("Get puppet modules that are available to be added to the content view")
+    param :id, :identifier, :desc => N_("content view numeric identifier"), :required => true
+    param :name, String, :desc => N_("module name to restrict modules for"), :required => false
     def available_puppet_modules
       current_ids = @view.content_view_puppet_modules.map(&:uuid).reject{|p| p.nil?}
 
@@ -138,8 +138,8 @@ module Katello
     end
 
     api :GET, "/content_views/:id/available_puppet_module_names",
-        "Get puppet modules names that are available to be added to the content view"
-    param :id, :identifier, :desc => "content view numeric identifier", :required => true
+        N_("Get puppet modules names that are available to be added to the content view")
+    param :id, :identifier, :desc => N_("content view numeric identifier"), :required => true
     def available_puppet_module_names
       current_names = @view.content_view_puppet_modules.map(&:name).reject{|p| p.nil?}
       repo_ids = @view.organization.library.puppet_repositories.readable(
@@ -156,8 +156,8 @@ module Katello
                         :collection => facet_search(PuppetModule, 'name', options)
     end
 
-    api :GET, "/content_views/:id/history", "Show a content view's history"
-    param :id, :number, :desc => "content view numeric identifier", :required => true
+    api :GET, "/content_views/:id/history", N_("Show a content view's history")
+    param :id, :number, :desc => N_("content view numeric identifier"), :required => true
     def history
       options = sort_params
       options[:load_records?] = true
@@ -167,22 +167,22 @@ module Katello
                         :collection => item_search(ContentViewHistory, params, options)
     end
 
-    api :DELETE, "/content_views/:id/environments/:environment_id", "Remove a content view from an environment"
-    param :id, :number, :desc => "content view numeric identifier", :required => true
-    param :environment_id, :number, :desc => "environment numeric identifier", :required => true
+    api :DELETE, "/content_views/:id/environments/:environment_id", N_("Remove a content view from an environment")
+    param :id, :number, :desc => N_("content view numeric identifier"), :required => true
+    param :environment_id, :number, :desc => N_("environment numeric identifier"), :required => true
     def remove_from_environment
       task = async_task(::Actions::Katello::ContentView::RemoveFromEnvironment, @view, @environment)
       respond_for_async :resource => task
     end
 
-    api :PUT, "/content_views/:id/remove", "Remove versions and/or environments from a content view and reassign systems and keys"
-    param :id, :number, :desc => "content view numeric identifier", :required => true
-    param :environment_ids, :number, :desc => "environment numeric identifiers to be removed"
-    param :content_view_version_ids, :number, :desc => "content view version identifiers to be deleted"
-    param :system_content_view_id, :number, :desc => "content view to reassign orphaned systems to"
-    param :system_environment_id, :number, :desc => "environment to reassign orphaned systems to"
-    param :key_content_view_id, :number, :desc => "content view to reassign orphaned activation keys to"
-    param :key_environment_id, :number, :desc => "environment to reassign orphaned activation keys to"
+    api :PUT, "/content_views/:id/remove", N_("Remove versions and/or environments from a content view and reassign systems and keys")
+    param :id, :number, :desc => N_("content view numeric identifier"), :required => true
+    param :environment_ids, :number, :desc => N_("environment numeric identifiers to be removed")
+    param :content_view_version_ids, :number, :desc => N_("content view version identifiers to be deleted")
+    param :system_content_view_id, :number, :desc => N_("content view to reassign orphaned systems to")
+    param :system_environment_id, :number, :desc => N_("environment to reassign orphaned systems to")
+    param :key_content_view_id, :number, :desc => N_("content view to reassign orphaned activation keys to")
+    param :key_environment_id, :number, :desc => N_("environment to reassign orphaned activation keys to")
     def remove
       cv_envs = ContentViewEnvironment.where(:environment_id => params[:environment_ids],
                                              :content_view_id => params[:id]
@@ -206,8 +206,8 @@ module Katello
       respond_for_async :resource => task
     end
 
-    api :DELETE, "/content_views/:id", "Delete a content view"
-    param :id, :number, :desc => "content view numeric identifier", :required => true
+    api :DELETE, "/content_views/:id", N_("Delete a content view")
+    param :id, :number, :desc => N_("content view numeric identifier"), :required => true
     def destroy
       task = async_task(::Actions::Katello::ContentView::Destroy, @view)
       respond_for_async :resource => task

--- a/app/controllers/katello/api/v2/custom_info_controller.rb
+++ b/app/controllers/katello/api/v2/custom_info_controller.rb
@@ -21,8 +21,8 @@ class Api::V2::CustomInfoController < Api::V1::CustomInfoController
   end
 
   def_param_group :informable_identifier do
-    param :informable_type, String, :desc => "name of the resource", :required => true
-    param :informable_id, :identifier, :desc => "resource identifier", :required => true
+    param :informable_type, String, :desc => N_("name of the resource"), :required => true
+    param :informable_id, :identifier, :desc => N_("resource identifier"), :required => true
   end
 
   def_param_group :custom_info do
@@ -32,9 +32,9 @@ class Api::V2::CustomInfoController < Api::V1::CustomInfoController
     end
   end
 
-  api :POST, "/custom_info/:informable_type/:informable_id", "Create custom info"
-  param :informable_type, String, :desc => "name of the resource", :required => true
-  param :informable_id, :identifier, :desc => "resource identifier", :required => true
+  api :POST, "/custom_info/:informable_type/:informable_id", N_("Create custom info")
+  param :informable_type, String, :desc => N_("name of the resource"), :required => true
+  param :informable_id, :identifier, :desc => N_("resource identifier"), :required => true
   param :custom_info, Hash, :required => true, :action_aware => true do
     param :keyname, String, :required => true
     param :value, String, :required => true
@@ -43,9 +43,9 @@ class Api::V2::CustomInfoController < Api::V1::CustomInfoController
     respond :resource => @informable.custom_info.create!(params[:custom_info])
   end
 
-  api :PUT, "/custom_info/:informable_type/:informable_id/:keyname", "Update custom info"
+  api :PUT, "/custom_info/:informable_type/:informable_id/:keyname", N_("Update custom info")
   param_group :informable_identifier
-  param :keyname, String, :desc => "Custom info key", :required => true
+  param :keyname, String, :desc => N_("Custom info key"), :required => true
   param :custom_info, Hash, :required => true, :action_aware => true do
     param :value, String, :required => true
   end

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -79,11 +79,11 @@ module Katello
       }
     end
 
-    api :GET, "/environments", "List environments in an organization"
-    api :GET, "/organizations/:organization_id/environments", "List environments in an organization"
-    param :organization_id, :number, :desc => "organization identifier", :required => true
-    param :library, [true, false], :desc => "set true if you want to see only library environments"
-    param :name, String, :desc => "filter only environments containing this name"
+    api :GET, "/environments", N_("List environments in an organization")
+    api :GET, "/organizations/:organization_id/environments", N_("List environments in an organization")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+    param :library, [true, false], :desc => N_("set true if you want to see only library environments")
+    param :name, String, :desc => N_("filter only environments containing this name")
     def index
       filters = []
 
@@ -99,19 +99,19 @@ module Katello
       respond_for_index(:collection => item_search(KTEnvironment, params, options))
     end
 
-    api :GET, "/environments/:id", "Show an environment"
-    api :GET, "/organizations/:organization_id/environments/:environment_id", "Show an environment"
-    param :id, :number, :desc => "ID of the environment", :required => true
-    param :organization_id, :number, :desc => "ID of the organization"
+    api :GET, "/environments/:id", N_("Show an environment")
+    api :GET, "/organizations/:organization_id/environments/:environment_id", N_("Show an environment")
+    param :id, :number, :desc => N_("ID of the environment"), :required => true
+    param :organization_id, :number, :desc => N_("ID of the organization")
     def show
       respond
     end
 
-    api :POST, "/environments", "Create an environment"
-    api :POST, "/organizations/:organization_id/environments", "Create an environment in an organization"
-    param :organization_id, :number, :desc => "name of organization", :required => true
-    param :name, String, :desc => "name of the environment", :required => true
-    param :description, String, :desc => "description of the environment"
+    api :POST, "/environments", N_("Create an environment")
+    api :POST, "/organizations/:organization_id/environments", N_("Create an environment in an organization")
+    param :organization_id, :number, :desc => N_("name of organization"), :required => true
+    param :name, String, :desc => N_("name of the environment"), :required => true
+    param :description, String, :desc => N_("description of the environment")
     param :prior, String, :required => true, :desc => <<-DESC
       Name of an environment that is prior to the new environment in the chain. It has to be
       either 'Library' or an environment at the end of a chain.
@@ -127,12 +127,12 @@ module Katello
       respond
     end
 
-    api :PUT, "/environments/:id", "Update an environment"
-    api :PUT, "/organizations/:organization_id/environments/:id", "Update an environment in an organization"
-    param :id, :number, :desc => "ID of the environment", :required => true
-    param :organization_id, :number, :desc => "name of the organization"
-    param :new_name, String, :desc => "new name to be given to the environment"
-    param :description, String, :desc => "description of the environment"
+    api :PUT, "/environments/:id", N_("Update an environment")
+    api :PUT, "/organizations/:organization_id/environments/:id", N_("Update an environment in an organization")
+    param :id, :number, :desc => N_("ID of the environment"), :required => true
+    param :organization_id, :number, :desc => N_("name of the organization")
+    param :new_name, String, :desc => N_("new name to be given to the environment")
+    param :description, String, :desc => N_("description of the environment")
     param :prior, String, :desc => <<-DESC
       Name of an environment that is prior to the new environment in the chain. It has to be
       either 'Library' or an environment at the end of a chain.
@@ -146,10 +146,10 @@ module Katello
       respond
     end
 
-    api :DELETE, "/environments/:id", "Destroy an environment"
-    api :DELETE, "/organizations/:organization_id/environments/:id", "Destroy an environment in an organization"
-    param :id, :number, :desc => "ID of the environment", :required => true
-    param :organization_id, :number, :desc => "organization identifier"
+    api :DELETE, "/environments/:id", N_("Destroy an environment")
+    api :DELETE, "/organizations/:organization_id/environments/:id", N_("Destroy an environment in an organization")
+    param :id, :number, :desc => N_("ID of the environment"), :required => true
+    param :organization_id, :number, :desc => N_("organization identifier")
     def destroy
       if @environment.is_deletable?
         @environment.destroy
@@ -161,15 +161,15 @@ module Katello
     end
 
     # TODO
-    # api :GET, "/organizations/:organization_id/environments/systems_registerable", "List environments that systems can be registered to"
-    # param :organization_id, :number, :desc => "organization identifier"
+    # api :GET, "/organizations/:organization_id/environments/systems_registerable", N_("List environments that systems can be registered to")
+    # param :organization_id, :number, :desc => N_("organization identifier")
     def systems_registerable
       @environments = KTEnvironment.systems_registerable(@organization)
       respond_for_index :collection => @environments
     end
 
-    api :GET, "/organizations/:organization_id/environments/paths", "List environment paths"
-    param :organization_id, :number, :desc => "organization identifier"
+    api :GET, "/organizations/:organization_id/environments/paths", N_("List environment paths")
+    param :organization_id, :number, :desc => N_("organization identifier")
     def paths
       paths = @organization.promotion_paths.inject([]) do |result, path|
         result << { :environments => [@organization.library] + path }

--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -14,8 +14,8 @@ module Katello
 class Api::V2::ErrataController < Api::V2::ApiController
 
   resource_description do
-    error :code => 401, :desc => "Unauthorized"
-    error :code => 404, :desc => "Not found"
+    error :code => 401, :desc => N_("Unauthorized")
+    error :code => 404, :desc => N_("Not found")
 
     api_version 'v2'
   end
@@ -39,14 +39,14 @@ class Api::V2::ErrataController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/errata", "List errata"
-  api :GET, "/content_views/:content_view_id/filters/:filter_id/errata", "List errata"
-  api :GET, "/content_view_filters/:content_view_filter_id/errata", "List errata"
-  api :GET, "/repositories/:repository_id/errata", "List errata"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :filter_id, :identifier, :desc => "content view filter identifier"
-  param :content_view_filter_id, :identifier, :desc => "content view filter identifier"
-  param :repository_id, :number, :desc => "repository identifier", :required => true
+  api :GET, "/errata", N_("List errata")
+  api :GET, "/content_views/:content_view_id/filters/:filter_id/errata", N_("List errata")
+  api :GET, "/content_view_filters/:content_view_filter_id/errata", N_("List errata")
+  api :GET, "/repositories/:repository_id/errata", N_("List errata")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :filter_id, :identifier, :desc => N_("content view filter identifier")
+  param :content_view_filter_id, :identifier, :desc => N_("content view filter identifier")
+  param :repository_id, :number, :desc => N_("repository identifier"), :required => true
   def index
     collection = if @repo && !@repo.puppet?
                    filter_by_repoids [@repo.pulp_id]
@@ -59,10 +59,10 @@ class Api::V2::ErrataController < Api::V2::ApiController
     respond(:collection => collection)
   end
 
-  api :GET, "/errata/:id", "Show an erratum"
-  api :GET, "/repositories/:repository_id/errata/:id", "Show an erratum"
-  param :repository_id, :number, :desc => "repository identifier"
-  param :id, String, :desc => "erratum identifier", :required => true
+  api :GET, "/errata/:id", N_("Show an erratum")
+  api :GET, "/repositories/:repository_id/errata/:id", N_("Show an erratum")
+  param :repository_id, :number, :desc => N_("repository identifier")
+  param :id, String, :desc => N_("erratum identifier"), :required => true
   def show
     respond :resource => @erratum
   end

--- a/app/controllers/katello/api/v2/gpg_keys_controller.rb
+++ b/app/controllers/katello/api/v2/gpg_keys_controller.rb
@@ -18,8 +18,8 @@ module Katello
     before_filter :authorize
 
     def_param_group :gpg_key do
-      param :name, :identifier, :action_aware => true, :required => true, :desc => "identifier of the gpg key"
-      param :content, String, :action_aware => true, :required => true, :desc => "public key block in DER encoding"
+      param :name, :identifier, :action_aware => true, :required => true, :desc => N_("identifier of the gpg key")
+      param :content, String, :action_aware => true, :required => true, :desc => N_("public key block in DER encoding")
     end
 
     def rules
@@ -46,8 +46,8 @@ module Katello
       api_version "v2"
     end
 
-    api :GET, "/gpg_keys", "List gpg keys"
-    param :organization_id, :number, :desc => "organization identifier", :required => true
+    api :GET, "/gpg_keys", N_("List gpg keys")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
     param_group :search, Api::V2::ApiController
     def index
       options = sort_params
@@ -62,8 +62,8 @@ module Katello
       respond_for_index(:collection => item_search(GpgKey, params, options))
     end
 
-    api :POST, "/gpg_keys", "Create a gpg key"
-    param :organization_id, :number, :desc => "organization identifier", :required => true
+    api :POST, "/gpg_keys", N_("Create a gpg key")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
     param_group :gpg_key, :as => :create
     def create
       filepath = params.try(:[], :file_path).try(:path)
@@ -79,30 +79,30 @@ module Katello
       respond_for_show(:resource => gpg_key)
     end
 
-    api :GET, "/gpg_keys/:id", "Show a gpg key"
-    param :id, :identifier, :desc => "gpg key numeric identifier", :required => true
+    api :GET, "/gpg_keys/:id", N_("Show a gpg key")
+    param :id, :identifier, :desc => N_("gpg key numeric identifier"), :required => true
     def show
       respond_for_show(:resource => @gpg_key)
     end
 
-    api :PUT, "/gpg_keys/:id", "Update a repository"
-    param :id, :identifier, :desc => "gpg key numeric identifier", :required => true
+    api :PUT, "/gpg_keys/:id", N_("Update a repository")
+    param :id, :identifier, :desc => N_("gpg key numeric identifier"), :required => true
     param_group :gpg_key
     def update
       @gpg_key.update_attributes!(gpg_key_params)
       respond_for_show({:resource => @gpg_key})
     end
 
-    api :DELETE, "/gpg_keys/:id", "Destroy a gpg key"
-    param :id, :number, :desc => "gpg key numeric identifier", :required => true
+    api :DELETE, "/gpg_keys/:id", N_("Destroy a gpg key")
+    param :id, :number, :desc => N_("gpg key numeric identifier"), :required => true
     def destroy
       @gpg_key.destroy
       respond_for_destroy
     end
 
-    api :POST, "/gpg_keys/:id/content", "Upload gpg key contents"
-    param :id, :number, :desc => "gpg key numeric identifier", :required => true
-    param :content, File, :required => true, :desc => "file contents", :required => true
+    api :POST, "/gpg_keys/:id/content", N_("Upload gpg key contents")
+    param :id, :number, :desc => N_("gpg key numeric identifier"), :required => true
+    param :content, File, :required => true, :desc => N_("file contents"), :required => true
     def content
       filepath = params.try(:[], :content).try(:path)
 

--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -46,27 +46,27 @@ module Katello
     end
 
     def_param_group :host_collection do
-      param :name, String, :required => true, :desc => "Host Collection name"
-      param :system_ids, Array, :required => false, :desc => "List of system uuids to be in the host collection"
+      param :name, String, :required => true, :desc => N_("Host Collection name")
+      param :system_ids, Array, :required => false, :desc => N_("List of system uuids to be in the host collection")
       param :description, String
-      param :max_content_hosts, Integer, :desc => "Maximum number of content hosts in the host collection"
+      param :max_content_hosts, Integer, :desc => N_("Maximum number of content hosts in the host collection")
     end
 
-    api :GET, "/host_collections/:id", "Show a host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
+    api :GET, "/host_collections/:id", N_("Show a host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     def show
       respond
     end
 
-    api :GET, "/host_collections", "List host collections"
+    api :GET, "/host_collections", N_("List host collections")
     api :GET, "/organizations/:organization_id/host_collections"
     api :GET, "/activation_keys/:activation_key_id/host_collections"
     api :GET, "/systems/:system_id/host_collections"
     param_group :search, Api::V2::ApiController
-    param :organization_id, :number, :desc => "organization identifier", :required => true
-    param :name, String, :desc => "host collection name to filter by"
-    param :activation_key_id, :identifier, :desc => "activation key identifier"
-    param :system_id, :identifier, :desc => "system identifier"
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+    param :name, String, :desc => N_("host collection name to filter by")
+    param :activation_key_id, :identifier, :desc => N_("activation key identifier")
+    param :system_id, :identifier, :desc => N_("system identifier")
     def index
       subscriptions = if @system
                         filter_system
@@ -79,9 +79,9 @@ module Katello
       respond_for_index(:collection => subscriptions)
     end
 
-    api :POST, "/host_collections", "Create a host collection"
-    api :POST, "/organizations/:organization_id/host_collections", "Create a host collection"
-    param :organization_id, :number, :desc => "organization identifier", :required => true
+    api :POST, "/host_collections", N_("Create a host collection")
+    api :POST, "/organizations/:organization_id/host_collections", N_("Create a host collection")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
     param_group :host_collection
     def create
       @host_collection = HostCollection.new(host_collection_params)
@@ -90,8 +90,8 @@ module Katello
       respond
     end
 
-    api :PUT, "/host_collections/:id", "Update a host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
+    api :PUT, "/host_collections/:id", N_("Update a host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     param_group :host_collection
     def update
       @host_collection.update_attributes(host_collection_params)
@@ -99,8 +99,8 @@ module Katello
     end
 
     # TODO: switch to systems controller index w/ @adprice pull-request
-    api :GET, "/host_collections/:id/systems", "List content hosts in the host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
+    api :GET, "/host_collections/:id/systems", N_("List content hosts in the host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     def systems
       options = {
           :filters       => [{:term => {:host_collection_ids => @host_collection.id }}],
@@ -109,9 +109,9 @@ module Katello
       respond_for_index(:collection => item_search(System, params, options))
     end
 
-    api :PUT, "/host_collections/:id/add_systems", "Add systems to the host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
-    param :system_ids, Array, :desc => "Array of system ids"
+    api :PUT, "/host_collections/:id/add_systems", N_("Add systems to the host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
+    param :system_ids, Array, :desc => N_("Array of system ids")
     def add_systems
       ids = system_uuids_to_ids(params[:system_ids])
       @systems = System.readable(@host_collection.organization).where(:id => ids)
@@ -121,9 +121,9 @@ module Katello
       respond_for_index(:collection => @host_collection.systems, :template => :delta_systems)
     end
 
-    api :PUT, "/host_collections/:id/remove_systems", "Remove systems from the host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
-    param :system_ids, Array, :desc => "Array of system ids"
+    api :PUT, "/host_collections/:id/remove_systems", N_("Remove systems from the host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
+    param :system_ids, Array, :desc => N_("Array of system ids")
     def remove_systems
       ids = system_uuids_to_ids(params[:system_ids])
       system_ids = System.readable(@host_collection.organization).where(:id => ids).collect { |s| s.id }
@@ -133,9 +133,9 @@ module Katello
       respond_for_index(:collection => @host_collection.systems, :template => :delta_systems)
     end
 
-    api :PUT, "/host_collections/:id/add_activation_keys", "Add activation keys to the host collection"
-    param :id, :identifier, :desc => "ID of the host collection", :required => true
-    param :activation_key_ids, Array, :desc => "Array of activation key IDs"
+    api :PUT, "/host_collections/:id/add_activation_keys", N_("Add activation keys to the host collection")
+    param :id, :identifier, :desc => N_("ID of the host collection"), :required => true
+    param :activation_key_ids, Array, :desc => N_("Array of activation key IDs")
     def add_activation_keys
       ids = params[:activation_key_ids]
       @activation_keys = ActivationKey.readable(@host_collection.organization).where(:id => ids)
@@ -145,9 +145,9 @@ module Katello
       respond_for_index(:collection => @host_collection.activation_keys, :template => :delta_activation_keys)
     end
 
-    api :PUT, "/host_collections/:id/remove_activation_keys", "Remove activation keys from the host collection"
-    param :id, :identifier, :desc => "ID of the activation key host collection", :required => true
-    param :activation_key_ids, Array, :desc => "Array of activation key IDs"
+    api :PUT, "/host_collections/:id/remove_activation_keys", N_("Remove activation keys from the host collection")
+    param :id, :identifier, :desc => N_("ID of the activation key host collection"), :required => true
+    param :activation_key_ids, Array, :desc => N_("Array of activation key IDs")
     def remove_activation_keys
       ids = params[:activation_key_ids]
       activation_key_ids = ActivationKey.readable(@host_collection.organization).where(:id => ids).collect { |s| s.id }
@@ -157,39 +157,39 @@ module Katello
       respond_for_index(:collection => @host_collection.activation_keys, :template => :delta_activation_keys)
     end
 
-    api :GET, "/host_collections/:id/history", "History of jobs performed on a host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
+    api :GET, "/host_collections/:id/history", N_("History of jobs performed on a host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     # TODO: v2 update
     def history
       super
     end
 
-    api :GET, "/host_collections/:id/history", "History of a job performed on a host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
-    param :job_id, :identifier, :desc => "Id of a job for filtering"
+    api :GET, "/host_collections/:id/history", N_("History of a job performed on a host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
+    param :job_id, :identifier, :desc => N_("Id of a job for filtering")
     # TODO: v2 update
     def history_show
       super
     end
 
-    api :DELETE, "/host_collections/:id", "Destroy a host collection"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
+    api :DELETE, "/host_collections/:id", N_("Destroy a host collection")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     # TODO: v2 update
     def destroy
       @host_collection.destroy
       respond_for_destroy
     end
 
-    api :DELETE, "/host_collections/:id/destroy_systems", "Destroy a host collection nad contained systems"
-    param :id, :identifier, :desc => "Id of the host collection", :required => true
+    api :DELETE, "/host_collections/:id/destroy_systems", N_("Destroy a host collection nad contained systems")
+    param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     # TODO: v2 update
     def destroy_systems
       super
     end
 
-    api :POST, "/host_collections/:id/copy", "Make copy of a host collection"
-    param :id, :identifier, :desc => "ID of the host collection", :required => true
-    param :name, String, :required => true, :desc => "New host collection name"
+    api :POST, "/host_collections/:id/copy", N_("Make copy of a host collection")
+    param :id, :identifier, :desc => N_("ID of the host collection"), :required => true
+    param :name, String, :required => true, :desc => N_("New host collection name")
     def copy
       new_host_collection                   = HostCollection.new
       new_host_collection.name              = params[:host_collection][:name]

--- a/app/controllers/katello/api/v2/organization_default_info_controller.rb
+++ b/app/controllers/katello/api/v2/organization_default_info_controller.rb
@@ -21,11 +21,11 @@ class Api::V2::OrganizationDefaultInfoController < Api::V1::OrganizationDefaultI
   end
 
   def_param_group :informable_identifier do
-    param :informable_type, String, :desc => "name of the resource", :required => true
-    param :informable_id, :identifier, :desc => "resource identifier", :required => true
+    param :informable_type, String, :desc => N_("name of the resource"), :required => true
+    param :informable_id, :identifier, :desc => N_("resource identifier"), :required => true
   end
 
-  api :POST, '/organizations/:organization_id/default_info/:informable_type', "Create default info"
+  api :POST, '/organizations/:organization_id/default_info/:informable_type', N_("Create default info")
   param_group :informable_identifier
   param :default_info, Hash, :required => true do
     param :keyname, String, :required => true

--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -42,23 +42,23 @@ module Katello
       }
     end
 
-    api :GET, '/organizations', 'List all organizations'
+    api :GET, '/organizations', N_('List all organizations')
     param_group :search, Api::V2::ApiController
     def index
       @render_template = 'katello/api/v2/organizations/index'
       super
     end
 
-    api :GET, '/organizations/:id', 'Show organization'
+    api :GET, '/organizations/:id', N_('Show organization')
     def show
       @render_template = 'katello/api/v2/organizations/show'
       super
     end
 
-    api :PUT, '/organizations/:id', 'Update organization'
+    api :PUT, '/organizations/:id', N_('Update organization')
     param_group :resource, ::Api::V2::TaxonomiesController
-    param :description, String, :desc => "description"
-    param :redhat_repository_url, String, :desc => "Redhat CDN url"
+    param :description, String, :desc => N_("description")
+    param :redhat_repository_url, String, :desc => N_("Redhat CDN url")
     def update
       if params.key?(:redhat_repository_url)
         @organization.redhat_provider.update_attributes!(:repository_url => params[:redhat_repository_url])
@@ -66,38 +66,38 @@ module Katello
       super
     end
 
-    api :POST, '/organizations', 'Create organization'
-    param :name, String, :desc => "name", :required => true
-    param :label, String, :desc => "unique label"
-    param :description, String, :desc => "description"
+    api :POST, '/organizations', N_('Create organization')
+    param :name, String, :desc => N_("name"), :required => true
+    param :label, String, :desc => N_("unique label")
+    param :description, String, :desc => N_("description")
     def create
       super
     end
 
-    api :DELETE, '/organizations/:id', 'Delete an organization'
+    api :DELETE, '/organizations/:id', N_('Delete an organization')
     def destroy
       process_response @organization.destroy, _("Deleted organization '%s'") % params[:id]
     end
 
-    api :PUT, "/organizations/:id/repo_discover", "Discover Repositories"
-    param :id, String, :desc => "organization id, label, or name"
-    param :url, String, :desc => "base url to perform repo discovery on"
+    api :PUT, "/organizations/:id/repo_discover", N_("Discover Repositories")
+    param :id, String, :desc => N_("organization id, label, or name")
+    param :url, String, :desc => N_("base url to perform repo discovery on")
     def repo_discover
       fail _("url not defined.") if params[:url].blank?
       task = async_task(::Actions::Katello::Repository::Discover, params[:url])
       respond_for_async :resource => task
     end
 
-    api :PUT, "/organizations/:label/cancel_repo_discover", "Cancel repository discovery"
-    param :label, String, :desc => "Organization label"
-    param :url, String, :desc => "base url to perform repo discovery on"
+    api :PUT, "/organizations/:label/cancel_repo_discover", N_("Cancel repository discovery")
+    param :label, String, :desc => N_("Organization label")
+    param :url, String, :desc => N_("base url to perform repo discovery on")
     def cancel_repo_discover
       # TODO: implement task canceling
       render :json => { message: "not implemented" }
     end
 
-    api :GET, "/organizations/:label/download_debug_certificate", "Download a debug certificate"
-    param :label, String, :desc => "Organization label"
+    api :GET, "/organizations/:label/download_debug_certificate", N_("Download a debug certificate")
+    param :label, String, :desc => N_("Organization label")
     def download_debug_certificate
       pem = @organization.debug_cert
       data = "#{ pem[:key] }\n\n#{ pem[:cert] }"
@@ -106,13 +106,13 @@ module Katello
                 :type => "application/text"
     end
 
-    api :POST, "/organizations/:id/autoattach_subscriptions", "Auto-attach available subscriptions to all systems within an organization. Asynchronous operation."
+    api :POST, "/organizations/:id/autoattach_subscriptions", N_("Auto-attach available subscriptions to all systems within an organization. Asynchronous operation.")
     def autoattach_subscriptions
       async_job = @organization.auto_attach_all_systems
       respond_for_async :resource => async_job
     end
 
-    api :GET, '/organizations/:id/redhat_provider', 'List all :resource_id'
+    api :GET, '/organizations/:id/redhat_provider', N_('List all :resource_id')
     def redhat_provider
       respond_for_show(:resource => @organization.redhat_provider,
                        :resource_name => "providers")

--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -30,14 +30,14 @@ class Api::V2::PackageGroupsController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/package_groups", "List package groups"
-  api :GET, "/content_views/:content_view_id/filters/:filter_id/package_groups", "List package groups"
-  api :GET, "/content_view_filters/:content_view_filter_id/package_groups", "List package groups"
-  api :GET, "/repositories/:repository_id/package_groups", "List package groups"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :filter_id, :identifier, :desc => "content view filter identifier"
-  param :content_view_filter_id, :identifier, :desc => "content view filter identifier"
-  param :repository_id, :identifier, :desc => "repository identifier", :required => true
+  api :GET, "/package_groups", N_("List package groups")
+  api :GET, "/content_views/:content_view_id/filters/:filter_id/package_groups", N_("List package groups")
+  api :GET, "/content_view_filters/:content_view_filter_id/package_groups", N_("List package groups")
+  api :GET, "/repositories/:repository_id/package_groups", N_("List package groups")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :filter_id, :identifier, :desc => N_("content view filter identifier")
+  param :content_view_filter_id, :identifier, :desc => N_("content view filter identifier")
+  param :repository_id, :identifier, :desc => N_("repository identifier"), :required => true
   def index
     collection = if @repo && !@repo.puppet?
                    filter_by_repo_id @repo.pulp_id
@@ -50,10 +50,10 @@ class Api::V2::PackageGroupsController < Api::V2::ApiController
     respond(:collection => collection)
   end
 
-  api :GET, "/package_groups/:id", "Show a package group"
-  api :GET, "/repositories/:repository_id/package_groups/:id", "Show a package group"
-  param :repository_id, :identifier, :desc => "repository identifier", :required => true
-  param :id, String, :desc => "package group identifier", :required => true
+  api :GET, "/package_groups/:id", N_("Show a package group")
+  api :GET, "/repositories/:repository_id/package_groups/:id", N_("Show a package group")
+  param :repository_id, :identifier, :desc => N_("repository identifier"), :required => true
+  param :id, String, :desc => N_("package group identifier"), :required => true
   def show
     respond :resource => @package_group
   end

--- a/app/controllers/katello/api/v2/permissions_controller.rb
+++ b/app/controllers/katello/api/v2/permissions_controller.rb
@@ -20,16 +20,16 @@ class Api::V2::PermissionsController < Api::V1::PermissionsController
     api_base_url "#{Katello.config.url_prefix}/api"
   end
 
-  api :POST, "/roles/:role_id/permissions", "Create a roles permission"
+  api :POST, "/roles/:role_id/permissions", N_("Create a roles permission")
   param :permission, Hash, :required => true do
     param :description, String, :allow_nil => true
     param :name, String, :required => true
     param :organization_id, :identifier
-    param :tags, Array, :desc => "array of tag ids"
-    param :type, String, :desc => "name of a resource or 'all'", :required => true
-    param :verbs, Array, :desc => "array of permission verbs"
-    param :all_tags, :bool, :desc => "True if the permission should use all tags"
-    param :all_verbs, :bool, :desc => "True if the permission should use all verbs"
+    param :tags, Array, :desc => N_("array of tag ids")
+    param :type, String, :desc => N_("name of a resource or 'all'"), :required => true
+    param :verbs, Array, :desc => N_("array of permission verbs")
+    param :all_tags, :bool, :desc => N_("True if the permission should use all tags")
+    param :all_verbs, :bool, :desc => N_("True if the permission should use all verbs")
   end
   def create
     perm_attrs = params[:permission].permit(:name, :description, :organization_id, :type)

--- a/app/controllers/katello/api/v2/ping_controller.rb
+++ b/app/controllers/katello/api/v2/ping_controller.rb
@@ -20,14 +20,14 @@ module Katello
     skip_before_filter :authorize
     skip_before_filter :require_user, :only => [:server_status]
 
-    api :GET, "/ping", "Shows status of system and it's subcomponents"
-    description "This service is only available for authenticated users"
+    api :GET, "/ping", N_("Shows status of system and it's subcomponents")
+    description N_("This service is only available for authenticated users")
     def index
       respond_for_show :resource => Ping.ping
     end
 
-    api :GET, "/status", "Shows version information"
-    description "This service is available for unauthenticated users"
+    api :GET, "/status", N_("Shows version information")
+    description N_("This service is available for unauthenticated users")
     def server_status
       # rubocop:disable SymbolName
       status = { :release    => Katello.config.app_name,

--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -30,8 +30,8 @@ module Katello
       hash
     end
 
-    api :PUT, "/products/bulk/destroy", "Destroy one or more products"
-    param :ids, Array, :desc => "List of product ids", :required => true
+    api :PUT, "/products/bulk/destroy", N_("Destroy one or more products")
+    param :ids, Array, :desc => N_("List of product ids"), :required => true
     def destroy_products
       display_messages = []
 
@@ -40,8 +40,8 @@ module Katello
       respond_for_show :template => 'bulk_action', :resource => { 'displayMessages' => display_messages }
     end
 
-    api :PUT, "/products/bulk/sync", "Sync one or more products"
-    param :ids, Array, :desc => "List of product ids", :required => true
+    api :PUT, "/products/bulk/sync", N_("Sync one or more products")
+    param :ids, Array, :desc => N_("List of product ids"), :required => true
     def sync_products
       display_messages = []
 
@@ -50,9 +50,9 @@ module Katello
       respond_for_show :template => 'bulk_action', :resource => { 'displayMessages' => display_messages }
     end
 
-    api :PUT, "/products/bulk/sync_plan", "Sync one or more products"
-    param :ids, Array, :desc => "List of product ids", :required => true
-    param :plan_id, :number, :desc => "Sync plan identifier to attach", :required => true
+    api :PUT, "/products/bulk/sync_plan", N_("Sync one or more products")
+    param :ids, Array, :desc => N_("List of product ids"), :required => true
+    param :plan_id, :number, :desc => N_("Sync plan identifier to attach"), :required => true
     def update_sync_plans
       display_messages = []
 

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -21,9 +21,9 @@ module Katello
     end
 
     def_param_group :product do
-      param :description, String, :desc => "Product description"
-      param :gpg_key_id, :number, :desc => "Identifier of the GPG key"
-      param :sync_plan_id, :number, :desc => "Plan numeric identifier", :allow_nil => true
+      param :description, String, :desc => N_("Product description")
+      param :gpg_key_id, :number, :desc => N_("Identifier of the GPG key")
+      param :sync_plan_id, :number, :desc => N_("Plan numeric identifier"), :allow_nil => true
     end
 
     def rules
@@ -42,13 +42,13 @@ module Katello
       }
     end
 
-    api :GET, "/products", "List products"
-    api :GET, "/subscriptions/:subscription_id/products", "List of subscription products in an organization"
-    api :GET, "/organizations/:organization_id/products", "List of products in an organization"
-    param :organization_id, :number, :desc => "Filter products by organization", :required => true
-    param :subscription_id, :identifier, :desc => "Filter products by subscription"
-    param :name, String, :desc => "Filter products by name"
-    param :enabled, :bool, :desc => "Filter products by enabled or disabled"
+    api :GET, "/products", N_("List products")
+    api :GET, "/subscriptions/:subscription_id/products", N_("List of subscription products in an organization")
+    api :GET, "/organizations/:organization_id/products", N_("List of products in an organization")
+    param :organization_id, :number, :desc => N_("Filter products by organization"), :required => true
+    param :subscription_id, :identifier, :desc => N_("Filter products by subscription")
+    param :name, String, :desc => N_("Filter products by name")
+    param :enabled, :bool, :desc => N_("Filter products by enabled or disabled")
     param_group :search, Api::V2::ApiController
     def index
       options = {
@@ -63,10 +63,10 @@ module Katello
       respond(:collection => item_search(Product, params, options))
     end
 
-    api :POST, "/products", "Create a product"
-    param :organization_id, :number, "ID of the organization", :required => true
+    api :POST, "/products", N_("Create a product")
+    param :organization_id, :number, N_("ID of the organization"), :required => true
     param_group :product
-    param :name, String, :desc => "Product name", :required => true
+    param :name, String, :desc => N_("Product name"), :required => true
     param :label, String, :required => false
     def create
       params[:product][:label] = labelize_params(product_params) if product_params
@@ -76,16 +76,16 @@ module Katello
       respond(:resource => product)
     end
 
-    api :GET, "/products/:id", "Show a product"
-    param :id, :number, :desc => "product numeric identifier", :required => true
+    api :GET, "/products/:id", N_("Show a product")
+    param :id, :number, :desc => N_("product numeric identifier"), :required => true
     def show
       respond_for_show(:resource => @product)
     end
 
-    api :PUT, "/products/:id", "Updates a product"
-    param :id, :number, :desc => "product numeric identifier", :required => true, :allow_nil => false
+    api :PUT, "/products/:id", N_("Updates a product")
+    param :id, :number, :desc => N_("product numeric identifier"), :required => true, :allow_nil => false
     param_group :product
-    param :name, String, :desc => "Product name"
+    param :name, String, :desc => N_("Product name")
     def update
       reset_gpg_keys = (product_params[:gpg_key_id] != @product.gpg_key_id)
       @product.reset_repo_gpgs! if reset_gpg_keys
@@ -94,8 +94,8 @@ module Katello
       respond(:resource => @product.reload)
     end
 
-    api :DELETE, "/products/:id", "Destroy a product"
-    param :id, :number, :desc => "product numeric identifier"
+    api :DELETE, "/products/:id", N_("Destroy a product")
+    param :id, :number, :desc => N_("product numeric identifier")
     def destroy
       @product.destroy
 

--- a/app/controllers/katello/api/v2/puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/puppet_modules_controller.rb
@@ -31,13 +31,13 @@ class Api::V2::PuppetModulesController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/puppet_modules", "List puppet modules"
-  api :GET, "/content_views/:content_view_id/puppet_modules", "List puppet modules"
-  api :GET, "/environments/:environment_id/puppet_modules", "List puppet modules"
-  api :GET, "/repositories/:repository_id/puppet_modules", "List puppet modules"
-  param :content_view_id, :identifier, :desc => "content view identifier"
-  param :environment_id, :identifier, :desc => "environment identifier"
-  param :repository_id, :identifier, :desc => "repository identifier", :required => true
+  api :GET, "/puppet_modules", N_("List puppet modules")
+  api :GET, "/content_views/:content_view_id/puppet_modules", N_("List puppet modules")
+  api :GET, "/environments/:environment_id/puppet_modules", N_("List puppet modules")
+  api :GET, "/repositories/:repository_id/puppet_modules", N_("List puppet modules")
+  param :content_view_id, :identifier, :desc => N_("content view identifier")
+  param :environment_id, :identifier, :desc => N_("environment identifier")
+  param :repository_id, :identifier, :desc => N_("repository identifier"), :required => true
   def index
     collection = if @repo && @repo.puppet?
                    filter_by_repoids [@repo.pulp_id]
@@ -52,10 +52,10 @@ class Api::V2::PuppetModulesController < Api::V2::ApiController
     respond(:collection => collection)
   end
 
-  api :GET, "/puppet_modules/:id", "Show a puppet module"
-  api :GET, "/repositories/:repository_id/puppet_modules/:id", "Show a puppet module"
-  param :repository_id, :identifier, :desc => "repository identifier", :required => true
-  param :id, String, :desc => "puppet module identifier", :required => true
+  api :GET, "/puppet_modules/:id", N_("Show a puppet module")
+  api :GET, "/repositories/:repository_id/puppet_modules/:id", N_("Show a puppet module")
+  param :repository_id, :identifier, :desc => N_("repository identifier"), :required => true
+  param :id, String, :desc => N_("puppet module identifier"), :required => true
   def show
     respond :resource => @puppet_module
   end

--- a/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
@@ -27,8 +27,8 @@ module Katello
       hash
     end
 
-    api :PUT, "/repositories/bulk/destroy", "Destroy one or more repositories"
-    param :ids, Array, :desc => "List of repository ids", :required => true
+    api :PUT, "/repositories/bulk/destroy", N_("Destroy one or more repositories")
+    param :ids, Array, :desc => N_("List of repository ids"), :required => true
     def destroy_repositories
       display_messages = []
 
@@ -40,8 +40,8 @@ module Katello
       respond_for_show :template => 'bulk_action', :resource => { 'displayMessages' => display_messages }
     end
 
-    api :POST, "/repositories/bulk/sync", "Synchronise repository"
-    param :ids, Array, :desc => "List of repository ids", :required => true
+    api :POST, "/repositories/bulk/sync", N_("Synchronise repository")
+    param :ids, Array, :desc => N_("List of repository ids"), :required => true
     def sync_repositories
       display_messages = []
 

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -33,11 +33,11 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
   def_param_group :repo do
     param :name, String, :required => true
     param :label, String, :required => false
-    param :product_id, :number, :required => true, :desc => "Product the repository belongs to"
-    param :url, String, :required => true, :desc => "repository source url"
-    param :gpg_key_id, :number, :desc => "id of the gpg key that will be assigned to the new repository"
-    param :unprotected, :bool, :desc => "true if this repository can be published via HTTP"
-    param :content_type, String, :desc => "type of repo (either 'yum' or 'puppet', defaults to 'yum')"
+    param :product_id, :number, :required => true, :desc => N_("Product the repository belongs to")
+    param :url, String, :required => true, :desc => N_("repository source url")
+    param :gpg_key_id, :number, :desc => N_("id of the gpg key that will be assigned to the new repository")
+    param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
+    param :content_type, String, :desc => N_("type of repo (either 'yum' or 'puppet', defaults to 'yum')")
   end
 
   def rules
@@ -57,14 +57,14 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/repositories", "List of enabled repositories"
-  api :GET, "/content_views/:id/repositories", "List of repositories for a content view"
-  param :organization_id, :number, :required => true, :desc => "ID of an organization to show repositories in"
-  param :product_id, :number, :desc => "ID of a product to show repositories of"
-  param :environment_id, :number, :desc => "ID of an environment to show repositories in"
-  param :content_view_id, :number, :desc => "ID of a content view to show repositories in"
-  param :library, :bool, :desc => "show repositories in Library and the default content view"
-  param :content_type, String, :desc => "limit to only repositories of this time"
+  api :GET, "/repositories", N_("List of enabled repositories")
+  api :GET, "/content_views/:id/repositories", N_("List of repositories for a content view")
+  param :organization_id, :number, :required => true, :desc => N_("ID of an organization to show repositories in")
+  param :product_id, :number, :desc => N_("ID of a product to show repositories of")
+  param :environment_id, :number, :desc => N_("ID of an environment to show repositories in")
+  param :content_view_id, :number, :desc => N_("ID of a content view to show repositories in")
+  param :library, :bool, :desc => N_("show repositories in Library and the default content view")
+  param :content_type, String, :desc => N_("limit to only repositories of this time")
   param_group :search, Api::V2::ApiController
   def index
     options = sort_params
@@ -87,7 +87,7 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
 
   end
 
-  api :POST, "/repositories", "Create a custom repository"
+  api :POST, "/repositories", N_("Create a custom repository")
   param_group :repo
   def create
     params[:label] = labelize_params(params)
@@ -104,24 +104,24 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
     respond_for_show(:resource => repository)
   end
 
-  api :GET, "/repositories/:id", "Show a custom repository"
-  param :id, :identifier, :required => true, :desc => "repository ID"
+  api :GET, "/repositories/:id", N_("Show a custom repository")
+  param :id, :identifier, :required => true, :desc => N_("repository ID")
   def show
     respond_for_show(:resource => @repository)
   end
 
-  api :POST, "/repositories/:id/sync", "Sync a repository"
-  param :id, :identifier, :required => true, :desc => "repository ID"
+  api :POST, "/repositories/:id/sync", N_("Sync a repository")
+  param :id, :identifier, :required => true, :desc => N_("repository ID")
   def sync
     task = async_task(::Actions::Katello::Repository::Sync, @repository)
     respond_for_async :resource => task
   end
 
-  api :PUT, "/repositories/:id", "Update a custom repository"
-  param :id, :identifier, :required => true, :desc => "repository ID"
-  param :gpg_key_id, :number, :desc => "ID of a gpg key that will be assigned to this repository"
-  param :unprotected, :bool, :desc => "true if this repository can be published via HTTP"
-  param :url, String, :desc => "the feed url of the original repository "
+  api :PUT, "/repositories/:id", N_("Update a custom repository")
+  param :id, :identifier, :required => true, :desc => N_("repository ID")
+  param :gpg_key_id, :number, :desc => N_("ID of a gpg key that will be assigned to this repository")
+  param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
+  param :url, String, :desc => N_("the feed url of the original repository ")
   def update
     repo_params = repository_params
     repo_params[:url] = nil if repository_params[:url].blank?
@@ -129,7 +129,7 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
     respond_for_show(:resource => @repository)
   end
 
-  api :DELETE, "/repositories/:id", "Destroy a custom repository"
+  api :DELETE, "/repositories/:id", N_("Destroy a custom repository")
   param :id, :identifier, :required => true
   def destroy
     trigger(::Actions::Katello::Repository::Destroy, @repository)
@@ -138,8 +138,8 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
   end
 
   api :POST, "/repositories/sync_complete"
-  desc "URL for post sync notification from pulp"
-  param 'token', String, :desc => "shared secret token", :required => true
+  desc N_("URL for post sync notification from pulp")
+  param 'token', String, :desc => N_("shared secret token"), :required => true
   param 'payload', Hash, :required => true do
     param 'repo_id', String, :required => true
   end

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -39,9 +39,9 @@ class Api::V2::RepositorySetsController < Api::V2::ApiController
     api_version "v2"
   end
 
-  api :GET, "/products/:product_id/repository_sets", "List repository sets for a product."
-  param :product_id, :number, :required => true, :desc => "ID of a product to list repository sets from"
-  param :name, String, :required => false, :desc => "Repository set name to search on"
+  api :GET, "/products/:product_id/repository_sets", N_("List repository sets for a product.")
+  param :product_id, :number, :required => true, :desc => N_("ID of a product to list repository sets from")
+  param :name, String, :required => false, :desc => N_("Repository set name to search on")
   def index
     collection = {}
     collection[:results] = @product.productContent
@@ -52,16 +52,16 @@ class Api::V2::RepositorySetsController < Api::V2::ApiController
     respond_for_index :collection => collection
   end
 
-  api :GET, "/products/:product_id/repository_sets/:id", "Get info about a repository set"
-  param :id, :number, :required => true, :desc => "ID of the repository set"
-  param :product_id, :number, :required => true, :desc => "ID of a product to list repository sets from"
+  api :GET, "/products/:product_id/repository_sets/:id", N_("Get info about a repository set")
+  param :id, :number, :required => true, :desc => N_("ID of the repository set")
+  param :product_id, :number, :required => true, :desc => N_("ID of a product to list repository sets from")
   def show
     respond :resource => @product_content
   end
 
-  api :GET, "/products/:product_id/repository_sets/:id/available_repositories", "Get list or available repositories for the repository set"
-  param :id, :number, :required => true, :desc => "ID of the repository set"
-  param :product_id, :number, :required => true, :desc => "ID of a product to list repository sets from"
+  api :GET, "/products/:product_id/repository_sets/:id/available_repositories", N_("Get list or available repositories for the repository set")
+  param :id, :number, :required => true, :desc => N_("ID of the repository set")
+  param :product_id, :number, :required => true, :desc => N_("ID of a product to list repository sets from")
   def available_repositories
     scan_cdn = sync_task(::Actions::Katello::RepositorySet::ScanCdn, @product, @product_content.content.id)
     collection = {
@@ -72,21 +72,21 @@ class Api::V2::RepositorySetsController < Api::V2::ApiController
     respond_for_index :collection => collection
   end
 
-  api :PUT, "/products/:product_id/repository_sets/:id/enable", "Enable a repository from the set"
-  param :id, :number, :required => true, :desc => "ID of the repository set to enable"
-  param :product_id, :number, :required => true, :desc => "ID of the product containing the repository set"
-  param :basearch, String, :required => true, :desc => "Basearch to enable"
-  param :releasever, String, :required => true, :desc => "Releasever to enable"
+  api :PUT, "/products/:product_id/repository_sets/:id/enable", N_("Enable a repository from the set")
+  param :id, :number, :required => true, :desc => N_("ID of the repository set to enable")
+  param :product_id, :number, :required => true, :desc => N_("ID of the product containing the repository set")
+  param :basearch, String, :required => true, :desc => N_("Basearch to enable")
+  param :releasever, String, :required => true, :desc => N_("Releasever to enable")
   def enable
     task = sync_task(::Actions::Katello::RepositorySet::EnableRepository, @product, @product_content.content, substitutions)
     respond_for_async :resource => task
   end
 
-  api :PUT, "/products/:product_id/repository_sets/:id/disable", "Disable a repository form the set"
-  param :id, :number, :required => true, :desc => "ID of the repository set to enable"
-  param :product_id, :number, :required => true, :desc => "ID of the product containing the repository set"
-  param :basearch, String, :required => true, :desc => "Basearch to disable"
-  param :releasever, String, :required => true, :desc => "Releasever to disable"
+  api :PUT, "/products/:product_id/repository_sets/:id/disable", N_("Disable a repository form the set")
+  param :id, :number, :required => true, :desc => N_("ID of the repository set to enable")
+  param :product_id, :number, :required => true, :desc => N_("ID of the product containing the repository set")
+  param :basearch, String, :required => true, :desc => N_("Basearch to disable")
+  param :releasever, String, :required => true, :desc => N_("Releasever to disable")
   def disable
     task = sync_task(::Actions::Katello::RepositorySet::DisableRepository, @product, @product_content.content, substitutions)
     respond_for_async :resource => task

--- a/app/controllers/katello/api/v2/role_ldap_groups_controller.rb
+++ b/app/controllers/katello/api/v2/role_ldap_groups_controller.rb
@@ -20,9 +20,9 @@ class Api::V2::RoleLdapGroupsController < Api::V1::RoleLdapGroupsController
     api_base_url "#{Katello.config.url_prefix}/api"
   end
 
-  api :POST, "/roles/:role_id/ldap_groups", "Add group to list of LDAP groups associated with the role"
+  api :POST, "/roles/:role_id/ldap_groups", N_("Add group to list of LDAP groups associated with the role")
   param :ldap_group, Hash, :required => true, :action_aware => true do
-    param :name, String, :desc => "name of the LDAP group", :required => true
+    param :name, String, :desc => N_("name of the LDAP group"), :required => true
   end
   def create
     @role.add_ldap_group(params[:ldap_group][:name])

--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -62,12 +62,12 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/systems/:system_id/subscriptions", "List a system's subscriptions"
-  api :GET, "/organizations/:organization_id/subscriptions", "List organization subscriptions"
-  api :GET, "/activation_keys/:activation_key_id/subscriptions", "List an activation key's subscriptions"
-  param :system_id, String, :desc => "UUID of the system", :required => false
-  param :activation_key_id, String, :desc => "Activation key ID", :required => false
-  param :organization_id, :number, :desc => "Organization ID", :required => false
+  api :GET, "/systems/:system_id/subscriptions", N_("List a system's subscriptions")
+  api :GET, "/organizations/:organization_id/subscriptions", N_("List organization subscriptions")
+  api :GET, "/activation_keys/:activation_key_id/subscriptions", N_("List an activation key's subscriptions")
+  param :system_id, String, :desc => N_("UUID of the system"), :required => false
+  param :activation_key_id, String, :desc => N_("Activation key ID"), :required => false
+  param :organization_id, :number, :desc => N_("Organization ID"), :required => false
   def index
     subscriptions = if @system
                       index_system
@@ -80,10 +80,10 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     respond_for_index(:collection => subscriptions)
   end
 
-  api :GET, "/organizations/:organization_id/subscriptions/:id", "Show a subscription"
-  api :GET, "/subscriptions/:id", "Show a subscription"
-  param :organization_id, :number, :desc => "Organization identifier"
-  param :id, :number, :desc => "Subscription identifier", :required => true
+  api :GET, "/organizations/:organization_id/subscriptions/:id", N_("Show a subscription")
+  api :GET, "/subscriptions/:id", N_("Show a subscription")
+  param :organization_id, :number, :desc => N_("Organization identifier")
+  param :id, :number, :desc => N_("Subscription identifier"), :required => true
   def show
     respond :resource => @subscription
   end
@@ -100,16 +100,16 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     respond_for_index(:collection => subscriptions, :template => 'index')
   end
 
-  api :POST, "/subscriptions/:id", "Add a subscription to a resource"
-  api :POST, "/systems/:system_id/subscriptions", "Add a subscription to a system"
-  api :POST, "/activation_keys/:activation_key_id/subscriptions", "Add a subscription to an activation key"
-  param :id, String, :desc => "Subscription Pool uuid", :required => false
-  param :system_id, String, :desc => "UUID of the system", :required => false
-  param :activation_key_id, String, :desc => "ID of the activation key", :required => false
-  param :quantity, :number, :desc => "Quantity of this subscriptions to add", :required => false
-  param :subscriptions, Array, :desc => "Array of subscriptions to add", :required => false do
-    param :id, String, :desc => "Subscription Pool uuid", :required => true
-    param :quantity, :number, :desc => "Quantity of this subscriptions to add", :required => true
+  api :POST, "/subscriptions/:id", N_("Add a subscription to a resource")
+  api :POST, "/systems/:system_id/subscriptions", N_("Add a subscription to a system")
+  api :POST, "/activation_keys/:activation_key_id/subscriptions", N_("Add a subscription to an activation key")
+  param :id, String, :desc => N_("Subscription Pool uuid"), :required => false
+  param :system_id, String, :desc => N_("UUID of the system"), :required => false
+  param :activation_key_id, String, :desc => N_("ID of the activation key"), :required => false
+  param :quantity, :number, :desc => N_("Quantity of this subscriptions to add"), :required => false
+  param :subscriptions, Array, :desc => N_("Array of subscriptions to add"), :required => false do
+    param :id, String, :desc => N_("Subscription Pool uuid"), :required => true
+    param :quantity, :number, :desc => N_("Quantity of this subscriptions to add"), :required => true
   end
   def create
     object = @system || @activation_key || @distributor
@@ -133,14 +133,14 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     respond_for_index(:collection => subscriptions, :template => 'index')
   end
 
-  api :DELETE, "/subscriptions/:id", "Unattach a subscription"
-  api :DELETE, "/systems/:system_id/subscriptions/:id", "Unattach a subscription"
-  api :DELETE, "/activation_keys/:activation_key_id/subscriptions/:id", "Unattach a subscription"
-  param :id, String, :desc => "Subscription ID", :required => false
-  param :system_id, String, :desc => "UUID of the system"
-  param :activation_key_id, String, :desc => "activation key ID"
-  param :subscriptions, Array, :desc => "Array of subscriptions to add", :required => false do
-    param :id, String, :desc => "Subscription Pool uuid", :required => true
+  api :DELETE, "/subscriptions/:id", N_("Unattach a subscription")
+  api :DELETE, "/systems/:system_id/subscriptions/:id", N_("Unattach a subscription")
+  api :DELETE, "/activation_keys/:activation_key_id/subscriptions/:id", N_("Unattach a subscription")
+  param :id, String, :desc => N_("Subscription ID"), :required => false
+  param :system_id, String, :desc => N_("UUID of the system")
+  param :activation_key_id, String, :desc => N_("activation key ID")
+  param :subscriptions, Array, :desc => N_("Array of subscriptions to add"), :required => false do
+    param :id, String, :desc => N_("Subscription Pool uuid"), :required => true
   end
   def destroy
     object = @system || @activation_key || @distributor
@@ -166,11 +166,11 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     respond_for_index(:collection => subscriptions, :template => 'index')
   end
 
-  api :POST, "/organizations/:organization_id/subscriptions/upload", "Upload a subscription manifest"
-  api :POST, "/subscriptions/upload", "Upload a subscription manifest"
-  param :organization_id, :number, :desc => "Organization id", :required => true
-  param :content, File, :desc => "Subscription manifest file", :required => true
-  param :repository_url, String, :desc => "repository url", :required => false
+  api :POST, "/organizations/:organization_id/subscriptions/upload", N_("Upload a subscription manifest")
+  api :POST, "/subscriptions/upload", N_("Upload a subscription manifest")
+  param :organization_id, :number, :desc => N_("Organization id"), :required => true
+  param :content, File, :desc => N_("Subscription manifest file"), :required => true
+  param :repository_url, String, :desc => N_("repository url"), :required => false
   def upload
     fail HttpErrors::BadRequest, _("No manifest file uploaded") if params[:content].blank?
 
@@ -192,8 +192,8 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     respond_for_async :resource => task
   end
 
-  api :PUT, "/organizations/:organization_id/subscriptions/refresh_manifest", "Refresh previously imported manifest for Red Hat provider"
-  param :organization_id, :number, :desc => "Organization id", :required => true
+  api :PUT, "/organizations/:organization_id/subscriptions/refresh_manifest", N_("Refresh previously imported manifest for Red Hat provider")
+  param :organization_id, :number, :desc => N_("Organization id"), :required => true
   def refresh_manifest
     details  = @provider.organization.owner_details
     upstream = details['upstreamConsumer'].blank? ? {} : details['upstreamConsumer']
@@ -202,15 +202,15 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     respond_for_async :resource => task
   end
 
-  api :POST, "/organizations/:organization_id/subscriptions/delete_manifest", "Delete manifest from Red Hat provider"
-  param :organization_id, :number, :desc => "Organization id", :required => true
+  api :POST, "/organizations/:organization_id/subscriptions/delete_manifest", N_("Delete manifest from Red Hat provider")
+  param :organization_id, :number, :desc => N_("Organization id"), :required => true
   def delete_manifest
     task = async_task(::Actions::Katello::Provider::ManifestDelete, @provider)
     respond_for_async :resource => task
   end
 
-  api :GET, "/organizations/:organization_id/subscriptions/manifest_history", "obtain manifest history for subscriptions"
-  param :organization_id, :number, :desc => "Organization ID", :required => true
+  api :GET, "/organizations/:organization_id/subscriptions/manifest_history", N_("obtain manifest history for subscriptions")
+  param :organization_id, :number, :desc => N_("Organization ID"), :required => true
   def manifest_history
     @manifest_history = @organization.manifest_history
     respond_with_template_collection(params[:action], "subscriptions", {collection: @manifest_history})
@@ -290,11 +290,11 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     return subscriptions
   end
 
-  api :GET, "/systems/:system_id/subscriptions/available", "List available subscriptions"
-  param :system_id, String, :desc => "UUID of the system", :required => true
-  param :match_system, :bool, :desc => "Return subscriptions that match system"
-  param :match_installed, :bool, :desc => "Return subscriptions that match installed"
-  param :no_overlap, :bool, :desc => "Return subscriptions that don't overlap"
+  api :GET, "/systems/:system_id/subscriptions/available", N_("List available subscriptions")
+  param :system_id, String, :desc => N_("UUID of the system"), :required => true
+  param :match_system, :bool, :desc => N_("Return subscriptions that match system")
+  param :match_installed, :bool, :desc => N_("Return subscriptions that match installed")
+  param :no_overlap, :bool, :desc => N_("Return subscriptions that don't overlap")
   def available_system
     params[:match_system] = params[:match_system].to_bool if params[:match_system]
     params[:match_installed] = params[:match_installed].to_bool if params[:match_installed]

--- a/app/controllers/katello/api/v2/sync_controller.rb
+++ b/app/controllers/katello/api/v2/sync_controller.rb
@@ -28,16 +28,16 @@ module Katello
       }
     end
 
-    api :GET, "/providers/:provider_id/sync", "Get status of repo synchronisation for given provider"
-    api :GET, "/organizations/:organization_id/products/:product_id/sync", "Get status of repo synchronisation for given product"
-    api :GET, "/repositories/:repository_id/sync", "Get status of synchronisation for given repository"
+    api :GET, "/providers/:provider_id/sync", N_("Get status of repo synchronisation for given provider")
+    api :GET, "/organizations/:organization_id/products/:product_id/sync", N_("Get status of repo synchronisation for given product")
+    api :GET, "/repositories/:repository_id/sync", N_("Get status of synchronisation for given repository")
     def index
       respond_for_async(:resource => @obj.sync_status)
     end
 
-    api :POST, "/providers/:provider_id/sync", "Synchronize all provider's repositories"
-    api :POST, "organizations/:organization_id/products/:product_id/sync", "Synchronise all repositories for given product"
-    api :POST, "/repositories/:repository_id/sync", "Synchronise repository"
+    api :POST, "/providers/:provider_id/sync", N_("Synchronize all provider's repositories")
+    api :POST, "organizations/:organization_id/products/:product_id/sync", N_("Synchronise all repositories for given product")
+    api :POST, "/repositories/:repository_id/sync", N_("Synchronise repository")
     def create
       respond_for_async(:resource => @obj.sync)
     end

--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -20,10 +20,10 @@ class Api::V2::SyncPlansController < Api::V2::ApiController
   before_filter :authorize
 
   def_param_group :sync_plan do
-    param :name, String, :desc => "sync plan name", :required => true, :action_aware => true
-    param :interval, SyncPlan::TYPES, :desc => "how often synchronization should run", :required => true, :action_aware => true
-    param :sync_date, String, :desc => "start datetime of synchronization", :required => true, :action_aware => true
-    param :description, String, :desc => "sync plan description"
+    param :name, String, :desc => N_("sync plan name"), :required => true, :action_aware => true
+    param :interval, SyncPlan::TYPES, :desc => N_("how often synchronization should run"), :required => true, :action_aware => true
+    param :sync_date, String, :desc => N_("start datetime of synchronization"), :required => true, :action_aware => true
+    param :description, String, :desc => N_("sync plan description")
   end
 
   def rules
@@ -40,11 +40,11 @@ class Api::V2::SyncPlansController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/organizations/:organization_id/sync_plans", "List sync plans"
-  param :organization_id, :number, :desc => "Filter sync plans by organization name or label", :required => true
-  param :name, String, :desc => "filter by name"
-  param :sync_date, String, :desc => "filter by sync date"
-  param :interval, SyncPlan::TYPES, :desc => "filter by interval"
+  api :GET, "/organizations/:organization_id/sync_plans", N_("List sync plans")
+  param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label"), :required => true
+  param :name, String, :desc => N_("filter by name")
+  param :sync_date, String, :desc => N_("filter by sync date")
+  param :interval, SyncPlan::TYPES, :desc => N_("filter by interval")
   def index
     filters = [{:term => {:organization_id => @organization.id} }]
 
@@ -62,16 +62,16 @@ class Api::V2::SyncPlansController < Api::V2::ApiController
     respond_for_index(:collection => item_search(SyncPlan, params, options))
   end
 
-  api :GET, "/organizations/:organization_id/sync_plans/:id", "Show a sync plan"
-  api :GET, "/sync_plans/:id", "Show a sync plan"
-  param :organization_id, :number, :desc => "Filter sync plans by organization name or label"
-  param :id, :number, :desc => "sync plan numeric identifier", :required => true
+  api :GET, "/organizations/:organization_id/sync_plans/:id", N_("Show a sync plan")
+  api :GET, "/sync_plans/:id", N_("Show a sync plan")
+  param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label")
+  param :id, :number, :desc => N_("sync plan numeric identifier"), :required => true
   def show
     respond_for_show(:resource => @sync_plan)
   end
 
-  api :POST, "/organizations/:organization_id/sync_plans", "Create a sync plan"
-  param :organization_id, :number, :desc => "Filter sync plans by organization name or label", :required => true
+  api :POST, "/organizations/:organization_id/sync_plans", N_("Create a sync plan")
+  param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label"), :required => true
   param_group :sync_plan
   def create
     sync_date = sync_plan_params[:sync_date].to_time
@@ -87,10 +87,10 @@ class Api::V2::SyncPlansController < Api::V2::ApiController
     respond_for_show(:resource => @sync_plan)
   end
 
-  api :PUT, "/organizations/:organization_id/sync_plans/:id", "Update a sync plan"
-  api :PUT, "/sync_plans/:id", "Update a sync plan"
-  param :organization_id, :number, :desc => "Filter sync plans by organization name or label"
-  param :id, :number, :desc => "sync plan numeric identifier", :required => true
+  api :PUT, "/organizations/:organization_id/sync_plans/:id", N_("Update a sync plan")
+  api :PUT, "/sync_plans/:id", N_("Update a sync plan")
+  param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label")
+  param :id, :number, :desc => N_("sync plan numeric identifier"), :required => true
   param_group :sync_plan
   def update
     sync_date = sync_plan_params.try(:[], :sync_date).try(:to_time)
@@ -106,18 +106,18 @@ class Api::V2::SyncPlansController < Api::V2::ApiController
     respond_for_show(:resource => @sync_plan)
   end
 
-  api :DELETE, "/organizations/:organization_id/sync_plans/:id", "Destroy a sync plan"
-  api :DELETE, "/sync_plans/:id", "Destroy a sync plan"
-  param :organization_id, :number, :desc => "Filter sync plans by organization name or label"
-  param :id, :number, :desc => "sync plan numeric identifier"
+  api :DELETE, "/organizations/:organization_id/sync_plans/:id", N_("Destroy a sync plan")
+  api :DELETE, "/sync_plans/:id", N_("Destroy a sync plan")
+  param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label")
+  param :id, :number, :desc => N_("sync plan numeric identifier")
   def destroy
     @sync_plan.destroy
     respond_for_show(:resource => @sync_plan)
   end
 
-  api :GET, "/organizations/:organization_id/sync_plans/:id/available_products", "List products that are not in this sync plan"
+  api :GET, "/organizations/:organization_id/sync_plans/:id/available_products", N_("List products that are not in this sync plan")
   param_group :search, Api::V2::ApiController
-  param :name, String, :desc => "product name to filter by"
+  param :name, String, :desc => N_("product name to filter by")
   def available_products
     enabled_product_ids = Product.all_readable(@sync_plan.organization).select{|p| p.enabled?}.collect(&:id)
 
@@ -133,9 +133,9 @@ class Api::V2::SyncPlansController < Api::V2::ApiController
     respond_for_index(:collection => products)
   end
 
-  api :PUT, "/organizations/:organization_id/sync_plans/:id/products", "Add products to sync plan"
-  param :id, String, :desc => "ID of the sync plan", :required => true
-  param :product_ids, Array, :desc => "List of product ids to add to the sync plan", :required => true
+  api :PUT, "/organizations/:organization_id/sync_plans/:id/products", N_("Add products to sync plan")
+  param :id, String, :desc => N_("ID of the sync plan"), :required => true
+  param :product_ids, Array, :desc => N_("List of product ids to add to the sync plan"), :required => true
   def add_products
     ids = params[:product_ids]
     @products  = Product.readable(@organization).where(:id => ids)
@@ -144,9 +144,9 @@ class Api::V2::SyncPlansController < Api::V2::ApiController
     respond_for_show
   end
 
-  api :PUT, "/organizations/:organization_id/sync_plans/:id/products", "Remove products from sync plan"
-  param :id, String, :desc => "ID of the sync plan", :required => true
-  param :product_ids, Array, :desc => "List of product ids to remove from the sync plan", :required => true
+  api :PUT, "/organizations/:organization_id/sync_plans/:id/products", N_("Remove products from sync plan")
+  param :id, String, :desc => N_("ID of the sync plan"), :required => true
+  param :product_ids, Array, :desc => N_("List of product ids to remove from the sync plan"), :required => true
   def remove_products
     ids = params[:product_ids]
     @products  = Product.readable(@organization).where(:id => ids)

--- a/app/controllers/katello/api/v2/system_errata_controller.rb
+++ b/app/controllers/katello/api/v2/system_errata_controller.rb
@@ -23,15 +23,15 @@ class Api::V2::SystemErrataController < Api::V2::ApiController
     }
   end
 
-  api :PUT, "/systems/:system_id/errata/", "Schedule errata for installation"
-  param :errata_ids, Array,  :desc => "List of Errata ids to install"
+  api :PUT, "/systems/:system_id/errata/", N_("Schedule errata for installation")
+  param :errata_ids, Array, :desc => N_("List of Errata ids to install")
   def apply
     task = async_task(::Actions::Katello::System::Erratum::Install, @system, params[:errata_ids])
     respond_for_async :resource => task
   end
 
-  api :GET, "/systems/:system_id/errata/:id", "Retrieve a single errata for a system"
-  param :id, String, :desc => "Errata id of the erratum (RHSA-2012:108)", :required => true
+  api :GET, "/systems/:system_id/errata/:id", N_("Retrieve a single errata for a system")
+  param :id, String, :desc => N_("Errata id of the erratum (RHSA-2012:108)"), :required => true
   def show
     errata = Errata.find_by_errata_id(params[:id])
     respond_for_show :resource => errata

--- a/app/controllers/katello/api/v2/system_packages_controller.rb
+++ b/app/controllers/katello/api/v2/system_packages_controller.rb
@@ -29,11 +29,11 @@ class Api::V2::SystemPackagesController < Api::V2::ApiController
   end
 
   def_param_group :packages_or_groups do
-    param :packages, Array, :desc => "List of package names", :required => false
-    param :groups, Array, :desc => "List of package group names", :required => false
+    param :packages, Array, :desc => N_("List of package names"), :required => false
+    param :groups, Array, :desc => N_("List of package group names"), :required => false
   end
 
-  api :POST, "/systems/:system_id/packages/install", "Install packages remotely"
+  api :POST, "/systems/:system_id/packages/install", N_("Install packages remotely")
   param_group :packages_or_groups
   def install
     if params[:packages]
@@ -52,8 +52,8 @@ class Api::V2::SystemPackagesController < Api::V2::ApiController
   end
 
   # update packages remotely
-  api :PUT, "/systems/:system_id/packages/upgrade", "Update packages remotely"
-  param :packages, Array, :desc => "list of packages names"
+  api :PUT, "/systems/:system_id/packages/upgrade", N_("Update packages remotely")
+  param :packages, Array, :desc => N_("list of packages names")
   def upgrade
     if params[:packages]
       packages = validate_package_list_format(params[:packages])
@@ -62,13 +62,13 @@ class Api::V2::SystemPackagesController < Api::V2::ApiController
     end
   end
 
-  api :PUT, "/systems/:system_id/packages/upgrade_all", "Update packages remotely"
+  api :PUT, "/systems/:system_id/packages/upgrade_all", N_("Update packages remotely")
   def upgrade_all
     task     = async_task(::Actions::Katello::System::Package::Update, @system, [])
     respond_for_async :resource => task
   end
 
-  api :POST, "/systems/:system_id/packages/remove", "Uninstall packages remotely"
+  api :POST, "/systems/:system_id/packages/remove", N_("Uninstall packages remotely")
   param_group :packages_or_groups
   def remove
     if params[:packages]

--- a/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
@@ -44,11 +44,11 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
 
   def_param_group :bulk_params do
     param :include, Hash, :required => true, :action_aware => true do
-      param :search, String, :required => false, :desc => "Search string for systems to perform an action on"
-      param :ids, Array, :required => false, :desc => "List of system ids to perform an action on"
+      param :search, String, :required => false, :desc => N_("Search string for systems to perform an action on")
+      param :ids, Array, :required => false, :desc => N_("List of system ids to perform an action on")
     end
     param :exclude, Hash, :required => true, :action_aware => true do
-      param :ids, Array, :required => false, :desc => "List of system ids to exclude and not run an action on"
+      param :ids, Array, :required => false, :desc => N_("List of system ids to exclude and not run an action on")
     end
   end
 
@@ -70,9 +70,9 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
   end
 
   api :PUT, "/systems/bulk/add_host_collections",
-      "Add one or more host collections to one or more content hosts"
+      N_("Add one or more host collections to one or more content hosts")
   param_group :bulk_params
-  param :host_collection_ids, Array, :desc => "List of host collection ids", :required => true
+  param :host_collection_ids, Array, :desc => N_("List of host collection ids"), :required => true
   def bulk_add_host_collections
     unless params[:host_collection_ids].blank?
       display_messages = []
@@ -92,9 +92,9 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
   end
 
   api :PUT, "/systems/bulk/remove_host_collections",
-      "Remove one or more host collections from one or more content hosts"
+      N_("Remove one or more host collections from one or more content hosts")
   param_group :bulk_params
-  param :host_collection_ids, Array, :desc => "List of host collection ids", :required => true
+  param :host_collection_ids, Array, :desc => N_("List of host collection ids"), :required => true
   def bulk_remove_host_collections
     display_messages = []
 
@@ -114,7 +114,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
   end
 
   api :POST, "/systems/bulk/applicable_errata",
-      "Fetch applicable errata for a system."
+      N_("Fetch applicable errata for a system.")
   param_group :bulk_params
   def applicable_errata
     @search_service = nil #reload search service after systems are loaded
@@ -126,37 +126,37 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
     respond_for_index(:collection => results)
   end
 
-  api :PUT, "/systems/bulk/install_content", "Install content on one or more systems"
+  api :PUT, "/systems/bulk/install_content", N_("Install content on one or more systems")
   param_group :bulk_params
   param :content_type, String,
-        :desc => "The type of content.  The following types are supported: 'package', 'package_group' and 'errata'.",
+        :desc => N_("The type of content.  The following types are supported: 'package', 'package_group' and 'errata'."),
         :required => true
-  param :content, Array, :desc => "List of content (e.g. package names, package group names or errata ids)", :required => true
+  param :content, Array, :desc => N_("List of content (e.g. package names, package group names or errata ids)"), :required => true
   def install_content
     content_action
   end
 
-  api :PUT, "/systems/bulk/update_content", "Update content on one or more systems"
+  api :PUT, "/systems/bulk/update_content", N_("Update content on one or more systems")
   param_group :bulk_params
   param :content_type, String,
-        :desc => "The type of content.  The following types are supported: 'package' and 'package_group.",
+        :desc => N_("The type of content.  The following types are supported: 'package' and 'package_group."),
         :required => true
-  param :content, Array, :desc => "List of content (e.g. package or package group names)", :required => true
+  param :content, Array, :desc => N_("List of content (e.g. package or package group names)"), :required => true
   def update_content
     content_action
   end
 
-  api :PUT, "/systems/bulk/remove_content", "Remove content on one or more systems"
+  api :PUT, "/systems/bulk/remove_content", N_("Remove content on one or more systems")
   param_group :bulk_params
   param :content_type, String,
-        :desc => "The type of content.  The following types are supported: 'package' and 'package_group.",
+        :desc => N_("The type of content.  The following types are supported: 'package' and 'package_group."),
         :required => true
-  param :content, Array, :desc => "List of content (e.g. package or package group names)", :required => true
+  param :content, Array, :desc => N_("List of content (e.g. package or package group names)"), :required => true
   def remove_content
     content_action
   end
 
-  api :PUT, "/systems/bulk/destroy", "Destroy one or more systems"
+  api :PUT, "/systems/bulk/destroy", N_("Destroy one or more systems")
   param_group :bulk_params
   def destroy_systems
     @systems.each{ |system| system.destroy }
@@ -164,7 +164,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
     respond_for_show :template => 'bulk_action', :resource => { 'displayMessages' => [display_message] }
   end
 
-  api :PUT, "/systems/bulk/environment_content_view", "Assign the environment and content view to one or more systems"
+  api :PUT, "/systems/bulk/environment_content_view", N_("Assign the environment and content view to one or more systems")
   param_group :bulk_params
   param :environment_id, Integer
   param :content_view_id, Integer

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -93,28 +93,28 @@ class Api::V2::SystemsController < Api::V2::ApiController
   end
 
   def_param_group :system do
-    param :facts, Hash, :desc => "Key-value hash of system-specific facts", :action_aware => true do
-      param :fact, String, :desc => "Any number of facts about this system"
+    param :facts, Hash, :desc => N_("Key-value hash of system-specific facts"), :action_aware => true do
+      param :fact, String, :desc => N_("Any number of facts about this system")
     end
-    param :installed_products, Array, :desc => "List of products installed on the system", :action_aware => true
-    param :name, String, :desc => "Name of the system", :required => true, :action_aware => true
-    param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true, :action_aware => true
-    param :service_level, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT", :action_aware => true
-    param :location, String, :desc => "Physical location of the system"
+    param :installed_products, Array, :desc => N_("List of products installed on the system"), :action_aware => true
+    param :name, String, :desc => N_("Name of the system"), :required => true, :action_aware => true
+    param :type, String, :desc => N_("Type of the system, it should always be 'system'"), :required => true, :action_aware => true
+    param :service_level, String, :allow_nil => true, :desc => N_("A service level for auto-healing process, e.g. SELF-SUPPORT"), :action_aware => true
+    param :location, String, :desc => N_("Physical location of the system")
     param :content_view_id, :identifier
     param :environment_id, :identifier
   end
 
-  api :GET, "/systems", "List systems"
-  api :GET, "/organizations/:organization_id/systems", "List systems in an organization"
-  api :GET, "/environments/:environment_id/systems", "List systems in environment"
-  api :GET, "/host_collections/:host_collection_id/systems", "List systems in a host collection"
-  param :name, String, :desc => "Filter systems by name"
-  param :pool_id, String, :desc => "Filter systems by subscribed pool"
-  param :uuid, String, :desc => "Filter systems by uuid"
-  param :organization_id, :number, :desc => "Specify the organization", :required => true
-  param :environment_id, String, :desc => "Filter by environment"
-  param :host_collection_id, String, :desc => "Filter by host collection"
+  api :GET, "/systems", N_("List systems")
+  api :GET, "/organizations/:organization_id/systems", N_("List systems in an organization")
+  api :GET, "/environments/:environment_id/systems", N_("List systems in environment")
+  api :GET, "/host_collections/:host_collection_id/systems", N_("List systems in a host collection")
+  param :name, String, :desc => N_("Filter systems by name")
+  param :pool_id, String, :desc => N_("Filter systems by subscribed pool")
+  param :uuid, String, :desc => N_("Filter systems by uuid")
+  param :organization_id, :number, :desc => N_("Specify the organization"), :required => true
+  param :environment_id, String, :desc => N_("Filter by environment")
+  param :host_collection_id, String, :desc => N_("Filter by host collection")
   param_group :search, Api::V2::ApiController
   def index
     filters = []
@@ -137,25 +137,25 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index(:collection => item_search(System, params, options))
   end
 
-  api :POST, "/systems", "Register a system"
-  api :POST, "/environments/:environment_id/systems", "Register a system in environment"
-  api :POST, "/host_collections/:host_collection_id/systems", "Register a system in environment"
-  param :name, String, :desc => "Name of the system", :required => true, :action_aware => true
-  param :description, String, :desc => "Description of the system"
-  param :location, String, :desc => "Physical location of the system"
-  param :facts, Hash, :desc => "Key-value hash of system-specific facts", :action_aware => true, :required => true do
-    param :fact, String, :desc => "Any number of facts about this system"
+  api :POST, "/systems", N_("Register a system")
+  api :POST, "/environments/:environment_id/systems", N_("Register a system in environment")
+  api :POST, "/host_collections/:host_collection_id/systems", N_("Register a system in environment")
+  param :name, String, :desc => N_("Name of the system"), :required => true, :action_aware => true
+  param :description, String, :desc => N_("Description of the system")
+  param :location, String, :desc => N_("Physical location of the system")
+  param :facts, Hash, :desc => N_("Key-value hash of system-specific facts"), :action_aware => true, :required => true do
+    param :fact, String, :desc => N_("Any number of facts about this system")
   end
-  param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true, :action_aware => true
-  param :guest_ids, Array, :desc => "IDs of the guests running on this system"
-  param :installed_products, Array, :desc => "List of products installed on the system", :action_aware => true
-  param :release_ver, String, :desc => "Release version of the system"
-  param :service_level, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT", :action_aware => true
-  param :last_checkin, String, :desc => "Last check-in time of this system"
-  param :organization_id, :number, :desc => "Specify the organization", :required => true
-  param :environment_id, String, :desc => "Specify the environment"
-  param :content_view_id, String, :desc => "Specify the content view"
-  param :host_collection_id, String, :desc => "Specify the host collection"
+  param :type, String, :desc => N_("Type of the system, it should always be 'system'"), :required => true, :action_aware => true
+  param :guest_ids, Array, :desc => N_("IDs of the guests running on this system")
+  param :installed_products, Array, :desc => N_("List of products installed on the system"), :action_aware => true
+  param :release_ver, String, :desc => N_("Release version of the system")
+  param :service_level, String, :allow_nil => true, :desc => N_("A service level for auto-healing process, e.g. SELF-SUPPORT"), :action_aware => true
+  param :last_checkin, String, :desc => N_("Last check-in time of this system")
+  param :organization_id, :number, :desc => N_("Specify the organization"), :required => true
+  param :environment_id, String, :desc => N_("Specify the environment")
+  param :content_view_id, String, :desc => N_("Specify the content view")
+  param :host_collection_id, String, :desc => N_("Specify the host collection")
   def create
     @system = System.new(system_params(params).merge(:environment  => @environment,
                                                      :content_view => @content_view))
@@ -164,38 +164,38 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_create
   end
 
-  api :PUT, "/systems/:id", "Update system information"
-  param :name, String, :desc => "Name of the system", :required => true, :action_aware => true
-  param :description, String, :desc => "Description of the system"
-  param :location, String, :desc => "Physical location of the system"
-  param :facts, Hash, :desc => "Key-value hash of system-specific facts", :action_aware => true, :required => true do
-    param :fact, String, :desc => "Any number of facts about this system"
+  api :PUT, "/systems/:id", N_("Update system information")
+  param :name, String, :desc => N_("Name of the system"), :required => true, :action_aware => true
+  param :description, String, :desc => N_("Description of the system")
+  param :location, String, :desc => N_("Physical location of the system")
+  param :facts, Hash, :desc => N_("Key-value hash of system-specific facts"), :action_aware => true, :required => true do
+    param :fact, String, :desc => N_("Any number of facts about this system")
   end
-  param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true, :action_aware => true
-  param :guest_ids, Array, :desc => "IDs of the guests running on this system"
-  param :installed_products, Array, :desc => "List of products installed on the system", :action_aware => true
-  param :release_ver, String, :desc => "Release version of the system"
-  param :service_level, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT", :action_aware => true
-  param :last_checkin, String, :desc => "Last check-in time of this system"
-  param :environment_id, String, :desc => "Specify the environment"
-  param :content_view_id, String, :desc => "Specify the content view"
+  param :type, String, :desc => N_("Type of the system, it should always be 'system'"), :required => true, :action_aware => true
+  param :guest_ids, Array, :desc => N_("IDs of the guests running on this system")
+  param :installed_products, Array, :desc => N_("List of products installed on the system"), :action_aware => true
+  param :release_ver, String, :desc => N_("Release version of the system")
+  param :service_level, String, :allow_nil => true, :desc => N_("A service level for auto-healing process, e.g. SELF-SUPPORT"), :action_aware => true
+  param :last_checkin, String, :desc => N_("Last check-in time of this system")
+  param :environment_id, String, :desc => N_("Specify the environment")
+  param :content_view_id, String, :desc => N_("Specify the content view")
   def update
     @system.update_attributes!(system_params(params))
 
     respond_for_update
   end
 
-  api :GET, "/systems/:id", "Show a system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id", N_("Show a system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def show
     @host_collections = @system.host_collections
     @custom_info = @system.custom_info
     respond
   end
 
-  api :GET, "/systems/:id/available_host_collections", "List host collections the system does not belong to"
+  api :GET, "/systems/:id/available_host_collections", N_("List host collections the system does not belong to")
   param_group :search, Api::V2::ApiController
-  param :name, String, :desc => "host collection name to filter by"
+  param :name, String, :desc => N_("host collection name to filter by")
   def available_host_collections
     filters = [:terms => {:id => HostCollection.readable(@system.organization).pluck("#{Katello::HostCollection.table_name}.id") - @system.host_collection_ids}]
     filters << {:term => {:name => params[:name].downcase}} if params[:name]
@@ -209,15 +209,15 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index(:collection => host_collections)
   end
 
-  api :DELETE, "/systems/:id", "Unregister a system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :DELETE, "/systems/:id", N_("Unregister a system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def destroy
     @system.destroy
     respond :message => _("Deleted system '%s'") % params[:id], :status => 204
   end
 
-  api :GET, "/systems/:id/packages", "List packages installed on the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/packages", N_("List packages installed on the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def package_profile
     packages = @system.simple_packages.sort { |a, b| a.name.downcase <=> b.name.downcase }
     response = {
@@ -228,15 +228,15 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index :collection => response
   end
 
-  api :PUT, "/systems/:id/refresh_subscriptions", "Trigger a refresh of subscriptions, auto-attaching if enabled"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :PUT, "/systems/:id/refresh_subscriptions", N_("Trigger a refresh of subscriptions, auto-attaching if enabled")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def refresh_subscriptions
     @system.refresh_subscriptions
     respond_for_show(:resource => @system)
   end
 
-  api :GET, "/systems/:id/errata", "List errata available for the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/errata", N_("List errata available for the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def errata
     errata = @system.errata
     response = {
@@ -248,8 +248,8 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index :collection => response
   end
 
-  api :GET, "/systems/:id/tasks", "List async tasks for the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/tasks", N_("List async tasks for the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def tasks
     @system.refresh_tasks
 
@@ -263,8 +263,8 @@ class Api::V2::SystemsController < Api::V2::ApiController
   end
 
   # TODO: break this mehtod up
-  api :GET, "/environments/:environment_id/systems/report", "Get system reports for the environment"
-  api :GET, "/organizations/:organization_id/systems/report", "Get system reports for the organization"
+  api :GET, "/environments/:environment_id/systems/report", N_("Get system reports for the environment")
+  api :GET, "/organizations/:organization_id/systems/report", N_("Get system reports for the organization")
   def report # rubocop:disable MethodLength
     data = @environment.nil? ? @organization.systems.readable(@organization) : @environment.systems.readable(@organization)
 
@@ -294,11 +294,11 @@ class Api::V2::SystemsController < Api::V2::ApiController
     end
   end
 
-  api :GET, "/systems/:id/pools", "List pools a system is subscribed to"
-  param :id, String, :desc => "UUID of the system", :required => true
-  param :match_system, [true, false], :desc => "Match pools to system"
-  param :match_installed, [true, false], :desc => "Match pools to installed"
-  param :no_overlap, [true, false], :desc => "allow overlap"
+  api :GET, "/systems/:id/pools", N_("List pools a system is subscribed to")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
+  param :match_system, [true, false], :desc => N_("Match pools to system")
+  param :match_installed, [true, false], :desc => N_("Match pools to installed")
+  param :no_overlap, [true, false], :desc => N_("allow overlap")
   def pools
     match_system    = params.key?(:match_system) ? params[:match_system].to_bool : false
     match_installed = params.key?(:match_installed) ? params[:match_installed].to_bool : false
@@ -312,8 +312,8 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index :collection => response
   end
 
-  api :GET, "/systems/:id/releases", "Show releases available for the system"
-  param :id, String, :desc => "UUID of the system", :required => true
+  api :GET, "/systems/:id/releases", N_("Show releases available for the system")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   desc <<-DESC
     A hint for choosing the right value for the releaseVer param
   DESC
@@ -325,24 +325,24 @@ class Api::V2::SystemsController < Api::V2::ApiController
   end
 
   # used for registering with activation keys
-  api :POST, "/organizations/:organization_id/systems", "Register a system with activation key"
-  param :name, String, :desc => "Name of the system", :required => true, :action_aware => true
-  param :description, String, :desc => "Description of the system"
-  param :location, String, :desc => "Physical location of the system"
-  param :facts, Hash, :desc => "Key-value hash of system-specific facts", :action_aware => true, :required => true do
-    param :fact, String, :desc => "Any number of facts about this system"
+  api :POST, "/organizations/:organization_id/systems", N_("Register a system with activation key")
+  param :name, String, :desc => N_("Name of the system"), :required => true, :action_aware => true
+  param :description, String, :desc => N_("Description of the system")
+  param :location, String, :desc => N_("Physical location of the system")
+  param :facts, Hash, :desc => N_("Key-value hash of system-specific facts"), :action_aware => true, :required => true do
+    param :fact, String, :desc => N_("Any number of facts about this system")
   end
-  param :type, String, :desc => "Type of the system, it should always be 'system'", :required => true, :action_aware => true
-  param :guest_ids, Array, :desc => "IDs of the guests running on this system"
-  param :installed_products, Array, :desc => "List of products installed on the system", :action_aware => true
-  param :release_ver, String, :desc => "Release version of the system"
-  param :service_level, String, :allow_nil => true, :desc => "A service level for auto-healing process, e.g. SELF-SUPPORT", :action_aware => true
-  param :last_checkin, String, :desc => "Last check-in time of this system"
-  param :organization_id, :number, :desc => "Specify the organization", :required => true
-  param :environment_id, String, :desc => "Specify the environment"
-  param :content_view_id, String, :desc => "Specify the content view"
-  param :host_collection_id, String, :desc => "Specify the host collection"
-  param :activation_keys, String, :desc => "comma-separated list of activation-key IDs", :required => true
+  param :type, String, :desc => N_("Type of the system, it should always be 'system'"), :required => true, :action_aware => true
+  param :guest_ids, Array, :desc => N_("IDs of the guests running on this system")
+  param :installed_products, Array, :desc => N_("List of products installed on the system"), :action_aware => true
+  param :release_ver, String, :desc => N_("Release version of the system")
+  param :service_level, String, :allow_nil => true, :desc => N_("A service level for auto-healing process, e.g. SELF-SUPPORT"), :action_aware => true
+  param :last_checkin, String, :desc => N_("Last check-in time of this system")
+  param :organization_id, :number, :desc => N_("Specify the organization"), :required => true
+  param :environment_id, String, :desc => N_("Specify the environment")
+  param :content_view_id, String, :desc => N_("Specify the content view")
+  param :host_collection_id, String, :desc => N_("Specify the host collection")
+  param :activation_keys, String, :desc => N_("comma-separated list of activation-key IDs"), :required => true
   def activate
     # Activation keys are userless by definition so use the internal generic user
     # Set it before calling find_activation_keys to allow communication with candlepin
@@ -369,17 +369,17 @@ class Api::V2::SystemsController < Api::V2::ApiController
     end
   end
 
-  api :PUT, "/systems/:id/enabled_repos", "Update the information about enabled repositories"
+  api :PUT, "/systems/:id/enabled_repos", N_("Update the information about enabled repositories")
   desc <<-DESC
     Used by katello-agent to keep the information about enabled repositories up to date.
     This information is then used for computing the errata available for the system.
   DESC
   param :enabled_repos, Hash, :required => true do
     param :repos, Array, :required => true do
-      param :baseurl, Array, :description => "List of enabled repo urls for the repo (Only first is used.)", :required => false
+      param :baseurl, Array, :desc => N_("List of enabled repo urls for the repo (Only first is used.)"), :required => false
     end
   end
-  param :id, String, :desc => "UUID of the system", :required => true
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   def enabled_repos
     repos_params = params['enabled_repos'] rescue raise(HttpErrors::BadRequest, _("Expected attribute is missing:") + " enabled_repos")
     repos_params = repos_params['repos'] || []

--- a/app/controllers/katello/api/v2/tasks_controller.rb
+++ b/app/controllers/katello/api/v2/tasks_controller.rb
@@ -36,14 +36,14 @@ class Api::V2::TasksController < Api::V2::ApiController
     }
   end
 
-  api :GET, "/organizations/:organization_id/tasks", "List tasks of given organization"
-  param :organization_id, :number, :desc => "organization identifier", :required => true
+  api :GET, "/organizations/:organization_id/tasks", N_("List tasks of given organization")
+  param :organization_id, :number, :desc => N_("organization identifier"), :required => true
   def index
     respond :collection => TaskStatus.where(:organization_id => @organization.id)
   end
 
-  api :GET, "/tasks/:id", "Show a task info"
-  param :id, :identifier, :desc => "task identifier", :required => true
+  api :GET, "/tasks/:id", N_("Show a task info")
+  param :id, :identifier, :desc => N_("task identifier"), :required => true
   def show
     @task.refresh
     respond_for_show


### PR DESCRIPTION
This is Katello part of localization of API docs. The API doc strings serve as a source  for API documenatation in HTML and description of the API in JSON which is used in CLI.
With this patch all the API doc strings are wrapped in _() and enabled for translation.

Foreman part is here https://github.com/theforeman/foreman/pull/1428 and related apipie-rails changes are here https://github.com/Apipie/apipie-rails/pull/232
