### PR TITLE
refs #5601, #5603 - host collections - updates to support cli

### DIFF
--- a/app/views/katello/api/v2/host_collections/_host_collection.json.rabl
+++ b/app/views/katello/api/v2/host_collections/_host_collection.json.rabl
@@ -3,6 +3,7 @@ attribute :pulp_id, :name, :organization_id, :max_content_hosts, :description, :
 node :id do |host_collection|
   host_collection.id.to_i
 end
+attributes :system_ids
 
 extends "katello/api/v2/common/timestamps"
 

--- a/app/views/katello/api/v2/host_collections/show.json.rabl
+++ b/app/views/katello/api/v2/host_collections/show.json.rabl
@@ -1,4 +1,3 @@
 object @host_collection
 
 extends "katello/api/v2/host_collections/host_collection"
-j


### PR DESCRIPTION
This commit contains a couple of minor changes to help
support the cli host-collection update, add-content-host
and remove-content-host commands.  They will also be useful
for API users.
