### PR TITLE
Fixes # 5702 - Updated CV index call to work with environment_id

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -38,7 +38,9 @@ module Katello
       options = sort_params
       options[:load_records?] = true
 
-      ids = ContentView.readable.pluck(:id)
+      readable_cvs = ContentView.readable
+      readable_cvs = readable_cvs.in_environment(@environment) if @environment
+      ids = readable_cvs.pluck(:id)
 
       options[:filters] = [{:terms => {:id => ids}}]
 


### PR DESCRIPTION
Updated Content Views index call to work with the environment_id. That was previously getting ignored.
