### PR TITLE
Fixes #5711 - Doc id in ContentHosts update

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -165,6 +165,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
   end
 
   api :PUT, "/systems/:id", N_("Update system information")
+  param :id, String, :desc => N_("UUID of the system"), :required => true
   param :name, String, :desc => N_("Name of the system"), :required => true, :action_aware => true
   param :description, String, :desc => N_("Description of the system")
   param :location, String, :desc => N_("Physical location of the system")


### PR DESCRIPTION
Hammer-cli-katello is unable to recognize --id param for in the
subcommand content-host update. Apipie param 'id' is missing for
the update in systems controller.
