### PR TITLE
Fixes #5715 - make sure the rest client doesn't get PhusionPassenger::Utils::TeeInput

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -148,19 +148,19 @@ module Katello
     end
 
     def delete
-      r = Resources::Candlepin::Proxy.delete(@request_path, @request_body)
+      r = Resources::Candlepin::Proxy.delete(@request_path, @request_body.read)
       logger.debug r
       render :json => r
     end
 
     def post
-      r = Resources::Candlepin::Proxy.post(@request_path, @request_body)
+      r = Resources::Candlepin::Proxy.post(@request_path, @request_body.read)
       logger.debug r
       render :json => r
     end
 
     def put
-      r = Resources::Candlepin::Proxy.put(@request_path, @request_body)
+      r = Resources::Candlepin::Proxy.put(@request_path, @request_body.read)
       logger.debug r
       render :json => r
     end


### PR DESCRIPTION
Rest client 1.6.7 is not able to handle that, passing the string instead. The
behavior should stay the same.
