### PR TITLE
Fixes #5682 - Handle Lifecycle env read perms better

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -62,7 +62,9 @@ module Katello
     param :name, String, :desc => N_("filter only environments containing this name")
     def index
       filters = []
+      ids = KTEnvironment.readable.pluck(:id)
 
+      filters << {:terms => {:id => ids}}
       filters << {:terms => {:organization_id => [@organization.id]}}
       # See http://projects.theforeman.org/issues/4405
       filters << {:terms => {:name => [params[:name].downcase]}} if params[:name]
@@ -139,7 +141,7 @@ module Katello
     api :GET, "/organizations/:organization_id/environments/paths", N_("List environment paths")
     param :organization_id, :number, :desc => N_("organization identifier")
     def paths
-      paths = @organization.promotion_paths.inject([]) do |result, path|
+      paths = @organization.readable_promotion_paths.inject([]) do |result, path|
         result << { :environments => [@organization.library] + path }
       end
       paths = [{ :environments => [@organization.library] }] if paths.empty?
@@ -175,7 +177,7 @@ module Katello
 
     def find_prior
       prior = params.require(:environment).require(:prior)
-      @prior = KTEnvironment.find(prior)
+      @prior = KTEnvironment.readable.find(prior)
       fail HttpErrors::NotFound, _("Couldn't find prior-environment '%s'") % prior.to_s if @prior.nil?
       @prior
     end

--- a/app/models/katello/authorization/lifecycle_environment.rb
+++ b/app/models/katello/authorization/lifecycle_environment.rb
@@ -19,6 +19,10 @@ module Authorization::LifecycleEnvironment
   DISTRIBUTORS_READABLE = [:read_distributors, :register_distributors, :update_distributors, :delete_distributors]
 
   module ClassMethods
+    def readable
+      authorized(:view_lifecycle_environments)
+    end
+
     def creatable?
       ::User.current.can?(:create_lifecycle_environments)
     end

--- a/app/models/katello/authorization/organization.rb
+++ b/app/models/katello/authorization/organization.rb
@@ -156,6 +156,18 @@ module Authorization::Organization
     def manifest_importable?
       authorized(:import_manifest)
     end
+
+    def readable_promotion_paths
+      permissible_promotion_paths(KTEnvironment.readable)
+    end
+
+    def permissible_promotion_paths(permissible_environments)
+      promotion_paths.select do |promotion_path|
+        # if at least one environment in the path is permissible
+        # the path is deemed permissible.
+        (promotion_path - permissible_environments).size != promotion_path.size
+      end
+    end
   end
 
 end

--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -16,6 +16,7 @@ end
 
 node :permissions do |env|
   {
+    :readable => env.readable?,
     :editable => env.editable?,
     :deletable => env.deletable?
   }

--- a/engines/bastion/app/assets/javascripts/bastion/environments/views/environments.html
+++ b/engines/bastion/app/assets/javascripts/bastion/environments/views/environments.html
@@ -38,14 +38,16 @@
 
             <td class="path-selector">
               <ul class="path-list">
-                <li class="path-list-item" ng-repeat="env in row.environments">
-                  <label ng-click="selectEnvironment(env)"
+                <li class="path-list-item" ng-repeat="env in row.environments" ng-class="{ 'disabled-item': !env.permissions.readable}">
+                  <label ng-click="env.permissions.readable && selectEnvironment(env)"
                          ng-class="{active: workingOn === env}"
-                         class="path-list-item-label">
+                         class="path-list-item-label"
+                         ng-disabled="!env.permissions.readable">
                     <div>
                       {{ env.name }}
                     </div>
                   </label>
+
                 </li>
                 <li class="path-list-item" ng-show="row.permissions.creatable">
                   <label ng-click="initiateCreateEnvironment()" class="path-list-item-label">

--- a/test/controllers/api/v2/environments_controller_test.rb
+++ b/test/controllers/api/v2/environments_controller_test.rb
@@ -74,6 +74,7 @@ module Katello
 
     def test_create_protected
       Organization.any_instance.stubs(:save!).returns(@organization)
+      KTEnvironment.expects(:readable).returns(KTEnvironment)
       allowed_perms = [@create_permission]
       denied_perms = [@view_permission, @update_permission, @destroy_permission, @no_permission]
 

--- a/test/fixtures/models/katello_environment_priors.yml
+++ b/test/fixtures/models/katello_environment_priors.yml
@@ -9,3 +9,27 @@ staging_library_prior:
 candlepin_dev_library_prior:
   prior_id: <%= ActiveRecord::Fixtures.identify(:candlepin_library) %>
   environment_id: <%= ActiveRecord::Fixtures.identify(:candlepin_dev) %>
+
+dev_path1_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:library) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:dev_path1) %>
+
+qa_path1_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:dev_path1) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:qa_path1) %>
+
+staging_path1_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:qa_path1) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:staging_path1) %>
+
+dev_path2_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:library) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:dev_path2) %>
+
+qa_path2_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:dev_path2) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:qa_path2) %>
+
+staging_path2_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:qa_path2) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:staging_path2) %>

--- a/test/fixtures/models/katello_environments.yml
+++ b/test/fixtures/models/katello_environments.yml
@@ -36,3 +36,39 @@ organization1_library:
   library:        true
   label:          organization1_library
   organization_id: <%= ActiveRecord::Fixtures.identify(:organization1) %>
+
+dev_path1:
+  name:           Dev Path1
+  description:    Dev environment.
+  label:          dev_path1_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
+qa_path1:
+  name:           QA Path1
+  description:    QA environment.
+  label:          qa_path1_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
+staging_path1:
+  name:           Staging Path1
+  description:    Staging environment.
+  label:          staging_path1_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
+dev_path2:
+  name:           Dev Path2
+  description:    Dev environment.
+  label:          dev_path2_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
+qa_path2:
+  name:           QA Path2
+  description:    QA environment.
+  label:          qa_path2_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
+staging_path2:
+  name:           Staging Path2
+  description:    Staging environment.
+  label:          staging_path2_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>

--- a/test/models/authorization/authorization_base.rb
+++ b/test/models/authorization/authorization_base.rb
@@ -14,6 +14,7 @@ require 'katello_test_helper'
 
 module Katello
 class AuthorizationTestBase < ActiveSupport::TestCase
+  include Katello::AuthorizationSupportMethods
 
   def self.before_suite
     services  = ['Candlepin', 'Pulp', 'ElasticSearch', 'Foreman']

--- a/test/models/authorization/lifecycle_environment_authorization_test.rb
+++ b/test/models/authorization/lifecycle_environment_authorization_test.rb
@@ -22,6 +22,10 @@ class EnvironmentAuthorizationAdminTest < AuthorizationTestBase
     @org = @acme_corporation
   end
 
+  def test_readable
+    refute_empty KTEnvironment.readable
+  end
+
   def test_content_readable
     refute_empty KTEnvironment.content_readable(@org)
   end
@@ -79,6 +83,10 @@ class EnvironmentAuthorizationNoPermsTest < AuthorizationTestBase
     User.current = User.find(users('restricted'))
     @env = @dev
     @org = @acme_corporation
+  end
+
+  def test_readable
+    assert_empty KTEnvironment.readable
   end
 
   def test_content_readable

--- a/test/models/authorization/organization_authorization_test.rb
+++ b/test/models/authorization/organization_authorization_test.rb
@@ -14,18 +14,20 @@ require 'models/authorization/authorization_base'
 
 module Katello
 class OrganizationAuthorizationAdminTest < AuthorizationTestBase
-
   def setup
     super
     User.current = User.find(users('admin'))
     @org = @acme_corporation
+  end
+  def test_promotion_paths
+    assert_equal(@org.promotion_paths, @org.readable_promotion_paths)
   end
 
   def test_class_readable
     refute_empty Organization.readable
   end
 
-  def def_class_creatable?
+  def test_creatable?
     assert Organization.creatable?
   end
 
@@ -135,5 +137,16 @@ class OrganizationAuthorizationNoPermsTest < AuthorizationTestBase
     refute @org.redhat_manageable?
   end
 
+  def test_read_promotion_paths
+    assert_empty @org.readable_promotion_paths
+  end
+
+  def test_read_promotion_paths_one
+    environment = katello_environments(:staging_path1)
+    add_role("view_lifecycle_environments", "name=\"#{environment.name}\"")
+
+    refute_equal(@org.promotion_paths, @org.readable_promotion_paths)
+    assert_equal(1, @org.readable_promotion_paths.size)
+  end
 end
 end

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -48,6 +48,14 @@ module AuthorizationSupportMethods
     role.save!
   end
 
+  def add_role(permission_name, search = nil)
+    role = FactoryGirl.create(:role)
+    role.add_permissions!([permission_name], :search => search)
+    user = users(:restricted)
+    user.roles = [role]
+    user
+  end
+
   class UserPermissionsGenerator
     def initialize(user)
       @user = user

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -85,16 +85,6 @@ module ControllerSupport
     user.own_role.permissions.delete_all
     user
   end
-
-  def add_role(permission_name)
-    permission = Permission.find_by_name(permission_name)
-    role = create(:role, :permissions => [permission])
-    user = users(:restricted)
-    filter = create(:filter, :role => role, :permissions => [permission])
-    user.roles = [role]
-    user
-  end
-
 end
 
 UserPermission = Struct.new(:verbs, :resource_type, :tags, :org, :options) do


### PR DESCRIPTION
1) Made env index call prune the return list based on read perms
2) Made the env page in the UI display paths appropriately based on read
perms
3) Updated the create env call to require read access on the prior
environment before one can create.
