### PR TITLE
Fixes #5654 - Permissions for env promotion/remove

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -15,6 +15,8 @@ module Katello
     before_filter :find_content_view_version, :only => [:show, :promote, :destroy]
     before_filter :find_content_view
     before_filter :find_environment, :only => [:promote]
+    before_filter :authorize_promotable, :only => [:promote]
+    before_filter :authorize_destroy, :only => [:destroy]
 
     api :GET, "/content_view_versions", N_("List content view versions")
     api :GET, "/content_views/:content_view_id/content_view_versions", N_("List content view versions")
@@ -66,5 +68,13 @@ module Katello
       @environment = KTEnvironment.find(params[:environment_id])
     end
 
+    def authorize_promotable
+      deny_access unless @environment.promotable_or_removable?
+      deny_access unless @version.content_view.promotable_or_removable?
+    end
+
+    def authorize_destroy
+      deny_access unless @version.content_view.deletable?
+    end
   end
 end

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -140,8 +140,19 @@ module Katello
 
     api :GET, "/organizations/:organization_id/environments/paths", N_("List environment paths")
     param :organization_id, :number, :desc => N_("organization identifier")
+    param :permission_type, String, :desc => <<-DESC
+      The associated permission type. One of (readable | promotable)
+      Default: readable
+    DESC
     def paths
-      paths = @organization.readable_promotion_paths.inject([]) do |result, path|
+      env_paths = case params[:permission_type]
+                  when "promotable"
+                    @organization.promotable_promotion_paths
+                  else
+                    @organization.readable_promotion_paths
+                  end
+
+      paths = env_paths.inject([]) do |result, path|
         result << { :environments => [@organization.library] + path }
       end
       paths = [{ :environments => [@organization.library] }] if paths.empty?

--- a/app/models/katello/authorization/content_view.rb
+++ b/app/models/katello/authorization/content_view.rb
@@ -45,6 +45,9 @@ module Katello
         authorized?(:destroy_content_views)
       end
 
+      def promotable_or_removable?
+        authorized?(:promote_or_remove_content_views)
+      end
     end
 
   end

--- a/app/models/katello/authorization/lifecycle_environment.rb
+++ b/app/models/katello/authorization/lifecycle_environment.rb
@@ -23,6 +23,14 @@ module Authorization::LifecycleEnvironment
       authorized(:view_lifecycle_environments)
     end
 
+    def promotable
+      authorized(:promote_or_remove_content_views_to_environments)
+    end
+
+    def any_promotable?
+      promotable.count > 0
+    end
+
     def creatable?
       ::User.current.can?(:create_lifecycle_environments)
     end
@@ -156,16 +164,13 @@ module Authorization::LifecycleEnvironment
       authorized?(:destroy_lifecycle_environments)
     end
 
+    def promotable_or_removable?
+      authorized?(:promote_or_remove_content_views_to_environments)
+    end
+
     def viewable_for_promotions?
       return false if !Katello.config.katello?
       ::User.allowed_to?(CONTENTS_READABLE, :environments, self.id, self.organization)
-    end
-
-    def any_operation_readable?
-      return false if !Katello.config.katello?
-      ::User.allowed_to?(self.class.list_verbs.keys, :environments, self.id, self.organization) ||
-          self.organization.systems_readable? || self.organization.any_systems_registerable? ||
-          self.organization.distributors_readable? || self.organization.any_distributors_registerable?
     end
 
     def contents_readable?

--- a/app/models/katello/authorization/organization.rb
+++ b/app/models/katello/authorization/organization.rb
@@ -158,7 +158,11 @@ module Authorization::Organization
     end
 
     def readable_promotion_paths
-      permissible_promotion_paths(KTEnvironment.readable)
+       permissible_promotion_paths(KTEnvironment.readable)
+    end
+
+    def promotable_promotion_paths
+      permissible_promotion_paths(KTEnvironment.promotable)
     end
 
     def permissible_promotion_paths(permissible_environments)

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -117,6 +117,10 @@ class ContentViewVersion < Katello::Model
       .order("#{Katello::ContentViewEnvironment.table_name}.environment_id")
   end
 
+  def removable?
+    content_view.promotable_or_removable? && KTEnvironment.where(:id => environments).any_promotable?
+  end
+
   def deletable?(from_env)
     !System.exists?(:environment_id => from_env, :content_view_id => self.content_view) ||
         self.content_view.versions.in_environment(from_env).count > 1

--- a/app/views/katello/api/v2/content_view_versions/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/show.json.rabl
@@ -18,11 +18,24 @@ child :composite_content_views do
   attributes :id, :name, :label
 end
 
+node :permissions do |cvv|
+  {
+    :deletable => cvv.removable?
+  }
+end
+
 extends 'katello/api/v2/common/timestamps'
 
 version = @object || @resource
 child :environments => :environments do
   attributes :id, :name, :label
+
+  node :permissions do |env|
+  {
+    :readable => env.readable?,
+    :promotable_or_removable => env.promotable_or_removable?
+  }
+  end
 
   node :system_count do |env|
     Katello::System.in_environment(env).where(:content_view_id => version.content_view_id).count

--- a/app/views/katello/api/v2/content_views/show.json.rabl
+++ b/app/views/katello/api/v2/content_views/show.json.rabl
@@ -17,6 +17,12 @@ end
 
 child :environments => :environments do
   attributes :id, :name, :label
+  node :permissions do |env|
+  {
+    :readable => env.readable?
+  }
+  end
+
 end
 
 child :repositories => :repositories do
@@ -33,6 +39,13 @@ child :versions => :versions do
   attributes :id, :version
   attributes :created_at => :published
   attributes :environment_ids
+end
+
+node :permissions do |cv|
+{
+  :promotable_or_removable => cv.promotable_or_removable? && Katello::KTEnvironment.any_promotable?,
+  :deletable => cv.deletable?
+}
 end
 
 child :components => :components do

--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -18,7 +18,8 @@ node :permissions do |env|
   {
     :readable => env.readable?,
     :editable => env.editable?,
-    :deletable => env.deletable?
+    :deletable => env.deletable?,
+    :promotable_or_removable => env.promotable_or_removable?
   }
 end
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-deletion.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-deletion.controller.js
@@ -40,7 +40,13 @@ angular.module('Bastion.content-views').controller('ContentViewDeletionControlle
         };
 
         $scope.environmentNames = function (version) {
-            return _.pluck(version.environments, 'name');
+            return _.pluck($scope.readableEnvironments(version), 'name');
+        };
+
+        $scope.readableEnvironments = function (version) {
+            return _.reject(version.environments, function (env) {
+                return !env.permissions.readable;
+            });
         };
 
         function success() {

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-environments.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-environments.controller.js
@@ -24,26 +24,36 @@
 angular.module('Bastion.content-views').controller('ContentViewVersionDeletionEnvironmentsController',
     ['$scope',
     function ($scope) {
-
         $scope.environmentsTable = {rows: {}};
         $scope.version.$promise.then(function () {
+            var numSelections;
             $scope.environmentsTable.rows = $scope.version.environments;
             if ($scope.version.environments.length === 0) {
                 $scope.deleteOptions.deleteArchive = true;
             } else {
+                angular.forEach($scope.environmentsTable.rows, function (row) {
+                    row.unselectable = !row.permissions['promotable_or_removable'];
+                });
+
                 if ($scope.deleteOptions.environments.length === 0) {
                     //select all by default
                     angular.forEach($scope.environmentsTable.rows, function (row) {
-                        row.selected = true;
+                        row.selected = !row.unselectable;
                     });
-                    $scope.environmentsTable.numSelected = $scope.environmentsTable.rows.length;
                 } else {
                     //set existing selections
                     angular.forEach($scope.environmentsTable.rows, function (row) {
-                        row.selected = _.findWhere($scope.deleteOptions.environments, {id: row.id}) !== undefined;
+                        row.selected = _.findWhere($scope.deleteOptions.environments,
+                                                    {unselectable: false, id: row.id}) !== undefined;
+
                     });
-                    $scope.environmentsTable.numSelected = $scope.deleteOptions.environments.length;
                 }
+
+                numSelections = _.countBy($scope.environmentsTable.rows, function (row) {
+                    return row.selected ? 'selected': 'unselected';
+                });
+
+                $scope.environmentsTable.numSelected = numSelections["selected"];
             }
         });
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/content-view-deletion.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/content-view-deletion.html
@@ -24,7 +24,7 @@
           <td>{{ version.version }}</td>
           <td>{{ environmentNames(version).join(', ') }}</td>
           <td>
-            <a ui-sref="content-views.details.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})">
+            <a ui-sref="content-views.details.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})" ng-show="version.permissions.deletable">
               <button class="btn btn-default">
                 <i class="icon-trash"></i>
                 <span translate>Remove Version</span>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/version-deletion-confirm.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/version-deletion-confirm.html
@@ -12,7 +12,7 @@
       <i class="icon-warning-sign"></i>
       <span translate>This version will be removed from:</span>
       <ul class="bullet">
-        <li ng-repeat="env in deleteOptions.environments">{{ env.name }}</li>
+        <li ng-repeat="env in deleteOptions.environments" ng-if="env.permissions.readable">{{ env.name }}</li>
       </ul>
     </div>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-promotion.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-promotion.controller.js
@@ -32,7 +32,7 @@ angular.module('Bastion.content-views').controller('ContentViewPromotionControll
 
         $scope.promotion = {};
 
-        $scope.availableEnvironments =  Organization.paths({id: CurrentOrganization});
+        $scope.availableEnvironments =  Organization.paths({id: CurrentOrganization, 'permission_type': 'promotable'});
 
         $scope.enabledCheck = function (env) {
             var enabled = false,
@@ -41,8 +41,9 @@ angular.module('Bastion.content-views').controller('ContentViewPromotionControll
             if (!env.prior) {
                 env.prior = {};
             }
-
-            if (envIds.indexOf(env.id) !== -1) {
+            if (!env.permissions['promotable_or_removable']) {
+                enabled = false;
+            } else if (envIds.indexOf(env.id) !== -1) {
                 //if version is already promoted to the environment
                 enabled = false;
             } else if (env.library) {

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-details.html
@@ -18,7 +18,7 @@
           <span translate>Clone View</span>
         </a>
 
-        <button class="btn btn-default" ui-sref="content-views.details.deletion">
+        <button class="btn btn-default" ui-sref="content-views.details.deletion" ng-show="contentView.permissions.deletable">
           <i class="icon-trash"></i>
           {{ "Remove View" | translate }}
         </button>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
@@ -38,7 +38,7 @@
           </span>
         </td>
         <td alch-table-cell>
-          <li ng-repeat="environment in version.environments">
+          <li ng-repeat="environment in version.environments" ng-if="environment.permissions.readable">
             {{ environment.name }}
           </li>
         </td>
@@ -57,7 +57,7 @@
         </td>
         <td alch-table-cell>{{ version.user }}</td>
         <td class="col-sm-2">
-          <a ui-sref="content-views.details.promotion({contentViewId: contentView.id, versionId: version.id})">
+          <a ui-sref="content-views.details.promotion({contentViewId: contentView.id, versionId: version.id})" ng-show="contentView.permissions.promotable_or_removable">
             <button class="btn btn-default">
               <i class="icon-share-alt"></i>
               <span translate>
@@ -65,7 +65,7 @@
               </span>
             </button>
           </a>
-          <a ui-sref="content-views.details.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})">
+          <a ui-sref="content-views.details.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})" ng-show="version.permissions.deletable">
             <button class="btn btn-default">
               <i class="icon-trash"></i>
               <span translate>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-full.html
@@ -29,7 +29,7 @@
       </td>
       <td alch-table-cell>
         <span ng-show="contentView.environments.length !== 0"
-              ng-repeat="environment in contentView.environments">
+              ng-repeat="environment in contentView.environments" ng-if="environment.permissions.readable">
           {{ environment.name }}<span ng-if="!$last">, </span>
         </span>
         <span ng-show="contentView.environments.length === 0" translate>

--- a/engines/bastion/app/assets/javascripts/bastion/incubator/alch-table.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/incubator/alch-table.directive.js
@@ -80,15 +80,17 @@ angular.module('alchemy')
         };
 
         this.selectAll = $scope.table.selectAll = function (selected) {
-            var table = $scope.table;
+            var table = $scope.table,
+                rowsSelected = 0;
 
             self.selection.allSelected = selected;
-
-            $scope.table.numSelected = self.selection.allSelected ? table.rows.length : 0;
-
             angular.forEach(table.rows, function (row) {
-                row.selected = self.selection.allSelected;
+                if (!row.unselectable) {
+                    row.selected = self.selection.allSelected;
+                    rowsSelected = rowsSelected + 1;
+                }
             });
+            $scope.table.numSelected = selected ? rowsSelected : 0;
         };
 
     }])
@@ -184,6 +186,7 @@ angular.module('alchemy')
             return '<td class="row-select">' +
                       '<input type="checkbox"' +
                               'ng-model="' + model + '.selected"' +
+                              'ng-disabled="' + model + '.unselectable"' +
                               'ng-change="itemSelected(' + model + ')">' +
                    '</td>';
         };
@@ -230,6 +233,10 @@ angular.module('alchemy')
 
                     if (attrs.rowSelect) {
                         scope.model = $parse(attrs.rowSelect)(scope);
+
+                        if ($parse(attrs.rowSelectIf)(scope)) {
+                            scope.model.unselectable = true;
+                        }
 
                         scope.$watch('model.selected', function (selected) {
                             if (selected) {

--- a/engines/bastion/app/assets/javascripts/bastion/organizations/organization.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/organizations/organization.factory.js
@@ -33,7 +33,8 @@ angular.module('Bastion.organizations').factory('Organization',
                 paths: {
                     method: 'GET',
                     url: '/api/v2/organizations/:id/environments/paths',
-                    isArray: true
+                    isArray: true,
+                    params: {'permission_type': '@permission_type'}
                 },
                 registerableEnvironments: {
                     method: 'GET',

--- a/engines/bastion/test/content-views/details/deletion/content-view-deletion.controller.test.js
+++ b/engines/bastion/test/content-views/details/deletion/content-view-deletion.controller.test.js
@@ -21,7 +21,7 @@ describe('Controller: ContentViewDeletionController', function() {
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller');
 
-        versions = [{version: 1, environments:[{name: "name"}]}, {version: 2, environments: []}];
+        versions = [{version: 1, environments:[{name: "name", permissions: {readable: true}}]}, {version: 2, environments: []}];
         ContentView = $injector.get('MockResource').$new();
 
         $scope = $injector.get('$rootScope').$new();

--- a/engines/bastion/test/content-views/details/deletion/content-view-version-deletion-environments.controller.test.js
+++ b/engines/bastion/test/content-views/details/deletion/content-view-version-deletion-environments.controller.test.js
@@ -19,7 +19,7 @@ describe('Controller: ContentViewVersionDeletionEnvironmentsController', functio
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller');
 
-        environments = [{name: 'dev'}];
+        environments = [{name: 'dev', permissions: {promotable_or_removable: true} }];
         version = {id: 1, environments: environments};
 
         $scope = $injector.get('$rootScope').$new();

--- a/engines/bastion/test/incubator/alch-table.directive.test.js
+++ b/engines/bastion/test/incubator/alch-table.directive.test.js
@@ -33,6 +33,10 @@ describe('Directive: alchTable', function() {
         },{
             name: 'Pilsner',
             style: 'lager'
+        },{
+            name: 'Quadrupel',
+            style: 'beer',
+            unselectable: true
         }]
     });
 
@@ -115,7 +119,7 @@ describe('Directive: alchTable', function() {
             expect(scope.table.allSelected()).toEqual(false);
         });
 
-        it("should select all rows", function() {
+        it("should select all selectable rows", function() {
             tableController.selectAll(true);
 
             expect(scope.table.numSelected).toEqual(2);

--- a/lib/katello/permissions/content_view_permissions.rb
+++ b/lib/katello/permissions/content_view_permissions.rb
@@ -39,7 +39,14 @@ Foreman::Plugin.find(:katello).security_block :content_views do
              :resource_type => 'Katello::ContentView'
   permission :publish_content_views,
              {
-                 'katello/api/v2/content_views' => [:publish],
+                 'katello/api/v2/content_views' => [:publish]
+             },
+             :resource_type => 'Katello::ContentView'
+
+  permission :promote_or_remove_content_views,
+             {
+                 'katello/api/v2/content_view_versions' => [:promote],
+                 'katello/api/v2/content_views' => [:remove_from_environment, :remove]
              },
              :resource_type => 'Katello::ContentView'
 end

--- a/lib/katello/permissions/lifecycle_environment_permissions.rb
+++ b/lib/katello/permissions/lifecycle_environment_permissions.rb
@@ -22,4 +22,6 @@ Foreman::Plugin.find(:katello).security_block :lifecycle_environments do
                 'katello/api/v2/environments' => [:destroy],
              },
              :resource_type => 'Katello::KTEnvironment'
+
+   permission :promote_or_remove_content_views_to_environments, {}, :resource_type => 'Katello::KTEnvironment'
 end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -30,7 +30,6 @@ describe KTEnvironment do
     describe "check on operations" do
 
       all_verb_methods = [:viewable_for_promotions?,
-                          :any_operation_readable?,
                           :contents_readable?,
                           :systems_readable?,
                           :systems_editable?,
@@ -38,11 +37,11 @@ describe KTEnvironment do
                           :systems_registerable?]
 
       permission_matrix = {
-          :read_contents =>  [:any_operation_readable?, :contents_readable?, :viewable_for_promotions?],
-          :read_systems => [:any_operation_readable?, :systems_readable?],
-          :register_systems => [:any_operation_readable?, :systems_readable?,:systems_registerable?],
-          :update_systems => [:any_operation_readable?, :systems_readable?, :systems_editable? ],
-          :delete_systems => [:any_operation_readable?, :systems_readable?, :systems_deletable? ],
+          :read_contents =>  [ :contents_readable?, :viewable_for_promotions?],
+          :read_systems => [ :systems_readable?],
+          :register_systems => [:systems_readable?,:systems_registerable?],
+          :update_systems => [:systems_readable?, :systems_editable? ],
+          :delete_systems => [:systems_readable?, :systems_deletable? ],
       }
       permission_matrix.each_pair do |perm, true_ops|
         true_ops.each do |op|

--- a/test/fixtures/models/katello_content_view_environments.yml
+++ b/test/fixtures/models/katello_content_view_environments.yml
@@ -60,6 +60,36 @@ library_dev_view_dev:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 
+library_dev_staging_view_library:
+  name:           Published Library - staging- dev view staging environment
+  label:          'library_dev_staging_view_library'
+  cp_id:          10
+  environment_id: <%= ActiveRecord::Fixtures.identify(:library) %>
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
+  content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+library_dev_staging_view_dev:
+  name:           Published Library - staging- dev view staging environment
+  label:          'library_dev_staging_view_dev'
+  cp_id:          11
+  environment_id: <%= ActiveRecord::Fixtures.identify(:dev) %>
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
+  content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+library_dev_staging_view_staging:
+  name:           Published Library - staging- dev view staging environment
+  label:          'library_dev_staging_view_staging'
+  cp_id:          12
+  environment_id: <%= ActiveRecord::Fixtures.identify(:staging) %>
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
+  content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
 candlepin_library_dev_cve:
   name:         Library and Dev Content View Environment
   label:        'candlepin_library_dev_cve'

--- a/test/fixtures/models/katello_content_view_versions.yml
+++ b/test/fixtures/models/katello_content_view_versions.yml
@@ -24,6 +24,10 @@ library_dev_view_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:library_dev_view) %>
   version: 1
 
+library_dev_stagin_view_version:
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
+  version: 3
+
 candlepin_library_dev_cv_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:candlepin_library_dev_cv) %>
   version: 1

--- a/test/fixtures/models/katello_content_views.yml
+++ b/test/fixtures/models/katello_content_views.yml
@@ -37,6 +37,14 @@ library_dev_view:
   updated_at: <%= Time.now %>
   organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
 
+library_dev_staging_view:
+  name:           Published Library - dev - staging view
+  label:          published_dev_staging_view
+  default:        false
+  next_version:   4
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
 
 candlepin_default_cv:
   name:           candlepin Default ContentView

--- a/test/models/authorization/content_view_authorization_test.rb
+++ b/test/models/authorization/content_view_authorization_test.rb
@@ -36,6 +36,10 @@ module Katello
     def test_key_deletable?
       assert @view.deletable?
     end
+
+    def test_promotable?
+      assert @view.promotable_or_removable?
+    end
   end
 
   class ContentViewAuthorizationNoPermsTest < AuthorizationTestBase
@@ -60,6 +64,17 @@ module Katello
 
     def test_key_deletable?
       refute @view.deletable?
+    end
+
+    def test_promotable?
+      refute @view.promotable_or_removable?
+    end
+
+    def test_promotable_perm
+      cv = katello_content_views(:library_dev_staging_view)
+      setup_current_user_with_permissions(:name => "promote_or_remove_content_views",
+                                        :search => "name=\"#{cv.name}\"")
+      assert cv.promotable_or_removable?
     end
 
   end

--- a/test/models/authorization/lifecycle_environment_authorization_test.rb
+++ b/test/models/authorization/lifecycle_environment_authorization_test.rb
@@ -26,8 +26,24 @@ class EnvironmentAuthorizationAdminTest < AuthorizationTestBase
     refute_empty KTEnvironment.readable
   end
 
+  def test_promotable?
+    assert @env.promotable_or_removable?
+  end
+
+  def test_promotable
+    refute_empty KTEnvironment.promotable
+  end
+
   def test_content_readable
     refute_empty KTEnvironment.content_readable(@org)
+  end
+
+  def test_any_promotable?
+    assert KTEnvironment.any_promotable?
+  end
+
+  def test_any_contents_readable?
+    assert KTEnvironment.any_contents_readable?(@org)
   end
 
   def test_systems_readable
@@ -38,21 +54,9 @@ class EnvironmentAuthorizationAdminTest < AuthorizationTestBase
     refute_empty KTEnvironment.systems_registerable(@org)
   end
 
-  def test_any_viewable_for_promotions?
-    assert KTEnvironment.any_viewable_for_promotions?(@org)
-  end
-
-  def test_any_contents_readable?
-    assert KTEnvironment.any_contents_readable?(@org)
-  end
-
   #instance tests
   def test_viewable_for_promotions?
     assert @env.viewable_for_promotions?
-  end
-
-  def test_any_operation_readable?
-    assert @env.any_operation_readable?
   end
 
   def test_contents_readable?
@@ -89,6 +93,18 @@ class EnvironmentAuthorizationNoPermsTest < AuthorizationTestBase
     assert_empty KTEnvironment.readable
   end
 
+  def test_promotable?
+    refute @env.promotable_or_removable?
+  end
+
+  def test_promotable
+    assert_empty KTEnvironment.promotable
+  end
+
+  def test_any_promotable?
+    refute KTEnvironment.any_promotable?
+  end
+
   def test_content_readable
     assert_empty KTEnvironment.content_readable(@org)
   end
@@ -114,10 +130,6 @@ class EnvironmentAuthorizationNoPermsTest < AuthorizationTestBase
     refute @env.viewable_for_promotions?
   end
 
-  def test_any_operation_readable?
-    refute @env.any_operation_readable?
-  end
-
   def test_contents_readable?
     refute @env.contents_readable?
   end
@@ -137,6 +149,30 @@ class EnvironmentAuthorizationNoPermsTest < AuthorizationTestBase
   def test_systems_registerable?
     refute @env.systems_registerable?
   end
+end
 
+class EnvironmentAuthorizationWithPermsTest < AuthorizationTestBase
+  def setup
+    super
+    User.current = User.find(users('restricted'))
+  end
+
+  def test_readables
+    environment = katello_environments(:staging_path1)
+    setup_current_user_with_permissions(:name => "view_lifecycle_environments",
+                                        :search => "name=\"#{environment.name}\"")
+    assert_equal([environment.id], KTEnvironment.readable.pluck(:id))
+    assert environment.readable?
+    refute environment.prior.readable?
+  end
+
+  def test_promotables
+    environment = katello_environments(:staging_path1)
+    setup_current_user_with_permissions(:name => "promote_or_remove_content_views_to_environments",
+                                        :search => "name=\"#{environment.name}\"")
+    assert_equal([environment.id], KTEnvironment.promotable.pluck(:id))
+    assert environment.promotable_or_removable?
+    refute environment.prior.promotable_or_removable?
+  end
 end
 end

--- a/test/models/authorization/organization_authorization_test.rb
+++ b/test/models/authorization/organization_authorization_test.rb
@@ -143,10 +143,20 @@ class OrganizationAuthorizationNoPermsTest < AuthorizationTestBase
 
   def test_read_promotion_paths_one
     environment = katello_environments(:staging_path1)
-    add_role("view_lifecycle_environments", "name=\"#{environment.name}\"")
+    setup_current_user_with_permissions(:name => "view_lifecycle_environments",
+                                        :search => "name=\"#{environment.name}\"")
 
     refute_equal(@org.promotion_paths, @org.readable_promotion_paths)
     assert_equal(1, @org.readable_promotion_paths.size)
+  end
+
+  def test_promotable_promotion_paths_one
+    environment = katello_environments(:staging_path1)
+    setup_current_user_with_permissions(:name => "promote_or_remove_content_views_to_environments",
+                                        :search => "name=\"#{environment.name}\"")
+
+    refute_equal(@org.promotion_paths, @org.promotable_promotion_paths)
+    assert_equal(1, @org.promotable_promotion_paths.size)
   end
 end
 end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -256,7 +256,6 @@ class ContentViewTest < ActiveSupport::TestCase
                                  :content_view => @library_dev_view)
     end
     @library_dev_view.add_environment(@library_dev_view.organization.library, ContentViewVersion.last)
-
     assert_equal 2, @library_dev_view.environments.length
   end
 

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -48,13 +48,46 @@ module AuthorizationSupportMethods
     role.save!
   end
 
-  def add_role(permission_name, search = nil)
+  # permissions => Array of hashes in the following format
+  #   [{:name => :view_lifecycle_environment, :search => 'name=Dev'}, ..]
+  def create_role_with_permissions(permissions)
     role = FactoryGirl.create(:role)
-    role.add_permissions!([permission_name], :search => search)
-    user = users(:restricted)
+    permissions.each do |perm|
+      role.add_permissions!([perm[:name]], :search => perm[:search])
+    end
+    role
+  end
+
+  # permissions => can be a permission(s) in one of the following formats
+  # {:name => :view_lifecycle_environments, :search => 'name=Dev'} OR
+  # [{:name => :view_lifecycle_environments, :search => 'name=Dev'}, ..] OR
+  # :view_lifecycle_environments
+  def setup_user_with_permissions(permissions, user)
+    actual_permissions =  if permissions.is_a?(Hash)
+                            [permissions]
+                          elsif permissions.is_a?(Array)
+                            permissions.collect do |perm|
+                              if perm.is_a?(Hash)
+                                perm
+                              else
+                                {:name => perm}
+                              end
+                            end
+                          else
+                            [{:name => permissions}]
+                          end
+
+    role = create_role_with_permissions(actual_permissions)
     user.roles = [role]
     user
   end
+
+  def setup_current_user_with_permissions(permissions)
+    fail("setup_current_user_with_permissions called with current user not set") unless User.current
+    setup_user_with_permissions(permissions, User.current)
+  end
+
+
 
   class UserPermissionsGenerator
     def initialize(user)

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -25,7 +25,8 @@ module ControllerSupport
         user = no_permission_user
         permission.call(Katello::AuthorizationSupportMethods::UserPermissionsGenerator.new(user))
       else
-        user = add_role(permission)
+        user = User.find(users(:restricted))
+        setup_user_with_permissions(permission, user)
       end
 
       action = params[:action]
@@ -36,22 +37,12 @@ module ControllerSupport
       req.call
 
       if params[:authorized]
-        if !user.own_role.nil?
-          msg = "Expected response for #{action} to be a <success>, but was <#{response.status}> instead. \n" +
-            "#{user.own_role.summary}"
-        else
-          msg = "Expected response for #{action} to be a <success>, but was <#{response.status}> instead. \n" +
-            "#{user.roles}"
-        end
-
+        msg = "Expected response for #{action} to be a <success>, but was <#{response.status}> instead. \n" +
+                 "permission -> #{permission.to_yaml}"
         assert_response :success, msg
       else
-        if !user.own_role.nil?
-          msg = "Security Violation (403) expected for #{action}, got #{response.status} instead. \n#{user.own_role.summary}"
-        else
-          msg = "Security Violation (403) expected for #{action}, got #{response.status} instead. \n#{user.roles}"
-        end
-
+        msg = "Security Violation (403) expected for #{action}, got #{response.status} instead. \n" +
+                "permission -> #{permission.to_yaml}"
         assert_equal 403, response.status, msg
       end
     end


### PR DESCRIPTION
This commit contains code to handle environment promotion and deletion.
Basic Rules
 To Promote/Remove you need
    1) promote_or_remove_content_views from content views
    2) promote_or_remove_content_views_to_environment from lifecycle environments.

```
Note: Remove of a content view is slightly different from "destroy".
Remove implies removal of content view versions which could entail
removal from environments.
```
