### PR TITLE
Fixes #5846 - CV index sql error

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -44,7 +44,7 @@ module Katello
 
       readable_cvs = ContentView.readable
       readable_cvs = readable_cvs.in_environment(@environment) if @environment
-      ids = readable_cvs.pluck(:id)
+      ids = readable_cvs.pluck("#{Katello::ContentView.table_name}.id")
 
       options[:filters] = [{:terms => {:id => ids}}]
 

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -58,6 +58,13 @@ module Katello
       assert_template 'api/v2/content_views/index'
     end
 
+    def test_index_in_environment
+      get :index, :organization_id => @organization.id, :environment_id => @dev.id
+
+      assert_response :success
+      assert_template 'api/v2/content_views/index'
+    end
+
     def test_index_fail_without_organization_id
       get :index
 


### PR DESCRIPTION
The pluck call in the Content Views index call previously did not specify the table name for the id.
So a SQL error was being raised in the AK page, when a list of content views were requested from the server
Fixed this by specifying the table name in the pluck call
