### PR TITLE
Refs #5681: Candlepin reset only needs to drop, create and migrate the d...

### DIFF
--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -22,10 +22,6 @@ namespace :katello do
 
       system(service_stop.gsub("%s", tomcat))
       system("sudo /usr/share/candlepin/cpdb --drop --create")
-      # If you see errors with 'javax.crypto.BadPaddingException: Given final block not properly padded'
-      # it is due to a candlepin dev setup with a different password on the keystre
-      # than in this file.
-      system("sudo /usr/share/candlepin/cpsetup -s -k `sudo cat /etc/katello/keystore_password-file`")
       system(service_start.gsub("%s", tomcat))
       puts "Candlepin database reset."
     end


### PR DESCRIPTION
...atabase.

Previously, we used cpdb and cpsetup to manage the Candlepin database,
cert and configuration file deployment when running Katello reset. With
the installer handling the cert and configuration file, we need only to
drop, create and migrate the Candlepin database when resetting.
