### PR TITLE
Fixes #5866 - Reduced Product json serialization footprint

### DIFF
--- a/app/views/katello/api/v2/activation_keys/show.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/show.json.rabl
@@ -15,7 +15,9 @@ attributes :usage_count, :user_id, :usage_limit, :pools, :system_template_id, :r
            :service_level
 attributes :get_key_pools => :pools
 
-attributes :products
+child :products => :products do |product|
+  attributes :id, :name
+end
 
 node :permissions do |activation_key|
   {


### PR DESCRIPTION
Activation Keys index call was loading all attributes of a Product using Product model's as_json call.
This lead to some serialization issues causing activation key list call to fail.
This commit intends to expose only the necessary attributes of products
related to the given activation key.
