### PR TITLE
Fixes #4946/BZ1093601 - allow org-switcher urls to pass through angular.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
@@ -142,16 +142,16 @@ angular.module('Bastion').config(
  * @requires gettextCatalog
  * @requires currentLocale
  * @requires $location
- * @requires $sniffer
+ * @requires $window
  * @requires PageTitle
  * @requires RootURL
  *
  * @description
  *   Set up some common state related functionality and set the current language.
  */
-angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$sniffer', 'PageTitle', 'RootURL',
-    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $sniffer, PageTitle, RootURL) {
-        var fromState, fromParams;
+angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', '$location', '$window', 'PageTitle', 'RootURL',
+    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, $location, $window, PageTitle, RootURL) {
+        var fromState, fromParams, orgSwitcherRegex;
 
         $rootScope.$state = $state;
         $rootScope.$stateParams = $stateParams;
@@ -204,5 +204,14 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
                 }
             }
         );
+
+        // Prevent angular from handling org/location switcher URLs
+        orgSwitcherRegex = new RegExp("/(organizations|locations)/.+/select");
+        $rootScope.$on('$locationChangeStart', function (event, newUrl) {
+            if (newUrl.match(orgSwitcherRegex)) {
+                event.preventDefault();
+                $window.location.href = newUrl;
+            }
+        });
     }
 ]);


### PR DESCRIPTION
This will prevent a redirect loop that occurs when switching orgs or
locations on a Bastion page.

http://projects.theforeman.org/issues/4946
https://bugzilla.redhat.com/show_bug.cgi?id=1093601
