### PR TITLE
Fixes #5886: Return organizations for the admin user.

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -126,7 +126,7 @@ module Katello
     end
 
     def list_owners
-      orgs = User.current.organizations
+      orgs = User.current.allowed_organizations
       # rhsm expects owner (Candlepin format)
       # rubocop:disable SymbolName
       respond_for_index :collection => orgs.map { |o| { :key => o.label, :displayName => o.name } }

--- a/app/controllers/katello/api/v1/users_controller.rb
+++ b/app/controllers/katello/api/v1/users_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::UsersController < Api::V1::ApiController
 
   api :GET, "/users/:id", N_("Show a user")
   def show
-    @user[:allowed_organizations] = @user.organizations
+    @user[:allowed_organizations] = @user.allowed_organizations
     @user[:roles] = @user.katello_roles
     respond
   end
@@ -155,7 +155,7 @@ class Api::V1::UsersController < Api::V1::ApiController
 
   # rhsm
   def list_owners
-    orgs = @user.organizations
+    orgs = @user.allowed_organizations
     # rhsm expects owner (Candlepin format)
     # rubocop:disable SymbolName
     respond_for_index :collection => orgs.map { |o| { :key => o.label, :displayName => o.name } }

--- a/app/controllers/katello/application_controller.rb
+++ b/app/controllers/katello/application_controller.rb
@@ -223,7 +223,7 @@ class ApplicationController < ::ApplicationController
       begin
         if @current_org.nil? && current_user
           o = Organization.find(session[:current_organization_id])
-          if current_user.organizations.include?(o)
+          if current_user.allowed_organizations.include?(o)
             @current_org = o
           else
             fail ActiveRecord::RecordNotFound.new _("Permission Denied. User '%{user}' does not have permissions to access organization '%{org}'.") % {:user => User.current.login, :org => o.name}

--- a/app/helpers/katello/users_helper.rb
+++ b/app/helpers/katello/users_helper.rb
@@ -15,7 +15,7 @@ module UsersHelper
 
   def organization_select(org_id = nil, optional = true, no_org_choice = nil)
     if current_user.id == @user.id
-      orgs = current_user.organizations.reject do |org|
+      orgs = current_user.allowed_organizations.reject do |org|
         !org.any_systems_registerable?
       end
     else

--- a/app/lib/katello/dashboard/content_views_widget.rb
+++ b/app/lib/katello/dashboard/content_views_widget.rb
@@ -16,7 +16,7 @@ class Dashboard::ContentViewsWidget < Dashboard::Widget
   def accessible?
     User.current.admin? ||
      (current_organization &&
-      User.current.organizations.include?(current_organization) &&
+      User.current.allowed_organizations.include?(current_organization) &&
       ContentView.readable?)
   end
 

--- a/app/lib/katello/dashboard/errata_widget.rb
+++ b/app/lib/katello/dashboard/errata_widget.rb
@@ -16,7 +16,7 @@ class Dashboard::ErrataWidget < Dashboard::Widget
   def accessible?
     User.current.admin? ||
      (current_organization &&
-      User.current.organizations.include?(current_organization) &&
+      User.current.allowed_organizations.include?(current_organization) &&
       System.readable?)
   end
 

--- a/app/lib/katello/dashboard/host_collections_widget.rb
+++ b/app/lib/katello/dashboard/host_collections_widget.rb
@@ -16,7 +16,7 @@ class Dashboard::HostCollectionsWidget < Dashboard::Widget
   def accessible?
     User.current.admin? ||
      (current_organization &&
-      User.current.organizations.include?(current_organization) &&
+      User.current.allowed_organizations.include?(current_organization) &&
       HostCollection.readable?)
   end
 

--- a/app/lib/katello/dashboard/promotions_widget.rb
+++ b/app/lib/katello/dashboard/promotions_widget.rb
@@ -16,7 +16,7 @@ class Dashboard::PromotionsWidget < Dashboard::Widget
   def accessible?
     User.current.admin? ||
      (current_organization &&
-      User.current.organizations.include?(current_organization) &&
+      User.current.allowed_organizations.include?(current_organization) &&
       ContentView.readable?)
   end
 

--- a/app/lib/katello/dashboard/sync_widget.rb
+++ b/app/lib/katello/dashboard/sync_widget.rb
@@ -16,7 +16,7 @@ class Dashboard::SyncWidget < Dashboard::Widget
   def accessible?
     User.current.admin? ||
      (current_organization &&
-      User.current.organizations.include?(current_organization) &&
+      User.current.allowed_organizations.include?(current_organization) &&
       Product.syncable?)
   end
 

--- a/app/models/katello/concerns/user_extensions.rb
+++ b/app/models/katello/concerns/user_extensions.rb
@@ -380,6 +380,10 @@ module Katello
           true
         end
 
+        def allowed_organizations
+          admin? ? Organization.all : self.organizations
+        end
+
         protected
 
         def can_be_deleted?

--- a/app/views/katello/dashboard/index.html.haml
+++ b/app/views/katello/dashboard/index.html.haml
@@ -1,6 +1,6 @@
 = javascript "katello/dashboard"
 
-- if current_user && current_user.organizations.length == 0
+- if current_user && current_user.allowed_organizations.length == 0
   .grid_16.flash_hud
     %ul.flash_messages.warning
       %li

--- a/test/controllers/api/v1/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/v1/candlepin_proxies_controller_test.rb
@@ -117,5 +117,24 @@ module Katello
       end
     end
 
+    describe "list owners" do
+
+      it 'should return organizations admin user is assigned to' do
+        User.current = User.find(users(:admin))
+        get :list_owners, :login => User.current.login
+
+        assert_empty (JSON.parse(response.body).collect { |org| org['displayName'] } - Organization.pluck(:name))
+      end
+
+      it 'should return organizations user is assigned to' do
+        User.current = User.find(users(:restricted))
+        User.current.organizations << taxonomies(:organization1)
+
+        get :list_owners, :login => User.current.login
+        assert_equal JSON.parse(response.body).first['displayName'], taxonomies(:organization1).name
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
Since the admin user is treated differently than other users, the
admin user doesn't have a direct relationship to any organizations.
Thus, we need to check if the user is an admin and return all
organizations.
