### PR TITLE
fixes #5819 - host groups - fix the cross-link to activation keys page

### DIFF
--- a/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
+++ b/app/overrides/foreman/activation_keys/_host_tab_pane.html.erb
@@ -244,7 +244,7 @@ $(function() {
     </div>
 
     <p><%= _('Activation keys and subscriptions can be managed') %>
-      <b><a href="/katello/activation_keys#/activation-keys" target="_blank"> <%= _('here') %></a></b>
+      <b><a href="/activation_keys" target="_blank"> <%= _('here') %></a></b>
     </p>
     <p><%= subscription_manager_configuration_url %></p>
     <p><a href="" id="ak_refresh_subscriptions"><%= _('Reload data') %></a></p>


### PR DESCRIPTION
This is a change needed after the 'single-page-app' changes went in.
