### PR TITLE
Fixes #5913, BZ1093601 let org-switcher clear URLs pass through bastion.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
@@ -212,7 +212,7 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
         );
 
         // Prevent angular from handling org/location switcher URLs
-        orgSwitcherRegex = new RegExp("/(organizations|locations)/.+/select");
+        orgSwitcherRegex = new RegExp("/(organizations|locations)/(.+/)*(select|clear)");
         $rootScope.$on('$locationChangeStart', function (event, newUrl) {
             if (newUrl.match(orgSwitcherRegex)) {
                 event.preventDefault();


### PR DESCRIPTION
See also PR #4137 which only allowed org/location selection URLs
to pass through bastion.  This adds org/location "clear" URLs as well.

http://projects.theforeman.org/issues/5913
https://bugzilla.redhat.com/show_bug.cgi?id=1093601
