### PR TITLE
fixes #5801 - host collection ui - update errors should be shown on UI

### DIFF
--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -73,7 +73,7 @@ module Katello
     param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     param_group :host_collection
     def update
-      @host_collection.update_attributes(host_collection_params)
+      @host_collection.update_attributes!(host_collection_params)
       respond
     end
 


### PR DESCRIPTION
The validations were being executed; however, the errors were not
being returned to the client due to how update_attributes was
being used.

Now (for example), if a user has 3 content hosts in a collection
and they try to set the max content hosts to 2, they will get an
error back.
