### PR TITLE
Fixes #5938: Some Candlepin routes need User authorization due to subscr...

### DIFF
--- a/lib/katello/permissions/content_host_permissions.rb
+++ b/lib/katello/permissions/content_host_permissions.rb
@@ -26,6 +26,8 @@ Foreman::Plugin.find(:katello).security_block :content_hosts do
               'katello/api/v2/systems_bulk_actions' => [:install_content, :update_content,
                                                         :remove_content, :environment_content_view,
                                                         :bulk_add_host_collections, :bulk_remove_host_collections],
+              'katello/api/v1/candlepin_proxies' => [:upload_package_profile, :regenerate_identity_certificates,
+                                                     :hypervisors_update],
              },
              :resource_type => 'Katello::System'
   permission :destroy_content_hosts,

--- a/test/controllers/api/v1/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/v1/candlepin_proxies_controller_test.rb
@@ -146,5 +146,43 @@ module Katello
       end
     end
 
+    it "test_list_owners_protected" do
+      assert_protected_action(:list_owners, :my_organizations) do
+        get :list_owners, :login => User.current.login
+      end
+    end
+
+    it "test_rhsm_index_protected" do
+      assert_protected_action(:rhsm_index, :view_lifecycle_environments) do
+        get :rhsm_index, :organization_id => @organization.label
+      end
+    end
+
+    it "test_consumer_create_protected" do
+      assert_protected_action(:consumer_create, :create_content_hosts) do
+        post :consumer_create, :environment_id => @organization.library.content_view_environments.first.cp_id
+      end
+    end
+
+    it "test_upload_package_profile_protected" do
+      Resources::Candlepin::Consumer.stubs(:get)
+      assert_protected_action(:upload_package_profile, :edit_content_hosts) do
+        put :upload_package_profile, :id => @system.uuid
+      end
+    end
+
+    it "test_regenerate_identity_certificates_protected" do
+      Resources::Candlepin::Consumer.stubs(:get)
+      assert_protected_action(:regenerate_identity_certificates, :edit_content_hosts) do
+        post :regenerate_identity_certificates, :id => @system.uuid
+      end
+    end
+
+    it "test_hypervisors_update" do
+      assert_protected_action(:hypervisors_update, :edit_content_hosts) do
+        post :hypervisors_update, :env => @organization.library.content_view_environments.first.label
+      end
+    end
+
   end
 end

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -53,7 +53,11 @@ module AuthorizationSupportMethods
   def create_role_with_permissions(permissions)
     role = FactoryGirl.create(:role)
     permissions.each do |perm|
-      role.add_permissions!([perm[:name]], :search => perm[:search])
+      begin
+        role.add_permissions!([perm[:name]], :search => perm[:search])
+      rescue ArgumentError => e
+        fail("Permissions not found: #{perm[:name]}")
+      end
     end
     role
   end

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -48,17 +48,20 @@ module ControllerSupport
     end
   end
 
-  def assert_protected_action(action_name, allowed_perms, denied_perms, &block)
+  def assert_protected_action(action_name, allowed_perms, denied_perms = [], &block)
     assert_authorized(
         :permission => allowed_perms,
         :action => action_name,
         :request => block
     )
-    refute_authorized(
-        :permission => denied_perms,
-        :action => action_name,
-        :request => block
-    )
+
+    if !denied_perms.empty?
+      refute_authorized(
+          :permission => denied_perms,
+          :action => action_name,
+          :request => block
+      )
+    end
   end
 
   def assert_authorized(params)


### PR DESCRIPTION
...iption manager GUI.

The following routes need to be accessible via User or Client authorization:

PUT /consumers/{consumer_uuid}/packages
POST /consumers/{consumer_uuid} (force regen of identity certificate)
GET /owners/{org_id}/servicelevels
PUT /hypervisors
