### PR TITLE
fixes #5954 - content search - fix puppet module details

### DIFF
--- a/app/controllers/katello/application_controller.rb
+++ b/app/controllers/katello/application_controller.rb
@@ -124,6 +124,8 @@ class ApplicationController < ::ApplicationController
       'katello/content_search',
       'katello/content_views',
       'katello/errata',
+      'katello/packages',
+      'katello/puppet_modules',
       'katello/repositories',
       'katello/dashboard'
     ]

--- a/app/controllers/katello/puppet_modules_controller.rb
+++ b/app/controllers/katello/puppet_modules_controller.rb
@@ -1,0 +1,28 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+class PuppetModulesController < Katello::ApplicationController
+  before_filter :find_puppet_module, only: [:show]
+
+  def show
+    render :partial => "show"
+  end
+
+  private
+
+  def find_puppet_module
+    @puppet_module = PuppetModule.find(params[:id])
+  end
+
+end
+end

--- a/app/views/katello/puppet_modules/_show.html.haml
+++ b/app/views/katello/puppet_modules/_show.html.haml
@@ -1,0 +1,88 @@
+.details_container
+  .item-container
+    %label.fl.ra
+      = _("ID")
+    %p
+      = @puppet_module.id
+
+  .item-container
+    %label.fl.ra
+      = _("Author: ")
+    %p
+      = @puppet_module.author
+
+  .item-container
+    %label.fl.ra
+      = _("Name: ")
+    %p
+      = @puppet_module.name
+
+  .item-container
+    %label.fl.ra
+      = _("Version: ")
+    %p
+      = @puppet_module.version
+
+  - unless @puppet_module.summary.blank?
+    .item-container
+      %label.fl.ra
+        = _("Summary: ")
+      %p
+        = @puppet_module.summary
+
+  - unless @puppet_module.description.blank?
+    .item-container
+      %label.fl.ra
+        = _("Description: ")
+      %p
+        = @puppet_module.description
+
+  - unless @puppet_module.license.blank?
+    .item-container
+      %label.fl.ra
+        = _("License: ")
+      %p
+        = @puppet_module.license
+
+  - unless @puppet_module.project_page.blank?
+    .item-container
+      %label.fl.ra
+        = _("Project Page: ")
+      %p
+        = @puppet_module.project_page
+
+  - unless @puppet_module.source.blank?
+    .item-container
+      %label.fl.ra
+        = _("Source: ")
+      %p
+        = @puppet_module.source
+
+  - unless @puppet_module.dependencies.blank?
+    .item-container
+      %label.fl.ra
+        = _("Dependencies: ")
+      %p
+        &nbsp;
+      %p
+        - @puppet_module.dependencies.each do |dependency|
+          %p
+            = _("Name: %{module_name}, Version: %{version}") % {:module_name => dependency[:name], :version => dependency[:version_requirement]}
+
+  - unless @puppet_module.checksums.blank?
+    .item-container
+      %label.fl.ra
+        = _("Checksums: ")
+      %p
+        &nbsp;
+      %p
+        - @puppet_module.checksums.each do |checksum|
+          %p
+            = _("File: %{file_name}, Checksum: %{checksum}") % {:file_name => checksum[0], :checksum => checksum[1]}
+
+  - unless @puppet_module.tag_list.blank?
+    .item-container
+      %label.fl.ra
+        = _("Tag List: ")
+      %p
+        = @puppet_module.tag_list.join(', ')

--- a/lib/katello/permissions/product_permissions.rb
+++ b/lib/katello/permissions/product_permissions.rb
@@ -13,6 +13,7 @@ Foreman::Plugin.find(:katello).security_block :products do
               'katello/api/v2/puppet_modules' => [:index, :show],
               'katello/errata' => [:short_details, :auto_complete],
               'katello/packages' => [:details, :auto_complete],
+              'katello/puppet_modules' => [:show],
               'katello/repositories' => [:auto_complete_library],
               'katello/content_search' => [:index,
                                            :products,


### PR DESCRIPTION
Commit a9900823f9e9a3e1af49b9944e2d3ab14456313d accidentally
removed code that was used to support displaying details
on puppet modules in content search.
