### PR TITLE
Fixes #5863 - create consumer in plan phase

### DIFF
--- a/app/lib/actions/candlepin/consumer/create.rb
+++ b/app/lib/actions/candlepin/consumer/create.rb
@@ -27,10 +27,13 @@ module Actions
           param :uuid
           param :capabilities
           param :activation_keys
+          param :response
         end
 
-        def run
-          output[:response] = ::Katello::Resources::Candlepin::Consumer.
+        # We need to call this in plan phase as this can lean to error responses
+        # when the activation key fails to subscribe to the products
+        def plan(input)
+          response = ::Katello::Resources::Candlepin::Consumer.
               create(input[:cp_environment_id],
                      input[:organization_label],
                      input[:name],
@@ -43,6 +46,14 @@ module Actions
                      input[:uuid],
                      input[:capabilities],
                      input[:activation_keys])
+          plan_self(input.merge(response: response))
+        end
+
+        def run
+          # we still keep the output interface the same for case there is other
+          # way how to check the ability to subscribe the system with the actiovation key
+          # or we have better support for rolling back in Dynflow
+          output[:response] = input[:response]
         end
       end
     end

--- a/test/actions/katello/system_test.rb
+++ b/test/actions/katello/system_test.rb
@@ -38,8 +38,6 @@ module ::Actions::Katello::System
       system.expects(:save!)
       action.stubs(:action_subject).with do |subject, params|
         subject.must_equal(system)
-        params[:uuid].must_be_kind_of Dynflow::ExecutionPlan::OutputReference
-        params[:uuid].subkeys.must_equal %w[response uuid]
       end
       #::Actions::Katello::System::ActivationKeys.any_instance.stubs(:error).returns(nil)
       Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:error).returns(nil)


### PR DESCRIPTION
The failure is quite possible when creating a consumer in Candlepin (mainly
because of the activation key might be over-consumed already).
