### PR TITLE
BZ 1101586 activation_keys.update should update only present parameters

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -75,7 +75,7 @@ module Katello
     param :release_version, String, :desc => N_("content release version")
     param :service_level, String, :desc => N_("service level")
     def update
-      @activation_key.update_attributes!(activation_key_params)
+      @activation_key.update_attributes!(activation_key_params.reject { | k| !(params[:activation_key].include?(k)) })
       respond_for_show(:resource => @activation_key)
     end
 


### PR DESCRIPTION
activation_keys.update API call also updates not present parameters
like usage_limit due to call of int_limit method which is needed
when creating activation key but not when updating it => filter out
items not present in API call params from activation_key_params
