### PR TITLE
Fixes #5975 - Fix for a Content Host  UI reload issue

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
@@ -227,7 +227,7 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
     });
 
     $stateProvider.state('content-hosts.details.packages', {
-        url: '/packages/',
+        url: '/packages',
         collapsed: true,
         controller: 'ContentHostPackagesController',
         templateUrl: 'content-hosts/content/views/content-host-packages.html'
@@ -241,12 +241,12 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
         template: '<div ui-view></div>'
     })
     .state('content-hosts.details.errata.index', {
-        url: '/errata/',
+        url: '/errata',
         collapsed: true,
         templateUrl: 'content-hosts/content/views/content-host-errata.html'
     })
     .state('content-hosts.details.errata.details', {
-        url: '/errata/:errataId/',
+        url: '/errata/:errataId',
         collapsed: true,
         templateUrl: 'content-hosts/content/views/errata-details.html'
     });


### PR DESCRIPTION
Previously when you went to content hosts page
and selected packages or errata links for a content host
you'd get multiple reloads. I was caused by a trailing slash.
Even though we have code to address / the modules javascript
tried to reload with a / version. This commit fixes that issue
