### PR TITLE
Fixes #5978 - Included content host in Host::Managed

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -101,6 +101,7 @@ module Katello
       # Model extensions
       ::Environment.send :include, Katello::Concerns::EnvironmentExtensions
       ::Host::Base.send :include, Katello::Concerns::HostBaseExtensions
+      ::Host.send :include, Katello::Concerns::HostBaseExtensions
       ::Medium.send :include, Katello::Concerns::MediumExtensions
       ::Operatingsystem.send :include, Katello::Concerns::OperatingsystemExtensions
       ::Organization.send :include, Katello::Concerns::OrganizationExtensions


### PR DESCRIPTION
Host::Managed extends Host::Base, but for some reason
probably due to server caching the change to Host::Base
is not geting reflected in the sub class causing the dreaded
Operation FAILED: undefined method `association_class' for nil:NilClass

irb(main):015:0> Host::Base.reflections.keys.grep /content_host/
=> [:content_host]
irb(main):016:0> Host.reflections.keys.grep /content_host/
=> []
irb(main):017:0> Host::Managed.reflections.keys.grep /content_host/
=> []
Even something like a reset_column_information didnt do the trick.
This happens only in production, could not reproduce in my Dev
Environment.

This commit fixes this by forcing the inclusion of
HostBaseExtensions in both subclass and super class.
