### PR TITLE
Fixes #5802 - HC update/create using system uuids

### DIFF
--- a/app/models/katello/system_host_collection.rb
+++ b/app/models/katello/system_host_collection.rb
@@ -15,7 +15,7 @@ module Katello
 class SystemHostCollection < Katello::Model
   self.include_root_in_json = false
 
-  belongs_to :system, :inverse_of => :system_host_collections
+  belongs_to :system, :inverse_of => :system_host_collections, :class_name => 'Katello::System'
   belongs_to :host_collection, :inverse_of => :system_host_collections
 
   validate :validate_max_content_hosts_not_exceeded

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -65,13 +65,26 @@ module Katello
 
     def test_create
       post :create, :organization_id => @organization,
-        :host_collection => {:name => 'Collection A', :description => 'Collection A, World Cup 2014'}
+        :host_collection => {:name => 'Collection A', :description => 'Collection A, World Cup 2014',
+          :system_ids => [@system.id]}
 
       results = JSON.parse(response.body)
       assert_equal results['name'], 'Collection A'
       assert_equal results['max_content_hosts'], -1
       assert_equal results['organization_id'], @organization.id
       assert_equal results['description'], 'Collection A, World Cup 2014'
+      assert_equal results['system_ids'], [@system.id]
+
+      assert_response :success
+      assert_template 'api/v2/host_collections/create'
+    end
+
+    def test_create_with_system_uuid
+      post :create, :organization_id => @organization, :system_uuids => [@system.uuid],
+        :host_collection => {:name => 'Collection A', :description => 'Collection A, World Cup 2014'}
+
+      results = JSON.parse(response.body)
+      assert_equal results['system_ids'], [@system.id]
 
       assert_response :success
       assert_template 'api/v2/host_collections/create'

--- a/test/models/system_test.rb
+++ b/test/models/system_test.rb
@@ -22,6 +22,27 @@ class SystemClassTest < SystemTestBase
     assert_equal 'Simple Server', system_json['name']
     assert_equal 'Dev', system_json['environment']['name']
   end
+
+  def test_uuids_to_ids
+    @alabama = build(:katello_system, :alabama, :name => 'alabama man', :description => 'Alabama system', :environment => @dev, :uuid => 'alabama')
+    @westeros = build(:katello_system, :name => 'westeros', :description => 'Westeros system', :environment => @dev, :uuid => 'westeros')
+    assert @alabama.save
+    assert @westeros.save
+    actual_ids = System.uuids_to_ids([@alabama, @westeros].map(&:uuid))
+    expected_ids = [@alabama, @westeros].map(&:id)
+    assert_equal(expected_ids.size, actual_ids.size)
+    assert_equal(expected_ids.to_set, actual_ids.to_set)
+  end
+
+  def test_uuids_to_ids_raises_not_found
+    @alabama = build(:katello_system, :alabama, :name => 'alabama man', :description => 'Alabama system', :environment => @dev, :uuid => 'alabama')
+    @westeros = build(:katello_system, :name => 'westeros', :description => 'Westeros system', :environment => @dev, :uuid => 'westeros')
+    assert @alabama.save
+    assert @westeros.save
+    assert_raises Errors::NotFound do
+      System.uuids_to_ids([@alabama, @westeros].map(&:uuid) + ['non_existent_uuid'])
+    end
+  end
 end
 
 class SystemCreateTest < SystemTestBase


### PR DESCRIPTION
Alter Host Collection api update/create actions to accept system uuids.
This is a fix related to hammer-cli-katello commands where some of
the commands take uuids and others take the data base id. This allows
the cli commands to uniformly take uuids.

related to https://github.com/Katello/hammer-cli-katello/pull/178
