### PR TITLE
Fixes #5985 - content_view_filters/index: validate required parameters

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -118,6 +118,7 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   private
 
   def find_content_view
+    fail HttpErrors::NotFound, _("One of parameters [ %s ] required but not specified.") % "content_view_id" unless params[:content_view_id]
     @view = ContentView.find(params[:content_view_id]) if params[:content_view_id]
   end
 


### PR DESCRIPTION
This pull requests resolves the issue described in http://projects.theforeman.org/issues/5985
