### PR TITLE
Fixes #5968: Intercept candlepin request to get available releases

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -16,13 +16,14 @@ module Katello
     include Katello::Authentication::ClientAuthentication
 
     before_filter :find_system, :only => [:consumer_show, :consumer_destroy, :consumer_checkin, :enabled_repos,
-                                          :upload_package_profile, :regenerate_identity_certificates, :facts]
+                                          :upload_package_profile, :regenerate_identity_certificates, :facts,
+                                          :available_releases]
     before_filter :authorize, :only => [:consumer_create, :list_owners, :rhsm_index]
     before_filter :authorize_client_or_user, :only => [:upload_package_profile, :regenerate_identity_certificates,
                                                        :hypervisors_update]
     before_filter :authorize_proxy_routes, :only => [:get, :post, :put, :delete]
     before_filter :authorize_client, :only => [:consumer_show, :consumer_destroy, :consumer_checkin,
-                                               :enabled_repos, :facts]
+                                               :enabled_repos, :facts, :available_releases]
 
     before_filter :add_candlepin_version_header
 
@@ -123,6 +124,10 @@ module Katello
       fail HttpErrors::BadRequest, _("No package profile received for %s") % @system.name unless params.key?(:_json)
       @system.upload_package_profile(params[:_json])
       render :json => Resources::Candlepin::Consumer.get(@system.uuid)
+    end
+
+    def available_releases
+      render :json => @system.available_releases
     end
 
     def list_owners

--- a/app/controllers/katello/api/v1/root_controller.rb
+++ b/app/controllers/katello/api/v1/root_controller.rb
@@ -35,6 +35,7 @@ class Api::V1::RootController < Api::V1::ApiController
     api_root_routes << { :href => '/api/status/', :rel => 'status' }
     api_root_routes << { :href => '/api/guestids', :rel => 'guestids'}
     api_root_routes << { :href => '/api/content_overrides', :rel => 'content_overrides'}
+    api_root_routes << { :href => '/api/available_releases', :rel => 'available_releases'}
 
     # katello only APIs
     katello_only = ["/api/templates/",

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -444,6 +444,7 @@ Katello::Engine.routes.draw do
       match '/consumers/:id/content_overrides/' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_content_overrides_path
       match '/consumers/:id/content_overrides/' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_content_overrides_put_path
       match '/consumers/:id/content_overrides/' => 'candlepin_proxies#delete', :via => :delete, :as => :proxy_consumer_content_overrides_delete_path
+      match '/consumers/:id/available_releases' => 'candlepin_proxies#available_releases', :via => :get
       match '/systems/:id/enabled_repos' => 'candlepin_proxies#enabled_repos', :via => :put
 
       # development / debugging support

--- a/spec/routing/api/v1/consumers_routing_spec.rb
+++ b/spec/routing/api/v1/consumers_routing_spec.rb
@@ -45,6 +45,7 @@ module Katello
         {:controller => proxies_controller, :action => "get", :id => "1", :api_version => "v2"}.must_recognize({ :method => "get", :path => "/api/consumers/1/content_overrides/" })
         {:controller => proxies_controller, :action => "put", :id => "1", :api_version => "v2"}.must_recognize({ :method => "put", :path => "/api/consumers/1/content_overrides/" })
         {:controller => proxies_controller, :action => "delete", :id => "1", :api_version => "v2"}.must_recognize({ :method => "delete", :path => "/api/consumers/1/content_overrides/" })
+        {:controller => proxies_controller, :action => "available_releases", :id => "1", :api_version => "v2"}.must_recognize({ :method => "get", :path => "/api/consumers/1/available_releases" })
       end
 
     end

--- a/test/controllers/api/v1/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/v1/candlepin_proxies_controller_test.rb
@@ -184,5 +184,29 @@ module Katello
       end
     end
 
+    describe "available releases" do
+
+      it "can be listed by matching consumer" do
+        # Stub out the current user to simulate consumer auth.
+        uuid = @system.uuid
+        User.stubs(:consumer?).returns(true)
+        User.stubs(:current).returns(CpConsumerUser.new(:uuid => uuid, :login => uuid, :remote_id => uuid))
+
+        get :available_releases, :id => @system.uuid
+        assert_response 200      
+      end
+
+      it "forbidden with invalid consumer" do
+        # Stub out the current user to simulate consumer auth.
+        uuid = 4444
+        User.stubs(:consumer?).returns(true)
+        User.stubs(:current).returns(CpConsumerUser.new(:uuid => uuid, :login => uuid, :remote_id => uuid))
+        # Getting the available releases for a different consumer
+        # should not be allowed.
+        get :available_releases, :id => @system.uuid
+        assert_response 403
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Intercept requests to GET /consumers/:id/available_releases and return
the system's available release versions as viewed by katello.

Added /api/available_releases to the root resource so that RHSM
can check to see if it is enabled on the server.
