### PR TITLE
refs #5184 - fix couple of issues when deleting foreman hosts

### DIFF
--- a/app/models/katello/concerns/host_base_extensions.rb
+++ b/app/models/katello/concerns/host_base_extensions.rb
@@ -15,7 +15,8 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
-        has_one :content_host, :class_name => "Katello::System", :foreign_key => :host_id, :dependent => :destroy
+        has_one :content_host, :class_name => "Katello::System", :foreign_key => :host_id,
+                :dependent => :destroy, :inverse_of => :foreman_host
       end
     end
   end

--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -33,7 +33,7 @@ class System < Katello::Model
   after_rollback :rollback_on_create, :on => :create
 
   belongs_to :environment, :class_name => "Katello::KTEnvironment", :inverse_of => :systems
-  belongs_to :foreman_host, :class_name => "Host::Base", :foreign_key => :host_id
+  belongs_to :foreman_host, :class_name => "::Host", :foreign_key => :host_id, :inverse_of => :content_host
 
   has_many :task_statuses, :class_name => "Katello::TaskStatus", :as => :task_owner, :dependent => :destroy
   has_many :system_activation_keys, :class_name => "Katello::SystemActivationKey", :dependent => :destroy

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -99,7 +99,6 @@ module Katello
 
       # Model extensions
       ::Environment.send :include, Katello::Concerns::EnvironmentExtensions
-      ::Host::Base.send :include, Katello::Concerns::HostBaseExtensions
       ::Host.send :include, Katello::Concerns::HostBaseExtensions
       ::Medium.send :include, Katello::Concerns::MediumExtensions
       ::Operatingsystem.send :include, Katello::Concerns::OperatingsystemExtensions


### PR DESCRIPTION
This commit addresses a couple of issues that were observed with the
foreman host <-> katello content host integration, in the production
configuration.
1. Deleting the foreman host would result in a 404 to the user.
2. Unregistering a content host and visiting the foreman host would
   show an 410 error to the user.

The key issues that caused these were:
a. There were 2 bindings of the host extensions to the host.  This
   triggered the deletion of the content host twice.
b. The model relation for host and content_host did not have the
   proper 'inverse_of' definition, so it could lead to foreign key
   errors.
