### PR TITLE
Fixes #5555 - fix org update action's apipie param

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -43,7 +43,13 @@ module Katello
     end
 
     api :PUT, '/organizations/:id', N_('Update organization')
-    param_group :resource, ::Api::V2::TaxonomiesController
+    # The organization param hash below is redefined from foreman's ::Api::V2::TaxonomiesController
+    # resource param_group instead of reusing the param_group :resource scoped from TaxonomiesController.
+    # This is because name substitutions of the param group's name from :resource to :organization are limited
+    # to the inclusion of a modules.
+    param :organization, Hash, :action_aware => true do
+      param :name, String, :required => true
+    end
     param :description, String, :desc => N_("description")
     param :redhat_repository_url, String, :desc => N_("Redhat CDN url")
     def update


### PR DESCRIPTION
In the OrganizationController v2 update action, the param_group
resource contained hash named resource. This was not substituted
for organization. As a result hammer-cli-katello, through
api-bindings, was incorrectly expecting and passing resource
instead of organization to the update action. Subsequently no
organization attrs were being updated.

Update action was moved to a module to be included in the controller
so that apipie_concern_subst can be used to sub out resource for
organization.
