### PR TITLE
Fixes #6005 - speeding up content reindexing

### DIFF
--- a/app/lib/katello/util/search.rb
+++ b/app/lib/katello/util/search.rb
@@ -63,9 +63,12 @@ module Util
     end
 
     def self.backend_search_classes
+      pulp_backend_search_classes + [Katello::Pool]
+    end
+
+    def self.pulp_backend_search_classes
       [Katello::Package,
        Katello::Errata,
-       Katello::Pool,
        Katello::PuppetModule,
        Katello::Distribution,
        Katello::PackageGroup]

--- a/app/models/katello/distribution.rb
+++ b/app/models/katello/distribution.rb
@@ -14,5 +14,6 @@ module Katello
 class Distribution
   include Glue::Pulp::Distribution if Katello.config.use_pulp
   include Glue::ElasticSearch::Distribution if Katello.config.use_elasticsearch
+  CONTENT_TYPE = "distribution"
 end
 end

--- a/app/models/katello/glue/pulp/package.rb
+++ b/app/models/katello/glue/pulp/package.rb
@@ -16,6 +16,11 @@ module Glue::Pulp::Package
   #fields we use to trim down our unit association calls to pulp
   PULP_SELECT_FIELDS = %w(name epoch version release arch checksumtype checksum)
 
+  PULP_INDEXED_FIELDS = %w(name version release arch suffix epoch
+                           download_url checksum checksumtype license group
+                           children vendor filename relativepath description
+                           size buildhost _id _content_type_id _href
+                           _storage_path _type _last_updated)
   def self.included(base)
     base.send :include, InstanceMethods
 

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -300,14 +300,10 @@ module Glue::Pulp::Repo
       #we fetch ids and then fetch packages by id, because repo packages
       #  does not contain all the info we need (bz 854260)
       tmp_packages = []
-      package_fields = %w(name version release arch suffix epoch
-                          download_url checksum checksumtype license group
-                          children vendor filename relativepath description
-                          size buildhost _id _content_type_id _href
-                          _storage_path _type _last_updated)
 
       self.package_ids.each_slice(Katello.config.pulp.bulk_load_size) do |sub_list|
-        tmp_packages.concat(Katello.pulp_server.extensions.rpm.find_all_by_unit_ids(sub_list, package_fields))
+        tmp_packages.concat(Katello.pulp_server.extensions.rpm.find_all_by_unit_ids(
+                                sub_list, Katello::Package::PULP_INDEXED_FIELDS))
       end
       self.packages = tmp_packages
 

--- a/lib/katello/tasks/reindex.rake
+++ b/lib/katello/tasks/reindex.rake
@@ -5,7 +5,7 @@ namespace :katello do
     Dir.glob(Katello::Engine.root.to_s + '/app/models/katello/*.rb').each { |file| require file }
 
     Katello::Util::Search.active_record_search_classes.each do |model|
-      print "Re-indexing #{model.name}\n"
+      puts "Re-indexing #{model.name}"
       model.create_elasticsearch_index
       sub_classes = model.subclasses
 
@@ -19,11 +19,13 @@ namespace :katello do
       model.index.import(objects) if objects.count > 0
     end
 
-    print "Re-indexing Repositories\n"
 
-    Katello::Repository.find_each{ |repo| repo.index_content }
+    Katello::Util::Search.pulp_backend_search_classes.each do |object_class|
+      puts "Re-indexing #{object_class.name}"
+      object_class.index_all
+    end
 
-    print "Re-indexing Pools\n"
+    puts "Re-indexing Pools"
     cp_pools = Katello::Resources::Candlepin::Pool.all
     if cp_pools
       # Pool objects


### PR DESCRIPTION
Instead of indexing per repo, we can index all of each content
and it will be much faster.  Sample times with a content view with about
5 versions:

Old Reindex: 7m05s
New Reindex: 3m13s

the more content views and versions you have the greater the difference
