### PR TITLE
fixes #5449 - adding CV filter option to include packages with no errata

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -38,6 +38,8 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
   param :name, String, :desc => N_("name of the filter"), :required => true
   param :type, String, :desc => N_("type of filter (e.g. rpm, package_group, erratum)"), :required => true
+  param :original_packages, :bool, :desc => N_("Add all packages without Errata to the included/excluded list. " +
+                                                     "(Package Filter only)")
   param :inclusion, :bool, :desc => N_("specifies if content should be included or excluded, default: inclusion=false")
   param :repository_ids, Array, :desc => N_("list of repository ids")
   def create
@@ -58,6 +60,8 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   param :content_view_id, :identifier, :desc => N_("content view identifier")
   param :id, :identifier, :desc => N_("filter identifier"), :required => true
   param :name, String, :desc => N_("new name for the filter")
+  param :original_packages, :bool, :desc => N_("Add all packages without Errata to the included/excluded list. " +
+                                                     "(Package Filter only)")
   param :inclusion, :bool, :desc => N_("specifies if content should be included or excluded, default: inclusion=false")
   param :repository_ids, Array, :desc => N_("list of repository ids")
   def update
@@ -134,7 +138,7 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   end
 
   def filter_params
-    params.require(:content_view_filter).permit(:name, :inclusion, :repository_ids => [])
+    params.require(:content_view_filter).permit(:name, :inclusion, :original_packages, :repository_ids => [])
   end
 
 end

--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -150,6 +150,10 @@ class ContentViewFilter < Katello::Model
     end
   end
 
+  def original_packages=(include_original)
+    fail "setting original_packages not supported for #{self.class.name}"
+  end
+
   protected
 
   def validate_repos

--- a/app/models/katello/content_view_package_filter.rb
+++ b/app/models/katello/content_view_package_filter.rb
@@ -30,7 +30,16 @@ class ContentViewPackageFilter < ContentViewFilter
       Package.legacy_search(rule.name, 0, repo.package_count, [repo.pulp_id], [:nvrea_sort, "asc"],
                      :all, 'name', filter).map(&:filename).compact
     end
+
+    if self.original_packages
+      package_filenames.concat(repo.packages_without_errata.map(&:filename))
+    end
+
     { 'filename' => { "$in" => package_filenames } } unless package_filenames.empty?
+  end
+
+  def original_packages=(value)
+    write_attribute(:original_packages, value)
   end
 
   protected

--- a/app/models/katello/glue/elastic_search/package.rb
+++ b/app/models/katello/glue/elastic_search/package.rb
@@ -60,6 +60,7 @@ module Glue::ElasticSearch::Package
               :nvrea         => { :type => 'string', :analyzer => :kt_name_analyzer},
               :nvrea_sort    => { :type => 'string', :index => :not_analyzed },
               :nvra         => { :type => 'string', :analyzer => :kt_name_analyzer},
+              :filename     => { :type => 'string', :analyzer => :kt_name_analyzer},
               :nvra_sort    => { :type => 'string', :index => :not_analyzed },
               :repoids       => { :type => 'string', :index => :not_analyzed},
               :sortable_version => { :type => 'string', :index => :not_analyzed },

--- a/app/views/katello/api/v2/content_view_filters/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filters/show.json.rabl
@@ -13,6 +13,10 @@ child :repositories => :repositories do
   extends 'katello/api/v2/repositories/show'
 end
 
+if @resource.respond_to?(:package_rules)
+  attributes :original_packages
+end
+
 node :rules do |filter|
   if filter.respond_to?(:package_rules)
     filter.package_rules.map do |rule|

--- a/db/migrate/20140531160506_package_filter_add_original_packages.rb
+++ b/db/migrate/20140531160506_package_filter_add_original_packages.rb
@@ -1,0 +1,9 @@
+class PackageFilterAddOriginalPackages < ActiveRecord::Migration
+  def up
+    add_column :katello_content_view_filters, :original_packages, :boolean, :default => false, :null => false
+  end
+
+  def down
+    remove_column :katello_content_view_filters, :original_packages
+  end
+end

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/filter-details.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/filter-details.controller.js
@@ -26,5 +26,9 @@ angular.module('Bastion.content-views').controller('FilterDetailsController',
 
         $scope.filter = Filter.get({'content_view_id': $scope.$stateParams.contentViewId, filterId: $scope.$stateParams.filterId});
 
+        $scope.updateFilter = function (filter) {
+            filter.$update();
+        };
+
     }]
 );

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
@@ -6,6 +6,20 @@
            ng-model="packageFilter"/>
   </div>
 
+  <div>
+    <input type="checkbox"
+           ng-model="filter.original_packages"
+           ng-change="updateFilter(filter)"/>
+
+    <span ng-show="filter.inclusion" translate>
+      Include all packages with no errata.
+    </span>
+
+    <span ng-show="!filter.inclusion" translate>
+      Exclude all packages with no errata.
+    </span>
+  </div>
+
   <button class="btn btn-default fr" ng-click="removeRules(filter)">
     <i class="icon-trash"></i>
     <span translate>Remove Packages</span>

--- a/engines/bastion/test/content-views/details/filters/filter-details.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/filter-details.controller.test.js
@@ -14,19 +14,18 @@
 describe('Controller: FilterDetailsController', function() {
     var $scope, Filter;
 
-    beforeEach(module('Bastion.content-views', 'Bastion.test-mocks'))
+    beforeEach(module('Bastion.content-views', 'Bastion.test-mocks'));
 
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller');
 
-        Filter = $injector.get('Filter');
-
+        Filter = $injector.get('MockResource').$new();
         $scope = $injector.get('$rootScope').$new();
         $scope.$stateParams = {
             contentViewId: 1,
             filterId: 1
         };
-        spyOn(Filter, 'get');
+        spyOn(Filter, 'get').andCallThrough();
 
         $controller('FilterDetailsController', {
             $scope: $scope,
@@ -36,6 +35,13 @@ describe('Controller: FilterDetailsController', function() {
 
     it("should put on the scope an individual filter object", function() {
         expect(Filter.get).toHaveBeenCalledWith({content_view_id: 1, filterId: 1});
+    });
+
+    it("should provide a way to update the filter", function () {
+        var filter = Filter.get({id: 1});
+        spyOn(filter, '$update');
+        $scope.updateFilter(filter);
+        expect(filter.$update).toHaveBeenCalled();
     });
 
 });

--- a/test/fixtures/vcr_cassettes/elasticsearch/package.yml
+++ b/test/fixtures/vcr_cassettes/elasticsearch/package.yml
@@ -26,20 +26,20 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"ok\":true,\"acknowledged\":true}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:57 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package
     body: 
       encoding: UTF-8
-      string: "{\"settings\":{\"index\":{\"analysis\":{\"filter\":{\"ngram_filter\":{\"type\":\"edgeNGram\",\"side\":\"front\",\"min_gram\":1,\"max_gram\":30}},\"analyzer\":{\"kt_name_analyzer\":{\"type\":\"custom\",\"tokenizer\":\"keyword\"},\"autcomplete_name_analyzer\":{\"type\":\"custom\",\"tokenizer\":\"keyword\",\"filter\":[\"standard\",\"lowercase\",\"ngram_filter\"]}}}}},\"mappings\":{\"package\":{\"properties\":{\"id\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"name\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"name_autocomplete\":{\"type\":\"string\",\"analyzer\":\"autcomplete_name_analyzer\"},\"nvrea_autocomplete\":{\"type\":\"string\",\"analyzer\":\"autcomplete_name_analyzer\"},\"nvrea\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"nvrea_sort\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"nvra\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"nvra_sort\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"repoids\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"sortable_version\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"sortable_release\":{\"type\":\"string\",\"index\":\"not_analyzed\"}}}}}"
+      string: "{\"settings\":{\"index\":{\"analysis\":{\"filter\":{\"ngram_filter\":{\"type\":\"edgeNGram\",\"side\":\"front\",\"min_gram\":1,\"max_gram\":30}},\"analyzer\":{\"kt_name_analyzer\":{\"type\":\"custom\",\"tokenizer\":\"keyword\"},\"autcomplete_name_analyzer\":{\"type\":\"custom\",\"tokenizer\":\"keyword\",\"filter\":[\"standard\",\"lowercase\",\"ngram_filter\"]}}}}},\"mappings\":{\"package\":{\"properties\":{\"id\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"name\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"name_autocomplete\":{\"type\":\"string\",\"analyzer\":\"autcomplete_name_analyzer\"},\"nvrea_autocomplete\":{\"type\":\"string\",\"analyzer\":\"autcomplete_name_analyzer\"},\"nvrea\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"nvrea_sort\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"nvra\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"filename\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"nvra_sort\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"repoids\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"sortable_version\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"sortable_release\":{\"type\":\"string\",\"index\":\"not_analyzed\"}}}}}"
     headers: 
       Accept: 
       - "*/*; q=0.5, application/xml"
       Accept-Encoding: 
       - gzip, deflate
       Content-Length: 
-      - "1000"
+      - "1059"
       User-Agent: 
       - Ruby
   response: 
@@ -55,7 +55,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"ok\":true,\"acknowledged\":true}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:57 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_bulk
@@ -96,12 +96,12 @@ http_interactions:
       Content-Type: 
       - application/json; charset=UTF-8
       Content-Length: 
-      - "836"
+      - "837"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":3,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":1,\"ok\":true}}]}"
+      string: "{\"took\":46,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":1,\"ok\":true}}]}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_refresh
@@ -130,7 +130,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"ok\":true,\"_shards\":{\"total\":6,\"successful\":3,\"failed\":0}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -157,7 +157,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -245,9 +245,9 @@ http_interactions:
       - "1163"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
+      string: "{\"took\":4,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -274,7 +274,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -364,7 +364,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":1,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_bulk
@@ -410,7 +410,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":2,\"ok\":true}}]}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_refresh
@@ -439,7 +439,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"ok\":true,\"_shards\":{\"total\":6,\"successful\":3,\"failed\":0}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -466,7 +466,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -538,9 +538,9 @@ http_interactions:
       - "418"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}}]}}"
+      string: "{\"took\":0,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -567,7 +567,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -639,9 +639,9 @@ http_interactions:
       - "1163"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":0,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -668,7 +668,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -758,7 +758,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -785,7 +785,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -875,7 +875,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":5,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_bulk
@@ -921,7 +921,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":3,\"ok\":true}}]}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_refresh
@@ -950,7 +950,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"ok\":true,\"_shards\":{\"total\":6,\"successful\":3,\"failed\":0}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -977,7 +977,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -1036,7 +1036,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":8,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_bulk
@@ -1080,9 +1080,9 @@ http_interactions:
       - "836"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":4,\"ok\":true}}]}"
+      string: "{\"took\":0,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":4,\"ok\":true}}]}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
     uri: http://localhost:9200/katello_test_package/_refresh
@@ -1111,7 +1111,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"ok\":true,\"_shards\":{\"total\":6,\"successful\":3,\"failed\":0}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -1138,7 +1138,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -1239,7 +1239,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":8,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -1266,7 +1266,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -1367,7 +1367,7 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":0,\"max_score\":null,\"hits\":[]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
     uri: http://localhost:9200/katello_test_package
@@ -1394,7 +1394,7 @@ http_interactions:
       encoding: US-ASCII
       string: ""
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
     uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
@@ -1511,5 +1511,5 @@ http_interactions:
       encoding: US-ASCII
       string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":3,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
     http_version: 
-  recorded_at: Thu, 05 Jun 2014 12:30:08 GMT
+  recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 recorded_with: VCR 2.9.2


### PR DESCRIPTION
Added to the Package Filter object, adds about 9 seconds for a full
RHEL 6 os repo.
