### PR TITLE
Fixes #6008 - Puppet environments capsule synchronization

### DIFF
--- a/app/lib/actions/katello/capsule_content/add_lifecycle_environment.rb
+++ b/app/lib/actions/katello/capsule_content/add_lifecycle_environment.rb
@@ -18,9 +18,8 @@ module Actions
         def plan(capsule_content, environment)
           capsule_content.add_lifecycle_environment(environment)
 
-          bound_repos = ::Katello::Repository.in_environment(environment)
-          bound_repos.each do |repo|
-            plan_action(CapsuleContent::AddRepository, capsule_content, repo)
+          capsule_content.pulp_repos(environment).each do |pulp_repo|
+            plan_action(CapsuleContent::AddRepository, capsule_content, pulp_repo)
           end
         end
 

--- a/app/lib/actions/katello/capsule_content/add_repository.rb
+++ b/app/lib/actions/katello/capsule_content/add_repository.rb
@@ -15,13 +15,13 @@ module Actions
     module CapsuleContent
       class AddRepository < ::Actions::EntryAction
 
-        def plan(capsule_content, repository)
-          if repository.node_syncable?
+        # @param capsule_content [::Katello::CapsuleContent]
+        # @param pulp_repo [::Katello::Glue::Pulp::Repo]
+        def plan(capsule_content, pulp_repo)
             plan_action(Pulp::Consumer::BindNodeDistributor,
                         consumer_uuid: capsule_content.consumer_uuid,
-                        repo_id: repository.pulp_id,
+                        repo_id: pulp_repo.pulp_id,
                         bind_options: bind_options)
-          end
         end
 
         private

--- a/app/lib/actions/katello/capsule_content/remove_lifecycle_environment.rb
+++ b/app/lib/actions/katello/capsule_content/remove_lifecycle_environment.rb
@@ -18,9 +18,8 @@ module Actions
         def plan(capsule_content, environment)
           capsule_content.remove_lifecycle_environment(environment)
 
-          bound_repos = ::Katello::Repository.in_environment(environment)
-          bound_repos.each do |repo|
-            plan_action(CapsuleContent::RemoveRepository, capsule_content, repo)
+          capsule_content.pulp_repos(environment).each do |pulp_repo|
+            plan_action(CapsuleContent::RemoveRepository, capsule_content, pulp_repo)
           end
         end
 

--- a/app/lib/actions/katello/capsule_content/remove_repository.rb
+++ b/app/lib/actions/katello/capsule_content/remove_repository.rb
@@ -15,14 +15,16 @@ module Actions
     module CapsuleContent
       class RemoveRepository < ::Actions::EntryAction
 
-        def plan(capsule_content, repository)
-          distributor = repository.find_node_distributor
+        # @param capsule_content [::Katello::CapsuleContent]
+        # @param pulp_repo [::Katello::Glue::Pulp::Repo]
+        def plan(capsule_content, pulp_repo)
+          distributor = pulp_repo.find_node_distributor
           if distributor
             plan_action(Pulp::Consumer::UnbindNodeDistributor,
                                   consumer_uuid: capsule_content.consumer_uuid,
-                                  repo_id: repository.pulp_id)
+                                  repo_id: pulp_repo.pulp_id)
           else
-            Rails.logger.error("Could not find node distributor for repository %s" % repository.pulp_id)
+            Rails.logger.error("Could not find node distributor for repository %s" % pulp_repo.pulp_id)
           end
         end
 

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -17,7 +17,7 @@ module Actions
 
         def plan(capsule_content, environment = nil)
           repository_ids = if environment
-                             ::Katello::Repository.in_environment(environment).pluck(:pulp_id)
+                             capsule_content.pulp_repos(environment).map(&:pulp_id)
                            end
 
           plan_action(Pulp::Consumer::SyncNode,

--- a/app/lib/actions/katello/content_view_puppet_environment/clone_to_environment.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/clone_to_environment.rb
@@ -37,6 +37,13 @@ module Actions
             concurrence do
               plan_action(Katello::Repository::MetadataGenerate, clone)
               plan_action(ElasticSearch::ContentViewPuppetEnvironment::IndexContent, id: clone.id)
+              sequence do
+                ::Katello::CapsuleContent.with_environment(environment).each do |capsule_content|
+                  plan_action(CapsuleContent::AddRepository, capsule_content, clone)
+                end
+
+                plan_action(Katello::Repository::NodeMetadataGenerate, clone)
+              end
             end
           end
         end

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -41,8 +41,10 @@ module Actions
 
             if repository.environment
               concurrence do
-                ::Katello::CapsuleContent.with_environment(repository.environment).each do |capsule_content|
-                  plan_action(CapsuleContent::AddRepository, capsule_content, repository)
+                if repository.node_syncable?
+                  ::Katello::CapsuleContent.with_environment(repository.environment).each do |capsule_content|
+                    plan_action(CapsuleContent::AddRepository, capsule_content, repository)
+                  end
                 end
               end
             end

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -14,6 +14,14 @@ module Katello
       scope
     end
 
+    def pulp_repos(environment)
+      yum_repos = Katello::Repository.in_environment(environment).find_all do |repo|
+        repo.node_syncable?
+      end
+      puppet_environments = Katello::ContentViewPuppetEnvironment.in_environment(environment)
+      yum_repos + puppet_environments
+    end
+
     def add_lifecycle_environment(environment)
       @capsule.lifecycle_environments << environment
     end

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -89,7 +89,7 @@ module ::Actions::Katello::CapsuleContent
     it 'allows limiting scope of the syncing to one environment' do
       action = create_and_plan_action(action_class, capsule_content, environment)
       assert_action_planed_with(action, ::Actions::Pulp::Consumer::SyncNode) do |(input)|
-        input[:repo_ids].size.must_equal 2
+        input[:repo_ids].size.must_equal 3
       end
     end
   end


### PR DESCRIPTION
Bind and synchronize puppet environments for attached lifecycle environments in the capsule
