### PR TITLE
Fixes 5992 and 5993 - qpid dependencies

### DIFF
--- a/rel-eng/comps/comps-katello-server-fedora19.xml
+++ b/rel-eng/comps/comps-katello-server-fedora19.xml
@@ -25,10 +25,9 @@
        <packagereq type="default">katello-repos-testing</packagereq>
        <packagereq type="default">katello-selinux</packagereq>
        <packagereq type="default">katello-utils</packagereq>
-       <packagereq type="default">pulp-katello-plugins</packagereq>
        <packagereq type="default">lucene4</packagereq>
        <packagereq type="default">lucene4-contrib</packagereq>
-       <packagereq type="default">pulp-katello-plugins</packagereq>
+       <packagereq type="default">pulp-katello</packagereq>
        <packagereq type="default">rubygem-angular-rails-templates</packagereq>
        <packagereq type="default">rubygem-ui_alchemy-rails</packagereq>
        <packagereq type="default">rubygem-anemone</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -27,10 +27,9 @@
        <packagereq type="default">katello-repos-testing</packagereq>
        <packagereq type="default">katello-selinux</packagereq>
        <packagereq type="default">katello-utils</packagereq>
-       <packagereq type="default">pulp-katello-plugins</packagereq>
        <packagereq type="default">lucene4</packagereq>
        <packagereq type="default">lucene4-contrib</packagereq>
-       <packagereq type="default">pulp-katello-plugins</packagereq>
+       <packagereq type="default">pulp-katello</packagereq>
        <packagereq type="default">sigar-java</packagereq>
        <packagereq type="default">sigar</packagereq>
        <packagereq type="default">snappy-java</packagereq>

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -77,7 +77,7 @@ Requires(preun): chkconfig
 Requires(preun): initscripts
 
 #Pulp Requirements
-Requires: pulp-katello-plugins
+Requires: pulp-katello
 Requires: pulp-nodes-parent
 Requires: pulp-puppet-plugins
 Requires: pulp-rpm-plugins
@@ -87,11 +87,6 @@ Requires: pulp-server
 Requires: mongodb
 Requires: mongodb-server
 Requires: cyrus-sasl-plain
-
-#Qpid Requirements
-Requires: qpid-cpp-client
-Requires: qpid-cpp-server
-Requires: qpid-tools
 
 Requires: candlepin-selinux
 Requires: createrepo >= 0.9.9-18%{?dist}


### PR DESCRIPTION
update dependencies for qpid. pulp-katello now pulls in all qpid dependencies
