### PR TITLE
Fixes #6026 - Fixed repo list api call for no env case.

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -62,7 +62,9 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
     options[:filters] << {:terms => {:id => ids}} if ids
     options[:filters] << {:term => {:environment_id => params[:environment_id]}} if params[:environment_id]
     options[:filters] << {:term => {:content_view_ids => params[:content_view_id]}} if params[:content_view_id]
-    options[:filters] << {:term => {:content_view_version_id => @organization.default_content_view.versions.first.id}} if params[:library]
+    if params[:library] || params[:environment_id].nil?
+      options[:filters] << {:term => {:content_view_version_id => @organization.default_content_view.versions.first.id}}
+    end
     options[:filters] << {:term => {:content_type => params[:content_type]}} if params[:content_type]
 
     respond :collection => item_search(Repository, params, options)


### PR DESCRIPTION
If you have a content view in library published few times and promoted a
few times

hammer repo list --organization-id=1 will return all repos across all
content views and environments. Meaning it will return repos with the
same name 10 or 20 times.

Ideal behaviour would be to say something along the lines of "If you
dont pass me an environment I am going to assume library/default content
view version."

This commit fixes this issue
