### PR TITLE
Fixes #6023 - Fixed code to associate gpg key to a product

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -170,7 +170,7 @@ class Api::V2::RepositoriesController < Api::V2::ApiController
 
   def find_gpg_key
     if params[:gpg_key_id]
-      @gpg_key = GpgKey.readable.find(:id => params[:gpg_key_id])
+      @gpg_key = GpgKey.readable.where(:id => params[:gpg_key_id], :organization_id => @organization).first
       fail HttpErrors::NotFound, _("Couldn't find gpg key '%s'") % params[:gpg_key_id] if @gpg_key.nil?
     end
   end


### PR DESCRIPTION
The gpg key find method was botched in the lookup. Fixed it with a where clause and an org check
