### PR TITLE
Fixes #6021 - Remove route mapping to UsersController

### DIFF
--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -392,9 +392,6 @@ Katello::Engine.routes.draw do
       match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#update', :via => :put, :as => :update_custom_info
       match '/custom_info/:informable_type/:informable_id/*keyname' => 'custom_info#destroy', :via => :delete, :as => :destroy_custom_info
 
-      # subscription-manager support
-      match '/users/:login/owners' => 'users#list_owners', :via => :get
-
     end # module v2
 
     # routes that didn't change in v2 and point to v1

--- a/test/routing/candlepin_proxies_test.rb
+++ b/test/routing/candlepin_proxies_test.rb
@@ -1,0 +1,26 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module Katello
+  class Api::V1::CandlepinProxiesControllerTest < ActionController::TestCase
+    def setup
+      setup_controller_defaults
+      @proxies_controller = "katello/api/v1/candlepin_proxies"
+    end
+
+    def test_user_resource_proxies
+      {:controller => @proxies_controller, :action => "list_owners", :login => "1", :api_version => "v2"}.must_recognize({ :method => "get", :path => "/api/users/1/owners" })
+    end
+  end
+end


### PR DESCRIPTION
GET /users/:login/owners was being mapped twice.

Remove route to UsersController and allow it to route
to the CandlepinProxiesController.

**NOTE**: Added test to v2 routing as v1 routing was removed.
