### PR TITLE
Fixes #6047: Prevent search grid from folding under row headers, BZ10833...

### DIFF
--- a/app/assets/stylesheets/katello/content_search.scss
+++ b/app/assets/stylesheets/katello/content_search.scss
@@ -503,7 +503,7 @@ table.changelog {
     }
 
     #grid_content_window {
-      width: $comparison_grid-width - $comparison_grid_filter-width - 2;
+      width: $comparison_grid-width - $comparison_grid_filter-width - 3;
       min-height: $comparison_grid-height - $comparison_grid_header-height;
       float: left;
       background: $white_color;


### PR DESCRIPTION
...19.

For some browser zoom levels, the grid rows would tuck up under the
row headers. This reduces the width of the grid area allowing it to
stay in place.
