### PR TITLE
Fixes #6050 - Better error message on filter rules create

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -88,7 +88,7 @@ module Katello
     end
 
     def rule_params
-      params.require(:content_view_filter_rule).permit(:name, :version, :min_version, :max_version,
+      params.fetch(:content_view_filter_rule, {}).permit(:name, :version, :min_version, :max_version,
                                                        :errata_id, :start_date, :end_date, :types => [])
     end
 


### PR DESCRIPTION
Basically cli did this on filter rule create with no filter rule params
specified.

``` bash
$ hammer  content-view filter rule create --content-view-id=4 --organization-id=1 --content-view-filter-id 1

Could not create the filter rule:
  Error: 400 Bad Request
```

This commit fixes that by giving more context on what needs to be
specified. This is slightly tricky because depending on errata or
package filters the "base" field requirement is bound to change. Here
are the 2 scenarios this fix now handles..
1) On a package filter specifying package rule it raises name cant be
blank.

``` bash
$ hammer  content-view filter rule create --content-view-id=4 --organization-id=1 --content-view-filter-id 1

Could not create the filter rule:
  Validation failed: Name can't be blank
```

2) On an erratum filter specifying erratum rule it raises something else

```
$ hammer  content-view filter rule create --content-view-id=4 --organization-id=1 --content-view-filter-id 2
Could not create the filter rule:
  Validation failed: Invalid erratum filter rule specified, Must specify at least one of the following: 'errata_id', 'start_date', 'end_date' or 'types'
```
