### PR TITLE
fixes #6053 - delete organization raises 404

### DIFF
--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -138,6 +138,8 @@ class HttpResource
       client = rest_client(Net::HTTP::Delete, :delete, a_path)
       result = process_response(client.delete(headers))
       result
+    rescue RestClient::ResourceNotFound => e
+      e.response
     rescue RestClient::Exception => e
       raise_rest_client_exception e, a_path, "DELETE"
     rescue Errno::ECONNREFUSED


### PR DESCRIPTION
http://projects.theforeman.org/issues/6053

Probably this patch should go in the other methods in http_resource, `get`, `put`, `post`
