### PR TITLE
fixes #5743/BZ1097124 - content host - host collections bulk action "loading" fix

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
@@ -208,7 +208,7 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
         templateUrl: 'content-hosts/bulk/views/errata-content-hosts.html'
     })
     .state('content-hosts.bulk-actions.host-collections', {
-        url: '/content_hosts/bulk-actions/host-collections',
+        url: '/content_hosts/bulk-actions/bulk-host-collections',
         collapsed: true,
         controller: 'ContentHostsBulkActionHostCollectionsController',
         templateUrl: 'content-hosts/bulk/views/bulk-actions-host-collections.html'


### PR DESCRIPTION
This small commit fixes an issue where the content host bulk
actions page for host collections would result in invalid requests
sent to the server, causing it to remain in a 'Loading' state.

The issue was due to a name conflict in the url (host-collections)
used by both the single content host as well as bulk actions.
