### PR TITLE
Fixes #6072 - Report issues on repo syncing and don't lock repository on failure

### DIFF
--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -50,6 +50,13 @@ module Actions
           Sync::Presenter.new(self)
         end
 
+        def rescue_strategy_for_self
+          # There are various reasons the syncing fails, not all of them are
+          # fatal: when fail on syncing, we continue with the task ending up
+          # in the warning state, but not locking further syncs
+          Dynflow::Action::Rescue::Skip
+        end
+
         class Presenter < Helpers::Presenter::Base
 
           # TODO: in Rails 4.0, the logic is possible to use from ActiveSupport

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -101,5 +101,23 @@ module Errors
 
   end
 
+  class PulpError < StandardError
+
+    # Return a CandlepinError with the displayMessage
+    # as the message set if
+    def self.from_task(task)
+      if task[:state] == 'error'
+        message = if task[:exception]
+                    Array(task[:exception]).join('; ')
+                  elsif task[:error]
+                    "#{task[:error][:code]}: #{task[:error][:description]}"
+                  else
+                    "Pulp task error"
+                  end
+        self.new(message)
+      end
+    end
+  end
+
 end
 end

--- a/engines/bastion/app/assets/javascripts/bastion/tasks/task.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/tasks/task.factory.js
@@ -57,7 +57,8 @@ angular.module('Bastion.tasks').factory('Task',
         }
 
         function taskProgressbar(task) {
-            var type = task.result === 'error' ? 'danger' : 'success';
+            var mapping = { 'error': 'danger', 'warning': 'warning', 'default': 'success' };
+            var type = mapping[task.result] || mapping['default'];
             return { value: task.progress * 100, type: type };
         }
 

--- a/engines/bastion/app/assets/javascripts/bastion/tasks/views/task-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/tasks/views/task-details.html
@@ -55,15 +55,16 @@
        <div ng-class="{ active: (task.state === 'pending' || task.state === 'running') }" class="progress progress-striped">
          <span progressbar animate="false" value="task.progressbar.value" type="{{task.progressbar.type}}"></span>
        </div>
-    </section>
 
-    <div class="divider"></div>
+       <div class="detail" ng-show="task.humanized.output.length > 0">
+         <span class="info-label" translate>Details</span>
+         <pre>{{ task.humanized.output }}</pre>
+       </div>
 
-    <section>
-      <div class="detail" ng-show="task.humanized.output.length > 0">
-        <span class="info-label" translate>Details</span>
-        <pre>{{ task.humanized.output }}</pre>
-      </div>
+       <a href="/foreman_tasks/tasks/{{task.id}}">
+         {{ "More Details" | translate }}
+       </a>
+
     </section>
   </div>
 </div>


### PR DESCRIPTION
Repo synchronization is an idempotent operation. There are also situations,
such as wrong url, that might lead to unexpected situations. Therefore,
instead of keeping the task paused, locking other operations to be performed,
just skip the syncing and report the errors.

The bastion task details page now also includes a link to "More details" that
leads to foreman_tasks/show page with even more details information useful for
debugging the issue and filing bugs.
