### PR TITLE
Fixes #6080, #6081, #6082: Fixing registration including adding back def...

### DIFF
--- a/app/lib/actions/katello/system/create.rb
+++ b/app/lib/actions/katello/system/create.rb
@@ -20,8 +20,10 @@ module Actions
         def plan(system, activation_keys = [])
           system.disable_auto_reindex!
 
-          activation_key_plan = plan_action(Katello::System::ActivationKeys, system, activation_keys)
-          return if activation_key_plan.error
+          if !activation_keys.empty?
+            activation_key_plan = plan_action(Katello::System::ActivationKeys, system, activation_keys)
+            return if activation_key_plan.error
+          end
 
           # we need to prepare the input for consumer create before we call save!
           # as the before filters do some magic with the attributes

--- a/app/models/katello/authorization/content_view_environment.rb
+++ b/app/models/katello/authorization/content_view_environment.rb
@@ -1,0 +1,22 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Authorization::ContentViewEnvironment
+    extend ActiveSupport::Concern
+
+    def readable?
+      self.content_view.readable? && self.environment.readable?
+    end
+
+  end
+end

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -17,6 +17,7 @@ class ContentViewEnvironment < Katello::Model
   include ForemanTasks::Concerns::ActionSubject
   include Glue::Candlepin::Environment if Katello.config.use_cp
   include Glue if Katello.config.use_cp
+  include Authorization::ContentViewEnvironment
 
   belongs_to :content_view, :class_name => "Katello::ContentView", :inverse_of => :content_view_environments
   belongs_to :environment, :class_name => "Katello::KTEnvironment", :inverse_of => :content_view_environments

--- a/test/controllers/api/v1/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/v1/candlepin_proxies_controller_test.rb
@@ -38,7 +38,7 @@ module Katello
       end
 
       it "should fail with known organization and no activation_keys" do
-        post('consumer_activate', :owner => @organization.name, :activation_keys => '')
+        post('consumer_activate', :owner => @organization.label, :activation_keys => '')
         assert_response 400
       end
     end
@@ -180,7 +180,8 @@ module Katello
     end
 
     it "test_hypervisors_update" do
-      assert_protected_action(:hypervisors_update, :edit_content_hosts) do
+      perms = [[:edit_content_hosts, :view_content_views, :view_lifecycle_environments]]
+      assert_protected_action(:hypervisors_update, perms) do
         post :hypervisors_update, :env => @organization.library.content_view_environments.first.label
       end
     end
@@ -194,7 +195,7 @@ module Katello
         User.stubs(:current).returns(CpConsumerUser.new(:uuid => uuid, :login => uuid, :remote_id => uuid))
 
         get :available_releases, :id => @system.uuid
-        assert_response 200      
+        assert_response 200
       end
 
       it "forbidden with invalid consumer" do

--- a/test/models/authorization/content_view_environment_authorization_test.rb
+++ b/test/models/authorization/content_view_environment_authorization_test.rb
@@ -1,0 +1,52 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'models/authorization/authorization_base'
+
+module Katello
+class ContentViewEnvironmentAuthorizationAdminTest < AuthorizationTestBase
+  def setup
+    super
+    User.current = User.find(users(:admin))
+    @content_view_environment = katello_content_view_environments(:library_default_view_environment)
+  end
+
+  def test_readable?
+    assert @content_view_environment.readable?
+  end
+end
+
+class ContentViewEnvironmentAuthorizationNonAuthUserTest < AuthorizationTestBase
+  def setup
+    super
+    User.current = User.find(users(:restricted))
+    @content_view_environment = katello_content_view_environments(:library_default_view_environment)
+  end
+
+  def test_readable?
+    refute @content_view_environment.readable?
+  end
+end
+
+class ContentViewEnvironmentAuthorizationAuthorizedUserTest < AuthorizationTestBase
+  def setup
+    super
+    User.current = User.find(users(:restricted))
+    @content_view_environment = katello_content_view_environments(:library_default_view_environment)
+  end
+
+  def test_readable?
+    setup_current_user_with_permissions([:view_content_views, :view_lifecycle_environments])
+    assert @content_view_environment.readable?
+  end
+end
+end


### PR DESCRIPTION
...ault organization.

Addresses the following BZs: BZ1103020, BZ1095925, BZ1096068

Addresses a number of issues that have crept up recently with registration
and attempts to support the following:
1. User specifies an organization.
   - User must belong to the organization
   - The consumer will register to the Library of that organization.
2. User does not specify an organization.
   - User must have a default organization set.
   - The consumer will register to the Library of the users default
     organization.
3. User specifies an organization and an environment.
   - The user must belong to the organization
   - The user must have view on the environment
   - The user must have create on content hosts in that organization
