### PR TITLE
Fixes #6084, bz 1079161 - Updated sync state link

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-repositories.html
@@ -80,16 +80,16 @@
           </td>
           <td alch-table-cell>{{ repository.content_type }}</td>
           <td alch-table-cell>
-              <span ng-show="repository.feed">
+              <span ng-show="repository.url">
                 <span ng-show="repository.last_sync == null" translate>
                   Not Synced
                 </span>
                 <span ng-hide="repository.last_sync == null">
-                  <a href="sync_management">{{ repository.sync_state | capitalize}}</a>
+                  <a href="/katello/sync_management">{{ repository.sync_state | capitalize}}</a>
                   ({{ repository.last_sync | date:"short" }})
                 </span>
               </span>
-            <span ng-hide="repository.feed" translate>N/A</span>
+            <span ng-hide="repository.url" translate>N/A</span>
           </td>
           <td alch-table-cell>
               <span ng-show="repository.content_type == 'puppet'">

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
@@ -94,16 +94,16 @@
             </td>
             <td alch-table-cell>{{ repository.product.name }}</td>
             <td alch-table-cell>
-              <span ng-show="repository.feed">
+              <span ng-show="repository.url">
                 {{ repository.last_sync | date:"short" }}
               </span>
-              <span ng-hide="repository.feed" translate>N/A</span>
+              <span ng-hide="repository.url" translate>N/A</span>
             </td>
             <td alch-table-cell>
-              <span ng-show="repository.feed">
-                <a href="sync_management">{{ repository.sync_state }}</a>
+              <span ng-show="repository.url">
+                <a href="/katello/sync_management">{{ repository.sync_state | capitalize }}</a>
               </span>
-              <span ng-hide="repository.feed" translate>N/A</span>
+              <span ng-hide="repository.url" translate>N/A</span>
             </td>
             <td alch-table-cell>
               <div>

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
@@ -66,16 +66,16 @@
         </td>
         <td alch-table-cell>{{ repository.content_type }}</td>
         <td alch-table-cell>
-          <span ng-show="repository.feed">
+          <span ng-show="repository.url">
             <span ng-show="repository.last_sync == null" translate>
               Not Synced
             </span>
             <span ng-hide="repository.last_sync == null">
-              <a href="sync_management">{{ repository.sync_state | capitalize}}</a>
+              <a href="/katello/sync_management">{{ repository.sync_state | capitalize}}</a>
               ({{ repository.last_sync | date:"short" }})
             </span>
           </span>
-          <span ng-hide="repository.feed" translate>N/A</span>
+          <span ng-hide="repository.url" translate>N/A</span>
         </td>
         <td alch-table-cell>
           <span ng-show="repository.content_type == 'puppet'">


### PR DESCRIPTION
The following 3 pages were not properly reflecting the sync state and the sync management urls.
1) Content View -> Content -> Repositories (both Add/List)
2) Product -> Repositories
3) Content View -> Content -> Filters -> {filter} -> Repositories

They all said N/A even for completed syncs and the urls pointed to by 'finished' state was incorrect.
They all pointed to http://<fqdn>/sync_management while ideally they should ve been pointing to
http://<fqdn>/katello/sync_management
This commit addresses this issue
