### PR TITLE
fixes #6108/BZ 1105310 - ensure unique name when creating installation media

### DIFF
--- a/app/models/katello/concerns/medium_extensions.rb
+++ b/app/models/katello/concerns/medium_extensions.rb
@@ -60,20 +60,13 @@ module Katello
           if repo.content_view && !repo.content_view.default?
             parts << repo.content_view.label
           end
-          parts = [parts.compact.join('/')]
-
-          parts << distribution.family
-          parts << distribution.variant
-          parts << distribution.version
-          parts << distribution.arch
-
-          name = parts.reject(&:blank?).join(' ')
-          return normalize_name(name)
+          parts << repo.label
+          return normalize_name(parts.compact.join('/'))
         end
 
         # Foreman and Puppet uses RedHat name for Red Hat Enterprise Linux
         def normalize_name(name)
-          name.sub('Red Hat Enterprise Linux', 'RedHat')
+          name.sub('Red_Hat_Enterprise_Linux', 'Red_Hat')
         end
 
         # takes repo uri from Katello and makes installation media url

--- a/test/models/concerns/medium_extensions_test.rb
+++ b/test/models/concerns/medium_extensions_test.rb
@@ -53,8 +53,8 @@ module Katello
     end
 
     def test_normalize_name
-      name = Medium.normalize_name('Red Hat Enterprise Linux OS')
-      assert_equal name, 'RedHat OS'
+      name = Medium.normalize_name('Red_Hat_Enterprise_Linux_6_Server')
+      assert_equal name, 'Red_Hat_6_Server'
 
       name = Medium.normalize_name('MyLinux OS')
       assert_equal name, 'MyLinux OS'


### PR DESCRIPTION
When publishing a kickstart repository (which could be the result of syncing the repo or publishing it as part of a content view), installation media will be created.

The media name currently uses the following convention:
   org.label/lifecycle_environment.label[/content_view.label] distro.family distro.variant distro.version distro.arch

For example:
   ACME_Corporation/Library RedHat Server 6.5 x86_64
   ACME_Corporation/Library/ks_view RedHat Server 6.5 x86_64

The current convention can cause name conflicts when creating the media as both the 6Server and 6.5 kickstart repos have distro.version of "6.5"; however, they are 2 separate repos/media from a content management point of view.

In order to address this, this commit adds 'repo.id' to the naming convention to ensure uniqiness.

The new convention is:
   org.label/lifecycle_environment.label[/content_view.label] distro.family distro.variant distro.version distro.arch - repo.id

E.g:
   ACME_Corporation/Library RedHat Server 6.5 x86_64 - 1
   ACME_Corporation/Library/ks_view RedHat Server 6.5 x86_64 - 3
