### PR TITLE
fixes #6120 / BZ1102963 - address error during content host bulk actions

### DIFF
--- a/app/lib/katello/bulk_actions.rb
+++ b/app/lib/katello/bulk_actions.rb
@@ -23,24 +23,21 @@ class BulkActions
 
   def install_errata(errata_ids)
     perform_bulk_action do |consumer_group|
-      pulp_job = consumer_group.install_consumer_errata(errata_ids)
-      save_job(pulp_job, :errata_install, :errata_ids, errata_ids)
+      consumer_group.install_consumer_errata(errata_ids)
     end
   end
 
   def install_packages(packages)
     fail Errors::HostCollectionEmptyException if self.systems.empty?
     perform_bulk_action do |consumer_group|
-      pulp_job = consumer_group.install_package(packages)
-      save_job(pulp_job, :package_install, :packages, packages)
+      consumer_group.install_package(packages)
     end
   end
 
   def uninstall_packages(packages)
     fail Errors::HostCollectionEmptyException if self.systems.empty?
     perform_bulk_action do |consumer_group|
-      pulp_job = consumer_group.uninstall_package(packages)
-      save_job(pulp_job, :package_remove, :packages, packages)
+      consumer_group.uninstall_package(packages)
     end
   end
 
@@ -48,32 +45,28 @@ class BulkActions
     # if no packages are provided, a full system update will be performed (e.g ''yum update' equivalent)
     fail Errors::HostCollectionEmptyException if self.systems.empty?
     perform_bulk_action do |consumer_group|
-      pulp_job = consumer_group.update_package(packages)
-      save_job(pulp_job, :package_update, :packages, packages)
+      consumer_group.update_package(packages)
     end
   end
 
   def install_package_groups(groups)
     fail Errors::HostCollectionEmptyException if self.systems.empty?
     perform_bulk_action do |consumer_group|
-      pulp_job = consumer_group.install_package_group(groups)
-      save_job(pulp_job, :package_group_install, :groups, groups)
+      consumer_group.install_package_group(groups)
     end
   end
 
   def update_package_groups(groups)
     fail Errors::HostCollectionEmptyException if self.systems.empty?
     perform_bulk_action do |consumer_group|
-      pulp_job = consumer_group.install_package_group(groups)
-      save_job(pulp_job, :package_group_update, :groups, groups)
+      consumer_group.install_package_group(groups)
     end
   end
 
   def uninstall_package_groups(groups)
     fail Errors::HostCollectionEmptyException if self.systems.empty?
     perform_bulk_action do |consumer_group|
-      pulp_job = consumer_group.uninstall_package_group(groups)
-      save_job(pulp_job, :package_group_remove, :groups, groups)
+      consumer_group.uninstall_package_group(groups)
     end
   end
 
@@ -88,12 +81,6 @@ class BulkActions
     yield(group)
   ensure
     group.del_pulp_consumer_group
-  end
-
-  def save_job(pulp_job, job_type, parameters_type, parameters)
-    job = Job.create!(:pulp_id => pulp_job.first[:task_group_id], :job_owner => self.user)
-    job.create_tasks(self.organization, pulp_job, job_type, parameters_type => parameters)
-    job
   end
 
 end


### PR DESCRIPTION
When performing a bulk action (e.g. pkg, pkg group or errata
install/update/remove) action, the user would get an error similar
to the following:

```
TypeError: can't convert Symbol into Integer
katello/app/lib/katello/bulk_actions.rb:94:in `[]'
katello/app/lib/katello/bulk_actions.rb:94:in `save_job'
katello/app/lib/katello/bulk_actions.rb:35:in `block in install_packages'
katello/app/lib/katello/bulk_actions.rb:88:in `perform_bulk_action'
katello/app/lib/katello/bulk_actions.rb:33:in `install_packages'
```

The cause of the error is that pulp 2.4 changed the response to consumer group
actions; however, the bulk actions had not been updated for this change.
In pulp 2.4, the response no longer returns a 'job' along with 'tasks'
associated with that job.  Instead, it returns a list of tasks that the user
must individually monitor.

Since the content host and host collections UIs no longer provide the
user a way for a user to see pulp job/task information (i.e. this was
removed in favor of using dynflow and displaying it's task info), this commit
removes the saving of the pulp job/task information on bulk actions.

In a future commit, we'll update the bulk actions to utilize
dynflow, so that a user can see details on the actions performed.
In the meantime, the user can see updates by looking on the affected
content hosts or via changes to the content hosts package profiles
(after uploads that occur after the bulk actions are performed).
