### PR TITLE
fixes #6124 / BZ1104807 - fix content host 'update all' action

### DIFF
--- a/app/lib/actions/katello/system/package/update.rb
+++ b/app/lib/actions/katello/system/package/update.rb
@@ -22,14 +22,14 @@ module Actions
             Type! system, ::Katello::System
 
             action_subject(system, :packages => packages)
-            plan_action(Pulp::Consumer::ContentInstall,
+            plan_action(Pulp::Consumer::ContentUpdate,
                         consumer_uuid: system.uuid,
                         type:          'rpm',
                         args:          packages)
           end
 
           def humanized_name
-            _("Install package")
+            _("Update package")
           end
 
           def humanized_input
@@ -37,7 +37,7 @@ module Actions
           end
 
           def presenter
-            Helpers::Presenter::Delegated.new(self, planned_actions(Pulp::Consumer::ContentInstall))
+            Helpers::Presenter::Delegated.new(self, planned_actions(Pulp::Consumer::ContentUpdate))
           end
         end
       end


### PR DESCRIPTION
The update action was incorrectly using the pulp install action.
