### PR TITLE
fixes #5761, #5899 - Update Katello kickstarts

### DIFF
--- a/app/views/foreman/unattended/kickstart-katello.erb
+++ b/app/views/foreman/unattended/kickstart-katello.erb
@@ -1,32 +1,40 @@
-#kind: provision
-#name: Community Kickstart
-#oses:
-#- CentOS 5
-#- CentOS 6
-#- Fedora 16
-#- Fedora 17
-#- Fedora 18
-#- Fedora 19
+<%#
+kind: provision
+name: Kickstart default
+oses:
+- CentOS 4
+- CentOS 5
+- CentOS 6
+- CentOS 7
+- Fedora 16
+- Fedora 17
+- Fedora 18
+- Fedora 19
+- Fedora 20
+%>
+<%
+  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
+  os_major = @host.operatingsystem.major.to_i
+  # safemode renderer does not support unary negation
+  pm_set = @host.puppetmaster.empty? ? false : true
+  puppet_enabled = pm_set || @host.params['force-puppet']
+%>
 install
 <%= @mediapath %>
 lang en_US.UTF-8
-selinux --permissive
+selinux --enforcing
 keyboard us
 skipx
-network --bootproto <%= @static ? "static" : "dhcp" %> --hostname <%= @host %>
+network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : 'dhcp' %> --hostname <%= @host %>
 rootpw --iscrypted <%= root_pass %>
-firewall --<%= @host.operatingsystem.major.to_i >= 6 ? "service=" : "" %>ssh
+firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
-timezone UTC
-services --disabled autofs,gpm,sendmail,cups,iptables,ip6tables,auditd,arptables_jf,xfs,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd,restorecond,mcstrans,rhnsd,yum-updatesd
-
-<% if @host.operatingsystem.name == "Fedora" -%>
-repo --name=fedora-everything --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %>
-<% elsif @host.operatingsystem.family == "Redhat" %>
-repo --name="Extra Packages for Enterprise Linux" --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-<%= @host.operatingsystem.major %>&arch=<%= @host.architecture %>
+timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
+<% if rhel_compatible && os_major > 4 -%>
+services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 <% end -%>
 
-<% if @host.operatingsystem.name == "Fedora" and @host.operatingsystem.major.to_i <= 16 -%>
+<% if @host.operatingsystem.name == 'Fedora' and os_major <= 16 -%>
 # Bootloader exception for Fedora 16:
 bootloader --append="nofb quiet splash=quiet <%=ks_console%>" <%= grub_pass %>
 part biosboot --fstype=biosboot --size=1
@@ -49,13 +57,15 @@ dhclient
 ntp
 wget
 @Core
-epel-release
+<% if puppet_enabled %>
 puppet
-<%= "%end\n" if @host.operatingsystem.name == "Fedora" %>
+<% end -%>
+%end
 
 <% if @dynamic -%>
 %pre
 <%= @host.diskLayout %>
+%end
 <% end -%>
 
 %post --nochroot
@@ -66,7 +76,7 @@ exec < /dev/tty3 > /dev/tty3
 cp -va /etc/resolv.conf /mnt/sysimage/etc/resolv.conf
 /usr/bin/chvt 1
 ) 2>&1 | tee /mnt/sysimage/root/install.postnochroot.log
-<%= "%end\n" if @host.operatingsystem.name == "Fedora" %>
+%end
 
 %post
 logger "Starting anaconda <%= @host %> postinstall"
@@ -76,23 +86,30 @@ exec < /dev/tty3 > /dev/tty3
 (
 #update local time
 echo "updating system time"
-/usr/sbin/ntpdate -sub <%= @host.params["ntp-server"] || "0.fedora.pool.ntp.org" %>
+/usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
+
+<%= snippet "subscription_manager_registration" %>
+
+<% if @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<%= snippet "freeipa_register" %>
+<% end -%>
+
 
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
 
-<%= snippets "subscription_manager_registration" %>
-
+<% if puppet_enabled %>
 echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippets "puppet.conf" %>
+<%= snippet 'puppet.conf' %>
 EOF
 
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on
 
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= @host.puppetmaster %>  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
+<% end -%>
 
 sync
 
@@ -103,4 +120,5 @@ wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
 ) 2>&1 | tee /root/install.post.log
 exit 0
 
-<%= "%end\n" if @host.operatingsystem.name == "Fedora" -%>
+%end
+

--- a/app/views/foreman/unattended/kickstart-katello_rhel.erb
+++ b/app/views/foreman/unattended/kickstart-katello_rhel.erb
@@ -1,24 +1,39 @@
-#kind: provision
-#name: Community Kickstart RHEL
-#oses:
-#- RedHat 5
-#- RedHat 6
+<%#
+kind: provision
+name: Kickstart RHEL default
+oses:
+- RedHat 4
+- RedHat 5
+- RedHat 6
+- RedHat 7
+%>
+<%
+  os_major = @host.operatingsystem.major.to_i
+  # safemode renderer does not support unary negation
+  pm_set = @host.puppetmaster.empty? ? false : true
+  puppet_enabled = pm_set || @host.params['force-puppet']
+%>
 install
 <%= @mediapath %>
 lang en_US.UTF-8
-selinux --permissive
+selinux --enforcing
 keyboard us
 skipx
-network --bootproto <%= @static ? "static" : "dhcp" %> --hostname <%= @host %>
+network --bootproto <%= @static ? "static --ip=#{@host.ip} --netmask=#{@host.subnet.mask} --gateway=#{@host.subnet.gateway} --nameserver=#{[@host.subnet.dns_primary,@host.subnet.dns_secondary].reject{|n| n.blank?}.join(',')}" : 'dhcp' %> --hostname <%= @host %>
 rootpw --iscrypted <%= root_pass %>
-firewall --<%= @host.operatingsystem.major.to_i >= 6 ? "service=" : "" %>ssh
+firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
-timezone UTC
-services --disabled autofs,gpm,sendmail,cups,iptables,ip6tables,auditd,arptables_jf,xfs,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd,restorecond,mcstrans,rhnsd,yum-updatesd
+timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
 
+<% if os_major > 4 -%>
+services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
+<% end -%>
 
 bootloader --location=mbr --append="nofb quiet splash=quiet" <%= grub_pass %>
+<% if os_major == 5 -%>
 key --skip
+<% end -%>
+
 
 <% if @dynamic -%>
 %include /tmp/diskpart.cfg
@@ -35,11 +50,15 @@ dhclient
 ntp
 wget
 @Core
+<% if puppet_enabled %>
 puppet
+<% end -%>
+%end
 
 <% if @dynamic -%>
 %pre
 <%= @host.diskLayout %>
+%end
 <% end -%>
 
 %post --nochroot
@@ -50,6 +69,7 @@ exec < /dev/tty3 > /dev/tty3
 cp -va /etc/resolv.conf /mnt/sysimage/etc/resolv.conf
 /usr/bin/chvt 1
 ) 2>&1 | tee /mnt/sysimage/root/install.postnochroot.log
+%end
 
 %post
 logger "Starting anaconda <%= @host %> postinstall"
@@ -59,26 +79,32 @@ exec < /dev/tty3 > /dev/tty3
 (
 #update local time
 echo "updating system time"
-/usr/sbin/ntpdate -sub <%= @host.params["ntp-server"] || "0.fedora.pool.ntp.org" %>
+/usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
+
+<%= snippet "subscription_manager_registration" %>
+
+<% if @host.info["parameters"]["realm"] && @host.otp && @host.realm && @host.realm.realm_type == "FreeIPA" -%>
+<%= snippet "freeipa_register" %>
+<% end -%>
 
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
 
-<%= snippets "subscription_manager_registration" %>
-
+<% if puppet_enabled %>
 # and add the puppet package
 yum -t -y -e 0 install puppet
 
 echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippets "puppet.conf" %>
+<%= snippet 'puppet.conf' %>
 EOF
 
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on
 
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= @host.puppetmaster %>  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
+<% end -%>
 
 sync
 
@@ -88,3 +114,5 @@ wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
 # Sleeping an hour for debug
 ) 2>&1 | tee /root/install.post.log
 exit 0
+
+%end


### PR DESCRIPTION
This change brings the Katello kickstarts forward to match what's in the
Foreman community versions, with the community yum repos removed as Katello
will manage content.

This includes the security hardening in #5895, and Realm integration from #1809.
