### PR TITLE
Fixes #6147 - filter both org and env in sys

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -69,11 +69,10 @@ class Api::V2::SystemsController < Api::V2::ApiController
     uuids = System.readable.pluck(:uuid).compact
     filters << {:terms => {:uuid => uuids}}
 
-    if params[:organization_id]
-      environment_ids = Organization.find(params[:organization_id]).kt_environments.pluck(:id)
-      filters << {:terms => {:environment_id => environment_ids}}
-    elsif params[:environment_id]
-      filters << {:terms => {:environment_id => [params[:environment_id]] }}
+    environment_ids = params[:organization_id] ? Organization.find(params[:organization_id]).kt_environments.pluck(:id) : []
+    environment_ids = environment_ids.empty? ? params[:environment_id] : environment_ids & [params[:environment_id].to_i] if params[:environment_id]
+    if !environment_ids.empty?
+      filters << {:terms => {:environment_id =>  environment_ids}}
     elsif params[:host_collection_id]
       filters << {:terms => {:host_collection_ids => [params[:host_collection_id]] }}
     end

--- a/test/controllers/api/v2/systems_controller_test.rb
+++ b/test/controllers/api/v2/systems_controller_test.rb
@@ -76,6 +76,42 @@ class Api::V2::SystemsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_index_with_system_id_only
+    Api::V2::SystemsController.any_instance.expects(:item_search).with do |model, params, options|
+      terms = options[:filters].inject({}){|all_terms, filter| all_terms.merge(filter[:terms]) }
+      terms[:environment_id] ==  @system.environment.id.to_s
+    end.returns({})
+
+    get :index, :environment_id => @system.environment.id
+
+    assert_response :success
+    assert_template 'api/v2/systems/index'
+  end
+
+  def test_index_with_org_id_only
+    Api::V2::SystemsController.any_instance.expects(:item_search).with do |model, params, options|
+      terms = options[:filters].inject({}){|all_terms, filter| all_terms.merge(filter[:terms]) }
+      terms[:environment_id] == @organization.kt_environments.pluck(:id)
+    end.returns({})
+
+    get :index, :organization_id=> @organization.id
+
+    assert_response :success
+    assert_template 'api/v2/systems/index'
+  end
+
+  def test_index_with_system_id_and_org_id
+    Api::V2::SystemsController.any_instance.expects(:item_search).with do |model, params, options|
+      terms = options[:filters].inject({}){|all_terms, filter| all_terms.merge(filter[:terms]) }
+      terms[:environment_id] == [@system.environment.id]
+    end.returns({})
+
+    get :index, :organization_id => @organization.id, :environment_id => @system.environment.id
+
+    assert_response :success
+    assert_template 'api/v2/systems/index'
+  end
+
   def test_show
     get :show, :id => @system.uuid
 


### PR DESCRIPTION
systems index action does not filter by environment_id when both
organization_id and environment_id are passed; it only filters by
organization_id. This allows the index action to filter by both.
