### PR TITLE
Fixes #6153, bz1107876 - Fixed cv package excludes publish

### DIFF
--- a/app/lib/actions/katello/repository/clone_content.rb
+++ b/app/lib/actions/katello/repository/clone_content.rb
@@ -35,7 +35,7 @@ module Actions
               process_errata_and_groups = true
             end
             if remove_clauses
-              plan_remove(Pulp::Repository::RemoveRpm, target_repo, remove_clauses)
+              plan_remove(Pulp::Repository::RemoveRpm, target_repo, {:unit => remove_clauses})
               process_errata_and_groups = true
             end
             if process_errata_and_groups


### PR DESCRIPTION
Previously if you published a content view with a package excludes
filter with a matching package in the repo. You would get the following
error from pulp (package name is gofer in the example)
pulp.server.webservices.controllers.repositories:ERROR: Error parsing
unassociation criteria [{'fields': {}, 't
ype_ids': ['rpm'], 'filters': {'$or': [{'filename': {'$in':
['gofer-1.2.0-1.el6.noarch.rpm']}}]}}]

This commit fixes that issue.
