### PR TITLE
fixes #5026 / BZ 1094176 - content view package group filter - handle duplicate group names across repos

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -88,8 +88,8 @@ module Katello
     end
 
     def rule_params
-      params.fetch(:content_view_filter_rule, {}).permit(:name, :version, :min_version, :max_version,
-                                                       :errata_id, :start_date, :end_date, :types => [])
+      params.fetch(:content_view_filter_rule, {}).permit(:uuid, :name, :version, :min_version, :max_version,
+                                                         :errata_id, :start_date, :end_date, :types => [])
     end
 
   end

--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -109,10 +109,10 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   param :content_view_id, :identifier, :desc => N_("content view identifier")
   param :id, :identifier, :desc => N_("filter identifier"), :required => true
   def available_package_groups
-    current_ids = @filter.package_group_rules.map(&:name)
-    repo_ids = @filter.applicable_repos.pluck(:pulp_id)
+    current_ids = @filter.package_group_rules.map(&:uuid)
+    repo_ids = @filter.applicable_repos.select([:pulp_id, "#{Katello::Repository.table_name}.name"])
     search_filters = [{ :terms => { :repo_id => repo_ids } },
-                      { :not => { :terms => { :name => current_ids } } }]
+                      { :not => { :terms => { :id => current_ids } } }]
 
     options = sort_params
     options[:filters] = search_filters

--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -30,7 +30,7 @@ class Api::V2::PackageGroupsController < Api::V2::ApiController
     collection = if @repo && !@repo.puppet?
                    filter_by_repo_id @repo.pulp_id
                  elsif @filter
-                   filter_by_name @filter.package_group_rules.map(&:name)
+                   filter_by_content_view_filter @filter
                  else
                    filter_by_repo_id
                  end
@@ -48,9 +48,11 @@ class Api::V2::PackageGroupsController < Api::V2::ApiController
 
   private
 
-  def filter_by_name(names)
+  def filter_by_content_view_filter(filter)
+    ids = filter.package_group_rules.map(&:uuid)
+    repo_ids = filter.applicable_repos.select([:pulp_id, "#{Katello::Repository.table_name}.name"])
     options = sort_params
-    options[:filters] = [{ :terms => { :name => names } }]
+    options[:filters] = [{ :terms => { :id => ids } }, { :terms => { :repo_id => repo_ids } }]
     item_search(PackageGroup, params, options)
   end
 

--- a/app/models/katello/content_view_package_group_filter.rb
+++ b/app/models/katello/content_view_package_group_filter.rb
@@ -20,8 +20,8 @@ class ContentViewPackageGroupFilter < ContentViewFilter
            :class_name => "Katello::ContentViewPackageGroupFilterRule"
 
   def generate_clauses(repo)
-    package_group_ids = package_group_rules.reject{ |rule| rule.name.blank? }.flat_map do |rule|
-      PackageGroup.legacy_search(rule.name, 0, 0, [repo.pulp_id]).map(&:package_group_id).compact
+    package_group_ids = package_group_rules.reject{ |rule| rule.uuid.blank? }.flat_map do |rule|
+      PackageGroup.legacy_search(rule.uuid, 0, 0, [repo.pulp_id], [:name_sort, "asc"], 'id').map(&:package_group_id).compact
     end
     { "id" => { "$in" => package_group_ids } } unless package_group_ids.empty?
   end

--- a/app/models/katello/content_view_package_group_filter_rule.rb
+++ b/app/models/katello/content_view_package_group_filter_rule.rb
@@ -21,6 +21,6 @@ module Katello
                :inverse_of => :package_group_rules,
                :foreign_key => :content_view_filter_id
 
-    validates :name, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
+    validates :uuid, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
   end
 end

--- a/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
@@ -3,6 +3,7 @@ object @resource
 extends 'katello/api/v2/common/identifier'
 
 attributes :content_view_filter_id
+attributes :uuid, :if => lambda { |rule| rule.respond_to?(:uuid) && !rule.uuid.blank? }
 attributes :version, :if => lambda { |rule| rule.respond_to?(:version) && !rule.version.blank? }
 attributes :min_version, :if => lambda { |rule| rule.respond_to?(:min_version) && !rule.min_version.blank? }
 attributes :max_version, :if => lambda { |rule| rule.respond_to?(:max_version) && !rule.max_version.blank? }

--- a/app/views/katello/api/v2/package_groups/show.json.rabl
+++ b/app/views/katello/api/v2/package_groups/show.json.rabl
@@ -9,3 +9,16 @@ attributes :default_package_names
 attributes :mandatory_package_names
 attributes :conditional_package_names
 attributes :optional_package_names
+
+node :repository do |package_group|
+  if repo = Katello::Repository.where(:pulp_id => package_group.repo_id).first
+    {
+        :id => repo.id,
+        :name => repo.name,
+        :product => {
+            :id => repo.product.id,
+            :name => repo.product.name
+        }
+    }
+  end
+end

--- a/db/migrate/20140610170142_add_uuid_to_content_view_package_group_filter_rule.rb
+++ b/db/migrate/20140610170142_add_uuid_to_content_view_package_group_filter_rule.rb
@@ -1,0 +1,5 @@
+class AddUuidToContentViewPackageGroupFilterRule < ActiveRecord::Migration
+  def change
+    add_column :katello_content_view_package_group_filter_rules, :uuid, :string
+  end
+end

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-package-group-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-package-group-filter.controller.js
@@ -40,10 +40,10 @@ angular.module('Bastion.content-views').controller('AvailablePackageGroupFilterC
         nutupane.table.closeItem = function () {};
 
         $scope.addPackageGroups = function (filter) {
-            var packageGroupNames = nutupane.getAllSelectedResults('name').included.ids;
+            var packageGroups = nutupane.getAllSelectedResults().included.resources;
 
-            angular.forEach(packageGroupNames, function (name) {
-                var rule = new Rule({name: name});
+            angular.forEach(packageGroups, function (group) {
+                var rule = new Rule({uuid: group.id, name: group.name});
                 saveRule(rule, filter);
             });
         };
@@ -55,7 +55,7 @@ angular.module('Bastion.content-views').controller('AvailablePackageGroupFilterC
         }
 
         function success(rule) {
-            nutupane.removeRow(rule.name, 'name');
+            nutupane.removeRow(rule.uuid, 'id');
             $scope.successMessages = [translate('Package Group successfully added.')];
         }
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-group-list-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-group-list-filter.controller.js
@@ -40,10 +40,10 @@ angular.module('Bastion.content-views').controller('PackageGroupFilterListContro
         nutupane.table.closeItem = function () {};
 
         $scope.removePackageGroups = function () {
-            var packageGroupNames = nutupane.getAllSelectedResults('name').included.ids,
+            var packageGroupIds = nutupane.getAllSelectedResults().included.ids,
                 rules;
 
-            rules = findRules(packageGroupNames);
+            rules = findRules(packageGroupIds);
 
             angular.forEach(rules, function (rule) {
                 rule.$delete(success, failure);
@@ -51,7 +51,7 @@ angular.module('Bastion.content-views').controller('PackageGroupFilterListContro
         };
 
         function success(rule) {
-            nutupane.removeRow(rule.name, 'name');
+            nutupane.removeRow(rule.uuid, 'id');
             $scope.successMessages = [translate('Package Group successfully removed.')];
         }
 
@@ -59,14 +59,14 @@ angular.module('Bastion.content-views').controller('PackageGroupFilterListContro
             $scope.errorMessages = [response.data.displayMessage];
         }
 
-        function findRules(packageGroupNames) {
+        function findRules(packageGroupIds) {
             var rules = [];
 
-            angular.forEach(packageGroupNames, function (id) {
+            angular.forEach(packageGroupIds, function (id) {
                 var found;
 
                 found = _.find($scope.filter.rules, function (rule) {
-                    return (rule.name === id);
+                    return (rule.uuid === id);
                 });
 
                 if (found) {

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter-details.html
@@ -22,6 +22,8 @@
       <thead>
         <tr alch-table-head row-select>
           <th alch-table-column>{{ "Name" | translate }}</th>
+          <th alch-table-column>{{ "Product" | translate }}</th>
+          <th alch-table-column>{{ "Repository" | translate }}</th>
           <th alch-table-column>{{ "Description" | translate }}</th>
         </tr>
       </thead>
@@ -29,6 +31,8 @@
       <tbody>
         <tr alch-table-row ng-repeat="packageGroup in detailsTable.rows" row-select="packageGroup">
           <td alch-table-cell>{{ packageGroup.name }}</td>
+          <td alch-table-cell>{{ packageGroup.repository.product.name }}</td>
+          <td alch-table-cell>{{ packageGroup.repository.name }}</td>
           <td alch-table-cell>{{ packageGroup.description }}</td>
         </tr>
       </tbody>

--- a/engines/bastion/test/content-views/details/filters/available-package-group-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/available-package-group-filter.controller.test.js
@@ -23,7 +23,7 @@ describe('Controller: AvailablePackageGroupFilterController', function() {
             Nutupane = function() {
                 this.table = {};
                 this.getAllSelectedResults = function () {
-                    return {included: {ids: ['packageGroup']}};
+                    return {included: {resources: ['packageGroup']}};
                 };
                 this.removeRow = function (item, field) {
                     return true;
@@ -49,7 +49,7 @@ describe('Controller: AvailablePackageGroupFilterController', function() {
         expect($scope.detailsTable).toBeDefined();
     });
 
-    it("should provide a method to add errata to the filter", function () {
+    it("should provide a method to add package groups to the filter", function () {
         $scope.addPackageGroups($scope.filter);
 
         expect($scope.successMessages.length).toBe(1);

--- a/engines/bastion/test/content-views/details/filters/package-group-list-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/package-group-list-filter.controller.test.js
@@ -24,7 +24,7 @@ describe('Controller: PackageGroupFilterListController', function() {
             Nutupane = function() {
                 this.table = {};
                 this.getAllSelectedResults = function () {
-                    return {included: {ids: ['packageGroup']}};
+                    return {included: {ids: ['9d288c85-1d40-4545-b88d-a11ac30cea93']}};
                 };
                 this.removeRow = function (item, field) {
                     return true;
@@ -34,7 +34,7 @@ describe('Controller: PackageGroupFilterListController', function() {
         $scope = $injector.get('$rootScope').$new();
         $scope.filter = Filter({id: 1});
         $scope.filter.rules = [
-            {id: 1, name: 'packageGroup'}
+            {id: 1, name: 'packageGroup', uuid: '9d288c85-1d40-4545-b88d-a11ac30cea93'}
         ];
 
         Rule = $injector.get('MockResource').$new();
@@ -44,7 +44,7 @@ describe('Controller: PackageGroupFilterListController', function() {
             translate: translate,
             Filter: Filter,
             Rule: Rule,
-            Nutupane: Nutupane,
+            Nutupane: Nutupane
         });
     }));
 
@@ -52,7 +52,7 @@ describe('Controller: PackageGroupFilterListController', function() {
         expect($scope.detailsTable).toBeDefined();
     });
 
-    it("should provide a method to remove errata to the filter", function () {
+    it("should provide a method to remove package groups from the filter", function () {
         $scope.removePackageGroups($scope.filter);
 
         expect($scope.successMessages.length).toBe(1);

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -60,7 +60,8 @@ class Api::V2::PackageGroupsControllerTest < ActionController::TestCase
   end
 
   def test_show
-    PackageGroup.expects(:find).once.returns(mock({}))
+    Repository.stubs(:where).returns([])
+    PackageGroup.expects(:find).once.returns(OpenStruct.new({ :repo_id => @repo.pulp_id }))
     get :show, :repository_id => @repo.id, :id => "3805853f-5cae-4a4a-8549-0ec86410f58f"
 
     assert_response :success

--- a/test/factories/content_view_filter_rule_factory.rb
+++ b/test/factories/content_view_filter_rule_factory.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
   factory :katello_content_view_package_group_filter_rule,
           :class => Katello::ContentViewPackageGroupFilterRule do
     sequence(:name) { |n| "package group #{n}"}
+    sequence(:uuid) { |n| "3805853f-5cae-4a4a-8549-0ec86410f#{n}"}
   end
 
   factory :katello_content_view_erratum_filter_rule,

--- a/test/models/content_view_package_group_filter_rule_test.rb
+++ b/test/models/content_view_package_group_filter_rule_test.rb
@@ -32,17 +32,17 @@ class ContentViewPackageGroupFilterRuleTest < ActiveSupport::TestCase
     refute_empty ContentViewPackageGroupFilterRule.where(:id => @rule)
   end
 
-  def test_without_name
+  def test_without_uuid
     assert_raises(ActiveRecord::RecordInvalid) do
-      @rule.name = nil
+      @rule.uuid = nil
       @rule.save!
     end
   end
 
-  def test_with_duplicate_name
+  def test_with_duplicate_uuid
     @rule.save!
     attrs = FactoryGirl.attributes_for(:katello_content_view_package_group_filter_rule,
-                                       :name => @rule.name)
+                                       :uuid => @rule.uuid)
 
     assert_raises(ActiveRecord::RecordInvalid) do
       ContentViewPackageGroupFilterRule.create!(attrs)


### PR DESCRIPTION
The current logic for package group filters does not properly handle the
case where a content view has multiple repositories with the same or overlapping
package groups (e.g. 2 repos w/ package group named X).  The issue is that
the package group selection is based upon name; however, it needs to be more
specific than that.

This commit updates the package group filtering to not identify the group
by name, but instead by the pulp id/uuid for the group.  This way when
a user selects a group, they are choosing a specific one from a specific
product/repo.

The following are high-level changes introduced with this commit:
1. add uuid to the content_view_package_group_filter_rule
2. update the API and UI to show the product and repo name that
   each package group is associated with
3. update API and UI to behave correctly when a user adds/removes
   package groups from a filter
4. update the publishing logic to utilize the package group uuid
   when applying the filter
