### PR TITLE
Fixes #6171: Remove nil UUIDs when generating content host list.

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -66,7 +66,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
   def index
     filters = []
 
-    uuids = System.readable.pluck(:uuid)
+    uuids = System.readable.pluck(:uuid).compact
     filters << {:terms => {:uuid => uuids}}
 
     if params[:organization_id]


### PR DESCRIPTION
The presence of nil UUIDs will cause ElasticSearch to fail when fetching
and thus no content hosts will be returned when hitting the index API method.
Content hosts with nil UUIDs can occur when an error occurs in a backend
system during content host registration.
