### PR TITLE
Fixes #6174/BZ 1020808 - ensure host advanced info link is displayed.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-details-info.controller.js
@@ -44,7 +44,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
 
         $scope.environments = Organization.readableEnvironments({id: CurrentOrganization});
 
-        $scope.$on('contentHost.loaded', function () {
+        $scope.contentHost.$promise.then(function () {
             $scope.contentHostFacts = dotNotationToObj($scope.contentHost.facts);
             populateExcludedFacts();
             $scope.originalEnvironment = $scope.contentHost.environment;

--- a/engines/bastion/test/content-hosts/details/content-host-details-info.controller.test.js
+++ b/engines/bastion/test/content-hosts/details/content-host-details-info.controller.test.js
@@ -72,17 +72,6 @@ describe('Controller: ContentHostDetailsInfoController', function() {
             return deferred.promise;
         };
 
-        $controller('ContentHostDetailsInfoController', {
-            $scope: $scope,
-            $q: $q,
-            translate: translate,
-            CustomInfo: CustomInfo,
-            ContentHost: ContentHost,
-            ContentView: ContentView,
-            Organization: Organization,
-            CurrentOrganization: 'ACME_Corporation'
-        });
-
         $scope.contentHost = new ContentHost({
             uuid: 2,
             facts: {
@@ -95,7 +84,18 @@ describe('Controller: ContentHostDetailsInfoController', function() {
                 id: 1
             }
         });
-        $scope.$broadcast('contentHost.loaded');
+        $scope.contentHost.$promise = {then: function (callback) { callback(); }};
+
+        $controller('ContentHostDetailsInfoController', {
+            $scope: $scope,
+            $q: $q,
+            translate: translate,
+            CustomInfo: CustomInfo,
+            ContentHost: ContentHost,
+            ContentView: ContentView,
+            Organization: Organization,
+            CurrentOrganization: 'ACME_Corporation'
+        });
     }));
 
     it("gets the available release versions and puts them on the $scope", function() {


### PR DESCRIPTION
The problem was that the event 'contentHost.loaded' only fired upon
the first visit to this page.  Using the $promise instead results
in the advanced info link being displayed each time.

http://projects.theforeman.org/issues/6174
https://bugzilla.redhat.com/show_bug.cgi?id=1020808
