### PR TITLE
Fixes #4964, #4963: Product json incorrectly grabbed all repositories.

### DIFF
--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -22,7 +22,7 @@ node :repository_count do |product|
   end
 end
 
-child :repositories => :library_repositories do
+child :library_repositories => :repositories do |repo|
     extends 'katello/api/v2/repositories/show'
 end
 


### PR DESCRIPTION
The products rabl view switched the order of the node name and the
scope to grab the data. Instead of calling 'library_repositories' and
setting that equal to a 'repository' node in the JSON output, the view
was getting all repositories and placing them at a library_repositories
node. The consequences of this were that attempting to fetch a product
list while a content view publish is occurring means that repositories
outside the default content view are attempted to have their sync status
checked before they ever exist in Pulp.
