### PR TITLE
Fixes #6176,BZ1103492: Improving interaction of content view errata id f...

### DIFF
--- a/app/models/katello/glue/elastic_search/errata.rb
+++ b/app/models/katello/glue/elastic_search/errata.rb
@@ -58,7 +58,8 @@ module Glue::ElasticSearch::Errata
               :severity     => { :type => 'string', :analyzer => :kt_name_analyzer},
               :type         => { :type => 'string', :analyzer => :kt_name_analyzer},
               :title        => { :type => 'string', :analyzer => :title_analyzer},
-              :issued       => { :type => 'date'}
+              :issued       => { :type => 'date'},
+              :issued_sort  => { :type => 'date', :index => :not_analyzed}
             }
           }
         }
@@ -78,7 +79,8 @@ module Glue::ElasticSearch::Errata
           :errata_id_exact => self.errata_id,
           :errata_id_sort => self.errata_id,
           :id_title => self.errata_id + ' : ' + self.title,
-          :issued => self.issued.split[0]
+          :issued => self.issued.split[0],
+          :issued_sort => self.issued.split[0]
         }
       end
 
@@ -236,6 +238,16 @@ module Glue::ElasticSearch::Errata
         end
 
         search.results
+      end
+
+      def self.filters(params)
+        search_filters = []
+        search_filters << {:terms => {:repoids => params[:repo_ids]}} if params[:repo_ids]
+        search_filters << {:terms => {:type => params[:types]}} if params[:types]
+        search_filters << {:terms => {:type => params['types[]']}} if params['types[]']
+        search_filters << {:range => {:issued => {'gte' => params[:start_date]}}} if params[:start_date]
+        search_filters << {:range => {:issued => {'lte' => params[:end_date]}}} if params[:end_date]
+        search_filters
       end
 
     end

--- a/app/models/katello/glue/elastic_search/items.rb
+++ b/app/models/katello/glue/elastic_search/items.rb
@@ -92,6 +92,7 @@ module Glue
           sort {by sort_by, sort_order.to_s.downcase } if sort_by && sort_order
 
           fields [:id] if search_options[:load_records?]
+          fields search_options[:fields] if search_options[:fields]
 
           filter :and, filters if filters.any?
 

--- a/app/views/katello/api/v2/errata/index.json.rabl
+++ b/app/views/katello/api/v2/errata/index.json.rabl
@@ -3,5 +3,5 @@ object false
 extends "katello/api/v2/common/metadata"
 
 child @collection[:results] => :results do
-  extends 'katello/api/v2/errata/_attributes'
+  extends 'katello/api/v2/errata/show'
 end

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter-list.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter-list.controller.js
@@ -30,20 +30,21 @@ angular.module('Bastion.content-views').controller('ErrataFilterListController',
     function ($scope, translate, Nutupane, Filter, Rule) {
         var nutupane;
 
-        nutupane = new Nutupane(Filter, {
-                filterId:     $scope.$stateParams.filterId,
-                'sort_by':    'errata_id',
-                'sort_order': 'DESC'
+        $scope.nutupane = nutupane = new Nutupane(Filter, {
+                filterId: $scope.$stateParams.filterId,
+                'sort_order': 'DESC',
+                'sort_by': 'issued'
             },
             'errata'
         );
 
-        $scope.errataTable = nutupane.table;
+        $scope.detailsTable = nutupane.table;
 
         $scope.removeErrata = function () {
             var errataIds = nutupane.getAllSelectedResults('errata_id').included.ids,
                 rules;
 
+            nutupane.table.working = true;
             rules = findRules(errataIds);
 
             angular.forEach(rules, function (rule) {

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter.controller.js
@@ -77,5 +77,14 @@ angular.module('Bastion.content-views').controller('ErrataFilterController',
             $scope.date.startOpen = true;
             $scope.date.endOpen = false;
         };
+
+        $scope.onlySelected = function (object, type) {
+            var selected = _.filter(object, function (value) {
+                return value;
+            });
+
+            return object[type] && (selected.length === 1);
+        };
+
     }]
 );

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/date-type-errata.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/date-type-errata.html
@@ -1,16 +1,35 @@
 <div alch-form-group label="{{ 'Errata Type' | translate }}">
+
   <label class="checkbox-inline">
-    <input type="checkbox" ng-model="types.security" ng-change="updateTypes(types)"/>
+    <input type="checkbox"
+           name="types"
+           value="{{ types.security }}"
+           ng-model="types.security"
+           ng-change="updateTypes(types)"
+           ng-disabled="onlySelected(types, 'security')"/>
     <span translate>Security</span>
   </label>
+
   <label class="checkbox-inline">
-    <input type="checkbox" ng-model="types.enhancement" ng-change="updateTypes(types)"/>
+    <input type="checkbox"
+           name="types"
+           value="{{ types.enhancement }}"
+           ng-model="types.enhancement"
+           ng-change="updateTypes(types)"
+           ng-disabled="onlySelected(types, 'enhancement')"/>
     <span translate>Enhancement</span>
   </label>
+
   <label class="checkbox-inline">
-    <input type="checkbox" ng-model="types.bugfix" ng-change="updateTypes(types)"/>
+    <input type="checkbox"
+           name="types"
+           value="{{ types.bugfix }}"
+           ng-model="types.bugfix"
+           ng-change="updateTypes(types)"
+           ng-disabled="onlySelected(types, 'bugfix')"/>
     <span translate>Bugfix</span>
   </label>
+
 </div>
 
 <div alch-form-group label="{{ 'Start Date' | translate }}">

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/errata-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/errata-filter-details.html
@@ -4,46 +4,49 @@
   </form>
 </div>
 
-<div class="col-sm-12">
-  <button class="btn btn-primary fr"
-          ng-show="isState('content-views.details.filters.details.erratum.list') && permitted('edit_content_views', contentView)"
-          ng-click="removeErrata(contentView)">
-    <i class="icon-trash"></i>
-    <span translate>Remove Errata</span>
-  </button>
-  <button class="btn btn-primary fr"
-          ng-show="isState('content-views.details.filters.details.erratum.available') && permitted('edit_content_views', contentView)"
-          ng-click="addErrata(filter)">
-    <i class="icon-plus"></i>
-    <span translate>Add Errata</span>
-  </button>
-</div>
+<div data-extend-template="layouts/details-nutupane.html">
 
-<div alch-table="errataTable" class="nutupane">
-  <div alch-infinite-scroll="errataTable.nextPage()" data="errataTable.rows">
+  <div data-block="header"></div>
 
-    <table class="table table-bordered table-striped">
-      <thead>
-        <tr alch-table-head row-select>
-          <th class="col-sm-2" alch-table-column translate>Errata ID</th>
-          <th class="col-sm-2" alch-table-column translate>Errata Type</th>
-          <th class="col-sm-2" alch-table-column translate>Issued</th>
-          <th alch-table-column translate>Title</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr alch-table-row ng-repeat="errata in errataTable.rows | filter:errataFilter" row-select="errata">
-          <td alch-table-cell>{{ errata.errata_id }}</td>
-          <td alch-table-cell>
-            {{ errata.type }}
-          </td>
-          <td alch-table-cell>
-            {{ errata.issued | date:'M/d/yy' }}
-          </td>
-          <td alch-table-cell>{{ errata.title }}</td>
-        </tr>
-      </tbody>
-    </table>
+  <div data-block="actions">
+    <button class="btn btn-primary fr"
+            ng-show="isState('content-views.details.filters.details.erratum.list') && permitted('edit_content_views', contentView)"
+            ng-disabled="detailsTable.working"
+            ng-click="removeErrata(contentView)">
+      <i class="icon-trash"></i>
+      <span translate>Remove Errata</span>
+    </button>
+    <button class="btn btn-primary fr"
+            ng-show="isState('content-views.details.filters.details.erratum.available') && permitted('edit_content_views', contentView)"
+            ng-disabled="detailsTable.working"
+            ng-click="addErrata(filter)">
+      <i class="icon-plus"></i>
+      <span translate>Add Errata</span>
+    </button>
   </div>
+
+  <table data-block="table" class="table table-bordered table-striped">
+    <thead>
+      <tr alch-table-head row-select>
+        <th alch-table-column translate>Errata ID</th>
+        <th alch-table-column translate>Errata Type</th>
+        <th alch-table-column translate>Issued</th>
+        <th alch-table-column translate>Title</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr alch-table-row ng-repeat="errata in detailsTable.rows" row-select="errata">
+        <td alch-table-cell>{{ errata.errata_id }}</td>
+        <td alch-table-cell>
+          {{ errata.type }}
+        </td>
+        <td alch-table-cell>
+          {{ errata.issued | date:'M/d/yy' }}
+        </td>
+        <td alch-table-cell>{{ errata.title }}</td>
+      </tr>
+    </tbody>
+  </table>
+
 </div>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/errata-filter.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/errata-filter.html
@@ -2,8 +2,6 @@
 
 <div class="details details-full">
   
-  <div data-block="messages" alch-alert success-messages="successMessages" error-messages="errorMessages"></div>
-
   <nav>
     <ul class="nav nav-tabs">
       <li ng-if="!filter.rules[0].types" ng-class="{active: isState('content-views.details.filters.details.erratum.list')}">

--- a/engines/bastion/app/assets/javascripts/bastion/incubator/alch-infinite-scroll.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/incubator/alch-infinite-scroll.directive.js
@@ -42,7 +42,7 @@ angular.module('alchemy').directive('alchInfiniteScroll', [function () {
 
             $element.bind('scroll', function () {
                 var sliderPosition = raw.scrollTop + raw.offsetHeight;
-                if (sliderPosition > 0 && sliderPosition >= raw.scrollHeight) {
+                if (sliderPosition > 0 && sliderPosition >= raw.scrollHeight - 1) {
                     $scope.loadMoreFunction();
                 }
             });

--- a/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -1,8 +1,4 @@
 <section>
-  <div data-block="pane-loading" class="loading-mask loading-mask-panel" ng-show="detailsTable.working">
-    <i class="icon-spinner icon-spin"></i>
-    {{ "Loading..." | translate }}
-  </div>
   <div data-block="messages" alch-alert success-messages="successMessages" error-messages="errorMessages"></div>
 
   <h4>
@@ -25,11 +21,16 @@
       </div>
     </div>
 
-    <div class="col-sm-3 nutupane-info">
-      <span data-block="result-count" translate>Showing {{ detailsTable.rows.length }} of {{ detailsTable.resource.subtotal }} ({{ detailsTable.resource.total }} Total)</span>
+    <div class="col-sm-3">
+      <span class="nutupane-info" data-block="result-count" translate>Showing {{ detailsTable.rows.length }} of {{ detailsTable.resource.subtotal }} ({{ detailsTable.resource.total }} Total)</span>
     </div>
 
-    <div class="col-sm-5 fr">
+    <div class="col-sm-2" ng-show="detailsTable.working">
+      <i class="icon-spinner icon-spin"></i>
+      <span translate>Working...</span>
+    </div>
+
+    <div class="col-sm-4 fr">
       <div class="fr">
         <span class="nutupane-info fl" data-block="selection-summary">
           <span translate>{{ detailsTable.numSelected }} Selected</span>
@@ -51,13 +52,21 @@
   </div>
 
   <div class="nutupane" alch-table="detailsTable" nutupane-table>
-    <div class="loading-mask" ng-show="detailsTable.refreshing">
-      <i class="icon-spinner icon-spin"></i>
-    </div>
 
     <div alch-container-scroll control-width="detailsTable" alch-infinite-scroll="detailsTable.nextPage()" 
-           data="detailsTable.rows" skip-initial-load="!detailsTable.initialLoad">
-      <div data-block="table" ui-view="table"></div>
+         data="detailsTable.rows" skip-initial-load="!detailsTable.initialLoad">
+
+      <div class="nutupane-select-all" ng-show="detailsTable.selectAllResultsEnabled && detailsTable.allSelected() && !detailsTable.allResultsSelected">
+        <span translate>All {{ detailsTable.rows.length }} items on this page are selected.</span>
+        <a ng-click="detailsTable.selectAllResults(true)" translate>Select all {{ detailsTable.resource.subtotal }}.</a>
+      </div>
+
+      <div class="nutupane-select-all-selected" ng-show="detailsTable.selectAllResultsEnabled && detailsTable.allResultsSelected">
+        <span translate>{{ detailsTable.allResultsSelectCount() }} results are selected.</span>
+        <a ng-click="detailsTable.selectAllResults(false)" translate>Deselect all</a>
+      </div>
+
+      <div data-block="table"></div>
     </div>
   </div>
 

--- a/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
@@ -124,6 +124,10 @@ angular.module('Bastion.widgets').factory('Nutupane',
                 params = newParams;
             };
 
+            self.addParam = function (param, value) {
+                params[param] = value;
+            };
+
             self.searchTransform = function (term) {
                 return term;
             };
@@ -172,7 +176,8 @@ angular.module('Bastion.widgets').factory('Nutupane',
                     included: {
                         ids: [],
                         resources: [],
-                        search: null
+                        search: null,
+                        params: params
                     },
                     excluded: {
                         ids: []

--- a/engines/bastion/test/content-views/details/filters/available-errata-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/available-errata-filter.controller.test.js
@@ -21,6 +21,8 @@ describe('Controller: AvailableErrataFilterController', function() {
             Filter = $injector.get('MockResource').$new(),
             translate = $injector.get('translateMock'),
             Nutupane = function() {
+                var params = {};
+
                 this.table = {};
                 this.getAllSelectedResults = function () {
                     return {included: {ids: [1]}};
@@ -28,6 +30,15 @@ describe('Controller: AvailableErrataFilterController', function() {
                 this.removeRow = function (item, field) {
                     return true;
                 };
+                this.enableSelectAllResults = function () {};
+                this.table.selectAllResults = function () {};
+                this.refresh = function () {};
+                this.addParam = function (key, value) {
+                    params[key] = value;
+                }
+                this.getParam = function (key) {
+                    return params[key];
+                }
             };
 
         Rule = $injector.get('MockResource').$new();
@@ -35,6 +46,7 @@ describe('Controller: AvailableErrataFilterController', function() {
 
         $scope = $injector.get('$rootScope').$new();
         $scope.filter = Filter({id: 1});
+        $scope.rule = {};
 
         $controller('AvailableErrataFilterController', {
             $scope: $scope,
@@ -46,13 +58,46 @@ describe('Controller: AvailableErrataFilterController', function() {
     }));
 
     it("puts a table object on the scope", function() {
-        expect($scope.errataTable).toBeDefined();
+        expect($scope.detailsTable).toBeDefined();
     });
 
     it("should provide a method to add errata to the filter", function () {
+        spyOn($scope.nutupane, 'refresh');
+        spyOn($scope.nutupane.table, 'selectAllResults');
         $scope.addErrata($scope.filter);
 
         expect($scope.successMessages.length).toBe(1);
+        expect($scope.nutupane.refresh).toHaveBeenCalled();
+        expect($scope.nutupane.table.selectAllResults).toHaveBeenCalledWith(false);
+    });
+
+    it("should provide a method to update the errata based on type", function () {
+        spyOn($scope.nutupane, 'refresh');
+        $scope.updateTypes({'security': true, 'enhancement': false, 'bugfix': false});
+
+        expect($scope.nutupane.getParam('types[]')).toContain('security');
+        expect($scope.nutupane.getParam('types[]')).not.toContain('bugfix');
+        expect($scope.nutupane.refresh).toHaveBeenCalled();
+    });
+
+    it("should update the errata by start date", function () {
+        var date = new Date();
+        spyOn($scope.nutupane, 'refresh');
+        $scope.rule['start_date'] = date;
+        $scope.$digest();
+
+        expect($scope.nutupane.refresh).toHaveBeenCalled();
+        expect($scope.nutupane.getParam('start_date')).toBe(date.toISOString().split('T')[0]);
+    });
+
+    it("should update the errata by end date", function () {
+        var date = new Date();
+        spyOn($scope.nutupane, 'refresh');
+        $scope.rule['end_date'] = date;
+        $scope.$digest();
+
+        expect($scope.nutupane.refresh).toHaveBeenCalled();
+        expect($scope.nutupane.getParam('end_date')).toBe(date.toISOString().split('T')[0]);
     });
 
 });

--- a/engines/bastion/test/content-views/details/filters/errata-filter-list.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/errata-filter-list.controller.test.js
@@ -50,10 +50,10 @@ describe('Controller: ErrataFilterListController', function() {
     }));
 
     it("puts a table object on the scope", function() {
-        expect($scope.errataTable).toBeDefined();
+        expect($scope.detailsTable).toBeDefined();
     });
 
-    it("should provide a method to add errata to the filter", function () {
+    it("should provide a method to remove errata from the filter", function () {
         $scope.removeErrata($scope.filter);
 
         expect($scope.successMessages.length).toBe(1);

--- a/engines/bastion/test/content-views/details/filters/errata-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/errata-filter.controller.test.js
@@ -99,4 +99,13 @@ describe('Controller: ErrataFilterController', function() {
         expect($scope.errataFilter(errata)).toBe(true);
     });
 
+    it("should provide a method to check if an errata type is the only one selected", function () {
+        var selections = {enhancement: false, bugfix: false, security: true};
+
+        expect($scope.onlySelected(selections, 'security')).toBe(true);
+
+        selections = {enhancement: false, bugfix: false, security: false};
+        expect($scope.onlySelected(selections, 'bugfix')).toBe(false);
+    });
+
 });

--- a/engines/bastion/test/incubator/nutupane.factory.test.js
+++ b/engines/bastion/test/incubator/nutupane.factory.test.js
@@ -273,7 +273,7 @@ describe('Factory: Nutupane', function() {
         });
     });
 
-    describe("recognizes custom actions by", function() {
+    describe("Nutupane should", function() {
         beforeEach(function() {
             nutupane = new Nutupane(Resource, {}, 'customAction');
             nutupane.table.working = false;
@@ -281,7 +281,7 @@ describe('Factory: Nutupane', function() {
             nutupane.table.allSelected = function () {};
         });
 
-        it("providing a method to fetch records for the table", function() {
+        it("provide a method to fetch records for the table via a custom action", function() {
             spyOn(Resource, 'customAction');
             nutupane.query();
 
@@ -293,6 +293,12 @@ describe('Factory: Nutupane', function() {
             nutupane.table.search('*');
 
             expect($location.search()['customActionSearch']).toBe('*');
+        });
+
+        it("provide a method to add params", function () {
+            nutupane.addParam('test', 'ABC');
+
+            expect(nutupane.getParams()['test']).toBe('ABC');
         });
     });
 

--- a/test/glue/elasticsearch/items_test.rb
+++ b/test/glue/elasticsearch/items_test.rb
@@ -38,6 +38,7 @@ class GlueElasticSearchTest < ActiveSupport::TestCase
   def test_items
     @results.expect(:total, 0)
     @results.expect(:total, 0)
+    @results.expect(:subtotal, 0)
     @results.expect(:results, [])
     @results.expect(:facets, {})
 


### PR DESCRIPTION
...ilters.

The previous content view errata id filter would continously load
all errata in chunks in order to allow client side filtering. And,
while this worked for small errata sets, larger errata sets such as
RHEL 6.5 (2500ish errata) were unwieldy and led to confusion. This
change does the following:
- moves all type and date filtering server side
- enabled UI select all behavior to allow adding errata that is not
  currently visible client side\
- adds a new option to create errata id content view filter rules
  with a bulk set of errata or based on a search/param query
