### PR TITLE
Fixes #6198: API methods that load database records should request only ...

### DIFF
--- a/app/models/katello/glue/elastic_search/items.rb
+++ b/app/models/katello/glue/elastic_search/items.rb
@@ -91,7 +91,7 @@ module Glue
           end
           sort {by sort_by, sort_order.to_s.downcase } if sort_by && sort_order
 
-          fields [:id] if options[:load_records?]
+          fields [:id] if search_options[:load_records?]
 
           filter :and, filters if filters.any?
 


### PR DESCRIPTION
...ID field.

During creation of the API search service utility, the loading of
only ID field for records being loaded from the database was incorrectly
handled. This change corrects that mistake and provides sped-up loading
times. For example, in development, a 20 item content host list was reduced
by 2-3 seconds on average.
