### PR TITLE
fixes #6204 / BZ 1099016 - Fix gpg key on repo create and yum retrieval

### DIFF
--- a/app/lib/actions/candlepin/product/content_update.rb
+++ b/app/lib/actions/candlepin/product/content_update.rb
@@ -1,0 +1,39 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Candlepin
+    module Product
+      class ContentUpdate < Candlepin::Abstract
+        input_format do
+          param :content_id
+          param :name
+          param :type
+          param :label
+          param :content_url
+          param :gpg_key_url
+        end
+
+        def run
+          output[:response] = ::Katello::Resources::Candlepin::Content.
+              update(id: input[:content_id],
+                     name: input[:name],
+                     contentUrl: input[:content_url],
+                     gpgUrl: input[:gpg_key_url],
+                     type: input[:type],
+                     label: input[:label],
+                     vendor: ::Katello::Provider::CUSTOM)
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -162,7 +162,7 @@ class Repository < Katello::Model
       host = Katello.config.host
       port = Katello.config.port
       host += ":" + port.to_s unless port.blank? || port.to_s == "443"
-      gpg_key_content_api_repository_url(self, :host => host + Katello.config.url_prefix.to_s, :protocol => 'https')
+      gpg_key_content_api_repository_url(self, :host => host, :protocol => 'https')
     end
   end
 

--- a/test/actions/candlepin/product_test.rb
+++ b/test/actions/candlepin/product_test.rb
@@ -1,0 +1,34 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+class Actions::Candlepin::Product::ContentUpdateTest < ActiveSupport::TestCase
+  include Dynflow::Testing
+  include Support::Actions::RemoteAction
+
+  before do
+    stub_remote_user
+  end
+
+  describe 'ContentUpdate' do
+    let(:action_class) { ::Actions::Candlepin::Product::ContentUpdate }
+    let(:planned_action) do
+      create_and_plan_action action_class, id: 123
+    end
+
+    it 'runs' do
+      ::Katello::Resources::Candlepin::Content.expects(:update)
+      run_action planned_action
+    end
+  end
+end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -309,5 +309,20 @@ class Api::V2::RepositoriesControllerTest < ActionController::TestCase
     end
   end
 
+  def test_gpg_key_content
+    get :gpg_key_content, :id => @repository.id
+
+    assert_response :success
+    assert_equal @repository.gpg_key.content, response.body
+  end
+
+  def test_no_gpg_key_content
+    @repository.gpg_key = nil
+    @repository.save
+    get :gpg_key_content, :id => @repository.id
+
+    assert_response 404
+  end
+
 end
 end


### PR DESCRIPTION
This commit addresses 2 issues:
1. update the repo create to support associating the gpg key url
   in candlepin
2. update the v2 api to expose the 'gpg_key_content' api to enable
   yum clients to retrieve the key
