### PR TITLE
Fixes #6221: Content host errata and host collection bulk actions no lon...

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-errata.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-errata.controller.js
@@ -38,7 +38,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionErrata
         nutupane.table.closeItem = function () {};
         $scope.detailsTable = nutupane.table;
         $scope.detailsTable.errataFilterTerm = "";
-        $scope.detailsTable.skipInitialLoad = true;
+        $scope.detailsTable.initialLoad = false;
         $scope.outOfDate = false;
         $scope.initialLoad = true;
 
@@ -61,8 +61,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionErrata
             }
         };
 
-        $scope.$watch('nutupane.table.rows', function () {
-            if ($scope.initialLoad) {
+        $scope.$watch('nutupane.table.rows', function (rows) {
+            if ($scope.initialLoad && rows.length > 0) {
                 $scope.initialLoad = false;
                 $scope.fetchErrata();
             }

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.js
@@ -45,7 +45,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionHostCo
             'paged':            true
         };
 
-        hostCollectionNutupane = new Nutupane(HostCollection, params);
+        hostCollectionNutupane = new Nutupane(HostCollection, params, 'queryPaged');
 
         $scope.setState(false, [], []);
         $scope.detailsTable = hostCollectionNutupane.table;

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions.html
@@ -32,42 +32,37 @@
 
   <nav class="details-navigation">
     <ul>
-      <li>
+      <li ng-class="{active: isState('content-hosts.bulk-actions.packages')}">
         <a translate
-           ui-sref="content-hosts.bulk-actions.packages"
-           ng-class="{active: isState('content-hosts.bulk-actions.packages')}">
+           ui-sref="content-hosts.bulk-actions.packages">
           Packages
         </a>
       </li>
 
-      <li>
+      <li ng-class="{active: stateIncludes('content-hosts.bulk-actions.errata')}">
         <a translate
-           ui-sref="content-hosts.bulk-actions.errata.list"
-           ng-class="{active: stateIncludes('content-hosts.bulk-actions.errata')}">
+           ui-sref="content-hosts.bulk-actions.errata.list">
           Errata
         </a>
       </li>
 
-      <li>
+      <li ng-class="{active: isState('content-hosts.bulk-actions.host-collections')}">
         <a translate
-           ui-sref="content-hosts.bulk-actions.host-collections"
-           ng-class="{active: isState('content-hosts.bulk-actions.host-collections')}">
+           ui-sref="content-hosts.bulk-actions.host-collections">
           Host Collections
         </a>
       </li>
 
-      <li>
+      <li ng-class="{active: isState('content-hosts.bulk-actions.environment')}">
         <a translate
-           ui-sref="content-hosts.bulk-actions.environment"
-           ng-class="{active: isState('content-hosts.bulk-actions.environment')}">
+           ui-sref="content-hosts.bulk-actions.environment">
           Content Host Content
         </a>
       </li>
 
-      <li>
+      <li ng-class="{active: isState('content-hosts.bulk-actions.subscriptions')}">
         <a translate
-           ui-sref="content-hosts.bulk-actions.subscriptions"
-           ng-class="{active: isState('content-hosts.bulk-actions.subscriptions')}">
+           ui-sref="content-hosts.bulk-actions.subscriptions">
           Subscriptions
         </a>
       </li>

--- a/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -56,7 +56,7 @@
     </div>
 
     <div alch-container-scroll control-width="detailsTable" alch-infinite-scroll="detailsTable.nextPage()" 
-           data="detailsTable.rows" skip-initial-load="detailsTable.initialLoad">
+           data="detailsTable.rows" skip-initial-load="!detailsTable.initialLoad">
       <div data-block="table" ui-view="table"></div>
     </div>
   </div>

--- a/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
@@ -46,12 +46,14 @@ angular.module('Bastion.widgets').factory('Nutupane',
             var self = this;
             params = params || {};
 
+            self.searchKey = action ? action + 'Search' : 'search';
+
             self.table = {
                 action: action || 'queryPaged',
                 params: params,
                 resource: resource,
                 rows: [],
-                searchTerm: $location.search().search
+                searchTerm: $location.search()[self.searchKey]
             };
 
             // Set default resource values
@@ -203,7 +205,7 @@ angular.module('Bastion.widgets').factory('Nutupane',
             };
 
             self.table.search = function (searchTerm) {
-                $location.search('search', searchTerm);
+                $location.search(self.searchKey, searchTerm);
                 self.table.resource.page = 1;
                 self.table.rows = [];
                 self.table.closeItem();

--- a/engines/bastion/test/content-hosts/bulk/content-hosts-bulk-action-errata.controller.test.js
+++ b/engines/bastion/test/content-hosts/bulk/content-hosts-bulk-action-errata.controller.test.js
@@ -36,14 +36,22 @@ describe('Controller: ContentHostsBulkActionErrataController', function() {
 
     beforeEach(inject(function($controller, $rootScope, $q) {
         $scope = $rootScope.$new();
-        $scope.nutupane = {};
+        $scope.nutupane = {
+            table: {
+                rows: [{}],
+                numSelected: 5
+            }
+        };
         $scope.nutupane.getAllSelectedResults = function () { return selectedContentHosts }
         $scope.setState = function(){};
 
-        $scope.detailsTable = {};
+        $scope.detailsTable = {
+            rows: [],
+            numSelected: 5
+        };
 
         $scope.table = {
-            rows: [],
+            rows: [{}],
             numSelected: 5
         };
 
@@ -71,7 +79,7 @@ describe('Controller: ContentHostsBulkActionErrataController', function() {
         );
     });
 
-    it("Should fetch new errata on initial load", function () {
+    it("Should fetch new errata on initial load if there are initial items present", function () {
         $scope.initialLoad = true;
         spyOn($scope, 'fetchErrata');
         $scope.$apply();

--- a/engines/bastion/test/incubator/nutupane.factory.test.js
+++ b/engines/bastion/test/incubator/nutupane.factory.test.js
@@ -277,6 +277,8 @@ describe('Factory: Nutupane', function() {
         beforeEach(function() {
             nutupane = new Nutupane(Resource, {}, 'customAction');
             nutupane.table.working = false;
+            nutupane.table.closeItem = function () {};
+            nutupane.table.allSelected = function () {};
         });
 
         it("providing a method to fetch records for the table", function() {
@@ -284,6 +286,13 @@ describe('Factory: Nutupane', function() {
             nutupane.query();
 
             expect(Resource.customAction).toHaveBeenCalled();
+        });
+
+        it("naming the URL search field based off the action", function() {
+            spyOn(Resource, 'customAction');
+            nutupane.table.search('*');
+
+            expect($location.search()['customActionSearch']).toBe('*');
         });
     });
 


### PR DESCRIPTION
...ger 400.

Content host errata and host collection bulk actions when entered via host
collection links would throw 400 errors and display no results. This was due
in part to attempting to fetch errata without content hosts populated and
the parameter to disable initial errata loading incorrectly specified.

Also, this changes the way search works on nutupane instances by using
'search' as the default in the URL unless an action was supplied to Nutupane.
If the action is supplied, for example 'availableErrata', then the search term
becomes 'availableErrataSearch'. This has the effect of fixing the coupling
of multiple nutupane search boxes to one another.
