### PR TITLE
Fixes #6222 - Auto Enables dynflow console for dev mode

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -149,3 +149,5 @@ Role.without_auditing do
     create_filters(Role.find_by_name(role_name), permissions)
   end
 end
+
+Setting.find_by_name("dynflow_enable_console").update_attributes!(:value => true) if Rails.env.development?


### PR DESCRIPTION
After a Katello reset we'd ideally like dynflow foreman tasks console to
be enabled (instead of having to go to Settings -> Foreman Tasks ->
Enable Dynflow Console).
This commit enables that.
