### PR TITLE
Fixes #4045: Repository name and label validations properly handled.

### DIFF
--- a/app/lib/katello/validators/repository_unique_attribute_validator.rb
+++ b/app/lib/katello/validators/repository_unique_attribute_validator.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Validators
+    class RepositoryUniqueAttributeValidator < ActiveModel::EachValidator
+
+      def validate_each(record, attribute, value)
+        unique = !record.exist_for_environment?(record.environment, record.content_view, attribute)
+
+        if !unique && record.send("#{attribute}_changed?")
+          record.errors[attribute] << _("has already been taken for this product.")
+        end
+      end
+
+    end
+  end
+end

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -295,7 +295,6 @@ module Glue::Pulp::Repos
 
     def add_repo(label, name, url, repo_type, unprotected = false, gpg = nil)
       unprotected = unprotected.nil? ? false : unprotected
-      check_for_repo_conflicts(name, label)
 
       Repository.new(:environment => self.organization.library,
                      :product => self,
@@ -353,25 +352,6 @@ module Glue::Pulp::Repos
         async_tasks << repo.promote(from_env, to_env)
       end
       async_tasks.flatten(1)
-    end
-
-    def check_for_repo_conflicts(repo_name, repo_label)
-      is_dupe =  Repository.where(:name => repo_name,
-                                  :product_id => self.id,
-                                  :environment_id => self.library.id
-                                 ).count > 0
-      if is_dupe
-        fail Errors::ConflictException.new(_("Label has already been taken"))
-      end
-      unless repo_label.blank?
-        is_dupe =  Repository.where(:label => repo_label,
-                                    :product_id => self.id,
-                                    :environment_id => self.library.id
-                                   ).count > 0
-        if is_dupe
-          fail Errors::ConflictException.new(_("Label has already been taken"))
-        end
-      end
     end
 
   end

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/new/new-repository.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/new/new-repository.controller.js
@@ -53,9 +53,18 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
         function error(response) {
             $scope.working = false;
 
+            angular.forEach($scope.repositoryForm, function (value, field) {
+                if ($scope.repositoryForm.hasOwnProperty(field) && value.hasOwnProperty('$setValidity')) {
+                    value.$setValidity('server', true);
+                    $scope.repositoryForm[field].$error.messages = [];
+                }
+            });
+
             angular.forEach(response.data.errors, function (errors, field) {
-                $scope.repositoryForm[field].$setValidity('server', false);
-                $scope.repositoryForm[field].$error.messages = errors;
+                if ($scope.repositoryForm.hasOwnProperty(field)) {
+                    $scope.repositoryForm[field].$setValidity('server', false);
+                    $scope.repositoryForm[field].$error.messages = errors;
+                }
             });
         }
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -142,31 +142,6 @@ describe Product, :katello => true do
       end
     end
 
-    describe "add repo" do
-      before(:each) do
-        Resources::Candlepin::Product.stubs(:create).returns({:id => ProductTestData::PRODUCT_ID})
-        Resources::Candlepin::Content.stubs(:create).returns({:id => "123", :type=>'yum'})
-        Resources::Candlepin::Content.stubs(:update).returns({:id => "123", :type=>'yum'})
-        Resources::Candlepin::Content.stubs(:get).returns({:id => "123", :type=>'yum'})
-        Repository.any_instance.stubs(:generate_metadata)
-        @p = Product.create!(ProductTestData::SIMPLE_PRODUCT)
-      end
-
-      describe "when there is a repo with the same name for the product" do
-        before do
-          @repo_name = "repo"
-          @repo_label = "repo"
-          disable_repo_orchestration
-          @p.add_repo(@repo_label, @repo_name, "http://test/repo","yum").save!
-        end
-
-        it "should raise conflict error" do
-          lambda {@p.add_repo(@repo_label, @repo_name, "http://test/repo","yum")}.must_raise(
-              Errors::ConflictException)
-        end
-      end
-    end
-
     describe "when importing product from candlepin" do
 
       describe "marketing product" do

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -34,6 +34,32 @@ class RepositoryCreateTest < RepositoryTestBase
     refute_empty  Repository.where(:id=>@repo.id)
   end
 
+  def test_unique_repository_name_per_product_and_environment
+    @repo.save
+    @repo2 = build(:katello_repository,
+                   :environment => @repo.environment,
+                   :product => @repo.product,
+                   :content_view_version => @repo.content_view_version,
+                   :name => @repo.name,
+                   :label => 'Another Label'
+                  )
+
+    refute @repo2.valid?
+  end
+
+  def test_unique_repository_label_per_product_and_environment
+    @repo.save
+    @repo2 = build(:katello_repository,
+                   :environment => @repo.environment,
+                   :product => @repo.product,
+                   :content_view_version => @repo.content_view_version,
+                   :name => 'Another Name',
+                   :label => @repo.label
+                  )
+
+    refute @repo2.valid?
+  end
+
   def test_create_with_no_type
     @repo.content_type = ''
     assert_raises ActiveRecord::RecordInvalid do
@@ -111,9 +137,11 @@ class RepositoryInstanceTest < RepositoryTestBase
     assert @fedora_17_x86_64.promoted?
 
     repo = build(:katello_repository,
+                 :environment => @dev,
                  :content_view_version => @fedora_17_x86_64.content_view_version,
                  :product => @fedora_17_x86_64.product
                 )
+
     assert repo.valid?
     refute_nil repo.organization
     refute repo.promoted?


### PR DESCRIPTION
Repository name and label validation were being handled improperly
and without the same format as other model validations. This creates
and proper active record validators for each and provides a message
indicating to the user the scope of the validation (i.e. Product).
