### PR TITLE
Fixes #6242 - remove unused distributor from rabl to fix error.

### DIFF
--- a/app/views/katello/api/v2/subscriptions/show.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/show.json.rabl
@@ -46,11 +46,6 @@ end
 #   subscription.activation_keys.readable(current_organization).map { |key| {id: key.id, name: key.name} }
 # end
 
-node :distributors, :if => (params[:action] == "show") do |subscription|
-  current_organization = subscription.organization
-  subscription.distributors.readable(current_organization).map { |dist| {id: dist.id, name: dist.name} }
-end
-
 node :host, :if => lambda { |sub| sub && sub.host } do |subscription|
   {id: subscription.host.id, name: subscription.host.name}
 end


### PR DESCRIPTION
There was an HTTP 500 on subscription show if you were not admin
(or didn't have the distributor read permission) because distributor
was still referenced from the rabl.  This commit removes the reference.

http://projects.theforeman.org/issues/6242
