### PR TITLE
Fixes #6195, bz1109386 - 403 on cv version delete

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -69,11 +69,13 @@ module Katello
     end
 
     def authorize_promotable
-      deny_access unless @environment.promotable_or_removable? && @version.content_view.promotable_or_removable?
+      return deny_access unless @environment.promotable_or_removable? && @version.content_view.promotable_or_removable?
+      true
     end
 
     def authorize_destroy
-      deny_access unless @version.content_view.deletable?
+      return deny_access unless @version.content_view.deletable?
+      true
     end
   end
 end

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -12,14 +12,12 @@
 
 module Katello
   class Api::V2::ContentViewsController < Api::V2::ApiController
+    include Concerns::Authorization::Api::V2::ContentViewsController
     before_filter :find_content_view, :except => [:index, :create]
     before_filter :find_organization, :only => [:index, :create]
     before_filter :load_search_service, :only => [:index, :history, :available_puppet_modules,
                                                   :available_puppet_module_names]
     before_filter :find_environment, :only => [:index, :remove_from_environment]
-    before_filter :authorize_remove_from_environment, :only => [:remove_from_environment]
-    before_filter :authorize_remove, :only => [:remove]
-    before_filter :authorize_destroy, :only => [:destroy]
 
     wrap_parameters :include => (ContentView.attribute_names + %w(repository_ids component_ids))
 
@@ -211,95 +209,5 @@ module Katello
       return if !params.key?(:environment_id) && params[:action] == "index"
       @environment = KTEnvironment.find(params[:environment_id])
     end
-
-    def authorize_remove_from_environment
-      deny_access unless @environment.promotable_or_removable? && @view.promotable_or_removable?
-    end
-
-    def authorize_remove
-      options = params.slice(:system_content_view_id,
-                             :system_environment_id,
-                             :key_content_view_id,
-                             :key_environment_id,
-                             :content_view_version_ids,
-                             :environment_ids
-                            )
-      options = options.reject { |k, v| v.nil? }
-
-      content_view_version_ids = options[:content_view_version_ids]
-      unless content_view_version_ids.blank?
-        # If we are deleting versions from the archives then we need content view delete.
-        deny_access unless @view.deletable?
-      end
-      env_ids = options[:environment_ids]
-      authorize_remove_environments(options) unless env_ids.blank?
-
-      authorize_system_options(options)
-      authorize_activation_key_options(options)
-    end
-
-    def authorize_destroy
-      deny_access unless @view.deletable?
-    end
-
-    def authorize_system_options(options)
-      if options[:system_content_view_id]
-        sys_content_view = ContentView.where(:organization_id => @view.organization,
-                                          :id => options[:system_content_view_id]).first
-        fail HttpErrors::NotFound, _("Couldn't find content host content view id '%s'") % options[:system_content_view_id] unless sys_content_view
-        # deny if we cannot register systems to the new content view id
-        deny_access unless sys_content_view.readable?
-      end
-
-      if options[:system_environment_id]
-        sys_env = KTEnvironment.where(:organization_id => @view.organization,
-                                          :id => options[:system_environment_id]).first
-        fail HttpErrors::NotFound, _("Couldn't find content host environment '%s'") % options[:system_environment_id] unless sys_env
-        # deny if we cannot register systems to the new env id
-        deny_access unless sys_env.readable?
-      end
-    end
-
-    def authorize_activation_key_options(options)
-      if options[:key_content_view_id]
-        key_content_view = ContentView.where(:organization_id => @view.organization,
-                                          :id => options[:key_content_view_id]).first
-        fail HttpErrors::NotFound, _("Couldn't find activation key content view id '%s'") % options[:key_content_view_id] unless key_content_view
-        # deny if we cannot reassign keys to the new content view id
-        deny_access unless key_content_view.readable?
-      end
-
-      if options[:key_environment_id]
-        key_env = KTEnvironment.where(:organization_id => @view.organization,
-                                          :id => options[:key_environment_id]).first
-        fail HttpErrors::NotFound, _("Couldn't find activation key environment '%s'") % options[:key_environment_id] unless key_env
-        # deny if we cannot reassign keys to the new env id
-        deny_access unless key_env.readable?
-      end
-    end
-
-    def authorize_remove_environments(options)
-      env_ids = options[:environment_ids]
-      deny_access unless (env_ids - @view.environment_ids.map(&:to_s)).empty?
-      # If we are removing from the environments
-      # then we need to be sure that cv has the "remove" permission
-      # and also ensure that the environments have the remove permission
-      deny_access unless KTEnvironment.promotable.where(:id => env_ids).count == env_ids.size && @view.promotable_or_removable?
-
-      # if we are reassigning systems to a diffent environment or cv
-      # make sure the systems in existing environments are editable.
-      if options[:system_content_view_id] || options[:system_environment_id]
-        # deny if none of the systems listed here are editable
-        deny_access unless Katello::System.all_editable?(@view, env_ids)
-      end
-
-      # if we are reassigning activation key environments/ cv
-      # make sure the activation key using present environments or cv are editable.
-      if options[:key_content_view_id] || options[:key_environment_id]
-        # deny if none of the activation keys listed here are editable
-        deny_access unless Katello::ActivationKey.all_editable?(@view, env_ids)
-      end
-    end
-
   end
 end

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -400,7 +400,8 @@ class Api::V2::SystemsController < Api::V2::ApiController
   end
 
   def authorize_environment
-    deny_access unless @environment.readable?
+    return deny_access unless @environment.readable?
+    true
   end
 
 end

--- a/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
@@ -1,0 +1,163 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Concerns::Authorization::Api::V2::ContentViewsController
+    extend ActiveSupport::Concern
+
+    included do
+      before_filter :authorize_destroy, :only => [:destroy]
+      before_filter :authorize_remove_from_environment, :only => [:remove_from_environment]
+      before_filter :authorize_remove, :only => [:remove]
+    end
+
+    private
+
+    def authorize_destroy
+      view = find_content_view_for_authorization
+      if view.deletable?
+        true
+      else
+        deny_access
+      end
+    end
+
+    def authorize_remove_from_environment
+      view = find_content_view_for_authorization
+      environment = find_environment_for_authorization
+      if view.promotable_or_removable? && environment.promotable_or_removable?
+        true
+      else
+        deny_access
+      end
+    end
+
+    def authorize_remove
+      view = find_content_view_for_authorization
+      options = params.permit(:system_content_view_id,
+                              :system_environment_id,
+                              :key_content_view_id,
+                              :key_environment_id,
+                              :content_view_version_ids => [],
+                              :environment_ids => []
+                              )
+      options = options.reject { |k, v| v.blank? }
+
+      authorize_remove_versions(view, options) &&
+        authorize_remove_environments(view, options) &&
+        authorize_system_content_view(view, options) &&
+        authorize_system_environments(view, options) &&
+        authorize_activation_key_content_view(view, options) &&
+        authorize_activation_key_environments(view, options)
+    end
+
+    def authorize_remove_versions(view, options)
+      return true if options[:content_view_version_ids].blank?
+
+      # If we are deleting versions from the archives then we need content view delete.
+      if view.deletable?
+        true
+      else
+        deny_access
+      end
+    end
+
+    def authorize_system_content_view(view, options)
+      system_content_view_id = options[:system_content_view_id]
+      if system_content_view_id
+        sys_content_view = ContentView.where(:organization_id => view.organization,
+                                             :id => system_content_view_id).first
+        fail HttpErrors::NotFound, _("Couldn't find content host content view id '%s'") % system_content_view_id unless sys_content_view
+        # deny if we cannot register systems to the new content view id
+        return deny_access unless sys_content_view.readable?
+      end
+      true
+    end
+
+    def authorize_system_environments(view, options)
+      system_environment_id = options[:system_environment_id]
+      if system_environment_id
+        sys_env = KTEnvironment.where(:organization_id => view.organization,
+                                      :id => system_environment_id).first
+        fail HttpErrors::NotFound, _("Couldn't find content host environment '%s'") % system_environment_id unless sys_env
+        # deny if we cannot register systems to the new env id
+        return deny_access unless sys_env.readable?
+      end
+      true
+    end
+
+    def authorize_activation_key_content_view(view, options)
+      key_content_view_id = options[:key_content_view_id]
+      if key_content_view_id
+        key_content_view = ContentView.where(:organization_id => view.organization,
+                                             :id => key_content_view_id).first
+        fail HttpErrors::NotFound, _("Couldn't find activation key content view id '%s'") % key_content_view_id unless key_content_view
+        # deny if we cannot reassign keys to the new content view id
+        return deny_access unless key_content_view.readable?
+      end
+      true
+    end
+
+    def authorize_activation_key_environments(view, options)
+      key_environment_id = options[:key_environment_id]
+      if key_environment_id
+        key_env = KTEnvironment.where(:organization_id => view.organization,
+                                      :id => key_environment_id).first
+        fail HttpErrors::NotFound, _("Couldn't find activation key environment '%s'") % key_environment_id unless key_env
+        # deny if we cannot reassign keys to the new env id
+        return deny_access unless key_env.readable?
+      end
+      true
+    end
+
+    def authorize_remove_environments(view, options)
+      env_ids = options[:environment_ids]
+
+      return true if env_ids.blank?
+
+      return deny_access unless (env_ids.map(&:to_s) - view.environment_ids.map(&:to_s)).empty?
+      # If we are removing from the environments
+      # then we need to be sure that cv has the "remove" permission
+      # and also ensure that the environments have the remove permission
+      return deny_access unless KTEnvironment.promotable.where(:id => env_ids).count == env_ids.size && view.promotable_or_removable?
+
+      if Katello::System.where(:content_view_id => view, :environment_id => env_ids).count > 0
+        unless options[:system_content_view_id] && options[:system_environment_id]
+          fail _("Unable to reassign systems. Please provide system_content_view_id and system_environment_id.")
+        end
+
+        # if we are reassigning systems to a diffent environment or cv
+        # make sure all the systems in existing environments are editable.
+        return deny_access unless Katello::System.all_editable?(view, env_ids)
+      end
+
+      if Katello::ActivationKey.where(:content_view_id => view, :environment_id => env_ids).count > 0
+        # if we are reassigning activation key environments/ cv
+        # make sure the activation key using present environments or cv are editable.
+        unless options[:key_content_view_id] && options[:key_environment_id]
+          fail _("Unable to reassign activation_keys. Please provide key_content_view_id and key_environment_id.")
+        end
+        # deny if any of the activation keys belonging to the selected environments are not editable
+        return deny_access unless Katello::ActivationKey.all_editable?(view, env_ids)
+      end
+      true
+    end
+
+    def find_content_view_for_authorization
+      ContentView.find(params[:id])
+    end
+
+    def find_environment_for_authorization
+      KTEnvironment.find(params[:environment_id])
+    end
+  end
+end

--- a/app/models/katello/concerns/user_extensions.rb
+++ b/app/models/katello/concerns/user_extensions.rb
@@ -50,7 +50,7 @@ module Katello
         include Ext::IndexedModel
 
         include AsyncOrchestration
-        include Authorization::Enforcement
+        include Katello::Authorization::Enforcement
         include Katello::Authorization::UserAuthorization
         include Util::ThreadSession::UserModel
 


### PR DESCRIPTION
Content view remove call specifying versions and envs to be removed / unasssociated
had a minor glitch -> env_ids - @view.environment_ids.map(&:to_s)).empty?
env_ids = [1,2,3]  while @view.environment_ids.map(&:to_s) = [1,2,3]
Problem was API was treating it like a list of strings while params code changed it to ints
This commit should fix that issue
