### PR TITLE
Fixes #6249,BZ1109398: Candlepin proxy routes properly looking up organi...

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -299,7 +299,7 @@ module Katello
         fail HttpErrors::NotFound, message % params[:organization_id]
       end
 
-      if User.current && !User.current.allowed_organizations.include?(organization)
+      if User.current && !User.consumer? && !User.current.allowed_organizations.include?(organization)
         message = _("User '%{user}' does not belong to Organization '%{organization}'.")
         fail HttpErrors::NotFound, message % {:user => current_user.login, :organization => params[:organization_id]}
       end
@@ -412,14 +412,14 @@ module Katello
       when "api_proxy_consumer_deletionrecord_delete_path"
         User.consumer? || Organization.deletable?
       when "api_proxy_owner_pools_path"
-        find_optional_organization
+        find_organization
         if params[:consumer]
           User.consumer? && current_user.uuid == params[:consumer]
         else
           User.consumer? || ::User.current.can?(:view_organizations, self)
         end
       when "api_proxy_owner_servicelevels_path"
-        find_optional_organization
+        find_organization
         (User.consumer? || ::User.current.can?(:view_organizations, self))
       when "api_proxy_consumer_certificates_path", "api_proxy_consumer_releases_path", "api_proxy_certificate_serials_path",
            "api_proxy_consumer_entitlements_path", "api_proxy_consumer_entitlements_post_path",


### PR DESCRIPTION
...zation.

When the API switched to looking up organization by ID, the Candlepin
proxy routes that required an organization broke since subscription-
manager GUI and CLI pass the organization label and not numerical ID.
