### PR TITLE
Fixes #6258 - make env_id optional in ak update

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -70,8 +70,8 @@ module Katello
     param :organization_id, :number, :desc => N_("organization identifier"), :required => true
     param :name, String, :desc => N_("name"), :required => true
     param :description, String, :desc => N_("description")
-    param :environment_id, :identifier, :desc => N_("environment id"), :required => true
-    param :content_view_id, :identifier, :desc => N_("content view id"), :required => true
+    param :environment_id, :identifier, :desc => N_("environment id")
+    param :content_view_id, :identifier, :desc => N_("content view id")
     param :usage_limit, :number, :desc => N_("maximum number of registered content hosts, or 'unlimited'")
     param :release_version, String, :desc => N_("content release version")
     param :service_level, String, :desc => N_("service level")


### PR DESCRIPTION
Activation Key update should allow passing of environment_id to be
optional since creation allows the existence of Activation Keys
without a lifecycle-environment asociated.
