### PR TITLE
BZ 1076357 - align "Cancel" link not to cross table border

### DIFF
--- a/app/assets/stylesheets/katello/contents.scss
+++ b/app/assets/stylesheets/katello/contents.scss
@@ -450,6 +450,7 @@ $container_width: ($static_width/2) - 36;
         text-align: left;
         bottom: 18px;
         left: 30px;
+        display: block;
       }
       .progress {
         display: inline-block;


### PR DESCRIPTION
This pull requests resolves the issue described in
https://bugzilla.redhat.com/show_bug.cgi?id=1076357
