### PR TITLE
fixes #6269 / BZ 1110486 - activation key - include description on details pane

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-info.html
@@ -14,6 +14,15 @@
       </div>
 
       <div class="detail">
+        <span class="info-label" translate>Description</span>
+        <span class="info-value"
+              alch-edit-textarea="activationKey.description"
+              readonly="activationKey.readonly"
+              on-save="save(activationKey)">
+        </span>
+        </div>
+
+      <div class="detail">
 
         <span class="info-label" translate>System Limit</span>
 


### PR DESCRIPTION
Add the description to the 'details' pane to support review/edit.
