### PR TITLE
Fixes #6271 - add var convention to Bastion readme

### DIFF
--- a/engines/bastion/README.md
+++ b/engines/bastion/README.md
@@ -229,7 +229,16 @@ To run the HTML linter:
 
         myFunction(parameters) {
         }
+* Declare all `var` statements at the top of a function in order to prevent problems associated with variable hoisting. Stack `var` statements for readability and assign values simultaneously if appropriate. 
 
+        $scope.myFunction = function (parameters) {
+            var success, 
+                error,
+                someOtherVar = 'blah';
+            
+            success = function () {};
+            error = function () {};
+        };
 
 ## i18n ##
 


### PR DESCRIPTION
The readme was missing information about our convention of declaring vars at the top of a function.

http://projects.theforeman.org/issues/6271
