### PR TITLE
fixes #6270 / BZ 1110020 - fix issues with content view version deletion

### DIFF
--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -73,9 +73,11 @@ module Actions
 
         def finalize
           input[:content_view_history_ids].each do |history_id|
-            history = ::Katello::ContentViewHistory.find(history_id)
-            history.status = ::Katello::ContentViewHistory::SUCCESSFUL
-            history.save!
+            history = ::Katello::ContentViewHistory.find_by_id(history_id)
+            if history
+              history.status = ::Katello::ContentViewHistory::SUCCESSFUL
+              history.save!
+            end
           end
         end
 

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -122,7 +122,11 @@ class ContentViewVersion < Katello::Model
   end
 
   def removable?
-    content_view.promotable_or_removable? && KTEnvironment.where(:id => environments).any_promotable?
+    if environments.blank?
+      content_view.promotable_or_removable?
+    else
+      content_view.promotable_or_removable? && KTEnvironment.where(:id => environments).any_promotable?
+    end
   end
 
   def deletable?(from_env)

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-environments.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-environments.controller.js
@@ -68,7 +68,13 @@ angular.module('Bastion.content-views').controller('ContentViewVersionDeletionEn
         };
 
         $scope.anySelectable = function () {
-            return _.findWhere($scope.environmentsTable.rows, {unselectable: false}) !== undefined;
+            var anySelectable;
+            if ($scope.environmentsTable.rows.length === 0) {
+                anySelectable = true;
+            } else {
+                anySelectable =  _.findWhere($scope.environmentsTable.rows, {unselectable: false}) !== undefined;
+            }
+            return anySelectable;
         };
 
         $scope.allSelectable = function () {


### PR DESCRIPTION
This commit fixes a few issues with content view version deletion.  They are:
1. The 'Remove' button is not available for an archived version that is not currently associated with a lifecycle environment
2. The 'Next' button in the removal widget is disabled on the Lifecycle Environment step
3. When deleting an archive, the version is deleted; however, the finalize step would fail in dynflow since all information associated with the version is being removed, including the history which is used in finalize.
