### PR TITLE
Fixes #5958 - content-view puppet module operations

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -29,10 +29,6 @@ module Katello
       api_base_url "#{Katello.config.url_prefix}/api"
     end
 
-    rescue_from(ActionController::ParameterMissing) do |parameter_missing_exception|
-      render :text => _("Missing values for #{parameter_missing_exception.param}."), :status => :bad_request
-    end
-
     def_param_group :search do
       param :search, String, :desc => N_("Search string")
       param :page, :number, :desc => N_("Page number, starting at 1")

--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -17,10 +17,17 @@ module Katello
 
     api :GET, "/content_views/:content_view_id/content_view_puppet_modules", N_("List content view puppet modules")
     param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
+    param :name, String, :desc => N_("name of the puppet module")
+    param :author, String, :desc => N_("author of the puppet module")
+    param :uuid, String, :desc => N_("the uuid of the puppet module to associate")
     def index
       options = sort_params
       options[:load_records?] = true
-      options[:filters] = [{ :terms => { :id => @view.content_view_puppet_module_ids } }]
+      options[:filters] = []
+      options[:filters] << { :terms => { :id => @view.content_view_puppet_module_ids } }
+      options[:filters] << { :term => {:name => params[:name]} } if params[:name]
+      options[:filters] << { :term => {:uuid => params[:uuid]} } if params[:uuid]
+      options[:filters] << { :term => {:author => params[:author]} } if params[:author]
 
       @search_service.model = ContentViewPuppetModule
       respond(:collection => item_search(ContentViewPuppetModule, params, options))
@@ -42,6 +49,7 @@ module Katello
 
     api :GET, "/content_views/:content_view_id/content_view_puppet_modules/:id", N_("Show a content view puppet module")
     param :content_view_id, :number, :desc => N_("content view numeric identifier"), :required => true
+    param :id, :identifier, :desc => N_("puppet module ID"), :required => true
     def show
       respond :resource => @puppet_module
     end
@@ -49,7 +57,7 @@ module Katello
     api :PUT, "/content_views/:content_view_id/content_view_puppet_modules/:id",
         N_("Update a puppet module associated with the content view")
     param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
-    param :id, :identifier, :desc => N_("puppet module identifier"), :required => true
+    param :id, :identifier, :desc => N_("puppet module ID"), :required => true
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
     param :uuid, String, :desc => N_("the uuid of the puppet module to associate")
@@ -61,7 +69,7 @@ module Katello
     api :DELETE, "/content_views/:content_view_id/content_view_puppet_modules/:id",
         N_("Remove a puppet module from the content view")
     param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
-    param :id, :identifier, :desc => N_("puppet module identifierr"), :required => true
+    param :id, :identifier, :desc => N_("puppet module ID"), :required => true
     def destroy
       @puppet_module.destroy
       respond :resource => @puppet_module
@@ -81,5 +89,6 @@ module Katello
       attrs = [:name, :author, :uuid]
       params.require(:content_view_puppet_module).permit(*attrs)
     end
+
   end
 end

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -33,9 +33,15 @@ module Api
         rescue_from Errors::ConflictException, :with => :rescue_from_conflict_exception
         rescue_from Errors::UnsupportedActionException, :with => :rescue_from_unsupported_action_exception
         rescue_from Errors::UsageLimitExhaustedException, :with => :rescue_from_usage_limit_exhausted_exception
+        rescue_from ActionController::ParameterMissing, :with => :rescue_from_missing_param
       end
 
       protected
+
+      def rescue_from_missing_param(exception)
+        text = "Missing values for #{exception.param}."
+        respond_for_exception(exception, :text => text, :display_message => text, :status => :bad_request)
+      end
 
       def rescue_from_exception(exception)
         text = 'Fatal Error: See logs for details or contact system administrator'

--- a/app/models/katello/content_view_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_module.rb
@@ -44,12 +44,25 @@ module Katello
     private
 
     def set_attributes
-      if self.uuid.present? && Katello.config.use_pulp
+      return unless Katello.config.use_pulp
+      if self.uuid.present?
         puppet_module = PuppetModule.find(self.uuid)
-        fail Errors::NotFound, _("Couldn't find Puppet Module with id=%s") % self.uuid unless puppet_module
+        fail Errors::NotFound, _("Couldn't find Puppet Module with id '%s'") % self.uuid unless puppet_module
 
         self.name = puppet_module.name
         self.author = puppet_module.author
+      elsif (self.name.present? && !self.author.present?)
+        puppet_modules = PuppetModule.latest_modules_search(
+          [{:name => self.name, :author => '*'}],
+          self.content_view.puppet_repos.map(&:pulp_id))
+
+        if puppet_modules.empty?
+          fail Errors::NotFound, _("Couldn't find Puppet Module '%s'.") % self.name
+        elsif puppet_modules.length > 1
+          fail Errors::NotFound, _("Puppet Module '%s' found more than once. Please specify the author.") % self.name
+        else
+          self.author = puppet_modules.first.author
+        end
       end
     end
   end


### PR DESCRIPTION
- puppet modules searchable by name, author and uuid
- required params for content-view puppet modules
- updated api docs
- standard error handling for required parameters

Related CLI update lives here https://github.com/Katello/hammer-cli-katello/pull/194
