### PR TITLE
Fixes #5451: Load only custom products for repo discovery.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/products/discovery/discovery-form.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/products/discovery/discovery-form.controller.js
@@ -31,7 +31,7 @@ angular.module('Bastion.products').controller('DiscoveryFormController',
     function ($scope, $q, CurrentOrganization, Product, Repository, GPGKey, FormUtils) {
 
         $scope.discovery = $scope.discovery || {selected: []};
-        $scope.panel = $scope.panel || {loading: false};
+        $scope.panel = {loading: true};
 
         $scope.$watch('createRepoChoices.product.name', function () {
             FormUtils.labelize($scope.createRepoChoices.product);
@@ -56,7 +56,7 @@ angular.module('Bastion.products').controller('DiscoveryFormController',
             FormUtils.labelize(repo);
         });
 
-        Product.queryUnpaged({'organization_id': CurrentOrganization}, function (values) {
+        Product.queryUnpaged({'organization_id': CurrentOrganization, custom: true}, function (values) {
             $scope.products = filterEditable(values.results);
 
             if ($scope.products.length > 0) {

--- a/engines/bastion/app/assets/javascripts/bastion/products/discovery/views/discovery-create.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/discovery/views/discovery-create.html
@@ -1,4 +1,9 @@
 <span page-title>{{ 'Create Repositories' | translate }}</span>
+  
+<div class="loading-mask loading-mask-panel" ng-show="panel.loading">
+  <i class="icon-spinner icon-spin"></i>
+  <span translate>Loading...</span>
+</div>
 
 <a ui-sref="products.discovery.scan">
   <i class="icon-double-angle-left"></i>

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -61,7 +61,6 @@ class Api::V2::ProductsControllerTest < ActionController::TestCase
     end
   end
 
-
   def test_create
     product_params = {
       :name => 'fedora product',


### PR DESCRIPTION
Adds 'custom' param option to the products index API call in order
to retrieve non-red hat products. Updates the repo discovery creation
screen to pass custom so that users are only creating repositories
for existing custom products.
