### PR TITLE
Fixes #5543/BZ1102322 - fix content search autocomplete.

### DIFF
--- a/app/controllers/katello/content_views_controller.rb
+++ b/app/controllers/katello/content_views_controller.rb
@@ -25,7 +25,7 @@ module Katello
           string query
         end
         filter :term, {:organization_id => org.id}
-        filter :term, {:id => readable_ids}
+        filter :terms, {:id => readable_ids}
       end
 
       render :json => content_views.collect{|s| {:label => s.name, :value => s.name, :id => s.id}}

--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -57,7 +57,7 @@ class ProductsController < Katello::ApplicationController
         string query
       end
       filter :term, {:organization_id => org.id}
-      filter :term, {:id => readable_ids}
+      filter :terms, {:id => readable_ids}
     end
 
     render :json => products.collect{|s| {:label => s.name, :value => s.name, :id => s.id}}

--- a/app/controllers/katello/repositories_controller.rb
+++ b/app/controllers/katello/repositories_controller.rb
@@ -17,9 +17,7 @@ class RepositoriesController < Katello::ApplicationController
 
   def auto_complete_library
     # retrieve and return a list (array) of repo names in library that contain the 'term' that was passed in
-    term = Util::Search.filter_input params[:term]
-    name = 'name:' + term
-    name_query = name + ' OR ' + name + '*'
+    query = "name_autocomplete:#{params[:term]}"
 
     ids = []
     ids += Product.readable_repositories.pluck(:id) if Product.readable?
@@ -27,11 +25,10 @@ class RepositoriesController < Katello::ApplicationController
     ids.uniq!
 
     repos = Repository.search do
-      query {string name_query}
-      filter "and", [
-          {:terms => {:id => ids}},
-          {:terms => {:enabled => [true]}}
-      ]
+      query do
+        string query
+      end
+      filter :terms, {:id => ids}
     end
 
     render :json => (repos.map do |repo|

--- a/app/models/katello/glue/elastic_search/repository.rb
+++ b/app/models/katello/glue/elastic_search/repository.rb
@@ -26,6 +26,7 @@ module Glue::ElasticSearch::Repository
         indexes :name, :type => 'string', :analyzer => :kt_name_analyzer
         indexes :name_sort, :type => 'string', :index => :not_analyzed
         indexes :labels, :type => 'string', :index => :not_analyzed
+        indexes :name_autocomplete, :type => 'string', :analyzer => 'autcomplete_name_analyzer'
       end
 
       after_save :update_related_index
@@ -41,7 +42,8 @@ module Glue::ElasticSearch::Repository
         :product_id => self.product.id,
         :default_content_view => self.content_view_version.has_default_content_view?,
         :name_sort => self.name,
-        :content_view_ids => self.content_view_ids
+        :content_view_ids => self.content_view_ids,
+        :name_autocomplete => self.name
       }
     end
 


### PR DESCRIPTION
Autocomplete was broken for products, repositories, and
content views in different ways.  This fixes each.

http://projects.theforeman.org/issues/5543
https://bugzilla.redhat.com/show_bug.cgi?id=1102322
