### PR TITLE
Fixes #6001 - specify local or server time for sync plan times.

### DIFF
--- a/app/views/katello/api/v2/common/_syncable.json.rabl
+++ b/app/views/katello/api/v2/common/_syncable.json.rabl
@@ -1,1 +1,7 @@
 attributes :sync_state, :last_sync
+
+node :last_sync_words do |object|
+  if (object.respond_to?('last_sync') && object.last_sync)
+    time_ago_in_words(Time.parse(object.last_sync))
+  end
+end

--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -3,6 +3,7 @@ object @resource
 attributes :id, :cp_id, :name, :label, :description
 
 extends 'katello/api/v2/common/org_reference'
+extends 'katello/api/v2/common/syncable'
 
 attributes :marketing_product
 attributes :provider_id

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/partials/sync-status.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/partials/sync-status.html
@@ -1,7 +1,3 @@
-<div alert type="'info'">
-  {{ 'All dates and times below are relative to this server.' | translate }}
-</div>
-
 <div class="detail">
   <span class="info-label" translate>Sync Interval</span>
   <span class="info-value" ng-if="product.sync_plan.interval == 'hourly'">
@@ -11,12 +7,12 @@
   </span>
   <span class="info-value" ng-if="product.sync_plan.interval == 'daily'">
     <span translate>
-      Daily at {{ product.sync_plan.sync_date | date:'mediumTime' }}
+      Daily at {{ product.sync_plan.sync_date | date:'mediumTime' }} (Server Time)
     </span>
   </span>
   <span class="info-value" ng-if="product.sync_plan.interval == 'weekly'">
     <span translate>
-      Weekly on {{ product.sync_plan.sync_date | date:'EEEE' }} at {{ product.sync_plan.sync_date | date:'mediumTime' }}
+      Weekly on {{ product.sync_plan.sync_date | date:'EEEE' }} at {{ product.sync_plan.sync_date | date:'mediumTime' }} (Server Time)
     </span>
   </span>
   <span class="info-value" ng-hide="product.sync_plan.next_sync">

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-info.html
@@ -64,13 +64,15 @@
 
     <div class="detail">
       <span class="info-label" translate>Last Sync</span>
-      <span class="info-value">{{ product.sync_status.finish_time | date:'medium' }}</span>
+      <span class="info-value" translate>
+        {{ product.last_sync_words }} Ago ({{ product.sync_status.finish_time | date:'medium' }} Local Time)
+      </span>
     </div>
 
     <div class="detail">
       <span class="info-label" translate>Next Sync</span>
-      <span class="info-value" ng-show="product.sync_plan.next_sync">
-        {{ product.sync_plan.next_sync | date:'medium' }}
+      <span class="info-value" ng-show="product.sync_plan.next_sync" translate>
+        {{ product.sync_plan.next_sync | date:'medium' }} (Server Time)
       </span>
       <span class="info-value" ng-hide="product.sync_plan.next_sync" translate>
         Synced manually, no interval set.

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
@@ -75,7 +75,7 @@
             </span>
             <span ng-hide="repository.last_sync == null">
               <a href="/katello/sync_management">{{ repository.sync_state | capitalize}}</a>
-              ({{ repository.last_sync | date:"short" }})
+              <span translate>{{ repository.last_sync_words }} ago</span>
             </span>
           </span>
           <span ng-hide="repository.url" translate>N/A</span>

--- a/engines/bastion/app/assets/javascripts/bastion/products/views/partials/product-table-sync-status.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/views/partials/product-table-sync-status.html
@@ -1,5 +1,7 @@
 <ul class="list-unstyled" ng-show="product.sync_status.finish_time">
-  <p translate>Last synced on {{ product.sync_status.finish_time | date:'short' }}</p>
+  <p translate>
+    Last synced {{ product.last_sync_words }} ago
+  </p>
   <li ng-repeat="(key, value) in product.repositoriesByState">
     <a ng-href="{{ RootURL }}/sync_management">{{ key | capitalize }}</a>:
             <span translate

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
@@ -106,13 +106,15 @@
 
     <div class="detail">
       <span class="info-label" translate>Last Sync</span>
-      <span class="info-value">{{ repository.last_sync | date:'medium' }}</span>
+      <span class="info-value" translate>
+        {{ repository.last_sync_words }} Ago ({{ repository.last_sync | date:'medium' }} Local Time)
+      </span>
     </div>
 
     <div class="detail">
       <span class="info-label" translate>Next Sync</span>
-      <span class="info-value" ng-show="repository.product.sync_plan.next_sync">
-        {{ repository.product.sync_plan.next_sync | date:'medium' }}
+      <span class="info-value" ng-show="repository.product.sync_plan.next_sync" translate>
+        {{ repository.product.sync_plan.next_sync | date:'medium' }} (Server Time)
       </span>
       <span class="info-value" ng-hide="repository.product.sync_plan.next_sync" translate>
         Synced manually, no interval set.

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -40,6 +40,7 @@ module Katello
       @request.env['HTTP_ACCEPT'] = 'application/json'
       @request.env['CONTENT_TYPE'] = 'application/json'
       @fake_search_service = @controller.load_search_service(Support::SearchService::FakeSearchService.new)
+      Repository.any_instance.stubs(:last_sync).returns(Time.now.asctime)
       models
       permissions
     end


### PR DESCRIPTION
Also display a "time as words" value such as "3 hours ago" or
"28 minutes ago" when displaying last synced time.

http://projects.theforeman.org/issues/6001
