### PR TITLE
Fixes #5944: Ensure links to old Katello pages are followed.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
@@ -68,6 +68,11 @@ angular.module('Bastion').config(
                 $window.location.href = oldBrowserBastionPath + $location.path();
             }
 
+            if (path.slice(0, '/katello'.length) === '/katello') {
+                $window.location.href = $location.url();
+                $window.location.reload();
+            }
+
             // removing trailing slash to prevent endless redirect
             if (path[path.length - 1] === '/') {
                 return path.slice(0, -1);


### PR DESCRIPTION
After switching to HTML5 history, links to older Katello pages that
included hashes would not properly redirect. This now checks if the path
starts with '/katello' and force redirects to the specified url.
