### PR TITLE
fixes #6276 / BZ 1106378 - content view package filter - allow user to change existing rules

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -64,7 +64,12 @@ module Katello
     param :end_date, String, :desc => N_("erratum: end date (YYYY-MM-DD)")
     param :types, Array, :desc => N_("erratum: types (enhancement, bugfix, security)")
     def update
-      @rule.update_attributes!(rule_params)
+      update_params = rule_params
+      update_params[:version] = "" unless rule_params[:version]
+      update_params[:min_version] = "" unless rule_params[:min_version]
+      update_params[:max_version] = "" unless rule_params[:max_version]
+
+      @rule.update_attributes!(update_params)
       respond :resource => @rule
     end
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-filter.controller.js
@@ -46,6 +46,7 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
 
             // Need access to the original rule
             success = function () {
+                rule.previous = {};
                 rule.editMode = false;
                 rule.working = false;
                 $scope.successMessages = [translate('Package successfully updated.')];
@@ -78,6 +79,16 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             rule.version = undefined;
             rule['min_version'] = undefined;
             rule['max_version'] = undefined;
+        };
+
+        $scope.backupPrevious = function (rule) {
+            rule.previous = {};
+            angular.copy(rule, rule.previous);
+        };
+
+        $scope.restorePrevious = function (rule) {
+            angular.copy(rule.previous, rule);
+            rule.previous = {};
         };
 
         $scope.removeRules = function (filter) {

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
@@ -121,7 +121,8 @@
                   ng-model="rule.type"
                   ng-hide="denied('edit_content_views', contentView)"
                   ng-readonly="!rule.editMode"
-                  ng-disabled="!rule.editMode">
+                  ng-disabled="!rule.editMode"
+                  ng-change="clearValues(rule)">
             <option value="all" translate>All Versions</option>
             <option value="equal" translate>Equal To</option>
             <option value="greater" translate>Greater Than</option>
@@ -158,13 +159,13 @@
         </span>
     </td>
     <td class="action-cell">
-      <button class="btn btn-default" ng-click="rule.editMode = true" ng-hide="rule.editMode">
+      <button class="btn btn-default" ng-click="rule.editMode = true; backupPrevious(rule)" ng-hide="rule.editMode">
         <i class="icon-edit"></i>
         <span translate>Edit</span>
       </button>
 
       <button alch-save-control
-              on-cancel="rule.editMode = false"
+              on-cancel="restorePrevious(rule); rule.editMode = false"
               on-save="updateRule(rule, filter)"
               working="rule.working"
               invalid="!valid(rule)"

--- a/engines/bastion/test/content-views/details/filters/package-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/package-filter.controller.test.js
@@ -91,6 +91,50 @@ describe('Controller: PackageFilterController', function() {
         expect(rule.max_version).toBe(undefined);
     });
 
+    it("should provide a method to backup a rule", function() {
+        var rule = {
+            name: 'test',
+            type: 'all',
+            version: '1',
+            min_version: '2',
+            max_version: '3'
+        };
+
+        $scope.backupPrevious(rule);
+
+        expect(rule.previous.name).toBe(rule.name);
+        expect(rule.previous.type).toBe(rule.type);
+        expect(rule.previous.version).toBe(rule.version);
+        expect(rule.previous.min_version).toBe(rule.min_version);
+        expect(rule.previous.max_version).toBe(rule.max_version);
+    });
+
+    it("should provide a method to restore a rule", function() {
+        var rule = {
+            name: 'current',
+            type: 'all',
+            version: '1',
+            min_version: '2',
+            max_version: '3'
+        }, previousRule = {
+            name: 'previous',
+            type: 'previous all',
+            version: '10',
+            min_version: '20',
+            max_version: '30'
+        };
+        rule.previous = previousRule;
+
+        $scope.restorePrevious(rule);
+
+        expect(rule.name).toBe(previousRule.name);
+        expect(rule.type).toBe(previousRule.type);
+        expect(rule.version).toBe(previousRule.version);
+        expect(rule.min_version).toBe(previousRule.min_version);
+        expect(rule.max_version).toBe(previousRule.max_version);
+        expect(Object.keys(rule.previous).length).toBe(0)
+    });
+
     it("should provide a method to determine if a rule is valid if no name is given", function() {
         var result,
             rule = {};


### PR DESCRIPTION
Without this change, a user cannot modify a package filter rule, if the
change involves going from an equal filter to greater/less/range filter
(or vice versa).

It also allows a user to 'Edit' the filter and then 'Cancel' returning
the entry to it's previous state.
