### PR TITLE
Fixes #4999: Allow repository creation using only the keyboard to traver...

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/repositories/new/new-repository.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/new/new-repository.controller.js
@@ -28,7 +28,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
     function ($scope, Repository, GPGKey, FormUtils) {
 
         $scope.repository = new Repository({'product_id': $scope.$stateParams.productId, unprotected: true});
-        $scope.repositoryTypes = [{name: 'yum'}, {name: 'puppet'}];
+        $scope.repositoryTypes = [{}, {name: 'yum'}, {name: 'puppet'}];
 
         $scope.$watch('repository.name', function () {
             if ($scope.repositoryForm.name) {


### PR DESCRIPTION
...se the form.

This adds an explicit blank option to account for the initial blank
being present from an empty model attribute on a new resource. The absence
of the blank leads to the position of selection being off when manipulating
the select via the arrow keys.
