### PR TITLE
fixes #5030 - reload filter on package group/errata rule list

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -52,7 +52,7 @@ module Katello
       end
 
       if rules && rule.nil?
-        respond_for_index(:collection => {:results => rules.collect(&:errata_id)})
+        respond_for_index(:collection => {:results => rules}, :template => 'index')
       else
         respond :resource => rule
       end

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-errata-filter.controller.js
@@ -50,18 +50,18 @@ angular.module('Bastion.content-views').controller('AvailableErrataFilterControl
 
         $scope.addErrata = function (filter) {
             var errataIds,
-                rule,
+                rules,
                 results = nutupane.getAllSelectedResults('errata_id');
 
             if (nutupane.table.allResultsSelected) {
-                rule = new Rule({'errata_ids': results});
+                rules = new Rule({'errata_ids': results});
             } else {
                 errataIds = results.included.ids;
-                rule = new Rule({'errata_ids': errataIds});
+                rules = new Rule({'errata_ids': errataIds});
             }
 
             nutupane.table.working = true;
-            saveRule(rule, filter);
+            saveRules(rules, filter);
         };
 
         $scope.updateTypes = function (errataTypes) {
@@ -89,13 +89,14 @@ angular.module('Bastion.content-views').controller('AvailableErrataFilterControl
             }
         });
 
-        function saveRule(rule, filter) {
+        function saveRules(rules, filter) {
             var params = {filterId: filter.id};
 
-            return rule.$save(params, success, failure);
+            return rules.$save(params, success, failure);
         }
 
-        function success() {
+        function success(data) {
+            $scope.filter.rules = _.union($scope.filter.rules, data.results);
             $scope.$parent.successMessages = [translate('Errata successfully added.')];
             nutupane.table.selectAllResults(false);
             nutupane.refresh();

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-package-group-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-package-group-filter.controller.js
@@ -56,6 +56,7 @@ angular.module('Bastion.content-views').controller('AvailablePackageGroupFilterC
 
         function success(rule) {
             nutupane.removeRow(rule.uuid, 'id');
+            $scope.filter.rules.push(rule);
             $scope.successMessages = [translate('Package Group successfully added.')];
         }
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter-list.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter-list.controller.js
@@ -58,6 +58,9 @@ angular.module('Bastion.content-views').controller('ErrataFilterListController',
 
         function success(rule) {
             nutupane.removeRow(rule['errata_id'], 'errata_id');
+            $scope.filter.rules = _.reject($scope.filter.rules, function (filterRule) {
+                return rule.id === filterRule.id;
+            });
             $scope.$parent.successMessages = [translate('Errata successfully removed.')];
         }
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-group-list-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-group-list-filter.controller.js
@@ -52,6 +52,9 @@ angular.module('Bastion.content-views').controller('PackageGroupFilterListContro
 
         function success(rule) {
             nutupane.removeRow(rule.uuid, 'id');
+            $scope.filter.rules = _.reject($scope.filter.rules, function (filterRule) {
+                return rule.id === filterRule.id;
+            });
             $scope.successMessages = [translate('Package Group successfully removed.')];
         }
 

--- a/engines/bastion/test/content-views/details/filters/available-package-group-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/available-package-group-filter.controller.test.js
@@ -34,7 +34,7 @@ describe('Controller: AvailablePackageGroupFilterController', function() {
         spyOn(Rule, 'save');
 
         $scope = $injector.get('$rootScope').$new();
-        $scope.filter = Filter({id: 1});
+        $scope.filter = Filter({id: 1, rules: []});
 
         $controller('AvailablePackageGroupFilterController', {
             $scope: $scope,
@@ -53,6 +53,7 @@ describe('Controller: AvailablePackageGroupFilterController', function() {
         $scope.addPackageGroups($scope.filter);
 
         expect($scope.successMessages.length).toBe(1);
+        expect($scope.filter.rules.length).toBe(1);
     });
 
 });

--- a/engines/bastion/test/content-views/details/filters/errata-filter-list.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/errata-filter-list.controller.test.js
@@ -54,9 +54,10 @@ describe('Controller: ErrataFilterListController', function() {
     });
 
     it("should provide a method to remove errata from the filter", function () {
-        $scope.removeErrata($scope.filter);
+        $scope.removeErrata();
 
         expect($scope.successMessages.length).toBe(1);
+        expect($scope.filter.rules.length).toBe(0);
     });
 
 });

--- a/engines/bastion/test/content-views/details/filters/package-group-list-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/package-group-list-filter.controller.test.js
@@ -53,9 +53,10 @@ describe('Controller: PackageGroupFilterListController', function() {
     });
 
     it("should provide a method to remove package groups from the filter", function () {
-        $scope.removePackageGroups($scope.filter);
+        $scope.removePackageGroups();
 
         expect($scope.successMessages.length).toBe(1);
+        expect($scope.filter.rules.length).toBe(0);
     });
 
 });


### PR DESCRIPTION
Since we are using the rule list on the filter object to determine which filter rule id to 
remove, we need to fetch the new list on each page load
