### PR TITLE
Fixes #6200: Rename nodes to capsules throughout UI.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/bastion-bootstrap.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion-bootstrap.js
@@ -34,7 +34,7 @@ BASTION_MODULES = [
     'Bastion.gpg-keys',
     'Bastion.i18n',
     'Bastion.menu',
-    'Bastion.nodes',
+    'Bastion.capsules',
     'Bastion.organizations',
     'Bastion.products',
     'Bastion.repositories',

--- a/engines/bastion/app/assets/javascripts/bastion/bastion.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.js
@@ -76,8 +76,8 @@
 //= require "bastion/environments/environments.module"
 //= require_tree "./environments"
 
-//= require "bastion/nodes/nodes.module.js"
-//= require_tree "./nodes"
+//= require "bastion/capsules/capsules.module.js"
+//= require_tree "./capsules"
 
 //= require "bastion/organizations/organizations.module.js"
 //= require_tree "./organizations"

--- a/engines/bastion/app/assets/javascripts/bastion/capsules/capsule.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/capsules/capsule.factory.js
@@ -13,17 +13,17 @@
 
 /**
  * @ngdoc service
- * @name  Bastion.nodes.factory:Node
+ * @name  Bastion.capsules.factory:Capsule
  *
  * @requires BastionResource
  *
  * @description
- *   Provides a BastionResource for nodes or list of nodes.
+ *   Provides a BastionResource for capsules or list of capsules.
  */
-angular.module('Bastion.nodes').factory('Node',
+angular.module('Bastion.capsules').factory('Capsule',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/api/nodes/:id/:action', {id: '@id'}, {
+        return BastionResource('/api/capsules/:id/:action', {id: '@id'}, {
         });
 
     }]

--- a/engines/bastion/app/assets/javascripts/bastion/capsules/capsules.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/capsules/capsules.module.js
@@ -13,12 +13,12 @@
 
 /**
  * @ngdoc module
- * @name  Bastion.nodes
+ * @name  Bastion.capsules
  *
  * @description
- *   Module for node related functionality.
+ *   Module for Capsule related functionality.
  */
-angular.module('Bastion.nodes', [
+angular.module('Bastion.capsules', [
     'ngResource',
     'Bastion'
 ]);

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-host-register.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-host-register.controller.js
@@ -17,7 +17,7 @@
  *
  * @requires $scope
  * @requires $location
- * @requires Node
+ * @requires Capsule
  * @requires Organization
  * @requires CurrentOrganization
  * @requires BastionConfig
@@ -26,16 +26,24 @@
  *     Provides values to populate the code commands for registering a content host.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostRegisterController',
-    ['$scope', '$location', 'Node', 'Organization', 'CurrentOrganization', 'BastionConfig',
-    function ($scope, $location, Node, Organization, CurrentOrganization, BastionConfig) {
+    ['$scope', '$location', 'Capsule', 'Organization', 'CurrentOrganization', 'BastionConfig',
+    function ($scope, $location, Capsule, Organization, CurrentOrganization, BastionConfig) {
 
         $scope.organization = Organization.get({id: CurrentOrganization});
         $scope.baseURL = 'http://' + $location.host();
         $scope.consumerCertRPM = BastionConfig.consumerCertRPM;
 
-        $scope.nodes = Node.queryUnpaged(function (data) {
-            $scope.selectedNode = data.results[0];
+        $scope.capsules = Capsule.queryUnpaged(function (data) {
+            $scope.selectedCapsule = data.results[0];
         });
+
+        $scope.hostname = function (url) {
+            if (url) {
+                url = url.split('https://')[1].split(':')[0];
+            }
+
+            return url;
+        };
 
     }]
 );

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
@@ -26,7 +26,7 @@ angular.module('Bastion.content-hosts', [
     'Bastion',
     'Bastion.widgets',
     'Bastion.subscriptions',
-    'Bastion.nodes',
+    'Bastion.capsules',
     'Bastion.errata',
     'Bastion.host-collections'
 ]);
@@ -57,7 +57,7 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
     });
 
     $stateProvider.state('content-hosts.register', {
-        url: '/content_host/register',
+        url: '/content_hosts/register',
         collapsed: true,
         views: {
             'table': {

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/register.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/register.html
@@ -23,15 +23,15 @@
 
   <pre><code>subscription-manager register --org="{{ organization.label }}" --environment="Library"</code></pre>
 
-  <div ng-show="nodes.results.length > 0">
+  <div ng-show="capsules.results.length > 0">
     <p>
-      <h5 translate>Consuming Content From a Node</h5>
-      {{ "Selected Node:" | translate }}
-      <select ng-model="selectedNode"
-              ng-options="node.hostname for node in nodes.results">
+      <h5 translate>Consuming Content From a Capsule</h5>
+      {{ "Selected Capsule:" | translate }}
+      <select ng-model="selectedCapsule"
+              ng-options="capsule.url for capsule in capsules.results">
       </select>
 
-      <pre><code>subscription-manager register --org="{{ organization.label }}" --baseurl="https://{{  selectedNode.hostname }}/pulp/repos"</code></pre>
+      <pre ng-show="selectedCapsule"><code>subscription-manager register --org="{{ organization.label }}" --baseurl="https://{{ hostname(selectedCapsule.url) }}/pulp/repos</code></pre>
     </p>
   </div>
 </section>

--- a/engines/bastion/app/assets/javascripts/bastion/errata/errata.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/errata/errata.module.js
@@ -16,7 +16,7 @@
  * @name  Bastion.errata
  *
  * @description
- *   Module for node related functionality.
+ *   Module for Errata related functionality.
  */
 angular.module('Bastion.errata', [
     'ngResource',

--- a/engines/bastion/test/capsules/capsule.factory.test.js
+++ b/engines/bastion/test/capsules/capsule.factory.test.js
@@ -11,18 +11,18 @@
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
  **/
 
-describe('Factory: Node', function() {
+describe('Factory: Capsule', function() {
     var $httpBackend,
-        nodes,
-        Node;
+        capsules,
+        Capsule;
 
-    beforeEach(module('Bastion.nodes', 'Bastion.test-mocks'));
+    beforeEach(module('Bastion.capsules', 'Bastion.test-mocks'));
 
     beforeEach(module(function($provide) {
-        nodes = {
+        capsules = {
             records: [
-                { name: 'Node1', id: 1 },
-                { name: 'Node2', id: 2 }
+                { name: 'Capsule1', id: 1 },
+                { name: 'Capsule2', id: 2 }
             ],
             total: 2,
             subtotal: 2
@@ -31,7 +31,7 @@ describe('Factory: Node', function() {
 
     beforeEach(inject(function($injector) {
         $httpBackend = $injector.get('$httpBackend');
-        Node = $injector.get('Node');
+        Capsule = $injector.get('Capsule');
     }));
 
     afterEach(function() {
@@ -41,10 +41,10 @@ describe('Factory: Node', function() {
     });
 
     it('provides a way to get a list of products', function() {
-        $httpBackend.expectGET('/api/nodes?full_result=true').respond(nodes);
+        $httpBackend.expectGET('/api/capsules?full_result=true').respond(capsules);
 
-        Node.queryUnpaged(function(nodes) {
-            expect(nodes.records.length).toBe(2);
+        Capsule.queryUnpaged(function(capsules) {
+            expect(capsules.records.length).toBe(2);
         });
     });
 

--- a/engines/bastion/test/content-hosts/content-host-register.controller.test.js
+++ b/engines/bastion/test/content-hosts/content-host-register.controller.test.js
@@ -19,14 +19,14 @@ describe('Controller: ContentHostRegisterController', function() {
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller'),
             $location = $injector.get('$location'),
-            Node = $injector.get('MockResource').$new(),
+            Capsule = $injector.get('MockResource').$new(),
             BastionConfig = {consumerCertRPM: 'katello-ca.rpm'};
 
         $scope = $injector.get('$rootScope').$new();
         $controller('ContentHostRegisterController', {
             $scope: $scope,
             $location: $location,
-            Node: Node,
+            Capsule: Capsule,
             CurrentOrganization: 'ACME',
             BastionConfig: BastionConfig
         });
@@ -40,9 +40,9 @@ describe('Controller: ContentHostRegisterController', function() {
         expect($scope.baseURL).toBeDefined();
     });
 
-    it('should fetch a list of nodes', function(){
-        expect($scope.nodes).toBeDefined();
-        expect($scope.selectedNode).toBeDefined();
+    it('should fetch a list of capsules', function(){
+        expect($scope.capsules).toBeDefined();
+        expect($scope.selectedCapsule).toBeDefined();
     });
 
 });


### PR DESCRIPTION
Note, this fixes issue with 404 when attempting to fetch available
capsules in the content host register page since the nodes API was
renamed to capsules.
