### PR TITLE
Fixes #6367 - cnsmer_shw auth client/usr BZ1112664

### DIFF
--- a/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/v1/candlepin_proxies_controller.rb
@@ -19,10 +19,10 @@ module Katello
                                           :upload_package_profile, :regenerate_identity_certificates, :facts,
                                           :available_releases]
     before_filter :authorize, :only => [:consumer_create, :list_owners, :rhsm_index]
-    before_filter :authorize_client_or_user, :only => [:upload_package_profile, :regenerate_identity_certificates,
+    before_filter :authorize_client_or_user, :only => [:consumer_show, :upload_package_profile, :regenerate_identity_certificates,
                                                        :hypervisors_update]
     before_filter :authorize_proxy_routes, :only => [:get, :post, :put, :delete]
-    before_filter :authorize_client, :only => [:consumer_show, :consumer_destroy, :consumer_checkin,
+    before_filter :authorize_client, :only => [:consumer_destroy, :consumer_checkin,
                                                :enabled_repos, :facts, :available_releases]
 
     before_filter :add_candlepin_version_header

--- a/lib/katello/permissions/content_host_permissions.rb
+++ b/lib/katello/permissions/content_host_permissions.rb
@@ -14,7 +14,7 @@ Foreman::Plugin.find(:katello).security_block :content_hosts do
   permission :create_content_hosts,
              {
               'katello/api/v2/systems' => [:create],
-              'katello/api/v1/candlepin_proxies' => [:consumer_create],
+              'katello/api/v1/candlepin_proxies' => [:consumer_create, :consumer_show],
              },
              :resource_type => 'Katello::System'
   permission :edit_content_hosts,

--- a/test/controllers/api/v1/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/v1/candlepin_proxies_controller_test.rb
@@ -260,5 +260,23 @@ module Katello
       end
     end
 
+    describe "consumer show" do
+      before do
+        Resources::Candlepin::Consumer.stubs(:get).returns(Resources::Candlepin::Consumer.new({:id => 1, :uuid => 2 }))
+      end
+
+       it "can be accessed by user" do
+         User.current = setup_user_with_permissions(:create_content_hosts, User.find(users(:restricted).id))
+         get :consumer_show, :id => @system.uuid
+         assert_response 200
+       end
+
+      it "can be accessed by client" do
+        uuid = @system.uuid
+        User.stubs(:current).returns(CpConsumerUser.new(:uuid => uuid, :login => uuid, :remote_id => uuid))
+        get :consumer_show, :id => @system.uuid
+        assert_response 200
+      end
+    end
   end
 end


### PR DESCRIPTION
access denied received when registering using subscription-manger using the
consumerId flag was for a preliminary call to check that the consumer
exists. This allows :consumer_show authorization through client or user
instead of solely by client.
