### PR TITLE
fixes #6373 - make lifecycle_environment_ids accessible

### DIFF
--- a/app/overrides/foreman/smart_proxies/_environment_tab.html.erb
+++ b/app/overrides/foreman/smart_proxies/_environment_tab.html.erb
@@ -1,3 +1,5 @@
-<li id="kt_environments_tab">
-  <a href="#kt_environments" data-toggle="tab"><%= _('Lifecyle Environments') %></a>
-</li>
+<% unless @smart_proxy.new_record? -%>
+  <li id="kt_environments_tab">
+    <a href="#kt_environments" data-toggle="tab"><%= _('Lifecyle Environments') %></a>
+  </li>
+<% end -%>  

--- a/app/overrides/foreman/smart_proxies/_environment_tab_pane.html.erb
+++ b/app/overrides/foreman/smart_proxies/_environment_tab_pane.html.erb
@@ -1,8 +1,9 @@
-<div class="tab-pane" id="kt_environments">
-  <%= multiple_selects f, :lifecycle_environments, Katello::KTEnvironment.completer_scope(:organization_id => ::Organization.current.try(:id)), @smart_proxy.lifecycle_environment_ids, {:label => _('Lifecyle Environments')}, @smart_proxy.default_capsule? ? {:disabled => :disabled } : {}  %>
+<% unless @smart_proxy.new_record? -%>
+  <div class="tab-pane" id="kt_environments">
+    <%= multiple_selects f, :lifecycle_environments, Katello::KTEnvironment.completer_scope(:organization_id => ::Organization.current.try(:id)), @smart_proxy.lifecycle_environment_ids, {:label => _('Lifecyle Environments')}, @smart_proxy.default_capsule? ? {:disabled => :disabled } : {}  %>
 
-  <% if @smart_proxy.default_capsule? %>
-    <%= _("Lifecycle environments cannot be modifed on the default Smart Proxy.  The content from all Lifecycle Environments will exist on this Smart Proxy.") % @smart_proxy.name  %>
-  <% end %>
-
-</div>
+    <% if @smart_proxy.default_capsule? %>
+      <%= _("Lifecycle environments cannot be modifed on the default Smart Proxy.  The content from all Lifecycle Environments will exist on this Smart Proxy.") % @smart_proxy.name  %>
+    <% end %>
+  </div>
+<% end -%>


### PR DESCRIPTION
Smart Proxies can now have lifecycle environments, but when adding a Smart
Proxy through the UI, it fails with a mass assignment error.
