### PR TITLE
Fixes #6366/BZ1112865 - restore readonly product functionality.

### DIFF
--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -152,6 +152,11 @@ class Product < Katello::Model
     provider.custom_provider?
   end
 
+  def published_content_views
+    Katello::ContentView.non_default.joins(:content_view_versions => :repositories).
+        where("#{Katello::Repository.table_name}.product_id" => self.id)
+  end
+
   def anonymous?
     provider.anonymouns_provider?
   end
@@ -160,7 +165,7 @@ class Product < Katello::Model
     if name.blank?
       self.gpg_key = nil
     else
-      self.gpg_key = GpgKey.readable(organization).find_by_name!(name)
+      self.gpg_key = GpgKey.readable.find_by_name!(name)
     end
   end
 

--- a/app/views/katello/api/v2/common/_readonly.json.rabl
+++ b/app/views/katello/api/v2/common/_readonly.json.rabl
@@ -1,3 +1,0 @@
-node :readonly do |resource|
-  !resource.editable?
-end

--- a/app/views/katello/api/v2/gpg_keys/show.json.rabl
+++ b/app/views/katello/api/v2/gpg_keys/show.json.rabl
@@ -3,7 +3,6 @@ object @resource
 extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 extends 'katello/api/v2/common/timestamps'
-extends 'katello/api/v2/common/readonly'
 
 attributes :name
 attributes :content

--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -47,5 +47,10 @@ node :permissions do |product|
   }
 end
 
+attributes :published_content_views
+
+node :readonly do |product|
+  product.redhat? || product.published_content_views.length > 0
+end
+
 extends 'katello/api/v2/common/timestamps'
-extends 'katello/api/v2/common/readonly'

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -33,7 +33,7 @@
         </a>
       </div>
 
-      <div ng-hide="activationKey.readonly" class="nutupane-actions pull-right">
+      <div class="nutupane-actions pull-right">
          <button class="btn btn-primary"
                  translate
                  ng-hide="denied('edit_activation_keys', activationKey)"

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/product-details.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/product-details.controller.js
@@ -24,7 +24,6 @@
  */
 angular.module('Bastion.products').controller('ProductDetailsController',
     ['$scope', '$state', 'Product', function ($scope, $state, Product) {
-
         $scope.successMessages = [];
         $scope.errorMessages = [];
 
@@ -48,8 +47,20 @@ angular.module('Bastion.products').controller('ProductDetailsController',
             });
         };
 
-        $scope.isReadOnly = function (product) {
-            return product.readonly || product.redhat;
+        $scope.getReadOnlyReason = function (product) {
+            var readOnlyReason = null;
+
+            if (product.$resolved) {
+                if ($scope.denied('delete_products', product)) {
+                    readOnlyReason = 'permissions';
+                } else if (product['published_content_views'].length > 0) {
+                    readOnlyReason = 'published';
+                } else if (product.redhat) {
+                    readOnlyReason = 'redhat';
+                }
+            }
+            
+            return readOnlyReason;
         };
     }]
 );

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-details.html
@@ -16,12 +16,23 @@
            modal-header='Remove Product "{{product.name}}"?'
            modal-body='Are you sure you want to remove product "{{ product.name }}"?'></div>
 
-      <i class="icon-question-sign" ng-show="denied('delete_products', product)"
-         tooltip="{{ 'You cannot remove this product because it was published to a content view or because you do not have permission.' | translate }}"
-         tooltip-append-to-body="true">
-      </i>
+      <span ng-switch="getReadOnlyReason(product)">
+        <i class="icon-question-sign" ng-switch-when="permissions"
+           tooltip="{{ 'You cannot remove this product because you do not have permission.' | translate }}"
+           tooltip-append-to-body="true">
+        </i>
+        <i class="icon-question-sign" ng-switch-when="published"
+           tooltip="{{ 'You cannot remove this product because it was published to a content view.' | translate }}"
+           tooltip-append-to-body="true">
+        </i>
+        <i class="icon-question-sign" ng-switch-when="redhat"
+           tooltip="{{ 'You cannot remove this product because it is a Red Hat product.' | translate }}"
+           tooltip-append-to-body="true">
+        </i>
+      </span>
+
       <button class="btn btn-default"
-              ng-hide="denied('delete_products', product)"
+              ng-hide="denied('delete_products', product) || product.readonly"
               ng-click="openModal()">
         <i class="icon-trash"></i>
         {{ "Remove Product" | translate }}

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-info.html
@@ -10,7 +10,7 @@
       <span class="info-value"
             alch-edit-text="product.name"
             on-save="save(product)"
-            readonly="isReadOnly(product) || denied('edit_products', product)">
+            readonly="product.readonly || denied('edit_products', product)">
       </span>
     </div>
 
@@ -23,7 +23,7 @@
       <span class="info-label" translate>GPG Key</span>
       <span class="info-value"
             alch-edit-select="product.gpg_key.name"
-            readonly="isReadOnly(product) || denied('edit_products', product)"
+            readonly="product.readonly || denied('edit_products', product)"
             selector="product.gpg_key_id"
             options="gpgKeys()"
             on-save="save(product)">
@@ -35,7 +35,7 @@
       <span class="info-value"
             alch-edit-textarea="product.description"
             on-save="save(product)"
-            readonly="isReadOnly(product) || denied('edit_products', product)">
+            readonly="product.readonly || denied('edit_products', product)">
        </span>
     </div>
 

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
@@ -42,7 +42,7 @@
     <button class="btn btn-primary"
             translate
             ng-hide="denied('edit_products', product)"
-            ng-disabled="isReadOnly(product)"
+            ng-disabled="product.readonly"
             ui-sref="products.details.repositories.new({productId: product.id})">
       Create Repository
     </button>

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
@@ -9,7 +9,7 @@
 
     <button class="btn btn-default"
             ui-sref="products.details.repositories.manage-packages({productId: product.id, repositoryId: repository.id})"
-            ng-hide="repository.content_type !== 'yum' || product.redhat || product.readonly">
+            ng-hide="repository.content_type !== 'yum' || product.readonly">
       <span translate>Manage Packages</span>
     </button>
 

--- a/engines/bastion/test/products/details/product-details.controller.test.js
+++ b/engines/bastion/test/products/details/product-details.controller.test.js
@@ -47,17 +47,29 @@ describe('Controller: ProductDetailsController', function() {
         expect($scope.removeRow).toHaveBeenCalledWith($scope.product.id);
     });
 
-    it("provivdes a method to check if a product is read only", function() {
-        var product = {readonly: false, redhat: false};
-        expect($scope.isReadOnly(product)).toBe(false);
+    describe("it provides a method to get the read only reason", function() {
+        var product;
 
-        product.readonly = true;
-        expect($scope.isReadOnly(product)).toBe(true);
+        beforeEach(function () {
+            product = {$resolved: true};
+            $scope.denied = function() {};
+        });
 
-        product.redhat = true;
-        expect($scope.isReadOnly(product)).toBe(true);
+        it ("if the permission was denied", function() {
+            spyOn($scope, 'denied').andReturn(true);
+            expect($scope.getReadOnlyReason(product)).toBe('permissions');
+            expect($scope.denied).toHaveBeenCalledWith('delete_products', product);
+        });
 
-        product.readonly = false;
-        expect($scope.isReadOnly(product)).toBe(true);
+        it("if the product was published in a content view", function() {
+            product['published_content_views'] = [1, 2];
+            expect($scope.getReadOnlyReason(product)).toBe('published');
+        });
+
+        it("if the product is a Red Hat product", function() {
+            product['published_content_views'] = [];
+            product.redhat = true;
+            expect($scope.getReadOnlyReason(product)).toBe('redhat');
+        });
     });
 });


### PR DESCRIPTION
When replacing the authorization system we removed the logic
that determines whether or not a product is read only.  This commit
restores that logic.

http://projects.theforeman.org/issues/6366
https://bugzilla.redhat.com/show_bug.cgi?id=1112865
