### PR TITLE
fixes #6387 - allow content_source in Foreman's SafeMode Jail

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -1,0 +1,27 @@
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Concerns
+    module HostManagedExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        # Foreman uses the SafeMode Jail in templates to limit what
+        # methods on @host can be accessed.  Katello-specific methods
+        # can be added here.
+        class ::Host::Managed::Jail
+          allow :content_source
+        end
+      end
+    end
+  end
+end

--- a/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
+++ b/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
@@ -7,5 +7,5 @@ echo "Registering the System"
 subscription-manager register --org="<%= @host.params['kt_org']%>" --name="<%= @host.name %>" --activationkey="<%= @host.params['kt_activation_keys'] %>"
 <% end %>
 <% if @host.content_source %>
-  subscription-manager config --rhsm.baseurl=https://<%= @host.content_source.hostname %>/pulp/repos
+  subscription-manager config --rhsm.baseurl=https://<%= @host.content_source %>/pulp/repos
 <% end %>

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -100,6 +100,7 @@ module Katello
       # Model extensions
       ::Environment.send :include, Katello::Concerns::EnvironmentExtensions
       ::Host.send :include, Katello::Concerns::HostBaseExtensions
+      ::Host::Managed.send :include, Katello::Concerns::HostManagedExtensions
       ::Hostgroup.send :include, Katello::Concerns::HostgroupExtensions
       ::Location.send :include, Katello::Concerns::LocationExtensions
       ::Medium.send :include, Katello::Concerns::MediumExtensions


### PR DESCRIPTION
Foreman uses a SafeMode Jail to restrict which Host methods are allowed in
templates.  This change adds a way to add Katello-specific methods to the Jail,
and allows content_source in templates.
