### PR TITLE
Fixes #6390/BZ1095098 - disabled table actions if no rows are selected.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-filter.controller.js
@@ -91,11 +91,19 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             rule.previous = {};
         };
 
-        $scope.removeRules = function (filter) {
+        $scope.getSelectedRules = function (filter) {
+            var rules = [];
             angular.forEach(filter.rules, function (rule) {
                 if (rule.selected) {
-                    removeRule(rule);
+                    rules.push(rule);
                 }
+            });
+            return rules;
+        };
+
+        $scope.removeRules = function (filter) {
+            angular.forEach($scope.getSelectedRules(filter), function (rule) {
+                removeRule(rule);
             });
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/errata-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/errata-filter-details.html
@@ -11,14 +11,14 @@
   <div data-block="actions">
     <button class="btn btn-primary fr"
             ng-show="isState('content-views.details.filters.details.erratum.list') && permitted('edit_content_views', contentView)"
-            ng-disabled="detailsTable.working"
+            ng-disabled="detailsTable.working || detailsTable.numSelected === 0"
             ng-click="removeErrata(contentView)">
       <i class="icon-trash"></i>
       <span translate>Remove Errata</span>
     </button>
     <button class="btn btn-primary fr"
             ng-show="isState('content-views.details.filters.details.erratum.available') && permitted('edit_content_views', contentView)"
-            ng-disabled="detailsTable.working"
+            ng-disabled="detailsTable.working || detailsTable.numSelected === 0"
             ng-click="addErrata(filter)">
       <i class="icon-plus"></i>
       <span translate>Add Errata</span>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-repositories.html
@@ -33,7 +33,7 @@
       <button class="btn btn-primary"
               translate
               ng-hide="denied('edit_content_views', contentView)"
-              ng-disabled="!showRepos"
+              ng-disabled="!showRepos || repositoriesTable.numSelected === 0"
               ng-click="updateRepositories()">
         Update Repositories
       </button>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filters.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filters.html
@@ -15,6 +15,7 @@
     </button>
     <button class="btn btn-default"
             ng-hide="denied('edit_content_views', contentView)"
+            ng-disabled="detailsTable.numSelected === 0"
             ng-click="removeFilters()">
       <i class="icon-trash"></i>
       <span translate>Remove Filters</span>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
@@ -21,6 +21,7 @@
   </div>
 
   <button class="btn btn-default fr"
+          ng-disabled="getSelectedRules(filter).length === 0"
           ng-hide="denied('edit_content_views', contentView)"
           ng-click="removeRules(filter)">
     <i class="icon-trash"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter-details.html
@@ -2,6 +2,7 @@
 
   <div data-block="actions">
     <button class="btn btn-primary fr"
+            ng-disabled="detailsTable.numSelected === 0"
             ng-show="isState('content-views.details.filters.details.package_group.list') && permitted('edit_content_views', contentView)"
             ng-click="removePackageGroups(filter)">
       <i class="icon-trash"></i>
@@ -9,6 +10,7 @@
     </button>
 
     <button class="btn btn-primary fr"
+            ng-disabled="detailsTable.numSelected === 0"
             ng-show="isState('content-views.details.filters.details.package_group.available') && permitted('edit_content_views', contentView)"
             ng-click="addPackageGroups(filter)">
       <i class="icon-plus"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-composite-available-content-views.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-composite-available-content-views.html
@@ -8,7 +8,9 @@
   </div>
 
   <div data-block="actions">
-    <button class="btn btn-primary fr" ng-click="addContentViews()">
+    <button class="btn btn-primary fr"
+            ng-disabled="detailsTable.numSelected === 0"
+            ng-click="addContentViews()">
       <i class="icon-plus"></i>
       <span translate>Add Content Views</span>
     </button>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-composite-content-views-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-composite-content-views-list.html
@@ -4,7 +4,10 @@
   <div data-block="messages"></div>
 
   <div data-block="actions">
-    <button ng-hide="denied('edit_content_views', contentView)" class="btn btn-primary fr" ng-click="removeContentViews()">
+    <button class="btn btn-primary fr"
+            ng-hide="denied('edit_content_views', contentView)"
+            ng-disabled="detailsTable.numSelected === 0"
+            ng-click="removeContentViews()">
       <i class="icon-trash"></i>
       <span translate>Remove Content Views</span>
     </button>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
@@ -43,12 +43,14 @@
 
     <div class="col-sm-4">
       <button class="btn btn-primary fr"
+              ng-disabled="repositoriesTable.numSelected === 0"
               ng-show="isState('content-views.details.repositories.list') && permitted('edit_content_views', contentView)"
               ng-click="removeRepositories(contentView)">
         <i class="icon-trash"></i>
         <span translate>Remove Repositories</span>
       </button>
       <button class="btn btn-primary fr"
+              ng-disabled="repositoriesTable.numSelected === 0"
               ng-show="isState('content-views.details.repositories.available') && permitted('edit_content_views', contentView)"
               ng-click="addRepositories(contentView)">
         <i class="icon-plus"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-manage-packages.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-manage-packages.html
@@ -25,7 +25,9 @@
   </div>
 
   <div data-block="actions">
-    <button class="btn btn-default" ng-click="removePackages()" ng-disabled="detailsTable.working">
+    <button class="btn btn-default"
+            ng-click="removePackages()"
+            ng-disabled="detailsTable.working || detailsTable.numSelected === 0">
       <i class="icon-trash" ng-hide="detailsTable.working"></i>
       <i class="icon-spinner icon-spin" ng-show="detailsTable.working"></i>
       <span translate>Remove Packages</span>

--- a/engines/bastion/test/content-views/details/filters/package-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/package-filter.controller.test.js
@@ -135,6 +135,20 @@ describe('Controller: PackageFilterController', function() {
         expect(Object.keys(rule.previous).length).toBe(0)
     });
 
+    it("should provide a method to get selected rules", function () {
+        $scope.filter.rules = [{id: 1, selected: true}, {id: 2, selected: false}];
+        expect($scope.getSelectedRules($scope.filter).length).toBe(1);
+        expect($scope.getSelectedRules($scope.filter)[0].id).toBe(1);
+    });
+
+    it("should provide a method to delete a rule", function () {
+        $scope.filter.rules = [{id: 1, selected: true}, {id: 2, selected: false}];
+
+        $scope.removeRules($scope.filter);
+        expect($scope.filter.rules.length).toBe(1);
+        expect($scope.filter.rules[0].id).toBe(2);
+    });
+
     it("should provide a method to determine if a rule is valid if no name is given", function() {
         var result,
             rule = {};


### PR DESCRIPTION
This commit disables all table actions across the application if no rows are selected.

http://projects.theforeman.org/issues/6390
https://bugzilla.redhat.com/show_bug.cgi?id=1095098
