### PR TITLE
fixes #6389 - removing available content for content hosts rabl

### DIFF
--- a/app/views/katello/api/v2/activation_keys/show.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/show.json.rabl
@@ -16,7 +16,7 @@ attributes :usage_count, :user_id, :usage_limit, :pools, :system_template_id, :r
 attributes :get_key_pools => :pools
 
 child :products => :products do |product|
-  attributes :id, :name, :available_content
+  attributes :id, :name
 end
 
 node :permissions do |activation_key|

--- a/app/views/katello/api/v2/systems/show.json.rabl
+++ b/app/views/katello/api/v2/systems/show.json.rabl
@@ -9,7 +9,7 @@ attributes :content_view, :content_view_id
 attributes :distribution
 
 child :products => :products do |product|
-  attributes :id, :name, :available_content
+  attributes :id, :name
 end
 attributes :content_overrides
 


### PR DESCRIPTION
as this was causing very very long load times for the content hosts page
