### PR TITLE
Fixes #6397 - cv sys in error msg BZ1111240

### DIFF
--- a/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
@@ -132,7 +132,7 @@ module Katello
 
       if Katello::System.where(:content_view_id => view, :environment_id => env_ids).count > 0
         unless options[:system_content_view_id] && options[:system_environment_id]
-          fail _("Unable to reassign systems. Please provide system_content_view_id and system_environment_id.")
+          fail _("Unable to reassign content hosts. Please provide system_content_view_id and system_environment_id.")
         end
 
         # if we are reassigning systems to a diffent environment or cv


### PR DESCRIPTION
Change error message in the authorize_remove_environments action the
ContentViewsController so that it references 'content host' instead
of 'system'.
