### PR TITLE
Fixes #4870, bz1113398 - Added missing foreign key associations

### DIFF
--- a/app/models/katello/capsule_lifecycle_environment.rb
+++ b/app/models/katello/capsule_lifecycle_environment.rb
@@ -16,7 +16,7 @@ class CapsuleLifecycleEnvironment < Katello::Model
             :uniqueness => { :scope => :capsule_id,
                              :message => _("is already attached to the capsule") }
 
-  belongs_to :capsule, :class_name => "::SmartProxy"
-  belongs_to :lifecycle_environment, :class_name => "Katello::KTEnvironment"
+  belongs_to :capsule, :class_name => "::SmartProxy", :inverse_of => :capsule_lifecycle_environments
+  belongs_to :lifecycle_environment, :class_name => "Katello::KTEnvironment", :inverse_of => :capsule_lifecycle_environments
 end
 end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -36,7 +36,7 @@ module Katello
 
         has_many :activation_keys, :class_name => "Katello::ActivationKey", :dependent => :destroy
         has_many :providers, :class_name => "Katello::Provider", :dependent => :destroy
-        has_many :products, :class_name => "Katello::Product", :through => :providers
+        has_many :products, :class_name => "Katello::Product", :dependent => :destroy, :inverse_of => :organization
         # has_many :environments is already defined in Foreman taxonomy.rb
         has_many :kt_environments, :class_name => "Katello::KTEnvironment", :dependent => :destroy, :inverse_of => :organization
         has_one :library, :class_name => "Katello::KTEnvironment", :conditions => {:library => true}, :dependent => :destroy

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -24,7 +24,8 @@ module Katello
         has_many :capsule_lifecycle_environments,
                  :class_name  => "Katello::CapsuleLifecycleEnvironment",
                  :foreign_key => :capsule_id,
-                 :dependent   => :destroy
+                 :dependent   => :destroy,
+                 :inverse_of => :capsule
 
         has_many :lifecycle_environments,
                  :class_name => "Katello::KTEnvironment",

--- a/app/models/katello/content_view_history.rb
+++ b/app/models/katello/content_view_history.rb
@@ -17,7 +17,7 @@ class ContentViewHistory < Katello::Model
 
   belongs_to :environment, :class_name => "Katello::KTEnvironment", :inverse_of => :content_view_histories,
              :foreign_key => :katello_environment_id
-  belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion", :foreign_key => :katello_content_view_version_id
+  belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion", :foreign_key => :katello_content_view_version_id, :inverse_of => :history
   belongs_to :task, :class_name => "ForemanTasks::Task::DynflowTask", :foreign_key => :task_id
 
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :notes

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -71,7 +71,7 @@ class KTEnvironment < Katello::Model
   validates_with Validators::PathDescendentsValidator
 
   has_many :capsule_lifecycle_environments, :foreign_key => :lifecycle_environment_id,
-           :dependent => :destroy
+           :dependent => :destroy, :inverse_of => :lifecycle_environment
 
   scope(:not_in_capsule,
         lambda do |capsule|

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -32,7 +32,7 @@ class Product < Katello::Model
            :foreign_key => :engineering_product_id, :dependent => :destroy
   has_many :marketing_products, :through => :marketing_engineering_products
 
-  belongs_to :organization
+  belongs_to :organization, :inverse_of => :products
   belongs_to :provider, :inverse_of => :products
   belongs_to :sync_plan, :inverse_of => :products, :class_name => 'Katello::SyncPlan'
   belongs_to :gpg_key, :inverse_of => :products

--- a/app/models/katello/provider.rb
+++ b/app/models/katello/provider.rb
@@ -29,7 +29,7 @@ class Provider < Katello::Model
 
   belongs_to :organization, :inverse_of => :providers, :class_name => "Organization"
   belongs_to :task_status, :inverse_of => :provider
-  has_many :products, :class_name => "Katello::Product", :inverse_of => :provider, :dependent => :destroy
+  has_many :products, :class_name => "Katello::Product", :inverse_of => :provider, :dependent => :restrict
   has_many :repositories, :through => :products
 
   validates :name, :uniqueness => {:scope => :organization_id}

--- a/db/migrate/20140624183938_add_foreign_keys_for_organizations.rb
+++ b/db/migrate/20140624183938_add_foreign_keys_for_organizations.rb
@@ -1,0 +1,38 @@
+class AddForeignKeysForOrganizations < ActiveRecord::Migration
+  def up
+    add_foreign_key(:katello_task_statuses, :taxonomies,
+                    :name => 'katello_task_statuses_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_permissions, :taxonomies,
+                    :name => 'katello_permissions_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_sync_plans, :taxonomies,
+                    :name => 'katello_sync_plans_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_providers, :taxonomies,
+                    :name => 'katello_providers_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_gpg_keys, :taxonomies,
+                    :name => 'katello_gpg_keys_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_products, :taxonomies,
+                    :name => 'katello_products_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_activation_keys, :taxonomies,
+                    :name => 'katello_activation_keys_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_notices, :taxonomies,
+                    :name => 'katello_notices_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_host_collections, :taxonomies,
+                    :name => 'katello_host_collections_organization_fk', :column => 'organization_id')
+    add_foreign_key(:katello_environments, :taxonomies,
+                    :name => 'katello_environments_organization_fk', :column => 'organization_id')
+  end
+
+  def down
+    remove_foreign_key('katello_task_statuses', :name => 'katello_task_statuses_organization_fk')
+    remove_foreign_key('katello_permissions', :name => 'katello_permissions_organization_fk')
+    remove_foreign_key('katello_sync_plans', :name => 'katello_sync_plans_organization_fk')
+    remove_foreign_key('katello_providers', :name => 'katello_providers_organization_fk')
+    remove_foreign_key('katello_gpg_keys', :name => 'katello_gpg_keys_organization_fk')
+    remove_foreign_key('katello_products', :name => 'katello_products_organization_fk')
+    remove_foreign_key('katello_activation_keys', :name => 'katello_activation_keys_organization_fk')
+    remove_foreign_key('katello_notices', :name => 'katello_notices_organization_fk')
+    remove_foreign_key('katello_host_collections', :name => 'katello_host_collections_organization_fk')
+    remove_foreign_key('katello_environments', :name => 'katello_environments_organization_fk')
+  end
+
+end

--- a/db/migrate/20140626055258_add_missing_foreign_keys.rb
+++ b/db/migrate/20140626055258_add_missing_foreign_keys.rb
@@ -1,0 +1,19 @@
+class AddMissingForeignKeys < ActiveRecord::Migration
+  def up
+    add_foreign_key(:katello_capsule_lifecycle_environments, :smart_proxies,
+                    :name => 'katello_capsule_lifecycle_environments_capsule_fk', :column => 'capsule_id')
+    add_foreign_key(:katello_capsule_lifecycle_environments, :katello_environments,
+                    :name => 'katello_capsule_lifecycle_environments_environment_fk', :column => 'lifecycle_environment_id')
+    add_foreign_key(:katello_repositories, :katello_environments,
+                    :name => 'katello_repositories_environment_fk', :column => 'environment_id')
+    add_foreign_key(:katello_repositories, :katello_products,
+                    :name => 'katello_repositories_product_fk', :column => 'product_id')
+  end
+
+  def down
+    remove_foreign_key('katello_capsule_lifecycle_environments', :name => 'katello_capsule_lifecycle_environments_capsule_fk')
+    remove_foreign_key('katello_capsule_lifecycle_environments', :name => 'katello_capsule_lifecycle_environments_environment_fk')
+    remove_foreign_key('katello_repositories', :name => 'katello_repositories_environment_fk')
+    remove_foreign_key('katello_repositories', :name => 'katello_repositories_product_fk')
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -110,7 +110,7 @@ describe Product, :katello => true do
     specify { Product.new(:label=> "shoo", :name => 'contains space', :provider => @provider).must_be :valid? }
     specify { Product.new(:label => "bar foo", :name=> "foo", :provider => @provider).wont_be :valid?}
     it "should not be successful when creating a product with a duplicate name in one organization" do
-      @p = Product.create!(ProductTestData::SIMPLE_PRODUCT)
+      @p = Product.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => @organization.id))
 
       Product.new({:name=>@p.name, :label=> @p.name,
         :id => @p.cp_id,
@@ -130,7 +130,7 @@ describe Product, :katello => true do
     describe "repo id" do
       before do
         Resources::Candlepin::Product.stubs(:create).returns({:id => ProductTestData::PRODUCT_ID})
-        @p = Product.create!(ProductTestData::SIMPLE_PRODUCT)
+        @p = Product.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => @organization.id))
       end
 
       specify "format" do
@@ -251,7 +251,7 @@ describe Product, :katello => true do
   describe "#environments" do
     it "should contain a unique list of environments" do
       disable_repo_orchestration
-      product = Product.create!(ProductTestData::SIMPLE_PRODUCT)
+      product = Product.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => @organization.id) )
       2.times do
         create(:katello_repository, product: product, environment: @organization.library,
                content_view_version: @organization.library.default_content_view_version,

--- a/spec/models/sync_plan_spec.rb
+++ b/spec/models/sync_plan_spec.rb
@@ -134,8 +134,8 @@ module Katello
 
         organization = get_organization
 
-        @plan.products.create! ProductTestData::SIMPLE_PRODUCT.merge(
-                                   :provider => organization.redhat_provider)
+        @plan.products.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => organization.id,
+                                                                     :provider => organization.redhat_provider))
         @plan.save!
         @plan.reload
         @plan.products.length.must_equal(1)

--- a/test/models/association_test.rb
+++ b/test/models/association_test.rb
@@ -15,7 +15,7 @@ require 'katello_test_helper'
 module Katello
 describe 'associations' do
   def location(model, association)
-    path     = "#{Katello::Engine.root}/app/models/#{model.name.underscore}.rb"
+    path     = "#{Katello::Engine.root}/app/models/katello/#{model.name.underscore}.rb"
     location = if File.exist? path
                  content     = File.read path
                  line_number = content.lines.find_index do |line|
@@ -28,29 +28,55 @@ describe 'associations' do
     return "\nin #{location}"
   end
 
-  ActiveRecord::Base.subclasses.each do |model|
+  def ignorable_foreign_keys
+    {
+      "katello_custom_info" => ["informable_id"],
+      "katello_task_statuses" => ["task_owner_id"],
+      "katello_content_view_erratum_filter_rules" => ["errata_id"],
+      "katello_repositories" => ["content_id"],
+    }
+  end
+
+  Katello::Model.subclasses.each do |model|
     next unless model.table_name && model.table_name.starts_with?('katello_')
 
     describe model do
       model.reflect_on_all_associations(:belongs_to).each do |association|
         describe "belongs_to: #{association.name.inspect}" do
-          next if association.options.key? :polymorphic
+          unless association.options.key? :polymorphic
+            it('has :inverse_of option') do
+              unless association.class_name.start_with?("ForemanTasks::")
+                assert(association.options.key?(:inverse_of),
+                       "inverse association cannot be found without the option set #{location(model, association)}")
+              end
+            end
 
-          it('has :inverse_of option') do
-            assert association.options.key?(:inverse_of),
-                   'inverse association cannot be found without the option set' +
-                       location(model, association)
-          end
+            it("inverse association exists") do
+              unless association.class_name.start_with?("ForemanTasks::")
+                assert(association.inverse_of,
+                       "the inverse association which would take care of deletion avoiding FK errors could not be found  #{location(model, association)}")
+              end
+            end
 
-          it('inverse association exists') do
-            assert association.inverse_of,
-                   'the inverse association which would take care of deletion avoiding FK errors could not be found' +
-                       location(model, association)
-          end
+            it('is using correct foreign_key') do
+              unless association.class_name.start_with?("ForemanTasks::")
+                assert model.column_names.include?(fk = association.foreign_key.to_s),
+                       "unknown foreign_key #{fk}  #{location(model, association)}"
+              end
+            end
 
-          it('is using correct foreign_key') do
-            assert model.column_names.include?(fk = association.foreign_key.to_s),
-                   "unknown foreign_key #{fk}" + location(model, association)
+            it "foreign_key_id actually exists for the table" do
+              unless association.class_name.start_with?("ForemanTasks::") || ignorable_foreign_keys.fetch(model.table_name, []).include?(association.foreign_key.to_s)
+                conn = ActiveRecord::Base.connection
+                fk_columns = conn.foreign_keys(model.table_name).map do |col|
+                  col.options[:column]
+                end
+                fk_columns.flatten!
+                fk_columns.uniq!
+                msg = "Foreign Key not defined for  #{model.table_name}.#{association.foreign_key}"
+                assert fk_columns.include?(association.foreign_key.to_s), msg
+              end
+            end
           end
         end
       end
@@ -70,7 +96,12 @@ describe 'associations' do
           end
 
           it('is using correct foreign_key') do
-            other_model = association.class_name.constantize
+
+            class_name = association.class_name
+            unless class_name.start_with?("Katello") || class_name == "User" || class_name == "Organization"
+              class_name = "Katello::" + association.class_name
+            end
+            other_model = class_name.constantize
             foreign_key = association.foreign_key.to_s
             assert other_model.column_names.include?(foreign_key),
                    "unknown foreign_key #{foreign_key} on #{other_model}" + location(model, association)


### PR DESCRIPTION
Also contains updates to association tests if foreign key constraints
are not defined in 'belongs_to' associations for all Katello models.
