### PR TITLE
Fixes #5957/BZ1091835 - prevent product tooltip from "blinking".

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-details.html
@@ -19,14 +19,17 @@
       <span ng-switch="getReadOnlyReason(product)">
         <i class="icon-question-sign" ng-switch-when="permissions"
            tooltip="{{ 'You cannot remove this product because you do not have permission.' | translate }}"
+           tooltip-animation="false"
            tooltip-append-to-body="true">
         </i>
         <i class="icon-question-sign" ng-switch-when="published"
            tooltip="{{ 'You cannot remove this product because it was published to a content view.' | translate }}"
+           tooltip-animation="false"
            tooltip-append-to-body="true">
         </i>
         <i class="icon-question-sign" ng-switch-when="redhat"
            tooltip="{{ 'You cannot remove this product because it is a Red Hat product.' | translate }}"
+           tooltip-animation="false"
            tooltip-append-to-body="true">
         </i>
       </span>


### PR DESCRIPTION
Prevent appended to body product tooltip from momentarily blinking
on some browsers by disabling the animation.

http://projects.theforeman.org/issues/5957
https://bugzilla.redhat.com/show_bug.cgi?id=1091835
