### PR TITLE
Fixes #6411 - filter params by path BZ1111484

### DIFF
--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -200,6 +200,14 @@ common:
     log_trace: false
     #do not log certain paths (example  /notices/get_new)
     ignored_paths: []
+    # filter discrete parameters based on request paths
+    # instead of a blanket filtering like in config.filer_parameters
+    # (example: prevent the name paramater from being logged when an activation key
+    #    is updated)
+    filter_parameters_by_path:
+       - path: 'content_uploads'
+         names:
+           - 'content'
     # configuration of all loggers used in app
     loggers:
       # this logger is parent of all other loggers, by default this is the only one having appender

--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -40,5 +40,6 @@ module Katello
   require "katello/load_configuration"
   require "katello/logging"
   require 'katello/middleware/silenced_logger.rb'
+  require 'katello/middleware/custom_ac_log_subscriber.rb'
 
 end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -6,6 +6,10 @@ module Katello
 
     initializer 'katello.silenced_logger', :before => :build_middleware_stack do |app|
       app.config.middleware.swap Rails::Rack::Logger, Katello::Middleware::SilencedLogger, {}
+      %w(start_processing).each do |evt|
+        ::ActiveSupport::Notifications.unsubscribe "#{evt}.action_controller"
+      end
+      Katello::Middleware::CustomAcLogSubscriber.attach_to :action_controller
     end
 
     initializer 'katello.mount_engine', :after => :build_middleware_stack do |app|

--- a/lib/katello/middleware/custom_ac_log_subscriber.rb
+++ b/lib/katello/middleware/custom_ac_log_subscriber.rb
@@ -1,0 +1,57 @@
+module Katello
+  module Middleware
+    class CustomAcLogSubscriber < ActionController::LogSubscriber
+      INTERNAL_PARAMS = ActionController::LogSubscriber::INTERNAL_PARAMS
+
+      def start_processing(event)
+        return unless logger.info?
+
+        if needs_filtering?(event)
+          params = event.payload[:params]
+          param_names_to_filter = parameter_names_to_filter_from_path(event)
+          log_payload(event.payload, filter_params(params, param_names_to_filter))
+        else
+          super
+        end
+      end
+
+      private
+
+      def parameters_to_filter
+        unless @filtered_parameters
+          configs = Katello.config.logging.filter_parameters_by_path
+          @filtered_parameters ||= configs ? configs.map{|fp| OpenStruct.new(fp)} : []
+        end
+        @filtered_parameters
+      end
+
+      def filter_params(params, names_to_filter)
+        result = params.clone
+        (result.keys & names_to_filter).each do |key|
+          result[key] = "[FILTERED]"
+        end
+        result
+      end
+
+      def log_payload(payload, params)
+        format  = payload[:format]
+        format  = format.to_s.upcase if format.is_a?(Symbol)
+
+        info "Processing by #{payload[:controller]}##{payload[:action]} as #{format}"
+        info "  Parameters: #{params.inspect}" unless params.empty?
+      end
+
+      def parameter_names_to_filter_from_path(event)
+        result = parameters_to_filter.find{ |p| event.payload[:path].include?(p.path) }
+        result.names
+      end
+
+      def needs_filtering?(event)
+        parameters_to_filter.any? do |p|
+          event.payload[:path].include?(p.path) &&
+            (event.payload[:params].keys & p.names).size > 0
+        end
+      end
+    end
+  end
+end

--- a/test/lib/middleware/custom_ac_log_subscriber_test.rb
+++ b/test/lib/middleware/custom_ac_log_subscriber_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+
+module Katello
+class CustomACLogSubscriberTest < ActiveSupport::TestCase
+  def setup
+    @log_subscriber = Katello::Middleware::CustomAcLogSubscriber.new
+    Katello.config.logging.stubs(:filter_parameters_by_path).returns([{"path"=> "foo_path", "names" => ['name', 'id']}])
+  end
+
+  def test_start_processing_when_config_is_not_set_
+    Katello.config.logging.stubs(:filter_parameters_by_path).returns(nil)
+    @event = OpenStruct.new({:payload => {:path => '/katello/foo_path', :params => {}}})
+    @log_subscriber.start_processing(@event)
+  end
+
+  def test_start_processing_with_filtering
+     @log_subscriber.expects(:log_payload).with do |payload, params|
+       params['foo'] == 'bar' && params['name'].include?("FILTERED") && params['id'].include?("FILTERED")
+     end
+    @event = OpenStruct.new({:payload => {:path => '/katello/foo_path', :params => {'foo' => 'bar', 'name' => 'blah', 'id' => 'blah' }}})
+    @log_subscriber.start_processing(@event)
+  end
+
+  def test_start_processing_without_filtering
+    @log_subscriber.expects(:log_payload).never
+    @event = OpenStruct.new({:payload => {:path => '/katello/api/users/1/show', :params => {}}})
+    @log_subscriber.start_processing(@event)
+  end
+end
+end


### PR DESCRIPTION
there is an issue where certain parameters for particular controllers are
causing the log to fill up. This allows the ability to filter parameters values
scoped to request url paths.

Example:

You can filter the parameters, content and name, for all requests where
the path contain 'content_uploads' .

```
filter_parameters_by_path:
   - path: 'content_uploads'
     names:
       - 'content'
       - 'name'
```

value for the parameters, content and name, will be filtered for urls like:
/katello/subscribers/content_uploads
/katello/content_uploads/1
