### PR TITLE
fixes 6415 - ignore non-bootable distributions in content view

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -125,6 +125,7 @@ module Katello
           distributions = Katello::Distribution.search do
             filter :and, filters
           end
+          distributions = distributions.select{ |dist| Katello::Distribution.new(dist.as_json).bootable? }
           distribution_repo_ids = distributions.map(&:repoids).flatten
 
           ::Katello::Repository.where(:pulp_id => (repo_ids & distribution_repo_ids))

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -20,6 +20,7 @@ module Katello
         before_create :associate_organizations
         before_create :associate_default_location
         before_create :associate_lifecycle_environments
+        attr_accessible :lifecycle_environment_ids
 
         has_many :capsule_lifecycle_environments,
                  :class_name  => "Katello::CapsuleLifecycleEnvironment",

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -629,6 +629,8 @@ class ContentView < Katello::Model
     distributions = Distribution.search do
       filter :terms, {:repoids => repo_ids}
     end
+    distributions = distributions.select{ |dist| Katello::Distribution.new(dist.as_json).bootable? }
+
     release_arches = {}
     distributions.each do |dist|
       key = [dist.version, dist.arch]
@@ -645,6 +647,7 @@ class ContentView < Katello::Model
     distributions = Distribution.search do
       filter :terms, {:repoids => repo_ids}
     end
+    distributions = distributions.select{ |dist| Katello::Distribution.new(dist.as_json).bootable? }
     distributions.find_all{|dist| (dist.repoids & repo_ids).length > 1}
   end
 

--- a/app/models/katello/distribution.rb
+++ b/app/models/katello/distribution.rb
@@ -15,5 +15,19 @@ class Distribution
   include Glue::Pulp::Distribution if Katello.config.use_pulp
   include Glue::ElasticSearch::Distribution if Katello.config.use_elasticsearch
   CONTENT_TYPE = "distribution"
+
+  def bootable?
+    # Not every distribution from Pulp represents a bootable
+    # repo. Determine based on the files in the repo.
+    self.files.any? do |file|
+      if file.is_a? Hash
+        filename = file[:relativepath]
+      else
+        filename = file
+      end
+      filename.include?("vmlinuz") || filename.include?("pxeboot")
+    end
+  end
+
 end
 end

--- a/app/models/katello/glue/pulp/distribution.rb
+++ b/app/models/katello/glue/pulp/distribution.rb
@@ -41,7 +41,7 @@ module Glue::Pulp::Distribution
 
     def as_json(*args)
       result = super(*args)
-      result['files'] = result['files'].inject([]) do |paths, file|
+      result['files'] = (result['files'] || []).inject([]) do |paths, file|
         paths << file['relativepath']
       end
       result

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -359,15 +359,7 @@ module Glue::Pulp::Repo
 
     def bootable_distribution
       return unless self.unprotected
-
-      # Not every distribution from Pulp represents a bootable
-      # repo. Determine based on the files in the repo.
-      return self.distributions.find do |distribution|
-        distribution.files.any? do |file|
-          file[:relativepath].include?("vmlinuz") ||
-              file[:relativepath].include?("pxeboot")
-        end
-      end
+      self.distributions.find{|distribution| distribution.bootable? }
     end
 
     def package_groups

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -302,11 +302,16 @@ class ContentViewTest < ActiveSupport::TestCase
     view.repositories << Repository.find(katello_repositories(:rhel_6_x86_64))
     view.save!
 
-    distro1 = Distribution.new()
+    distro1 = Distribution.new
     distro1.repoids = view.repositories.pluck(:pulp_id)
-    distro2 = Distribution.new()
+    distro1.files = [{'relativepath' => 'vmlinuz'}]
+
+    distro2 = Distribution.new
     distro2.repoids = []
+    distro2.files = [{'relativepath' => 'vmlinuz'}]
+
     Distribution.stubs(:search).returns([distro1, distro2])
+
     assert_raises(RuntimeError) do
       view.check_distribution_conflicts!
     end
@@ -317,12 +322,12 @@ class ContentViewTest < ActiveSupport::TestCase
     view.repositories << Repository.find(katello_repositories(:rhel_6_x86_64))
     view.save!
 
-    distro1 = Distribution.new()
+    distro1 = Distribution.new
     distro1.repoids = []
+    distro1.files = [{'relativepath' => 'vmlinuz'}]
 
     Distribution.stubs(:search).returns([distro1])
     assert_nil view.check_distribution_conflicts!
-
   end
 
   def test_duplicate_distributions
@@ -330,12 +335,15 @@ class ContentViewTest < ActiveSupport::TestCase
     view.repositories << Repository.find(katello_repositories(:rhel_6_x86_64))
     view.save!
 
-    distro1 = Distribution.new()
+    distro1 = Distribution.new
     distro1.repoids = view.repositories.pluck(:pulp_id)
-    distro2 = Distribution.new()
-    distro2.repoids = []
-    Distribution.stubs(:search).returns([distro1, distro2])
+    distro1.files = [{'relativepath' => 'vmlinuz'}]
 
+    distro2 = Distribution.new
+    distro2.repoids = []
+    distro2.files = [{'relativepath' => 'vmlinuz'}]
+
+    Distribution.stubs(:search).returns([distro1, distro2])
     assert_equal [distro1], view.duplicate_distributions
   end
 
@@ -346,10 +354,15 @@ class ContentViewTest < ActiveSupport::TestCase
 
     distro1 = Distribution.new(:version => '6.4', :arch => 'x86_64')
     distro1.repoids = [view.repositories[0].pulp_id]
+    distro1.files = [{'relativepath' => 'vmlinuz'}]
+
     distro2 = Distribution.new(:version => '6.4', :arch => 'x86_64')
     distro2.repoids = [view.repositories[1].pulp_id]
+    distro2.files = [{'relativepath' => 'vmlinuz'}]
+
     distro3 = Distribution.new(:version => '6.5', :arch => 'x86_64')
     distro3.repoids = []
+    distro3.files = [{'relativepath' => 'vmlinuz'}]
 
     Distribution.stubs(:search).returns([distro1, distro2, distro3])
 


### PR DESCRIPTION
ignoring:
  a) as part of validation to not allow 2 dists with the same arch and version
  b) as part of calculating the kickstart url for a new host
