### PR TITLE
Fixes #6419 - Change the default org name

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,8 @@ require 'util/password'
 
 # Can be specified via the command line using:
 # rake db:seed SEED_INITIAL_ORGANIZATION=MyOrg SEED_INITIAL_LOCATION=MyDefault
-first_org_name = ENV['SEED_INITIAL_ORGANIZATION'] || 'ACME_Corporation'
-first_location_name = ENV['SEED_INITIAL_LOCATION'] || 'Default'
+first_org_name = ENV['SEED_INITIAL_ORGANIZATION'] || 'Default_Organization'
+first_location_name = ENV['SEED_INITIAL_LOCATION'] || 'Default_Location'
 
 def format_errors(model = nil)
   return '(nil found)' if model.nil?


### PR DESCRIPTION
We got some feedback on the default org name. I know we're making changing to the installer to perhaps make org name a requirement but I don't think this should hurt to have this as well.
