### PR TITLE
fixes #6427 / BZ 1109737 - remove Nest option from taxonomy actions

### DIFF
--- a/app/overrides/foreman/taxonomies/_action_buttons.html.erb
+++ b/app/overrides/foreman/taxonomies/_action_buttons.html.erb
@@ -1,7 +1,6 @@
 <% if taxonomy.is_a?(Organization) %>
   <%= action_buttons(
     display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy) ),
-    display_link_if_authorized(_("Nest"), hash_for_nest_taxonomy_path(taxonomy) ),
     display_link_if_authorized(_("Clone"), hash_for_clone_taxonomy_path(taxonomy) ),
     (link_to((_("Select hosts to assign to %s") % taxonomy.name), assign_hosts_taxonomy_path(taxonomy)) if @count_nil_hosts > 0),
     (link_to(n_("Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}", "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}", @count_nil_hosts) % {:count => @count_nil_hosts, :taxonomy_single => taxonomy_single, :taxonomy_name => taxonomy.name}  ,

--- a/app/overrides/override_taxonomy_actions.rb
+++ b/app/overrides/override_taxonomy_actions.rb
@@ -1,6 +1,7 @@
 # TODO: ORG_DESTROY - temporarily remove the org destroy link
+# Remove support for organization nesting
 Deface::Override.new(:virtual_path => "taxonomies/index",
-                     :name => "remove_organization_delete",
+                     :name => "override_taxonomy_actions",
                      :replace => 'code[erb-loud]:contains("action_buttons")',
                      :partial => '../overrides/foreman/taxonomies/action_buttons'
                     )


### PR DESCRIPTION
This commit removes Nest as a valid option for taxonomies (e.g Organization
& Location)
