### PR TITLE
fixes #6248 / BZ 1109062 - Bulk Host Collection - disable add/remove when no hosts selected

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-host-collections.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-host-collections.html
@@ -24,13 +24,17 @@
     </div>
 
     <div data-block="actions">
-      <button class="btn btn-default" ng-disable="detailsTable.numSelected == 0 || denied('edit_content_hosts', contentHost)"
+      <button class="btn btn-default"
+              ng-hide="denied('edit_content_hosts', contentHost)"
+              ng-disabled="table.numSelected == 0 || detailsTable.numSelected == 0"
               ng-click="hostCollections.action = 'add'; hostCollections.working = true">
         <i class="icon-plus"></i>
         {{ "Add To" | translate }}
       </button>
 
-      <button class="btn btn-default" ng-disable="detailsTable.numSelected == 0 || denied('edit_content_hosts', contentHost)"
+      <button class="btn btn-default"
+              ng-hide="denied('edit_content_hosts', contentHost)"
+              ng-disabled="table.numSelected == 0 || detailsTable.numSelected == 0"
               ng-click="hostCollections.action = 'remove'; hostCollections.working = true">
         <i class="icon-minus"></i>
         {{ "Remove From" | translate }}


### PR DESCRIPTION
When the user is performing a content host bulk action, if they do
not select any content hosts, disable the add/remove buttons
for host collections.
