### PR TITLE
Fixes #6411 - filter params by path BZ1111484

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -14,6 +14,9 @@ module Katello
 class Api::V2::ContentUploadsController < Api::V2::ApiController
   before_filter :find_repository
 
+  include Foreman::Controller::FilterParameters
+  filter_parameters :content
+
   api :POST, "/repositories/:repository_id/content_uploads", N_("Create an upload request")
   param :repository_id, :identifier, :required => true, :desc => N_("repository id")
   def create


### PR DESCRIPTION
DEPENDS on https://github.com/theforeman/foreman/pull/1548
The content param in the content_uploads action is causing
the log to fill up with garbage since content is binary.  This
filters the log so that the content_uploads the content param is
filtered.
