### PR TITLE
fixes #6433 - allow a lifecycle environment to be unselected

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/widgets/path-selector.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/path-selector.directive.js
@@ -37,11 +37,15 @@ angular.module('Bastion.widgets').directive('pathSelector',
         link: function (scope, element, attrs, ngModel) {
             var activeItemId, convertPathObjects;
 
-            scope.itemSelected = function (item) {
+            scope.itemChanged = function (item) {
                 if (item && scope.mode === 'singleSelect') {
-                    unselectActive();
-                    selectById(item.id);
-                    activeItemId = item.id;
+                    if (item.selected) {
+                        unselectActive();
+                        selectById(item.id);
+                        activeItemId = item.id;
+                    } else {
+                        ngModel.$setViewValue(undefined);
+                    }
                 }
             };
 
@@ -55,15 +59,15 @@ angular.module('Bastion.widgets').directive('pathSelector',
             if (scope.paths.$promise) {
                 scope.paths.$promise.then(function (paths) {
                     scope.paths = convertPathObjects(paths);
-                    scope.itemSelected(ngModel.$modelValue);
+                    scope.itemChanged(ngModel.$modelValue);
                 });
             } else {
                 scope.paths = convertPathObjects(scope.paths);
-                scope.itemSelected(ngModel.$modelValue);
+                scope.itemChanged(ngModel.$modelValue);
             }
 
             ngModel.$render = function () {
-                scope.itemSelected(ngModel.$modelValue);
+                scope.itemChanged(ngModel.$modelValue);
             };
 
             scope.$watch('disableTrigger', function (disable) {

--- a/engines/bastion/app/assets/javascripts/bastion/widgets/views/path-selector.html
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/views/path-selector.html
@@ -3,7 +3,7 @@
   <ul class="path-list">
     <li class="path-list-item" ng-repeat="item in path" ng-class="{ 'disabled-item': item.disabled }">
       <label class="path-list-item-label" ng-disabled="item.disabled" ng-class="{ active: item.selected }" ng-mouseenter="hover" ng-mouseleave="hover = false">
-        <input type="checkbox" ng-model="item.selected" ng-change="itemSelected(item)" ng-disabled="item.disabled"/>
+        <input type="checkbox" ng-model="item.selected" ng-change="itemChanged(item)" ng-disabled="item.disabled"/>
         {{ item.name }}
       </label>
     </li>

--- a/engines/bastion/test/widgets/path-selector.directive.test.js
+++ b/engines/bastion/test/widgets/path-selector.directive.test.js
@@ -103,4 +103,17 @@ describe('Directive: pathSelector', function() {
         expect(element.find('.path-list:first .path-list-item').length).toBe(3);
 
     });
+
+    it("should provide a way to unselect an environment", function () {
+        var checkbox = element.find('.path-list:first .path-list-item:first').find('input');
+        expect(checkbox.is(':checked')).toBe(false);
+        
+        checkbox.click();
+        expect(checkbox.is(':checked')).toBe(true);
+
+        checkbox.click();
+        expect(checkbox.is(':checked')).toBe(false);
+    });
+
+
 });


### PR DESCRIPTION
When promoting a content view version, it's now possible to uncheck the
lifecycle environment checkbox.
