### PR TITLE
fixes #6439 / BZ 1094190 - Include notification on add/remove pkg filter rule

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/package-filter.controller.js
@@ -121,6 +121,7 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
                         $scope.filter.rules.splice(index, 1);
                     }
                 });
+                $scope.successMessages = [translate('Package successfully removed.')];
             };
 
             Rule.delete({filterId: rule['content_view_filter_id'], ruleId: ruleId}, success, failure);

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-filter-details.html
@@ -1,3 +1,5 @@
+<div alch-alert success-messages="successMessages" error-messages="errorMessages"></div>
+
 <div class="details-header">
   <div>
     <input type="text"


### PR DESCRIPTION
When the user adds/removes a rule from a package filter (associated
with a content view), display a notification consistent with what
is done for package groups.
