### PR TITLE
Fixes #6448 - cr/update CH with type CH BZ1114065

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -97,7 +97,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
   param :facts, Hash, :desc => N_("Key-value hash of content host-specific facts"), :action_aware => true, :required => true do
     param :fact, String, :desc => N_("Any number of facts about this content host")
   end
-  param :type, String, :desc => N_("Type of the content host, it should always be 'content host'"), :required => true, :action_aware => true
+  param :type, String, :desc => N_("Type of the content host, it should always be 'system'"), :required => true, :action_aware => true
   param :guest_ids, Array, :desc => N_("IDs of the virtual guests running on this content host")
   param :installed_products, Array, :desc => N_("List of products installed on the content host"), :action_aware => true
   param :release_ver, String, :desc => N_("Release version of the content host")
@@ -123,7 +123,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
   param :facts, Hash, :desc => N_("Key-value hash of content host-specific facts"), :action_aware => true, :required => true do
     param :fact, String, :desc => N_("Any number of facts about this content host")
   end
-  param :type, String, :desc => N_("Type of the content host, it should always be 'content host'"), :required => true, :action_aware => true
+  param :type, String, :desc => N_("Type of the content host, it should always be 'system'"), :required => true, :action_aware => true
   param :guest_ids, Array, :desc => N_("IDs of the virtual guests running on this content host")
   param :installed_products, Array, :desc => N_("List of products installed on the content host"), :action_aware => true
   param :release_ver, String, :desc => N_("Release version of the content host")
@@ -355,10 +355,8 @@ class Api::V2::SystemsController < Api::V2::ApiController
                                                    :service_level, {:facts => []},
                                                    :guest_ids, {:host_collection_ids => []})
 
-    if params[:system].key?(:type)
-      system_params[:cp_type] = params[:type]
-      system_params.delete(:type)
-    end
+    system_params[:cp_type] = params[:type] ? params[:type] : ::Katello::System::DEFAULT_CP_TYPE
+    system_params.delete(:type) if params[:system].key?(:type)
 
     # TODO: permit :facts above not working, why?
     system_params[:facts] = params[:facts] if params[:facts]

--- a/app/models/katello/glue/candlepin/consumer.rb
+++ b/app/models/katello/glue/candlepin/consumer.rb
@@ -12,6 +12,10 @@
 
 module Katello
 module Glue::Candlepin::Consumer
+  SYSTEM = "system"
+  HYPERVISOR = "hypervisor"
+  CANDLEPIN = "candlepin"
+  CP_TYPES = [SYSTEM, HYPERVISOR, CANDLEPIN]
 
   # TODO: break up method
   # rubocop:disable MethodLength
@@ -52,7 +56,7 @@ module Glue::Candlepin::Consumer
       lazy_accessor :compliance, :initializer => lambda {|s| Resources::Candlepin::Consumer.compliance(uuid) }
       lazy_accessor :events, :initializer => lambda {|s| Resources::Candlepin::Consumer.events(uuid) }
 
-      validates :cp_type, :inclusion => {:in => %w(system hypervisor candlepin)},
+      validates :cp_type, :inclusion => {:in => CP_TYPES},
                           :if => :new_record?
       validates :facts, :presence => true, :if => :new_record?
     end

--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -13,6 +13,8 @@
 
 module Katello
 class System < Katello::Model
+  DEFAULT_CP_TYPE = Glue::Candlepin::Consumer::SYSTEM
+
   self.include_root_in_json = false
 
   include Hooks


### PR DESCRIPTION
creating or updating a content host with the type set to 'content host'¬
causes the validation for candlepin to fail because type must be one of¬
the following: system hypervisor candlepin.
