### PR TITLE
Refs #4478 - API localization - Apipie setup moved

### DIFF
--- a/db/migrate/20140626204657_add_unlimited_to_activation_keys.rb
+++ b/db/migrate/20140626204657_add_unlimited_to_activation_keys.rb
@@ -1,22 +1,26 @@
 class AddUnlimitedToActivationKeys < ActiveRecord::Migration
+  class ::Katello::ActivationKeys < ActiveRecord::Base
+  end
+
   def up
     add_column :katello_activation_keys, :unlimited_content_hosts, :boolean, :default => true
     rename_column :katello_activation_keys, :usage_limit, :max_content_hosts
     change_column_default :katello_activation_keys, :max_content_hosts, nil
 
-    update "UPDATE katello_activation_keys
-            SET unlimited_content_hosts = true, max_content_hosts = null
-            WHERE max_content_hosts = -1"
-
-    update "UPDATE katello_activation_keys
-            SET unlimited_content_hosts = false
-            WHERE max_content_hosts > 0"
+    Katello::ActivationKeys.reset_column_information
+    Katello::ActivationKeys.all.each do |coll|
+      if coll.max_content_hosts == -1
+        coll.update_attributes(:unlimited_content_hosts => true, :max_content_hosts => nil)
+      elsif coll.max_content_hosts > 0
+        coll.update_attributes(:unlimited_content_hosts => false)
+      end
+    end
   end
 
   def down
-    update "UPDATE katello_activation_keys
-            SET max_content_hosts = -1
-            WHERE unlimited_content_hosts = true"
+    Katello::ActivationKeys.all.each do |key|
+      key.update_attributes(:max_content_hosts => -1) if key.unlimited_content_hosts
+    end
 
     remove_column :katello_activation_keys, :unlimited_content_hosts
     rename_column :katello_activation_keys, :max_content_hosts, :usage_limit

--- a/db/migrate/20140626204902_add_unlimited_to_host_collection.rb
+++ b/db/migrate/20140626204902_add_unlimited_to_host_collection.rb
@@ -1,21 +1,25 @@
 class AddUnlimitedToHostCollection < ActiveRecord::Migration
+  class ::Katello::HostCollections < ActiveRecord::Base
+  end
+
   def up
     add_column :katello_host_collections, :unlimited_content_hosts, :boolean, :default => true
     change_column :katello_host_collections, :max_content_hosts, :integer, :null => true, :default => nil
 
-    update "UPDATE katello_host_collections
-            SET unlimited_content_hosts = true, max_content_hosts = null
-            WHERE max_content_hosts = -1"
-
-    update "UPDATE katello_host_collections
-            SET unlimited_content_hosts = false
-            WHERE max_content_hosts > 0"
+    Katello::HostCollections.reset_column_information
+    Katello::HostCollections.all.each do |coll|
+      if coll.max_content_hosts == -1
+        coll.update_attributes(:unlimited_content_hosts => true, :max_content_hosts => nil)
+      elsif coll.max_content_hosts > 0
+        coll.update_attributes(:unlimited_content_hosts => false)
+      end
+    end
   end
 
   def down
-    update "UPDATE katello_host_collections
-            SET max_content_hosts = -1
-            WHERE unlimited_content_hosts = true"
+    Katello::HostCollections.all.each do |coll|
+      coll.update_attributes(:max_content_hosts => -1) if coll.unlimited_content_hosts
+    end
 
     remove_column :katello_host_collections, :unlimited_content_hosts
     change_column :katello_host_collections, :max_content_hosts, :integer, :null => false, :default => -1

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -15,8 +15,6 @@ module Katello
     end
 
     initializer "katello.apipie" do
-      Apipie.configuration.api_controllers_matcher << "#{Katello::Engine.root}/app/controllers/katello/api/v2/*.rb"
-      Apipie.configuration.ignored += %w(Api::V2::OrganizationsController)
       Apipie.configuration.checksum_path += ['/katello/api/']
       require 'katello/apipie/validators'
     end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -159,8 +159,9 @@ Foreman::Plugin.register :katello do
        :turbolinks => false
 
   allowed_template_helpers :subscription_manager_configuration_url
-
   search_path_override("Katello") do |resource|
     "/#{Katello::Util::Model.model_to_controller_path(resource)}/auto_complete_search"
   end
+  apipie_documented_controllers ["#{Katello::Engine.root}/app/controllers/katello/api/v2/*.rb"]
+  apipie_ignored_controllers %w(::Api::V2::OrganizationsController)
 end

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -96,7 +96,7 @@ Requires: katello-selinux
 Requires: candlepin-selinux
 Requires: createrepo >= 0.9.9-18%{?dist}
 Requires: elasticsearch
-Requires: foreman >= 1.3.0
+Requires: foreman >= 1.7.0
 Requires: java-openjdk >= 1:1.7.0
 # Still Requires katello-common which clashes with
 # new build - will re-enable after fixing
@@ -133,7 +133,7 @@ Requires: %{?scl_prefix}rubygem-deface < 1.0.0
 Requires: %{?scl_prefix}rubygem-strong_parameters
 Requires: %{?scl_prefix}rubygem-qpid_messaging >= 0.22.0
 Requires: %{?scl_prefix}rubygem-qpid_messaging <= 0.28.1
-BuildRequires: foreman >= 1.3.0
+BuildRequires: foreman >= 1.7.0
 BuildRequires: foreman-assets >= 1.7.0
 BuildRequires: %{?scl_prefix}rubygem-angular-rails-templates >= 0.0.4
 BuildRequires: %{?scl_prefix}rubygem-bastion < 1.0.0
@@ -190,7 +190,39 @@ cp -a .%{gem_dir}/* \
 mkdir -p ./usr/share
 cp -r %{foreman_dir} ./usr/share || echo 0
 
+mkdir -p ./%{_localstatedir}/lib/foreman
+cp -r /var/lib/foreman/db ./%{_localstatedir}/lib/foreman || echo 0
+unlink ./usr/share/foreman/db
+ln -sv `pwd`/%{_localstatedir}/lib/foreman/db ./usr/share/foreman/db
+
+cp -r /var/lib/foreman/public ./%{_localstatedir}/lib/foreman || echo 0
+unlink ./usr/share/foreman/public
+ln -sv `pwd`/%{_localstatedir}/lib/foreman/public ./usr/share/foreman/public
+
+unlink ./usr/share/foreman/config/database.yml
+unlink ./usr/share/foreman/config/settings.yaml
+unlink ./usr/share/foreman/config/initializers/encryption_key.rb
+
+cp /etc/foreman/settings.yaml ./usr/share/foreman/config
+
+cat <<DBPROD >> ./usr/share/foreman/config/database.yml
+production:
+  adapter: sqlite3
+  database: db/production.sqlite3
+  pool: 5
+  timeout: 5000
+
+development:
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
+DBPROD
+
+
 pushd ./usr/share/foreman
+sed -i 's/:locations_enabled: false/:locations_enabled: true/' config/settings.yaml
+sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' config/settings.yaml
 export GEM_PATH=%{gem_dir}:%{buildroot}%{gem_dir}
 
 cat <<GEMFILE > ./bundler.d/%{gem_name}.rb
@@ -204,7 +236,11 @@ cp %{buildroot}%{gem_instdir}/config/katello_defaults.yml %{buildroot}%{gem_inst
 
 export BUNDLER_EXT_NOSTRICT=1
 export BUNDLER_EXT_GROUPS="default assets katello"
+
+%{scl_rake} security:generate_encryption_key
 %{scl_rake} assets:precompile:katello RAILS_ENV=production --trace
+%{scl_rake} db:migrate RAILS_ENV=development --trace
+%{scl_rake} plugin:apipie:cache['katello'] RAILS_ENV=development cache_part=resources OUT=%{buildroot}%{gem_instdir}/public/apipie-cache/plugin/katello --trace
 
 popd
 rm -rf ./usr
@@ -217,9 +253,16 @@ group :katello do
 end
 GEMFILE
 
+
 mkdir -p %{buildroot}%{foreman_dir}/public/assets
+mkdir -p %{buildroot}%{foreman_dir}/public/apipie-cache/plugin
 ln -s %{gem_instdir}/public/assets/katello %{buildroot}%{foreman_dir}/public/assets/katello
 ln -s %{gem_instdir}/public/assets/bastion_katello %{buildroot}%{foreman_dir}/public/assets/bastion_katello
+ln -s %{gem_instdir}/public/apipie-cache/plugin/katello %{buildroot}%{foreman_dir}/public/apipie-cache/plugin/katello
+
+%post
+cp -r %{foreman_dir}/public/apipie-cache/plugin/katello/* %{foreman_dir}/public/apipie-cache/
+chown -R foreman.foreman %{foreman_dir}/public/apipie-cache
 
 %clean
 %{__rm} -rf %{buildroot}
@@ -232,6 +275,7 @@ ln -s %{gem_instdir}/public/assets/bastion_katello %{buildroot}%{foreman_dir}/pu
 %{foreman_bundlerd_dir}/%{gem_name}.rb
 %{foreman_dir}/public/assets/katello
 %{foreman_dir}/public/assets/bastion_katello
+%{foreman_dir}/public/apipie-cache/plugin/katello
 
 %files doc
 %{gem_dir}/doc/%{gem_name}-%{version}


### PR DESCRIPTION
*DO NOT MERGE*
This is suggestion to move Apipie setup to plugin atributes. This will bring us better control over the Apipie configuration e.g. this change will make it possible to pre-generate apipie cache for the plugins during the package build time with ```rake plugin:apipie:cache['katello']``` 

