### PR TITLE
fixes #6469 / BZ 1113740 - content view promotion - remove org id from user message

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-promotion.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-promotion.html
@@ -10,8 +10,7 @@
   <h3 translate>Promote Version {{ version.version }}</h3>
 
   <p class="details" translate>
-    Choose a lifecycle environment from the existing promotion paths
-    available in '{{ currentOrganization }}'.
+    Choose a lifecycle environment from the available promotion paths.
   </p>
 
   <p ng-hide="working">


### PR DESCRIPTION
When promoting a content view version, a message like the following
was displayed to the user:

Choose one or more lifecycle environments from the existing promotion paths available in '1'.

The '1' was intended to represent the organization.  In the past, this was the
org label; however, CurrentOrganization has since been updated
to use org id, resulting in this behavior.

Rather than add another request to the server to obtain the org
name and since we generally don't use that type of terminology
elsewhere in the UI, this commit is making the message generic.
(Note:the user can still see what org they are in via the org
switcher located on every page)
