### PR TITLE
fixes #6472 / BZ 1113230 - content view filter - fix issue where filter not available

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-details.html
@@ -1,6 +1,11 @@
 <span page-title ng-model="filter">{{ 'Filter:' | translate }} {{ filter.name }}</span>
 
-<div class="details details-full">
+<div class="loading-mask loading-mask-panel icon-3x" ng-show="filter.id === undefined">
+    <i class="icon-spinner icon-spin"></i>
+    {{ "Loading..." | translate }}
+</div>
+
+<div class="details details-full" ng-show="filter.id !== undefined">
 
   <ol class="breadcrumb">
     <li ng-class="{active: isState('content-views.details.filters.list')}">


### PR DESCRIPTION
On the content view filter edit screens, it was possible for a
"really fast" user to click links that utilized the filter, before
it had actually been loaded.  Eg. Open a filter and click the 'Add' tab.

This small change will ensure that we do not render the content of the
filter edit, before the filter is actually available.
