### PR TITLE
fixes #6477 - fixing host/smart proxy association

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -33,9 +33,9 @@ module Katello
                  :source     => :lifecycle_environment
 
         has_many :hosts,      :class_name => "::Host::Managed", :foreign_key => :content_source_id,
-                 :inverse_of => :smart_proxies
+                 :inverse_of => :content_source
         has_many :hostgroups, :class_name => "::Hostgroup",     :foreign_key => :content_source_id,
-                 :inverse_of => :smart_proxies
+                 :inverse_of => :content_source
       end
 
       def default_capsule?


### PR DESCRIPTION
Which prevents smart proxies from being deleted.
