### PR TITLE
Fixes #6479/BZ1115633: hide product content edit button if applicable

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-products.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-products.html
@@ -37,7 +37,7 @@
             <span class="col-sm-4" translate>Enabled by Default</span>
             <span class="col-sm-3"
                   alch-edit-select="content.enabledText"
-                  readonly="contentHost.readonly"
+                  readonly="denied('edit_content_hosts', contentHost)"
                   selector="content.overrideEnabled"
                   options="overrideEnableChoices(content)"
                   on-save="saveContentOverride(content)">


### PR DESCRIPTION
If the user does not have permission do not show the product content
edit button.

http://projects.theforeman.org/issues/6479
https://bugzilla.redhat.com/show_bug.cgi?id=1115633
