### PR TITLE
Revert "fixes #6336 - Fixes issue with not being able to use same name f...

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -57,6 +57,7 @@ module Katello
     param :usage_limit, :number, :desc => N_("maximum number of registered content hosts, or 'unlimited'")
     def create
       @activation_key = ActivationKey.create!(activation_key_params) do |activation_key|
+        activation_key.label ||= labelize_params(params[:activation_key])
         activation_key.environment = @environment if @environment
         activation_key.organization = @organization
         activation_key.user = current_user

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -18,6 +18,7 @@ class ActivationKey < Katello::Model
   include Glue::ElasticSearch::ActivationKey if Katello.config.use_elasticsearch
   include Glue if Katello.config.use_cp
   include Katello::Authorization::ActivationKey
+  include Ext::LabelFromName
   include ForemanTasks::Concerns::ActionSubject
 
   belongs_to :organization, :inverse_of => :activation_keys
@@ -32,7 +33,8 @@ class ActivationKey < Katello::Model
   has_many :systems, :through => :system_activation_keys
 
   before_validation :set_default_content_view, :unless => :persisted?
-
+  validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
+  validates :label, :uniqueness => {:scope => :organization_id}, :presence => true
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates :name, :presence => true
   validates :name, :uniqueness => {:scope => :organization_id}

--- a/app/models/katello/glue/candlepin/activation_key.rb
+++ b/app/models/katello/glue/candlepin/activation_key.rb
@@ -48,28 +48,28 @@ module Glue::Candlepin::ActivationKey
     end
 
     def set_activation_key
-      Rails.logger.debug "Creating an activation key in candlepin: #{name}"
-      json = Resources::Candlepin::ActivationKey.create(Util::Model.uuid, self.organization.label)
+      Rails.logger.debug "Creating an activation key in candlepin: #{label}"
+      json = Resources::Candlepin::ActivationKey.create(self.label, self.organization.label)
       self.cp_id = json[:id]
     rescue => e
-      Rails.logger.error _("Failed to create candlepin activation_key %s") % "#{self.name}: #{e}, #{e.backtrace.join("\n")}"
+      Rails.logger.error _("Failed to create candlepin activation_key %s") % "#{self.label}: #{e}, #{e.backtrace.join("\n")}"
       raise e
     end
 
     def update_activation_key
-      Rails.logger.debug "Updating an activation key in candlepin: #{name}"
+      Rails.logger.debug "Updating an activation key in candlepin: #{label}"
       Resources::Candlepin::ActivationKey.update(self.cp_id, self.release_version, @service_level)
     rescue => e
-      Rails.logger.error _("Failed to update candlepin activation_key %s") % "#{self.name}: #{e}, #{e.backtrace.join("\n")}"
+      Rails.logger.error _("Failed to update candlepin activation_key %s") % "#{self.label}: #{e}, #{e.backtrace.join("\n")}"
       raise e
     end
 
     def save_activation_key_orchestration
       case self.orchestration_for
       when :create
-        pre_queue.create(:name => "candlepin activation_key: #{self.name}", :priority => 2, :action => [self, :set_activation_key])
+        pre_queue.create(:name => "candlepin activation_key: #{self.label}", :priority => 2, :action => [self, :set_activation_key])
       when :update
-        pre_queue.create(:name => "update candlepin activation_key: #{self.name}", :priority => 2, :action => [self, :update_activation_key])
+        pre_queue.create(:name => "update candlepin activation_key: #{self.label}", :priority => 2, :action => [self, :update_activation_key])
       end
     end
 

--- a/db/migrate/20140624184401_remove_label_from_activation_key.rb
+++ b/db/migrate/20140624184401_remove_label_from_activation_key.rb
@@ -1,9 +1,0 @@
-class RemoveLabelFromActivationKey < ActiveRecord::Migration
-  def up
-    remove_column :katello_activation_keys, :label
-  end
-
-  def down
-    add_column :katello_activation_keys, :label, :string
-  end
-end

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -16,8 +16,8 @@ module Katello
 class ActivationKeyTest < ActiveSupport::TestCase
 
   def self.before_suite
-    models = ["ActivationKey", "KTEnvironment", "ContentViewEnvironment", "ContentView", "Organization"]
-    disable_glue_layers(["Candlepin", "Pulp", "ElasticSearch"], models, true)
+    models = ["ActivationKey", "KTEnvironment", "ContentViewEnvironment", "ContentView"]
+    disable_glue_layers([], models, true)
   end
 
   def setup
@@ -47,21 +47,6 @@ class ActivationKeyTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::RecordInvalid) do
       @dev_key.save!
     end
-  end
-
-  test "same name can be used across organizations" do
-    org = Organization.find(taxonomies(:organization2))
-    key = ActivationKey.find(katello_activation_keys(:simple_key))
-    assert ActivationKey.new(:name => key.name, :organization => org).valid?
-  end
-
-  test "renamed key can be used again" do
-    key1 = ActivationKey.find(katello_activation_keys(:simple_key))
-    org = key1.organization
-    original_name = key1.name
-    key1.name = "new name"
-    key1.save!
-    assert ActivationKey.new(:name => original_name, :organization => org).valid?
   end
 
 end


### PR DESCRIPTION
Reverts Katello/katello#4328

This breaks registration with activation keys since the label was what is needed to reference the key in candlepin.
