### PR TITLE
fixes #6510 / BZ 1109138 - disable pkg action buttons when no content hosts selected

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-packages.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-packages.html
@@ -39,7 +39,7 @@
                 translate
                 ng-hide="denied('edit_content_hosts', contentHost)"
                 ng-click="confirmContentAction('install', content)"
-                ng-disabled="!systemContentForm.$valid || content.confirm">
+                ng-disabled="(table.numSelected === 0) || !systemContentForm.$valid || content.confirm">
           Install
         </button>
 
@@ -47,7 +47,7 @@
                 translate
                 ng-hide="denied('edit_content_hosts', contentHost)"
                 ng-click="confirmContentAction('update', content)"
-                ng-disabled="!systemContentForm.$valid || content.confirm"
+                ng-disabled="(table.numSelected === 0) || !systemContentForm.$valid || content.confirm"
                 ng-hide="content.contentType == 'errata'">
           Update
         </button>
@@ -56,7 +56,7 @@
                 translate
                 ng-hide="content.contentType == 'errata' || denied('edit_content_hosts', contentHost)"
                 ng-click="confirmContentAction('remove', content)"
-                ng-disabled="!systemContentForm.$valid || content.confirm">
+                ng-disabled="(table.numSelected === 0) || !systemContentForm.$valid || content.confirm">
           Remove
         </button>
       </div>


### PR DESCRIPTION
Disable the install/update/remove buttons when the user hasn't selected
any content hosts.
