### PR TITLE
fixes #6508 - fixing package group search

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -117,9 +117,9 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   param :id, :identifier, :desc => N_("filter identifier"), :required => true
   def available_package_groups
     current_ids = @filter.package_group_rules.map(&:uuid)
-    repo_ids = @filter.applicable_repos.select([:pulp_id, "#{Katello::Repository.table_name}.name"])
-    search_filters = [{ :terms => { :repo_id => repo_ids } },
-                      { :not => { :terms => { :id => current_ids } } }]
+    repo_ids = @filter.applicable_repos.readable.pluck("#{Repository.table_name}.pulp_id")
+    search_filters = [{ :terms => { :repo_id => repo_ids } }]
+    search_filters << { :not => { :terms => { :id => current_ids } } } unless current_ids.blank?
 
     options = sort_params
     options[:filters] = search_filters

--- a/app/models/katello/glue/elastic_search/items.rb
+++ b/app/models/katello/glue/elastic_search/items.rb
@@ -65,6 +65,7 @@ module Glue
         # set the query default field, if one was provided.
         query_options = {}
         query_options[:default_field] = search_options[:default_field] || 'name'
+        query_options[:lowercase_expanded_terms] = false
 
         if query_string.blank?
           all_rows = true


### PR DESCRIPTION
With the removal of the lowercase filter previously
in the kt_name_analyzer, filters would work properly
but search were still being downcased by default, thus
anything with an uppercase letter could not be searched for

also the controller logic had some incorrect code
