### PR TITLE
fixes #6512 - move valid notices routes inside resources block

### DIFF
--- a/app/controllers/katello/notices_controller.rb
+++ b/app/controllers/katello/notices_controller.rb
@@ -18,7 +18,6 @@ class NoticesController < Katello::ApplicationController
 
   skip_before_filter :authorize, :require_org
   before_filter :notices_authorize
-  before_filter :readable_by, :only => [:auto_complete_search]
 
   helper_method :sort_column, :sort_direction
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,9 +39,12 @@ Katello::Engine.routes.draw do
     end
   end
 
-  get "notices/note_count"
-  get "notices/get_new"
-  get "notices/auto_complete_search"
+  resources :notices, :only => [] do
+   collection do
+    get :get_new
+   end
+  end
+
   match 'notices/:id/details' => 'notices#details', :via => :get, :as => 'notices_details'
   match 'notices' => 'notices#show', :via => :get
   match 'notices' => 'notices#destroy_all', :via => :delete


### PR DESCRIPTION
In Rails 3.2.8, it's not seeing the previous notice route get_new as
being part of the engine.  Moving inside a resource block fixes that
problem.  I also removed 2 routes that aren't valid and shouldn't exist
anymore - note_count and auto_complete_search.
