### PR TITLE
Fixes #6391/BZ1091844 - use complete links for content search.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
@@ -113,21 +113,21 @@
             </td>
             <td alch-table-cell>
               <div>
-                <a ng-href="/katello/content_search#/!=&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_packages"
+                <a ng-href="/katello/content_search#/!=&search[packages][search]=&search[content_type]=packages&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_packages"
                    ng-show="repository.content_type == 'yum'"
                    translate>
                   {{ repository.content_counts.rpm || 0 }} Packages
                 </a>
               </div>
               <div>
-                <a ng-href="/katello/content_search#/!=&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_errata"
+                <a ng-href="/katello/content_search#/!=&search[errata][search]=&search[content_type]=errata&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_errata"
                    ng-show="repository.content_type == 'yum'"
                    translate>
                   {{ repository.content_counts.erratum || 0 }} Errata
                 </a>
               </div>
               <div>
-                <a ng-href="/katello/content_search#/!=&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_puppet_modules"
+                <a ng-href="/katello/content_search#/!=&search[puppet_modules][search]=&search[content_type]=puppet_modules&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_puppet_modules"
                    ng-show="repository.content_type == 'puppet'"
                    translate>
                   {{ repository.content_counts.puppet_module || 0 }} Puppet Modules


### PR DESCRIPTION
The links for content search were missing part of the required
structure for the "back to results" button to function correctly.

http://projects.theforeman.org/issues/6391
https://bugzilla.redhat.com/show_bug.cgi?id=1091844
