### PR TITLE
Fixes #6513/bz1116933- Fixed search issues with product destroy

### DIFF
--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -36,7 +36,7 @@ class Product < Katello::Model
   belongs_to :provider, :inverse_of => :products
   belongs_to :sync_plan, :inverse_of => :products, :class_name => 'Katello::SyncPlan'
   belongs_to :gpg_key, :inverse_of => :products
-  has_many :repositories, :class_name => "Katello::Repository", :dependent => :destroy
+  has_many :repositories, :class_name => "Katello::Repository", :dependent => :restrict
 
   validates :provider_id, :presence => true
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name


### PR DESCRIPTION
Product destroy dynflow code would prematurely remove the product from
the elastic search before removing from the db. So product record would
be wiped off the search index even if  product delete failed due to
some validation issue. This commit fixes that.
