### PR TITLE
fixes #6511 / BZ 1109085 - content host bulk errata fixes

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-errata.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-errata.controller.js
@@ -50,7 +50,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionErrata
             nutupane.setParams(params);
             $scope.detailsTable.working = true;
             $scope.outOfDate = false;
-            if ($scope.nutupane.anyResultsSelected()) {
+            if ($scope.table.numSelected > 0) {
                 nutupane.refresh().then(function () {
                     $scope.detailsTable.working = false;
                     $scope.outOfDate = false;
@@ -68,8 +68,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionErrata
             }
         });
 
-        $scope.$watch('nutupane.table.numSelected', function () {
-            if (!$scope.detailsTable.working) {
+        $scope.$watch('nutupane.table.numSelected', function (numSelected) {
+            if ((numSelected > 0) && !$scope.detailsTable.working) {
                 $scope.outOfDate = true;
             }
         });

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-errata.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-errata.html
@@ -10,7 +10,7 @@
     <button class="btn btn-default" ng-click="confirm = false; installErrata()" translate>Yes</button>
   </div>
 
-  <div class="alert alert-warning" ng-show="outOfDate">
+  <div class="alert alert-warning" ng-show="outOfDate && table.numSelected > 0">
     <i class="inline-icon icon-exclamation"></i>
     <span translate>
       Your selected content hosts have changed, it is highly recommended to refresh the calculated list of errata using the 'Refresh Errata' button below.
@@ -25,13 +25,15 @@
     <div data-block="header" translate>Content Host Errata Management</div>
 
     <div data-block="actions">
-      <button class="btn btn-default" ng-disabled="detailsTable.working" ng-click="fetchErrata()">
+      <button class="btn btn-default"
+              ng-disabled="table.numSelected === 0 || detailsTable.working"
+              ng-click="fetchErrata()">
         <i class="icon-refresh"></i>
         {{ "Refresh Table" | translate }}
       </button>
 
       <button class="btn btn-primary"
-              ng-disabled="detailsTable.working || detailsTable.numSelected == 0"
+              ng-disabled="table.numSelected === 0 || detailsTable.working || detailsTable.numSelected === 0"
               ng-click="confirm = true">
         <i class="icon-plus"></i>
         {{ "Install Selected" | translate }}

--- a/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
@@ -195,11 +195,6 @@ angular.module('Bastion.widgets').factory('Nutupane',
                 return selected;
             };
 
-            self.anyResultsSelected = function () {
-                var results = self.getAllSelectedResults();
-                return results.included.search !== undefined || results.included.ids.length > 0;
-            };
-
             self.getDeselected = function () {
                 var deselectedRows = [];
                 angular.forEach(self.table.rows, function (row, rowIndex) {


### PR DESCRIPTION
This commit addresses a couple of small UI issues with the
content host bulk errata action.  The issues were:
1. If no content hosts are selected, do not retrieve applicable
   errata from the server.  The API requires the user to provide
   at least 1 content host; therefore, no need to send the request
   with 0.
2. If no content hosts are selected, disable the refresh and
   install actions.
