### PR TITLE
fixes #6515 / BZ 1107604 - content host package action: disable Perform on empty input.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
@@ -24,6 +24,7 @@
         <span class="input-group-btn">
           <button class="btn btn-default"
                   ng-hide="denied('edit_content_hosts', contentHost)"
+                  ng-disabled="packageAction.term === undefined || packageAction.term.length === 0"
                   translate>
             Perform</button>
         </span>


### PR DESCRIPTION
On "Hosts -> Content Hosts -> [somehost] -> Packages", disable the
"Perform" button, unless the user has provided content in the text
input.
