### PR TITLE
fixes #6527 / BZ 1115955 - activation keys - filter host collections by organization

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -96,9 +96,10 @@ module Katello
     param_group :search, Api::V2::ApiController
     param :name, String, :desc => N_("host collection name to filter by")
     def available_host_collections
-      filters = [:terms => {:id => HostCollection.readable.pluck("#{Katello::HostCollection.table_name}.id") -
-                   @activation_key.host_collections.pluck("#{Katello::HostCollection.table_name}.id")}]
-      filters << {:term => {:name => params[:name]}} if params[:name]
+      filters = [:terms => { :id => HostCollection.readable.pluck("#{Katello::HostCollection.table_name}.id") -
+                   @activation_key.host_collections.pluck("#{Katello::HostCollection.table_name}.id") }]
+      filters << { :term => { :name => params[:name] } } if params[:name]
+      filters << { :term => { :organization_id => @activation_key.organization_id } }
 
       options = {
           :filters       => filters,


### PR DESCRIPTION
When a user requests 'available host collections' for an activation key,
it should only show those that are available within the same organization
as the activation key being queried for.
