### PR TITLE
Fixes #6531/BZ1117487 - set active menu on $state change.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/bastion.module.js
@@ -156,13 +156,14 @@ angular.module('Bastion').config(
  * @requires $location
  * @requires $window
  * @requires PageTitle
+ * @requires markActiveMenu
  * @requires RootURL
  *
  * @description
  *   Set up some common state related functionality and set the current language.
  */
-angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', 'Authorization', '$location', '$window', 'PageTitle', 'RootURL',
-    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, Authorization, $location, $window, PageTitle, RootURL) {
+angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextCatalog', 'currentLocale', 'Authorization', '$location', '$window', 'PageTitle', 'markActiveMenu', 'RootURL',
+    function ($rootScope, $state, $stateParams, gettextCatalog, currentLocale, Authorization, $location, $window, PageTitle, markActiveMenu, RootURL) {
         var fromState, fromParams, orgSwitcherRegex;
 
         $rootScope.$state = $state;
@@ -218,6 +219,9 @@ angular.module('Bastion').run(['$rootScope', '$state', '$stateParams', 'gettextC
                 if (PageTitle.titles.length > 1) {
                     PageTitle.resetToFirst();
                 }
+
+                //Set the active menu item in Foreman
+                markActiveMenu();
             }
         );
 

--- a/engines/bastion/app/views/bastion/layouts/application.html.haml
+++ b/engines/bastion/app/views/bastion/layouts/application.html.haml
@@ -17,6 +17,7 @@
       angular.module('Bastion').value('CurrentOrganization', "#{current_organization.id if current_organization}");
       angular.module('Bastion').value('Permissions', angular.fromJson('#{ current_user.roles.collect { |role| role.permissions }.flatten.to_json }'));
       angular.module('Bastion').value('CurrentUser', angular.fromJson('#{current_user.to_json}').user);
+      angular.module('Bastion').value('markActiveMenu', mark_active_menu);
       angular.module('Bastion').constant('BastionConfig', {
           consumerCertRPM: "#{Katello.config.consumer_cert_rpm}",
           markTranslated: #{SETTINGS[:mark_translated] || false}

--- a/engines/bastion/test/bastion/test-constants.js
+++ b/engines/bastion/test/bastion/test-constants.js
@@ -16,6 +16,7 @@ angular.module('Bastion').value('CurrentOrganization', "ACME");
 angular.module('Bastion').value('CurrentUser', {id: "User"});
 angular.module('Bastion').value('Permissions', []);
 angular.module('Bastion').value('Authorization', {});
+angular.module('Bastion').value('markActiveMenu', function () {});
 angular.module('Bastion').constant('BastionConfig', {
     consumerCertRPM: "consumer_cert_rpm",
     markTranslated: false


### PR DESCRIPTION
Ensure the highlighted active menu item is updated on $state
changes.

http://projects.theforeman.org/issues/6531
https://bugzilla.redhat.com/show_bug.cgi?id=1117487

Note that to see the behavior in this PR you must either wait until  https://github.com/theforeman/foreman/pull/1572 is merged or run those changes locally.
