### PR TITLE
fixes #6547 / BZ 1115468 - delete puppet modules from content view on repo delete

### DIFF
--- a/app/lib/actions/katello/content_view_puppet_module/destroy.rb
+++ b/app/lib/actions/katello/content_view_puppet_module/destroy.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module ContentViewPuppetModule
+      class Destroy < Actions::EntryAction
+
+        def plan(repository)
+          action_subject(repository)
+
+          # For each puppet module in the repository, if the module exists
+          # only in this repository, then locate and destroy all content view
+          # puppet modules that are referring to it
+          repository.puppet_modules.each do |puppet_module|
+
+            # first, process content view puppet modules that have been specified by version
+            library_repos = ::Katello::Repository.in_environment(repository.organization.library).
+                                                  where(:pulp_id => puppet_module.repoids)
+
+            if library_repos.length == 1
+              content_view_puppet_modules = ::Katello::ContentViewPuppetModule.joins(:content_view).
+                  where("#{::Katello::ContentView.table_name}.organization_id" => repository.organization.id).
+                  where(:uuid => puppet_module.id)
+
+              content_view_puppet_modules.destroy_all
+            end
+
+            # second, process content view puppet modules that have been specified by name/author (i.e. latest version)
+            content_view_puppet_modules = ::Katello::ContentViewPuppetModule.joins(:content_view).
+                where("#{::Katello::ContentView.table_name}.organization_id" => repository.organization.id).
+                where(:name => puppet_module.name).where(:author => puppet_module.author)
+
+            if content_view_puppet_modules.any?
+              puppet_repoids = ::Katello::Repository.puppet_type.in_environment(repository.organization.library).
+                  pluck(:pulp_id).reject{ |repoid| repoid == repository.pulp_id }
+              found_puppet_module = ::Katello::PuppetModule.latest_modules_search([{:name => puppet_module.name,
+                                                                                    :author => puppet_module.author}],
+                                                                                  puppet_repoids).first
+
+              content_view_puppet_modules.destroy_all unless found_puppet_module
+            end
+          end
+        end
+
+        def humanized_name
+          _("Delete")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -21,6 +21,7 @@ module Actions
         def plan(repository, options = {})
           skip_environment_update = options.fetch(:skip_environment_update, false)
           action_subject(repository)
+          plan_action(ContentViewPuppetModule::Destroy, repository) if repository.puppet?
           plan_action(Pulp::Repository::Destroy, pulp_id: repository.pulp_id)
           plan_action(Product::ContentDestroy, repository)
           plan_action(ElasticSearch::Repository::Destroy, pulp_id: repository.pulp_id)

--- a/test/actions/katello/content_view_puppet_module_test.rb
+++ b/test/actions/katello/content_view_puppet_module_test.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module ::Actions::Katello::ContentViewPuppetModule
+
+  class TestBase < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryGirl::Syntax::Methods
+    include Support::CapsuleSupport
+  end
+
+  class DestroyTest < TestBase
+    let(:action_class) { ::Actions::Katello::ContentViewPuppetModule::Destroy }
+    let(:action) { create_action action_class }
+
+    let(:puppet_repository) { katello_repositories(:p_forge) }
+    let(:puppet_module) { katello_content_view_puppet_modules(:library_view_module_by_uuid) }
+
+    it 'plans' do
+      puppet_module = ::Katello::ContentViewPuppetModule.find(katello_content_view_puppet_modules(:library_view_module_by_uuid))
+      puppet_repository.stubs(:puppet_modules).returns([OpenStruct.new({ :id => puppet_module.uuid,
+                                                                         :repoids => [puppet_repository.pulp_id] })])
+      action.expects(:action_subject).with(puppet_repository)
+      plan_action action, puppet_repository
+
+      assert_nil ::Katello::ContentViewPuppetModule.find_by_id(puppet_module.id)
+    end
+  end
+end


### PR DESCRIPTION
When a puppet repository is deleted (e.g. from Content -> Products),
if any of the puppet modules in that repository are associated with
an existing content view (via ContentViewPuppetModule), they need
to be removed from the content view.  This commit will do just
that, providing a behavior that is consistent with when a user
deletes a yum repository (i.e those repositories are removed
from the content view).
