### PR TITLE
Fixes #6553/BZ111225: add "repositories" to product resource type name.

### DIFF
--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -242,7 +242,7 @@ class Product < Katello::Model
   private
 
   def self.humanize_class_name(name = nil)
-    _("Product")
+    _("Product and Repositories")
   end
 
 end


### PR DESCRIPTION
There was some confusion about Repository permissions being underneath
Products.  This commit simply updates the resource type name to make
it obvious that repositories are also affected by these permissions.

http://projects.theforeman.org/issues/6553
https://bugzilla.redhat.com/show_bug.cgi?id=1112255
