### PR TITLE
Fixes #6551/BZ1112644: show add/remove content hosts if user able

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-content-hosts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-content-hosts.html
@@ -1,7 +1,7 @@
 <span page-title ng-model="hostCollection">{{ 'Content Hosts for: ' | translate }} {{ hostCollection.name }}</span>
 
 <nav>
-  <ul class="nav nav-tabs" ng-show="permitted('edit_host_collections', hostCollection)">
+  <ul class="nav nav-tabs" ng-show="permitted('edit_host_collections', hostCollection) && permitted('edit_content_hosts')">
     <li ng-class="{active: isState('host-collections.details.content-hosts.list')}">
       <a ui-sref="host-collections.details.content-hosts.list">
         <span translate>


### PR DESCRIPTION
The permissions that show/hide the UI for adding/removing content
hosts to/from a host collection were incorrect.  This commit fixes
those permissions.

http://projects.theforeman.org/issues/6551
https://bugzilla.redhat.com/show_bug.cgi?id=1112644
