### PR TITLE
fixes #6322 - clean up puppet environment on cv delete

### DIFF
--- a/app/lib/actions/foreman/environment/destroy.rb
+++ b/app/lib/actions/foreman/environment/destroy.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Foreman
+    module Environment
+      class Destroy < Actions::Base
+
+        def plan(environment)
+          if environment.hosts.count > 0
+            names = environment.hosts.limit(5).pluck(:name).join(', ')
+            fail _("The puppet environment %{name} is in use by %{count} Host(s) including %{names}") %
+                     {:name => environment.name, :names => names, :count => environment.hosts.count}
+          end
+
+          if environment.hostgroups.count > 0
+            names = environment.hostgroups.limit(5).pluck(:name).join(', ')
+            fail _("The puppet environment %{name} is in use by %{count} Host Group(s) including %{names}") %
+                     {:name => environment.name, :names => names, :count => environment.hostgroups.count}
+          end
+
+          environment.destroy!
+        end
+
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_environment/destroy.rb
@@ -27,6 +27,7 @@ module Actions
               end
 
               if puppet_env = content_view.puppet_env(environment)
+                plan_action(Actions::Foreman::Environment::Destroy, puppet_env.puppet_environment) if puppet_env.puppet_environment
                 plan_action(ContentViewPuppetEnvironment::Destroy, puppet_env)
               end
             end

--- a/app/lib/actions/katello/system/reassign.rb
+++ b/app/lib/actions/katello/system/reassign.rb
@@ -18,6 +18,16 @@ module Actions
         def plan(system, content_view_id, environment_id)
           system.content_view_id = content_view_id
           system.environment_id = environment_id
+
+          if system.foreman_host
+            cve = ::Katello::ContentViewPuppetEnvironment.in_content_view(content_view_id).in_environment(environment_id).first
+            if cve && cve.puppet_environment
+              system.foreman_host.environment = cve.puppet_environment
+              system.foreman_host.save!
+            end
+
+          end
+
           # TODO: update cp
           system.save!
         end

--- a/app/models/katello/concerns/environment_extensions.rb
+++ b/app/models/katello/concerns/environment_extensions.rb
@@ -19,7 +19,7 @@ module Katello
       included do
         has_one :content_view_puppet_environment, :class_name => "Katello::ContentViewPuppetEnvironment",
                 :foreign_key => :puppet_environment_id,
-                :dependent => :destroy, :inverse_of => :puppet_environment
+                :dependent => :nullify, :inverse_of => :puppet_environment
       end
 
       def content_view
@@ -28,6 +28,12 @@ module Katello
 
       def lifecycle_environment
         self.content_view_puppet_environment.try(:environment)
+      end
+
+      def destroy!
+        unless destroy
+          fail self.errors.full_messages.join('; ')
+        end
       end
 
       module ClassMethods

--- a/app/models/katello/content_view_puppet_environment.rb
+++ b/app/models/katello/content_view_puppet_environment.rb
@@ -26,7 +26,7 @@ module Katello
                :inverse_of => :content_view_puppet_environments
 
     belongs_to :puppet_environment, :class_name => "Environment",
-               :inverse_of => :content_view_puppet_environment
+               :inverse_of => :content_view_puppet_environment, :dependent => :destroy
 
     validates :pulp_id, :presence => true, :uniqueness => true
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name

--- a/test/actions/foreman/environment_test.rb
+++ b/test/actions/foreman/environment_test.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module ::Actions::Foreman::Environment
+
+  class TestBase < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include Support::Actions::RemoteAction
+    include FactoryGirl::Syntax::Methods
+
+    let( :action ) { create_action action_class }
+
+    before :all do
+      @production = environments(:production)
+    end
+
+  end
+
+  class DestroyTest < TestBase
+    let( :action_class ) { ::Actions::Foreman::Environment::Destroy }
+    let( :product ) do
+      katello_products( :fedora )
+    end
+
+    it 'fails to destroy when there are hosts' do
+      assert @production.hosts.count > 0
+
+      @production.hostgroups = []
+      assert_raises RuntimeError do
+        plan_action(action, @production)
+      end
+    end
+
+    it 'fails to destroy when there are host groups' do
+      assert @production.hostgroups.count > 0
+
+      @production.hosts = []
+      assert_raises RuntimeError do
+        plan_action(action, @production)
+      end
+    end
+
+    it 'destroys the environment' do
+      env = ::Environment.create(:name => "subdev")
+      assert plan_action(action, env)
+    end
+
+  end
+end


### PR DESCRIPTION
Attempt to move content host's hosts.  If there are others left
or host groups attached, throw a nice error.  In the future
we should add host and host group puppet environment selection
to the content view version deletion
