### PR TITLE
fixes #6592 / BZ 1118895 - Activation Keys UI: replace 'System' references

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-info.html
@@ -24,7 +24,7 @@
 
       <div class="detail">
 
-        <span class="info-label" translate>System Limit</span>
+        <span class="info-label" translate>Content Host Limit</span>
 
         <span class="info-value"
               alch-edit-custom="activationKey.max_content_hosts"
@@ -36,7 +36,7 @@
           <div class="form input">
             <div>
               <span translate>
-                Unlimited Systems:
+                Unlimited Content Hosts:
               </span>
               <input type='checkbox' ng-model="activationKey.unlimited_content_hosts"/>
             </div>

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/new/views/activation-key-new.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/new/views/activation-key-new.html
@@ -29,8 +29,8 @@
              required/>
     </div>
 
-    <div alch-form-group label="{{ 'System Limit' | translate }}" field="max_content_hosts">
-      <span translate>Unlimited Systems:</span>
+    <div alch-form-group label="{{ 'Content Host Limit' | translate }}" field="max_content_hosts">
+      <span translate>Unlimited Content Hosts:</span>
       <input type="checkbox"
              name="limit"
              ng-model="activationKey.unlimited_content_hosts"/>


### PR DESCRIPTION
In the UI, System should be replaced with Content Host on both the
new & edit screens for activation keys.
