### PR TITLE
fixes #6573 - need better errors when sorting by a non-sortable field

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -36,10 +36,6 @@ module Katello
       param :per_page,  :number, :desc => N_("Number of results per page to return")
       param :order, String, :desc => N_("Sort field and order, eg. 'name DESC'")
       param :full_results, :bool, :desc => N_("Whether or not to show all results")
-      param :sort, Hash, :desc => N_("Hash version of 'order' param") do
-        param :by, String, :desc => N_("Field to sort the results on")
-        param :order, String, :desc => N_("How to order the sorted results (e.g. ASC for ascending)")
-      end
     end
 
     param :object_root, String, :desc => N_("root-node of single-resource responses (optional)")
@@ -47,11 +43,7 @@ module Katello
 
     def item_search(item_class, params, options)
       fail "@search_service search not defined" if @search_service.nil?
-      if params[:order]
-        (params[:sort_by], params[:sort_order]) = params[:order].split(' ')
-      end
-      options[:sort_by] = params[:sort_by] if params[:sort_by]
-      options[:sort_order] = params[:sort_order] if params[:sort_order]
+      options[:sort_by], _, options[:sort_order] = params[:order].rpartition(' ') if params[:order]
       options[:full_result] = params[:full_result] if params[:full_result]
 
       unless options[:full_result]
@@ -77,6 +69,8 @@ module Katello
         :page     => options[:page],
         :per_page => options[:per_page]
       }
+    rescue Katello::Glue::ElasticSearch::UnsortableFieldError => e
+      raise HttpErrors::BadRequest, e.message
     end
 
     def facet_search(item_class, term , options)
@@ -93,7 +87,7 @@ module Katello
       facets = @search_service.facets[facet_name]['terms']
       results = facets.collect{|f| Katello::Glue::ElasticSearch::FacetItem.new(f)}
       {
-        :results  => results.sort_by{|f| f.term },
+        :results  => results.sort_by {|f| f.term },
         :subtotal => results.length,
         :total    => results.length,
       }

--- a/app/models/katello/ext/indexed_model.rb
+++ b/app/models/katello/ext/indexed_model.rb
@@ -24,13 +24,17 @@ module Ext::IndexedModel
         self.class_index_options[:display_attrs].sort{|a, b| a.to_s <=> b.to_s}
       end
 
+      def self.sortable_fields
+        %w(name)
+      end
+
       if Rails.env.development? || Rails.env.production?
         include Tire::Model::Search
         include Tire::Model::Callbacks
         index_name Katello.config.elastic_index + '_' +  self.base_class.name.downcase
 
-        #Shared analyzers.  If you need a model-specific analyzer for some reason,
-        #  we'll need to refactor this to support that.
+        # Shared analyzers.  If you need a model-specific analyzer for some reason,
+        # we'll need to refactor this to support that.
         settings :analysis => {
                     :filter => Util::Search.custom_filters,
                     :analyzer => Util::Search.custom_analyzers
@@ -47,10 +51,8 @@ module Ext::IndexedModel
         def self.mapping(*args)
           {}
         end
-        def self.index_import(list)
-        end
-        def self.index_name(name)
-        end
+        def self.index_import(list); end
+        def self.index_name(name); end
       end
 
       def disable_auto_reindex!

--- a/app/models/katello/glue/elastic_search/activation_key.rb
+++ b/app/models/katello/glue/elastic_search/activation_key.rb
@@ -12,6 +12,7 @@
 
 module Katello
 module Glue::ElasticSearch::ActivationKey
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/backend_indexed_model.rb
+++ b/app/models/katello/glue/elastic_search/backend_indexed_model.rb
@@ -20,10 +20,13 @@ module Glue::ElasticSearch::BackendIndexedModel
   end
 
   module InstanceMethods
-
   end
 
   module ClassMethods
+
+    def sortable_fields
+      %w(name)
+    end
 
     def index_all
       self.create_index

--- a/app/models/katello/glue/elastic_search/content_view.rb
+++ b/app/models/katello/glue/elastic_search/content_view.rb
@@ -14,6 +14,12 @@ module Katello
 module Glue::ElasticSearch::ContentView
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def sortable_fields
+      %w(name default composite)
+    end
+  end
+
   included do
     include Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/content_view_erratum_filter_rule.rb
+++ b/app/models/katello/glue/elastic_search/content_view_erratum_filter_rule.rb
@@ -14,6 +14,12 @@ module Katello
   module Glue::ElasticSearch::ContentViewErratumFilterRule
     extend ActiveSupport::Concern
 
+    module ClassMethods
+      def sortable_fields
+        %w(errata_id)
+      end
+    end
+
     included do
       include Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/content_view_filter.rb
+++ b/app/models/katello/glue/elastic_search/content_view_filter.rb
@@ -14,6 +14,12 @@ module Katello
   module Glue::ElasticSearch::ContentViewFilter
     extend ActiveSupport::Concern
 
+    module ClassMethods
+      def sortable_fields
+        %w(name type)
+      end
+    end
+
     included do
       include Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/content_view_history.rb
+++ b/app/models/katello/glue/elastic_search/content_view_history.rb
@@ -14,6 +14,12 @@ module Katello
 module Glue::ElasticSearch::ContentViewHistory
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def sortable_fields
+      []
+    end
+  end
+
   included do
     include Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/content_view_package_filter_rule.rb
+++ b/app/models/katello/glue/elastic_search/content_view_package_filter_rule.rb
@@ -14,6 +14,12 @@ module Katello
   module Glue::ElasticSearch::ContentViewPackageFilterRule
     extend ActiveSupport::Concern
 
+    module ClassMethods
+      def sortable_fields
+        %w(name)
+      end
+    end
+
     included do
       include Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/content_view_package_group_filter_rule.rb
+++ b/app/models/katello/glue/elastic_search/content_view_package_group_filter_rule.rb
@@ -14,6 +14,12 @@ module Katello
   module Glue::ElasticSearch::ContentViewPackageGroupFilterRule
     extend ActiveSupport::Concern
 
+    module ClassMethods
+      def sortable_fields
+        %w(name)
+      end
+    end
+
     included do
       include Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/content_view_puppet_environment.rb
+++ b/app/models/katello/glue/elastic_search/content_view_puppet_environment.rb
@@ -13,10 +13,17 @@
 module Katello
   module Glue::ElasticSearch::ContentViewPuppetEnvironment
 
+    module ClassMethods
+      def sortable_fields
+        %w(name)
+      end
+    end
+
     # TODO: break this up into modules
     # rubocop:disable MethodLength
     def self.included(base)
       base.send :include, Ext::IndexedModel
+      base.send :extend, ClassMethods
 
       base.class_eval do
         index_options :extended_json => :extended_index_attrs,

--- a/app/models/katello/glue/elastic_search/content_view_puppet_module.rb
+++ b/app/models/katello/glue/elastic_search/content_view_puppet_module.rb
@@ -14,6 +14,12 @@ module Katello
   module Glue::ElasticSearch::ContentViewPuppetModule
     extend ActiveSupport::Concern
 
+    module ClassMethods
+      def sortable_fields
+        %w(name)
+      end
+    end
+
     included do
       include Ext::IndexedModel
 

--- a/app/models/katello/glue/elastic_search/distribution.rb
+++ b/app/models/katello/glue/elastic_search/distribution.rb
@@ -13,11 +13,18 @@
 module Katello
 module Glue::ElasticSearch::Distribution
 
+  module ClassMethods
+    def sortable_fields
+      []
+    end
+  end
+
   # TODO: break this up into modules
   # rubocop:disable MethodLength
   def self.included(base)
     base.class_eval do
       include Glue::ElasticSearch::BackendIndexedModel
+      extend ClassMethods
 
       def index_options
         {

--- a/app/models/katello/glue/elastic_search/distributor.rb
+++ b/app/models/katello/glue/elastic_search/distributor.rb
@@ -14,11 +14,18 @@
 module Katello
 module Glue::ElasticSearch::Distributor
 
+  module ClassMethods
+    def sortable_fields
+      %w(name lastCheckin)
+    end
+  end
+
   # TODO: break this up into modules
   # rubocop:disable MethodLength
   def self.included(base)
     base.class_eval do
       include Ext::IndexedModel
+      extend ClassMethods
 
       index_options :extended_json => :extended_index_attrs,
                     :json => {:only => [:name, :description, :id, :uuid, :created_at, :lastCheckin, :environment_id]},

--- a/app/models/katello/glue/elastic_search/environment.rb
+++ b/app/models/katello/glue/elastic_search/environment.rb
@@ -13,9 +13,16 @@
 module Katello
   module Glue::ElasticSearch::Environment
 
+    module ClassMethods
+      def sortable_fields
+        %w(name library)
+      end
+    end
+
     def self.included(base)
       base.class_eval do
         include Ext::IndexedModel
+        extend ClassMethods
         after_save :update_related_index
         after_destroy :delete_related_index
 

--- a/app/models/katello/glue/elastic_search/errata.rb
+++ b/app/models/katello/glue/elastic_search/errata.rb
@@ -13,6 +13,12 @@
 module Katello
 module Glue::ElasticSearch::Errata
 
+  module ClassMethods
+    def sortable_fields
+      %w(id errata_id issued)
+    end
+  end
+
   SHORT_FIELDS =  [:id, :errata_id, :type, :summary, :severity, :title, :issued]
 
   # TODO: break this up into modules
@@ -20,6 +26,7 @@ module Glue::ElasticSearch::Errata
   def self.included(base)
     base.class_eval do
       include Glue::ElasticSearch::BackendIndexedModel
+      extend ClassMethods
 
       def self.index_settings
         {
@@ -58,8 +65,7 @@ module Glue::ElasticSearch::Errata
               :severity     => { :type => 'string', :analyzer => :kt_name_analyzer},
               :type         => { :type => 'string', :analyzer => :kt_name_analyzer},
               :title        => { :type => 'string', :analyzer => :title_analyzer},
-              :issued       => { :type => 'date'},
-              :issued_sort  => { :type => 'date', :index => :not_analyzed}
+              :issued       => { :type => 'date'}
             }
           }
         }

--- a/app/models/katello/glue/elastic_search/gpg_key.rb
+++ b/app/models/katello/glue/elastic_search/gpg_key.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::GpgKey
+
+  module ClassMethods
+    def sortable_fields
+      %w(name)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :extended_json => :extended_index_attrs,

--- a/app/models/katello/glue/elastic_search/host_collection.rb
+++ b/app/models/katello/glue/elastic_search/host_collection.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::HostCollection
+
+  module ClassMethods
+    def sortable_fields
+      %w(name)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       update_related_indexes :systems, :name

--- a/app/models/katello/glue/elastic_search/job.rb
+++ b/app/models/katello/glue/elastic_search/job.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::Job
+
+  module ClassMethods
+    def sortable_fields
+      []
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :json => {:only => [:job_owner_id, :job_owner_type]},

--- a/app/models/katello/glue/elastic_search/marketing_product.rb
+++ b/app/models/katello/glue/elastic_search/marketing_product.rb
@@ -13,7 +13,14 @@
 module Katello
 module Glue::ElasticSearch::MarketingProduct
 
+  module ClassMethods
+    def sortable_fields
+      []
+    end
+  end
+
   def self.included(base)
+    base.send :extend, ClassMethods
     base.class_eval do
       index_name "#{Katello.config.elastic_index}_marketing_product"
     end

--- a/app/models/katello/glue/elastic_search/notice.rb
+++ b/app/models/katello/glue/elastic_search/notice.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::Notice
+
+  module ClassMethods
+    def sortable_fields
+      %(level)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
 

--- a/app/models/katello/glue/elastic_search/organization.rb
+++ b/app/models/katello/glue/elastic_search/organization.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::Organization
+
+  module ClassMethods
+    def sortable_fields
+      %w(name)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :extended_json => :extended_index_attrs,

--- a/app/models/katello/glue/elastic_search/package.rb
+++ b/app/models/katello/glue/elastic_search/package.rb
@@ -13,12 +13,19 @@
 module Katello
 module Glue::ElasticSearch::Package
 
+  module ClassMethods
+    def sortable_fields
+      %w(nvrea nvra)
+    end
+  end
+
   # TODO: break up into modules
   # rubocop:disable MethodLength
   def self.included(base)
     base.class_eval do
 
       include Glue::ElasticSearch::BackendIndexedModel
+      extend ClassMethods
 
       def index_options
         {

--- a/app/models/katello/glue/elastic_search/package_group.rb
+++ b/app/models/katello/glue/elastic_search/package_group.rb
@@ -13,11 +13,19 @@
 module Katello
 module Glue::ElasticSearch::PackageGroup
 
+  module ClassMethods
+    def sortable_fields
+      %w(name)
+    end
+  end
+
   # TODO: break up into modules
   # rubocop:disable MethodLength
   def self.included(base)
     base.class_eval do
       include Glue::ElasticSearch::BackendIndexedModel
+      extend ClassMethods
+
       def index_options
         {
           "_type" => Katello::PackageGroup.search_type,

--- a/app/models/katello/glue/elastic_search/pool.rb
+++ b/app/models/katello/glue/elastic_search/pool.rb
@@ -13,6 +13,12 @@
 module Katello
 module Glue::ElasticSearch::Pool
 
+  module ClassMethods
+    def sortable_fields
+      %w(name product_name support_level)
+    end
+  end
+
   # TODO: break this up into modules
   # rubocop:disable MethodLength
   def self.included(base)
@@ -20,6 +26,7 @@ module Glue::ElasticSearch::Pool
     base.class_eval do
 
       include Glue::ElasticSearch::BackendIndexedModel
+      extend ClassMethods
 
       def self.search_type
         :pool

--- a/app/models/katello/glue/elastic_search/product.rb
+++ b/app/models/katello/glue/elastic_search/product.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::Product
+
+  module ClassMethods
+    def sortable_fields
+      %w(name enabled)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       after_save :update_related_index

--- a/app/models/katello/glue/elastic_search/provider.rb
+++ b/app/models/katello/glue/elastic_search/provider.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::Provider
+
+  module ClassMethods
+    def sortable_fields
+      %w(name provider_type)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :extended_json => :extended_index_attrs,

--- a/app/models/katello/glue/elastic_search/puppet_module.rb
+++ b/app/models/katello/glue/elastic_search/puppet_module.rb
@@ -14,6 +14,12 @@ module Katello
 module Glue::ElasticSearch::PuppetModule
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def sortable_fields
+      %w(name)
+    end
+  end
+
   included do
     include Glue::ElasticSearch::BackendIndexedModel
   end

--- a/app/models/katello/glue/elastic_search/repository.rb
+++ b/app/models/katello/glue/elastic_search/repository.rb
@@ -13,10 +13,17 @@
 module Katello
 module Glue::ElasticSearch::Repository
 
+  module ClassMethods
+    def sortable_fields
+      %w(name)
+    end
+  end
+
   # TODO: break this up into modules
   # rubocop:disable MethodLength
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :extended_json => :extended_index_attrs,

--- a/app/models/katello/glue/elastic_search/sync_plan.rb
+++ b/app/models/katello/glue/elastic_search/sync_plan.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::SyncPlan
+
+  module ClassMethods
+    def sortable_fields
+      %w(name sync_date)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :extended_json => :extended_index_attrs,

--- a/app/models/katello/glue/elastic_search/system.rb
+++ b/app/models/katello/glue/elastic_search/system.rb
@@ -17,10 +17,17 @@
 module Katello
 module Glue::ElasticSearch::System
 
+  module ClassMethods
+    def sortable_fields
+      %w(name environment content_view)
+    end
+  end
+
   # rubocop:disable MethodLength
   def self.included(base)
     base.class_eval do
       include Ext::IndexedModel
+      extend ClassMethods
 
       add_host_collection_hook     lambda { |host_collection| reindex_on_association_change(host_collection) }
       remove_host_collection_hook  lambda { |host_collection| reindex_on_association_change(host_collection) }

--- a/app/models/katello/glue/elastic_search/task_status.rb
+++ b/app/models/katello/glue/elastic_search/task_status.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::TaskStatus
+
+  module ClassMethods
+    def sortable_fields
+      %w(start_time finish_time)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :json => { :only => [:parameters, :organization_id, :start_time,

--- a/app/models/katello/glue/elastic_search/user.rb
+++ b/app/models/katello/glue/elastic_search/user.rb
@@ -12,8 +12,16 @@
 
 module Katello
 module Glue::ElasticSearch::User
+
+  module ClassMethods
+    def sortable_fields
+      %w(login)
+    end
+  end
+
   def self.included(base)
     base.send :include, Ext::IndexedModel
+    base.send :extend, ClassMethods
 
     base.class_eval do
       index_options :extended_json => :extended_index_attrs,

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/activation-keys.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/activation-keys.controller.js
@@ -34,8 +34,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeysController',
         var params = {
             'organization_id':  CurrentOrganization,
             'search':           $location.search().search || "",
-            'sort_by':          'name',
-            'sort_order':       'ASC',
+            'order':            'name ASC',
             'paged':            true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-add-host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-add-host-collections.controller.js
@@ -35,8 +35,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAddHostCollec
 
         params = {
             'search':      $location.search().search || "",
-            'sort_by':     'name',
-            'sort_order':  'ASC',
+            'order':       'name ASC',
             'paged':       true,
             'id':          $scope.$stateParams.activationKeyId
         };

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-add-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-add-subscriptions.controller.js
@@ -38,8 +38,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAddSubscripti
             'id':                       $scope.$stateParams.activationKeyId,
             'organization_id':          CurrentOrganization,
             'search':                   $location.search().search || "",
-            'sort_by':                  'name',
-            'sort_order':               'ASC'
+            'order':                    'name ASC'
         };
 
         addSubscriptionsPane = new Nutupane(ActivationKey, params, 'availableSubscriptions');

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-host-collections.controller.js
@@ -36,8 +36,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyHostCollectio
         params = {
             'id':          $scope.$stateParams.activationKeyId,
             'search':      $location.search().search || "",
-            'sort_by':     'name',
-            'sort_order':  'ASC',
+            'order':       'name ASC',
             'paged':       true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/activation-key-subscriptions.controller.js
@@ -33,8 +33,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeySubscriptions
         params = {
             'id':          $scope.$stateParams.activationKeyId,
             'search':      $location.search().search || "",
-            'sort_by':     'name',
-            'sort_order':  'ASC',
+            'order':       'name ASC',
             'paged':       true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.js
@@ -40,8 +40,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionHostCo
         params = {
             'organization_id':  CurrentOrganization,
             'offset':           0,
-            'sort_by':          'name',
-            'sort_order':       'ASC',
+            'order':            'name ASC',
             'paged':            true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.controller.js
@@ -38,8 +38,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
         var params = {
             'organization_id':  CurrentOrganization,
             'search':           $location.search().search || "",
-            'sort_by':          'name',
-            'sort_order':       'ASC'
+            'order':            'name ASC'
         };
 
         var nutupane = new Nutupane(ContentHost, params);

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-host-collections.controller.js
@@ -35,8 +35,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddHostCollection
 
         params = {
             'search':      $location.search().search || "",
-            'sort_by':     'name',
-            'sort_order':  'ASC',
+            'order':       'name ASC',
             'paged':       true,
             'id':            $scope.$stateParams.contentHostId
         };

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -29,7 +29,7 @@
 angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsController',
     ['$scope', '$location', 'translate', 'CurrentOrganization', 'Subscription', 'ContentHost', 'SubscriptionsHelper',
     function ($scope, $location, translate, CurrentOrganization, Subscription, ContentHost, SubscriptionsHelper) {
-        
+
         $scope.addSubscriptionsTable = $scope.addSubscriptionsPane.table;
         $scope.isAdding  = false;
         $scope.addSubscriptionsTable.closeItem = function () {};

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-base-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-base-subscriptions.controller.js
@@ -31,8 +31,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostBaseSubscriptions
         var params = {
             'id':                       $scope.$stateParams.contentHostId,
             'organization_id':          CurrentOrganization,
-            'sort_by':                  'name',
-            'sort_order':               'ASC'
+            'order':                    'name ASC'
         };
 
         $scope.subscription = {

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-host-collections.controller.js
@@ -36,8 +36,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostHostCollectionsCo
         params = {
             'id':          $scope.$stateParams.contentHostId,
             'search':      $location.search().search || "",
-            'sort_by':     'name',
-            'sort_order':  'ASC',
+            'order':       'name ASC',
             'paged':       true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-subscriptions.controller.js
@@ -28,7 +28,7 @@
 angular.module('Bastion.content-hosts').controller('ContentHostSubscriptionsController',
     ['$scope', '$location', 'translate', 'Subscription', 'ContentHost', 'SubscriptionsHelper',
     function ($scope, $location, translate, Subscription, ContentHost, SubscriptionsHelper) {
-        
+
         $scope.subscriptionsTable = $scope.subscriptionsPane.table;
         $scope.subscriptionsTable.closeItem = function () {};
         $scope.isRemoving = false;

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/content-views.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/content-views.controller.js
@@ -32,8 +32,7 @@ angular.module('Bastion.content-views').controller('ContentViewsController',
         var nutupane = new Nutupane(ContentView, {
             'nondefault':       true,
             'organization_id':  CurrentOrganization,
-            'sort_by':          'name',
-            'sort_order':       'ASC'
+            'order':            'name ASC'
         });
 
         $scope.table = nutupane.table;

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
@@ -35,8 +35,7 @@ angular.module('Bastion.content-views').controller('ContentViewVersionDeletionAc
         params = {
             'organization_id':  CurrentOrganization,
             'content_view_id':  $scope.contentView.id,
-            'sort_by':          'name',
-            'sort_order':       'ASC'
+            'order':            'name ASC'
         };
         nutupane = new Nutupane(ActivationKey, params);
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-content-hosts.controller.js
@@ -36,8 +36,7 @@ angular.module('Bastion.content-views').controller('ContentViewVersionDeletionCo
         params = {
             'organization_id':  CurrentOrganization,
             'content_view_id':  $scope.contentView.id,
-            'sort_by':          'name',
-            'sort_order':       'ASC'
+            'order':            'name ASC'
         };
         nutupane = new Nutupane(ContentHost, params);
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-details-history.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-details-history.controller.js
@@ -29,8 +29,7 @@ angular.module('Bastion.content-views').controller('ContentViewHistoryController
 
         nutupane = new Nutupane(ContentView, {
             id: $scope.$stateParams.contentViewId,
-            'sort_by':          'created_at',
-            'sort_order':       'DESC'
+            'order':            'created_at DESC'
         }, 'history');
 
         nutupane.table.closeItem = function () {};

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/available-errata-filter.controller.js
@@ -33,8 +33,7 @@ angular.module('Bastion.content-views').controller('AvailableErrataFilterControl
 
         $scope.nutupane = nutupane = new Nutupane(Filter, {
                 filterId: $scope.$stateParams.filterId,
-                'sort_order': 'DESC',
-                'sort_by': 'issued'
+                'order': 'issued DESC'
             },
             'availableErrata'
         );

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter-list.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/errata-filter-list.controller.js
@@ -32,8 +32,7 @@ angular.module('Bastion.content-views').controller('ErrataFilterListController',
 
         $scope.nutupane = nutupane = new Nutupane(Filter, {
                 filterId: $scope.$stateParams.filterId,
-                'sort_order': 'DESC',
-                'sort_by': 'issued'
+                'order': 'issued DESC'
             },
             'errata'
         );

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/gpg-keys.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/gpg-keys.controller.js
@@ -32,8 +32,7 @@ angular.module('Bastion.gpg-keys').controller('GPGKeysController',
         var params = {
             'organization_id':  CurrentOrganization,
             'search':           $location.search().search || "",
-            'sort_by':          'name',
-            'sort_order':       'ASC',
+            'order':            'name ASC',
             'paged':            true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-add-content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-add-content-hosts.controller.js
@@ -35,8 +35,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionAddContentH
             'organization_id':          CurrentOrganization,
             'search':                   $location.search().search || "",
             'page':                     1,
-            'sort_by':                  'name',
-            'sort_order':               'ASC',
+            'order':                    'name ASC',
             'paged':                    true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-content-hosts.controller.js
@@ -32,8 +32,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionContentHost
         params = {
             'id':          $scope.$stateParams.hostCollectionId,
             'search':      $location.search().search || "",
-            'sort_by':     'name',
-            'sort_order':  'ASC',
+            'order':       'name ASC',
             'paged':       true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/host-collections.controller.js
@@ -34,8 +34,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionsController
         var params = {
             'organization_id':  CurrentOrganization,
             'search':           $location.search().search || "",
-            'sort_by':          'name',
-            'sort_order':       'ASC',
+            'order':            'name ASC',
             'paged':            true
         };
 

--- a/engines/bastion/app/assets/javascripts/bastion/products/products.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/products/products.controller.js
@@ -33,8 +33,7 @@ angular.module('Bastion.products').controller('ProductsController',
         var watch, params = {
             'organization_id':  CurrentOrganization,
             'search':           $location.search().search || "",
-            'sort_by':          'name',
-            'sort_order':       'ASC',
+            'order':            'name ASC',
             'enabled' :         true,
             'paged':            true
         };

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/subscriptions.controller.js
@@ -37,8 +37,7 @@ angular.module('Bastion.subscriptions').controller('SubscriptionsController',
         var params = {
             'organization_id':  CurrentOrganization,
             'search':           $location.search().search || "",
-            'sort_by':          'name',
-            'sort_order':       'ASC',
+            'order':            'name ASC',
             'enabled' :         true,
             'paged':            true
         };

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-add-products.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-add-products.controller.js
@@ -34,11 +34,10 @@ angular.module('Bastion.sync-plans').controller('SyncPlanAddProductsController',
             $scope.errorMessages = [];
 
             params = {
-                'search': $location.search().search || "",
-                'sort_by': 'name',
-                'sort_order': 'ASC',
-                'full_result': true,
-                'id': $scope.$stateParams.syncPlanId
+                'search':       $location.search().search || "",
+                'order':        'name ASC',
+                'full_result':  true,
+                'id':           $scope.$stateParams.syncPlanId
             };
 
             productsNutupane = new Nutupane(SyncPlan, params, 'availableProducts');

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-products.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-products.controller.js
@@ -34,11 +34,10 @@ angular.module('Bastion.sync-plans').controller('SyncPlanProductsController',
             $scope.errorMessages = [];
 
             params = {
-                'id': $scope.$stateParams.syncPlanId,
-                'search': $location.search().search || "",
-                'sort_by': 'name',
-                'sort_order': 'ASC',
-                'full_result': true
+                'id':           $scope.$stateParams.syncPlanId,
+                'search':       $location.search().search || "",
+                'order':        'name ASC',
+                'full_result':  true
             };
 
             productsNutupane = new Nutupane(SyncPlan, params, 'products');

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/sync-plans.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/sync-plans.controller.js
@@ -37,8 +37,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlansController',
             var params = {
                 'organization_id':  CurrentOrganization,
                 'search':           $location.search().search || "",
-                'sort_by':          'name',
-                'sort_order':       'ASC'
+                'order':            'name ASC'
             };
 
             var nutupane = new Nutupane(SyncPlan, params);

--- a/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/nutupane.factory.js
@@ -298,15 +298,18 @@ angular.module('Bastion.widgets').factory('Nutupane',
                     return;
                 }
 
-                params["sort_by"] = column.id;
+                var sortOrder, sortBy = column.id;
                 if (column.id === sort.by) {
-                    params["sort_order"] = (sort.order === 'ASC') ? 'DESC' : 'ASC';
+                    sortOrder = (sort.order === 'ASC') ? 'DESC' : 'ASC';
                 } else {
-                    params["sort_order"] = 'ASC';
+                    sortOrder = 'ASC';
                 }
 
-                column.sortOrder = params["sort_order"];
+                column.sortOrder = sortOrder;
                 column.active = true;
+
+                params['order'] = sortBy + ' ' + sortOrder;
+
                 self.table.rows = [];
                 self.query();
             };

--- a/engines/bastion/test/incubator/nutupane.factory.test.js
+++ b/engines/bastion/test/incubator/nutupane.factory.test.js
@@ -235,7 +235,7 @@ describe('Factory: Nutupane', function() {
 
         describe("provides a way to sort the table", function() {
             it ("defaults the sort to ascending if the previous sort does not match the new sort.", function() {
-                var expectedParams = {sort_by: 'name', sort_order: 'ASC', search: '', page: 1};
+                var expectedParams = {order: 'name ASC', search: '', page: 1};
                 nutupane.table.resource.sort = {};
 
                 spyOn(Resource, 'queryPaged');
@@ -245,7 +245,7 @@ describe('Factory: Nutupane', function() {
             });
 
             it("toggles the sort order if already sorting by that column", function() {
-                var expectedParams = {sort_by: 'name', sort_order: 'DESC', search: '', page: 1};
+                var expectedParams = {order: 'name DESC', search: '', page: 1};
                 nutupane.table.resource.sort = {
                     by: 'name',
                     order: 'ASC'

--- a/test/glue/elasticsearch/items_test.rb
+++ b/test/glue/elasticsearch/items_test.rb
@@ -26,6 +26,10 @@ class GlueElasticSearchTest < ActiveSupport::TestCase
       def self.mapping(*args)
         {}
       end
+
+      def self.sortable_fields
+        %w(name)
+      end
     end
 
     @results = MiniTest::Mock.new


### PR DESCRIPTION
- [x] removing `sort[by]` and `sort[order]` params
- [x] define `sortable_fields` for all the elasticsearch objects
- [x] validate sort params
- [x] update to UI that utilizes sorting
