### PR TITLE
fixes #6601 / BZ 1115364 - content search - fix package license

### DIFF
--- a/app/views/katello/packages/_details.html.haml
+++ b/app/views/katello/packages/_details.html.haml
@@ -39,7 +39,7 @@
     %label.fl.ra
       =_("License:")
     %p
-      = @package.buildhost
+      = @package.license
 
   .item-container
     %label.fl.ra
@@ -60,10 +60,12 @@
         = format_package_details(item)
 
   .details-link-container
-    %a{class: "package-filelist-link", data: {id: "#{@package.id}"}}View package files
+    %a{class: "package-filelist-link", data: {id: "#{@package.id}"}}
+      = _("View package files")
 
   .details-link-container
-    %a{class: "package-changelog-link", data: {id: "#{@package.id}"}}View package changelog
+    %a{class: "package-changelog-link", data: {id: "#{@package.id}"}}
+      = _("View package changelog")
 
 .package-filelist{id: "package-filelist-#{@package.id}", title: (_("Files for %s") % @package.name)}
   - if @package.files[:file].length > 0


### PR DESCRIPTION
Small update to:
- properly show the package license information
- correctly i18n a couple strings being rendered
