### PR TITLE
fixes #6603 / BZ 1115341 - content search - fix for missing package metadata

### DIFF
--- a/app/views/katello/packages/_details.html.haml
+++ b/app/views/katello/packages/_details.html.haml
@@ -46,18 +46,20 @@
       =_("Requires:")
     %p
       &nbsp;
-    - @package.requires.each do |item|
-      %p
-        = format_package_details(item)
+    - if @package.requires
+      - @package.requires.each do |item|
+        %p
+          = format_package_details(item)
 
   .item-container
     %label.fl.ra
       =_("Provides:")
     %p
       &nbsp;
-    - @package.provides.each do |item|
-      %p
-        = format_package_details(item)
+    - if @package.provides
+      - @package.provides.each do |item|
+        %p
+          = format_package_details(item)
 
   .details-link-container
     %a{class: "package-filelist-link", data: {id: "#{@package.id}"}}View package files
@@ -66,13 +68,14 @@
     %a{class: "package-changelog-link", data: {id: "#{@package.id}"}}View package changelog
 
 .package-filelist{id: "package-filelist-#{@package.id}", title: (_("Files for %s") % @package.name)}
-  - if @package.files[:file].length > 0
-    - @package.files[:file].each do |file|
+  - if @package.files
+    - if @package.files[:file].length > 0
+      - @package.files[:file].each do |file|
+        %p
+          = file
+    - else
       %p
-        = file
-  - else
-    %p
-      = _("There are no files in this repository.")
+        = _("There are no files in this package.")
 
 .package-changelog{id: "package-changelog-#{@package.id}", title: (_("Changelog for %s") % @package.name)}
   %table.changelog
@@ -84,11 +87,12 @@
           = _("Author/Release")
         %th
           = _("Changes")
-        - @package.changelog.each do |change|
-          %tr
-            %td
-              = format_changelog_date(change[0].to_s)
-            %td
-              = change.try(:[], 1)
-            %td
-              = changelog_changes(change.try(:[], 2))
+        - if @package.changelog
+          - @package.changelog.each do |change|
+            %tr
+              %td
+                = format_changelog_date(change[0].to_s)
+              %td
+                = change.try(:[], 1)
+              %td
+                = changelog_changes(change.try(:[], 2))


### PR DESCRIPTION
This commit is to address errors that could occur if the package
metadata was missing information for fields such as provides,
requires, files or changelog.
