### PR TITLE
fixes #6607 / BZ 1106565 - Content View Package Filter Rules - allow duplicate name

### DIFF
--- a/app/models/katello/content_view_package_filter_rule.rb
+++ b/app/models/katello/content_view_package_filter_rule.rb
@@ -21,7 +21,7 @@ module Katello
                :inverse_of => :package_rules,
                :foreign_key => :content_view_filter_id
 
-    validates :name, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
+    validates :name, :presence => true
     validates_with Validators::ContentViewFilterVersionValidator
   end
 end

--- a/test/lib/validators/content_view_filter_version_validator_test.rb
+++ b/test/lib/validators/content_view_filter_version_validator_test.rb
@@ -1,0 +1,78 @@
+# encoding: utf-8
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module Katello
+  class ContentViewFilterVersionValidatorTest < ActiveSupport::TestCase
+
+    def self.before_suite
+      models = ["Organization", "KTEnvironment", "User", "ContentView", "ContentViewVersion",
+                "ContentViewEnvironment", "ContentViewFilter",
+                "ContentViewPackageFilter", "ContentViewPackageFilterRule"]
+      disable_glue_layers(["Candlepin", "Pulp", "ElasticSearch"], models, true)
+    end
+
+    def setup
+      User.current = User.first
+      @validator = Validators::ContentViewFilterVersionValidator.new({})
+      @filter = FactoryGirl.create(:katello_content_view_package_filter)
+    end
+
+    test "fails if version and min_version provided" do
+      model = ContentViewPackageFilterRule.new(:content_view_filter_id => @filter.id,
+                                               :version => '1.0', :min_version => '1.0')
+      @validator.validate(model)
+      refute_empty model.errors[:base]
+    end
+
+    test "fails if version and max_version provided" do
+      model = ContentViewPackageFilterRule.new(:content_view_filter_id => @filter.id,
+                                               :version => '1.0', :max_version => '5.0')
+      @validator.validate(model)
+      refute_empty model.errors[:base]
+    end
+
+    test "fails if version, min_version and max_version provided" do
+      model = ContentViewPackageFilterRule.new(:content_view_filter_id => @filter.id, :version => '1.0',
+                                               :min_version => '1.0', :max_version => '5.0')
+      @validator.validate(model)
+      refute_empty model.errors[:base]
+    end
+
+    test "passes with version" do
+      model = ContentViewPackageFilterRule.new(:content_view_filter_id => @filter.id, :version => '1.0')
+      @validator.validate(model)
+      assert_empty model.errors[:base]
+    end
+
+    test "passes with min_version" do
+      model = ContentViewPackageFilterRule.new(:content_view_filter_id => @filter.id, :min_version => '1.0')
+      @validator.validate(model)
+      assert_empty model.errors[:base]
+    end
+
+    test "passes with max_version" do
+      model = ContentViewPackageFilterRule.new(:content_view_filter_id => @filter.id, :max_version => '5.0')
+      @validator.validate(model)
+      assert_empty model.errors[:base]
+    end
+
+    test "passes with min_version and max_version" do
+      model = ContentViewPackageFilterRule.new(:content_view_filter_id => @filter.id,
+                                               :min_version => '1.0', :max_version => '5.0')
+      @validator.validate(model)
+      assert_empty model.errors[:base]
+    end
+  end
+end

--- a/test/models/content_view_package_filter_rule_test.rb
+++ b/test/models/content_view_package_filter_rule_test.rb
@@ -44,12 +44,9 @@ class ContentViewPackageFilterRuleTest < ActiveSupport::TestCase
     attrs = FactoryGirl.attributes_for(:katello_content_view_package_filter_rule,
                                        :name => @rule.name)
 
-    assert_raises(ActiveRecord::RecordInvalid) do
-      ContentViewPackageFilterRule.create!(attrs)
-    end
     rule_item = ContentViewPackageFilterRule.create(attrs)
-    refute rule_item.persisted?
-    refute rule_item.save
+    assert rule_item.persisted?
+    assert rule_item.save
   end
 
   def test_version


### PR DESCRIPTION
Prior to this commit, a user could not create multiple package filter
rules for the same package (i.e. name) but different specific versions.

For example, if a repo had the following packages:
  package-0:1.0.0
  package-0:2.0.0
  package-0:3.0.0
  package-0:4.0.0

A user could not create rules to include/exclude the following packages:
  package-0:2.0.0
  package-0:4.0.0

With this commit, a user may now do that.
