### PR TITLE
fixes #6619 / BZ 1111733 - Lifecycle Environment: do not update label

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -118,7 +118,6 @@ module Katello
       fail HttpErrors::BadRequest, _("Can't update the '%s' environment") % "Library" if @environment.library?
       update_params = environment_params
       update_params[:name] = params[:environment][:new_name] if params[:environment][:new_name]
-      update_params[:label] = labelize_params(update_params) if update_params[:name]
       @environment.update_attributes!(update_params)
       respond
     end

--- a/test/controllers/api/v2/environments_controller_test.rb
+++ b/test/controllers/api/v2/environments_controller_test.rb
@@ -89,15 +89,21 @@ module Katello
     end
 
     def test_update
+      original_label = @staging.label
+
       put :update,
         :organization_id => @organization.id,
         :id => @staging.id,
         :environment => {
-          :new_name => 'New Name'
+          :new_name => 'New Name',
+          :label => 'New Label'
         }
 
       assert_response :success
       assert_template 'api/v2/common/update'
+      assert_equal 'New Name', @staging.reload.name
+      # note: label is not editable; therefore, confirm that it is unchanged
+      assert_equal original_label, @staging.label
     end
 
     def test_update_protected


### PR DESCRIPTION
The lifecycle environment label was being 'auto updated' when a user
would change the environment name.  This should not be done as the
label is intended to be read-only.
