### PR TITLE
fixes #6624 / BZ 1105617 - content host package actions - disable buttons when busy

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/content-host-packages.controller.js
@@ -36,16 +36,20 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
             } else {
                 $scope.transitionTo('content-hosts.details.events.details', {eventId: event.id});
             }
+            $scope.working = false;
         };
 
         var errorHandler = function (response) {
             $scope.errorMessages = response.data.errors;
+            $scope.working = false;
         };
 
         $scope.packageAction = {actionType: 'packageInstall'}; //default to packageInstall
         $scope.errorMessages = [];
+        $scope.working = false;
 
         $scope.updateAll = function () {
+            $scope.working = true;
             ContentHostPackage.updateAll({uuid: $scope.contentHost.uuid}, openEventInfo, errorHandler);
         };
 
@@ -53,6 +57,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
             var action, terms;
             action = $scope.packageAction.actionType;
             terms = $scope.packageAction.term.split(/ *, */);
+            $scope.working = true;
             packageActions[action](terms);
         };
 
@@ -84,11 +89,14 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
         };
 
         $scope.currentPackagesTable.removePackage = function (pkg) {
-            ContentHostPackage.remove({
-                uuid: $scope.contentHost.uuid,
-                packages: [{name: pkg.name, version: pkg.version,
-                            arch: pkg.arch, release: pkg.release}]
-            }, openEventInfo, errorHandler);
+            if (!$scope.working) {
+                $scope.working = true;
+                ContentHostPackage.remove({
+                    uuid: $scope.contentHost.uuid,
+                    packages: [{name: pkg.name, version: pkg.version,
+                        arch: pkg.arch, release: pkg.release}]
+                }, openEventInfo, errorHandler);
+            }
         };
     }
 ]);

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
@@ -24,7 +24,7 @@
         <span class="input-group-btn">
           <button class="btn btn-default"
                   ng-hide="denied('edit_content_hosts', contentHost)"
-                  ng-disabled="packageAction.term === undefined || packageAction.term.length === 0"
+                  ng-disabled="working || packageAction.term === undefined || packageAction.term.length === 0"
                   translate>
             Perform</button>
         </span>
@@ -48,7 +48,8 @@
     <div class="fr" ng-hide="denied('edit_content_hosts', contentHost)">
        <button class="btn btn-primary"
                translate
-               ng-click="updateAll()">
+               ng-click="updateAll()"
+               ng-disabled="working">
          Update All
        </button>
     </div>

--- a/engines/bastion/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion/test/content-hosts/content/content-host-packages.controller.test.js
@@ -77,7 +77,6 @@ describe('Controller: ContentHostPackagesController', function() {
         expect($scope.currentPackagesTable.taskFailed({failed: false})).toBe(false);
         expect($scope.currentPackagesTable.taskFailed({failed: false, affected_units: 0})).toBe(true);
         expect($scope.currentPackagesTable.taskFailed({failed: false, affected_units: 1})).toBe(false);
-
     });
 
     it("performs a package update", function() {
@@ -87,6 +86,7 @@ describe('Controller: ContentHostPackagesController', function() {
         $scope.performPackageAction();
         expect(ContentHostPackage.update).toHaveBeenCalledWith({uuid: mockContentHost.uuid, packages: ["foo"]},
                                                           jasmine.any(Function), jasmine.any(Function));
+        expect($scope.working).toBe(true);
     });
 
     it("performs a package update with multiple packages", function() {
@@ -96,6 +96,7 @@ describe('Controller: ContentHostPackagesController', function() {
         $scope.performPackageAction();
         expect(ContentHostPackage.update).toHaveBeenCalledWith({uuid: mockContentHost.uuid, packages: ["foo", "bar"]},
                                                           jasmine.any(Function), jasmine.any(Function));
+        expect($scope.working).toBe(true);
     });
 
     it("performs a package group install", function() {
@@ -105,6 +106,7 @@ describe('Controller: ContentHostPackagesController', function() {
         $scope.performPackageAction();
         expect(ContentHostPackage.install).toHaveBeenCalledWith({uuid: mockContentHost.uuid, groups: ["bigGroup"]},
                                                           jasmine.any(Function), jasmine.any(Function));
+        expect($scope.working).toBe(true);
     });
 
     it("performs a selected package removal", function() {
@@ -112,10 +114,11 @@ describe('Controller: ContentHostPackagesController', function() {
         mockPackage = {name: 'foo', version: '3', release: '14', arch: 'noarch'};
         mockPackageClone = {name: 'foo', version: '3', release: '14', arch: 'noarch'};
 
-        spyOn(ContentHostPackage, 'remove').andCallThrough();
+        spyOn(ContentHostPackage, 'remove');
         $scope.currentPackagesTable.removePackage(mockPackage);
         expect(ContentHostPackage.remove).toHaveBeenCalledWith({uuid: mockContentHost.uuid, packages: [mockPackageClone]},
                                                           jasmine.any(Function), jasmine.any(Function));
+        expect($scope.working).toBe(true);
     });
 
     it("provides a way to upgrade all packages", function() {
@@ -123,6 +126,7 @@ describe('Controller: ContentHostPackagesController', function() {
         $scope.updateAll();
         expect(ContentHostPackage.updateAll).toHaveBeenCalledWith({uuid: mockContentHost.uuid}, jasmine.any(Function),
             jasmine.any(Function));
+        expect($scope.working).toBe(true);
     });
 
 });


### PR DESCRIPTION
This commit contains a minor change to disable the ability to initiate a new action,
until the current action has been accepted (202) by the server.  The most common
use case for this is if the user were to double-click the 'Perform', 'Update All'
or '(X)' items in the UI.

Without this change, the user might observe an error like the following in the log:
  ForemanTasks::Lock::LockConflict: Required lock is already taken by other running tasks.

In spite of the above error, the user could later go back and re-execute a new request.
