### PR TITLE
Fixes #6543 - updt index on cp event bz1115602

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -246,13 +246,6 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
         :default_field => :product_name
     }
 
-    # TODO: remove this fragile logic
-    # Without any search terms, reindex all subscriptions in elasticsearch. This is to ensure
-    # that the latest information is searchable.
-    if params[:page].to_i == 1 && params[:search].blank?
-      @organization.redhat_provider.index_subscriptions
-    end
-
     subscriptions = item_search(Pool, params, options)
 
     return subscriptions
@@ -307,13 +300,6 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
         :load_records? => false,
         :default_field => :product_name
     }
-
-    # TODO: remove this fragile logic
-    # Without any search terms, reindex all subscriptions in elasticsearch. This is to ensure
-    # that the latest information is searchable.
-    if params[:offset].to_i == 0 && params[:search].blank?
-      @organization.redhat_provider.index_subscriptions
-    end
 
     subscriptions = item_search(Pool, params, options)
 

--- a/app/lib/actions/candlepin/candlepin_listening_service.rb
+++ b/app/lib/actions/candlepin/candlepin_listening_service.rb
@@ -1,0 +1,146 @@
+
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+module Actions
+  module Candlepin
+    class MessageStore
+      def initialize
+        @messages = {}
+      end
+
+      def add(id, message)
+        @messages[id] = message
+      end
+
+      def delete(id)
+        @messages.delete(id) if @messages.key?(id)
+      end
+
+      def message(id)
+        @messages[id]
+      end
+    end
+
+    class ConnectionError < StandardError
+    end
+
+    class CandlepinListeningService
+      RECONNECT_ATTEMPTS = 30
+      TIMEOUT =  Qpid::Messaging::Duration::SECOND
+      NO_MESSAGE_AVAILABLE_ERROR_TYPE = 'NoMessageAvailable'
+
+      attr_reader :messages, :errors
+
+      class << self
+        attr_reader :instance
+
+        def initialize(logger, url, address)
+          @instance ||= self.new(logger, url, address)
+        end
+
+        def close
+          @instance.close
+          @instance = nil
+        end
+      end
+
+      def initialize(logger, url, address)
+        @url = url
+        @address = address
+        @connection = create_connection
+        @messages = MessageStore.new
+        @errors = {}
+        @counter = 0
+        @logger = logger
+      end
+
+      def create_connection
+        Qpid::Messaging::Connection.new({:url => @url, :options => {:transport => 'ssl'}})
+      end
+
+      def close
+        @connection.close
+      ensure
+        super
+      end
+
+      def retrieve
+        return @receiver.fetch(TIMEOUT)
+      rescue => e
+        if e.class.name.include? "TransportFailure"
+          raise ::Actions::Candlepin::ConnectionError, "failed to connect to #{@url}"
+        else
+          raise e unless e.class.name.include? NO_MESSAGE_AVAILABLE_ERROR_TYPE
+        end
+      end
+
+      def acknowledge_message(message_id)
+        @session.acknowledge(@messages.message(message_id))
+        @messages.delete(message_id)
+      end
+
+      def start(suspended_action)
+        unless @connection.open?
+          @connection.open
+          @session = @connection.create_session
+          @receiver = @session.create_receiver(@address)
+          @messages = Actions::Candlepin::MessageStore.new
+        end
+        if @connection.open?
+          suspended_action.notify_connected
+        else
+          suspended_action.notify_not_connected("Not Connected")
+        end
+      rescue TransportFailure => e
+        suspended_action.notify_not_connected(e.message)
+      end
+
+      def close
+        @thread.kill if @thread
+      end
+
+      def fetch_message(suspended_action)
+        result = nil
+        begin
+          result = retrieve
+        rescue Actions::Candlepin::ConnectionError => e
+          suspended_action.notify_not_connected(e.message)
+        rescue => e
+          notify_fatal(e)
+          raise e
+        end
+        result
+      end
+
+      def poll_for_messages(suspended_action)
+        @thread.kill if @thread
+        @thread = Thread.new do
+          loop do
+            @counter += 1
+            message = fetch_message(suspended_action)
+            if message
+              messages.add(@counter, message)
+              suspended_action.notify_message_recieved(@counter)
+            end
+            sleep 3
+          end
+        end
+      end
+
+      def notify_fatal(error, suspended_action)
+        @errors[@counter] = error
+        suspended_action.notify_fatal(@counter)
+      end
+    end
+  end
+end

--- a/app/lib/actions/candlepin/listen_on_candlepin_events.rb
+++ b/app/lib/actions/candlepin/listen_on_candlepin_events.rb
@@ -1,0 +1,171 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+module Actions
+  module Candlepin
+    class SuspendedAction
+      def initialize(suspended_action)
+        @suspended_action = suspended_action
+      end
+
+      def notify_message_recieved(id)
+        @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::Event[id]
+      end
+
+      def notify_fatal(id)
+        @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::Fatal[id]
+      end
+
+      def notify_connected
+        @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::Connected
+      end
+
+      def notify_not_connected(message)
+        @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::NotConnected[message]
+      end
+    end
+
+    class ListenOnCandlepinEvents < Actions::Base
+
+      Connected = Algebrick.atom
+
+      NotConnected = Algebrick.type do
+        fields! message: String
+      end
+
+      Event = Algebrick.type do
+        fields! message_id: Integer
+      end
+
+      Fatal = Algebrick.type do
+        fields! id: Integer
+      end
+
+      Close = Algebrick.atom
+
+      def plan
+        # Make sure we don't have two concurrent listening services competing
+        if already_running?
+          fail "Action #{self.class.name} is already active"
+        end
+        plan_self
+      end
+
+      def run(event = nil)
+        match(event,
+              (on nil do
+                 # initialize the listening service
+                 initialize_service
+               end),
+              (on NotConnected do
+                 connect_listening_service(event)
+               end),
+              (on Connected do
+                 poll_listening_service(event)
+               end),
+              (on Event do
+                 # react on the event, probably calling ForemanTasks.async_task
+                 act_on_event(event)
+               end),
+              (on Close | Dynflow::Action::Cancellable::Cancel do
+                 # we finished with the listening serivce
+                 close_service
+               end),
+              (on Fatal do
+                 begin
+                   error!(error_message(event.id))
+                 ensure
+                   close_service
+                 end
+               end),
+              (on Dynflow::Action::Skip do
+                 # do nothing, just skip
+               end))
+      rescue => e
+        action_logger.error(e.message)
+        error!(e)
+      end
+
+      def connect_listening_service(event)
+        CandlepinListeningService.instance.close
+        sleep 5
+        output[:connection] = event.message
+        suspend do |suspended_action|
+          CandlepinListeningService.instance.start(SuspendedAction.new(suspended_action))
+        end
+      end
+
+      def poll_listening_service(event)
+        output[:connection] = "Connected"
+        suspend do |suspended_action|
+          CandlepinListeningService.instance.poll_for_messages(SuspendedAction.new(suspended_action))
+        end
+      end
+
+      def initialize_service
+        output[:messages] = 0
+        output[:last_message] = nil
+        suspend do |suspended_action|
+          #send back @event_type by wake up action like
+          # suspended_action << @event_type
+          begin
+            initialize_listening_service(SuspendedAction.new(suspended_action))
+          rescue => e
+            raise e
+          end
+          at_exit do
+            # make sure we close the service at exit to finish the listening action
+            suspended_action << Close
+          end
+        end
+      end
+
+      def act_on_event(event)
+        begin
+          output[:connection] = "Connected"
+          on_event(event, output)
+        rescue => e
+          error!(e)
+          raise e
+        end
+        suspend
+      end
+
+      def initialize_listening_service(suspended_action)
+        CandlepinListeningService.initialize(world.logger,
+                                             ::Katello.config.qpid.url,
+                                             ::Katello.config.qpid.subscriptions_queue_address)
+        suspended_action.notify_not_connected("initialized...have not connected yet")
+        rescue => e
+          Rails.logger.error(e.message)
+          Rails.logger.error(e.backtrace)
+          error!(e)
+      end
+
+      def on_event(event, ouput)
+        message = CandlepinListeningService.instance.messages.message(event.message_id)
+        Actions::Candlepin::ReindexPoolSubscriptionHandler.new(Rails.logger).handle(message)
+        CandlepinListeningService.instance.acknowledge_message(event.message_id)
+        output[:last_message] = "#{event.message_id} - #{message.subject}"
+        output[:messages] = message.message_id
+      end
+
+      def error_message(error_id)
+        CandlepinListeningService.instance.errors[error_id]
+      end
+
+      def close_service
+        CandlepinListeningService.close
+      end
+    end
+  end
+end

--- a/app/lib/actions/candlepin/reindex_pool_subscription_handler.rb
+++ b/app/lib/actions/candlepin/reindex_pool_subscription_handler.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Candlepin
+    class ReindexPoolSubscriptionHandler
+
+      def initialize(logger)
+        @logger = logger
+      end
+
+      def handle(message)
+        @logger.debug("message received from subscriptions queue ")
+        @logger.debug("message subject: #{message.subject}")
+
+        ::User.current = ::User.anonymous_admin
+
+        case message.subject
+        when /entitlement\.(deleted|created)$/
+          index_pool(message)
+        end
+      end
+
+      def index_pool(message)
+        content = JSON.parse(message.content)
+        pool_id = content['referenceId']
+        pool = ::Katello::Pool.find_pool(pool_id)
+        @logger.info "re-indexing #{pool_id}."
+        ::Katello::Pool.index_pools([pool])
+      end
+    end
+  end
+end

--- a/deploy/script/katello-service
+++ b/deploy/script/katello-service
@@ -24,7 +24,9 @@ if [ -x /etc/init.d/tomcat6 -o -x /lib/systemd/system/tomcat6.service ]; then
   TOMCAT="tomcat6"
 fi
 
-SERVICES="$TOMCAT mongod qpidd elasticsearch pulp_resource_manager pulp_workers pulp_celerybeat httpd foreman-tasks"
+# qpidd needs to be started prior to tomcat. candlepin currently does not automatically reconnect to qpidd
+# when qpidd is restarted. Order should not mater when Bugzilla 1147263 is resolved.
+SERVICES="qpidd $TOMCAT mongod elasticsearch pulp_resource_manager pulp_workers pulp_celerybeat httpd foreman-tasks"
 if [ -f /etc/katello/service-list ] ; then
   . /etc/katello/service-list
 fi

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "justified"
   gem.add_dependency "strong_parameters", "~> 0.2.1" # remove after we upgrade to Rails 4
 
+  gem.add_dependency "qpid_messaging", ">= 0.26.1"
+
   gem.add_dependency "gettext_i18n_rails"
   gem.add_dependency "i18n_data", ">= 0.2.6"
 

--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -24,6 +24,7 @@ require "ninesixty"
 require "ui_alchemy-rails"
 require "deface"
 require 'jquery-ui-rails'
+require 'qpid_messaging'
 
 require "uuidtools"
 

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -41,6 +41,12 @@ module Katello
       end
     end
 
+    initializer "katello.initialize_cp_listener", after: "foreman_tasks.initialize_dynflow" do
+      unless ForemanTasks.dynflow.config.remote? || File.basename($PROGRAM_NAME) == 'rake' || Rails.env.test?
+        ForemanTasks.async_task(::Actions::Candlepin::ListenOnCandlepinEvents)
+      end
+    end
+
     initializer "katello.load_app_instance_data" do |app|
       app.config.paths['db/migrate'] += Katello::Engine.paths['db/migrate'].existent
       app.config.autoload_paths += Dir["#{config.root}/app/lib"]

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -120,6 +120,7 @@
        <packagereq type="default">rubygem-hammer_cli_import</packagereq>
        <packagereq type="default">rubygem-hammer_cli_katello</packagereq>
        <packagereq type="default">rubygem-katello_api</packagereq>
+       <packagereq type="default">ruby193-rubygem-qpid_messaging</packagereq>
 
        <!-- katello installer packages -->
        <packagereq type="default">katello-installer</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel7.xml
+++ b/rel-eng/comps/comps-katello-server-rhel7.xml
@@ -120,6 +120,7 @@
        <packagereq type="default">rubygem-hammer_cli_import</packagereq>
        <packagereq type="default">rubygem-hammer_cli_katello</packagereq>
        <packagereq type="default">rubygem-katello_api</packagereq>
+       <packagereq type="default">ruby193-rubygem-qpid_messaging</packagereq>
 
        <!-- katello installer packages -->
        <packagereq type="default">katello-installer</packagereq>

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -131,6 +131,7 @@ Requires: %{?scl_prefix}rubygem-haml-rails
 Requires: %{?scl_prefix}rubygem-ui_alchemy-rails = 1.0.12
 Requires: %{?scl_prefix}rubygem-deface < 1.0.0
 Requires: %{?scl_prefix}rubygem-strong_parameters
+Requires: %{?scl_prefix}rubygem-qpid_messaging
 BuildRequires: foreman >= 1.3.0
 BuildRequires: %{?scl_prefix}rubygem-angular-rails-templates >= 0.0.4
 BuildRequires: %{?scl_prefix}rubygem-sqlite3
@@ -155,6 +156,7 @@ BuildRequires: %{?scl_prefix}rubygem-ui_alchemy-rails = 1.0.12
 BuildRequires: %{?scl_prefix}rubygem-deface < 1.0.0
 BuildRequires: %{?scl_prefix}rubygem(uglifier) >= 1.0.3
 BuildRequires: %{?scl_prefix}rubygem-strong_parameters
+BuildRequires: %{?scl_prefix}rubygem-qpid_messaging
 BuildRequires: %{?scl_prefix}rubygems
 BuildArch: noarch
 Provides: %{?scl_prefix}rubygem(katello) = %{version}

--- a/test/actions/candlepin/listen_on_events_test.rb
+++ b/test/actions/candlepin/listen_on_events_test.rb
@@ -1,0 +1,40 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+class Actions::Candlepin::ListenOnCandlepinEventsTest < ActiveSupport::TestCase
+  include Dynflow::Testing
+  include Support::Actions::RemoteAction
+
+  describe 'run' do
+    let(:action_class) { ::Actions::Candlepin::ListenOnCandlepinEvents }
+    let(:planned_action) do
+      create_and_plan_action action_class
+    end
+
+
+    it 'reindexes and acknowledges messages' do
+      Actions::Candlepin::ListenOnCandlepinEvents.any_instance.stubs(:suspend)
+      Actions::Candlepin::CandlepinListeningService.any_instance.stubs(:create_connection)
+      listening_service = Actions::Candlepin::CandlepinListeningService.new(nil,nil,nil)
+      listening_service.messages.add(123, OpenStruct.new(:subject => 'entitlement.created'))
+      Actions::Candlepin::CandlepinListeningService.stubs(:instance).returns(listening_service)
+
+      Actions::Candlepin::ReindexPoolSubscriptionHandler.any_instance.expects(:handle)
+      Actions::Candlepin::CandlepinListeningService.any_instance.expects(:acknowledge_message)
+
+      action = run_action planned_action
+      action.run(Actions::Candlepin::ListenOnCandlepinEvents::Event[123])
+    end
+  end
+end

--- a/test/actions/katello/reindex_pool_subscription_handler.rb
+++ b/test/actions/katello/reindex_pool_subscription_handler.rb
@@ -1,0 +1,33 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+require 'katello_test_helper'
+
+module Katello
+  describe ::Actions::Candlepin::ReindexPoolSubscriptionHandler do
+    describe 'when notified with entitlement.deleted' do
+      let(:mymessage) do
+        result = {:subject => "entitlement.deleted" }
+        result[:content] = JSON.generate({:referenceId => 123})
+        OpenStruct.new(result)
+      end
+
+      it 'reindex the pool' do
+        pool = rand(1100);
+        ::Katello::Pool.stubs(:find_pool).returns(pool)
+        ::Katello::Pool.expects(:index_pools).with([pool])
+
+        ::Actions::Candlepin::ReindexPoolSubscriptionHandler.new(Rails.logger).handle(mymessage)
+      end
+    end
+  end
+end


### PR DESCRIPTION
DON'T MERGE UNTIL the following are merged:
https://github.com/Katello/puppet-qpid/pull/8
https://github.com/Katello/puppet-katello_devel/pull/14
https://github.com/Katello/puppet-certs/pull/34
https://github.com/Katello/puppet-katello/pull/33

This listens for entitlement events from candlepin and updates the specific
pool index instead of pulling all the subscription information each time
the user accesses the subscriptions page.

New gem dependency added: qpid_messaging
gem has dependency qpid-cpp-client-devel and qpid-cpp-client
rpm packages.
