### PR TITLE
fixes #6628 - fixing live glue pulp vcr tests

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -98,7 +98,7 @@ module FixtureTestCase
       @loaded_fixtures = load_fixtures
 
       @@admin = ::User.find(@loaded_fixtures['users']['admin']['id'])
-      @@admin.remote_id = @@admin.login
+      @@admin.remote_id = Katello.config.pulp.default_login
       User.current = @@admin
     end
   end


### PR DESCRIPTION
due to a fixture change in foreman, the user was no
longer a user that existed in pulp
