### PR TITLE
Fixes #6639: Allow user actions to not be blocked by update.

### DIFF
--- a/app/lib/actions/katello/user/update.rb
+++ b/app/lib/actions/katello/user/update.rb
@@ -21,6 +21,10 @@ module Actions
           plan_action ElasticSearch::Reindex, user
         end
 
+        def resource_locks
+          :link
+        end
+
       end
     end
   end


### PR DESCRIPTION
This will also allow a subset of Foreman core unit tests to be
run and pass with Katello enabled.
