### PR TITLE
fixes #6572 - fix default check on path selector

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/new/views/activation-key-new.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/new/views/activation-key-new.html
@@ -60,13 +60,14 @@
       <div class="col-sm-5 input">
         <span path-selector="environments"
               ng-model="activationKey.environment"
+              selection-required="false"
               mode="singleSelect">
         </span>
       </div>
     </div>
 
     <div alch-form-group label="{{ 'Content View' | translate }}">
-      <select ng-hide="contentViews.length === 0"
+      <select ng-hide="contentViews.length === 0 || activationKey.environment === undefined "
               id="content_view_id"
               name="content_view_id"
               ng-model="activationKey.content_view_id"

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-promotion.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-promotion.html
@@ -20,6 +20,7 @@
   <div path-selector="availableEnvironments"
        ng-model="selectedEnvironment"
        mode="singleSelect"
+       selection-required="false"
        path-attribute="environments"
        disabled="denied('promote_or_remove_content_views', contentView)"
        ng-show="working">

--- a/engines/bastion/app/assets/javascripts/bastion/widgets/path-selector.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/widgets/path-selector.directive.js
@@ -35,11 +35,12 @@ angular.module('Bastion.widgets').directive('pathSelector',
         },
         templateUrl: 'widgets/views/path-selector.html',
         link: function (scope, element, attrs, ngModel) {
-            var activeItemId, convertPathObjects;
+            var activeItemId, convertPathObjects, selectionRequired;
+            selectionRequired = attrs['selectionRequired'] ? attrs['selectionRequired'] === 'true' : true;
 
             scope.itemChanged = function (item) {
                 if (item && scope.mode === 'singleSelect') {
-                    if (item.selected) {
+                    if (item.selected || selectionRequired) {
                         unselectActive();
                         selectById(item.id);
                         activeItemId = item.id;
@@ -67,7 +68,10 @@ angular.module('Bastion.widgets').directive('pathSelector',
             }
 
             ngModel.$render = function () {
-                scope.itemChanged(ngModel.$modelValue);
+                if (ngModel.$modelValue) {
+                    ngModel.$modelValue.selected = true;
+                    scope.itemChanged(ngModel.$modelValue);
+                }
             };
 
             scope.$watch('disableTrigger', function (disable) {

--- a/engines/bastion/test/widgets/path-selector.directive.test.js
+++ b/engines/bastion/test/widgets/path-selector.directive.test.js
@@ -101,13 +101,30 @@ describe('Directive: pathSelector', function() {
 
         expect(element.find('.path-list').length).toBe(1);
         expect(element.find('.path-list:first .path-list-item').length).toBe(3);
+    });
 
+    it ("should not unselect by default", function () {
+        var checkbox = element.find('.path-list:first .path-list-item:first').find('input');
+
+        expect(checkbox.is(':checked')).toBe(false);
+
+        checkbox.click();
+        expect(checkbox.is(':checked')).toBe(true);
+
+        checkbox.click();
+        expect(checkbox.is(':checked')).toBe(true);
     });
 
     it("should provide a way to unselect an environment", function () {
-        var checkbox = element.find('.path-list:first .path-list-item:first').find('input');
+        var checkbox, element;
+
+        element = angular.element('<div path-selector="paths" ng-model="environment" mode="singleSelect" selection-required="false"></div>');
+        compile(element)(scope);
+        scope.$digest();
+        checkbox = element.find('.path-list:first .path-list-item:first').find('input');
+
         expect(checkbox.is(':checked')).toBe(false);
-        
+
         checkbox.click();
         expect(checkbox.is(':checked')).toBe(true);
 


### PR DESCRIPTION
also do not allow unselect by default, since it
does not make sense in most cases.  Added an option
"required-selection" to path selector that default to true
