### PR TITLE
fixes #6646 / BZ 1104104 - Content View - disable version promote/remove during publish/promote

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-versions.controller.js
@@ -77,6 +77,14 @@ angular.module('Bastion.content-views').controller('ContentViewVersionsControlle
             return messages;
         };
 
+        $scope.taskInProgress = function (version) {
+            var inProgress = false;
+            if (version.task && (version.task.state === 'pending' || version.task.state === 'running')) {
+                inProgress = true;
+            }
+            return inProgress;
+        };
+
         function findTaskTypes(activeHistory, taskType) {
             return _.filter(activeHistory, function (history) {
                 return history.task.label === taskType;

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
@@ -30,7 +30,7 @@
         <td alch-table-cell translate>Version {{ version.version }}</td>
         <td alch-table-cell >
           <a ui-sref="content-views.details.history" ng-hide="hideProgress(version)">
-            <div ng-class="{ active: (version.task.state === 'pending' || version.task.state === 'running') }"
+            <div ng-class="{ active: taskInProgress(version) }"
                  class="progress progress-striped">
               <span progressbar animate="false" value="version.task.progressbar.value" type="{{version.task.progressbar.type}}"></span>
             </div>
@@ -66,22 +66,24 @@
         </td>
         <td alch-table-cell>{{ version.user }}</td>
         <td class="col-sm-2">
-          <a ui-sref="content-views.details.promotion({contentViewId: contentView.id, versionId: version.id})">
-            <button class="btn btn-default" ng-hide="denied('promote_or_remove_content_views', contentView)">
-              <i class="icon-share-alt"></i>
-              <span translate>
-                Promote
-              </span>
-            </button>
-          </a>
-          <a ui-sref="content-views.details.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})">
-            <button class="btn btn-default" ng-hide="denied('promote_or_remove_content_views', contentView)">
-              <i class="icon-trash"></i>
-              <span translate>
-                Remove
-              </span>
-            </button>
-          </a>
+          <button class="btn btn-default"
+                  ui-sref="content-views.details.promotion({contentViewId: contentView.id, versionId: version.id})"
+                  ng-hide="denied('promote_or_remove_content_views', contentView)"
+                  ng-disabled="taskInProgress(version)">
+            <i class="icon-share-alt"></i>
+            <span translate>
+              Promote
+            </span>
+          </button>
+          <button class="btn btn-default"
+                  ui-sref="content-views.details.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})"
+                  ng-hide="denied('promote_or_remove_content_views', contentView)"
+                  ng-disabled="taskInProgress(version)">
+            <i class="icon-trash"></i>
+            <span translate>
+              Remove
+            </span>
+          </button>
         </td>
       </tr>
     </tbody>

--- a/engines/bastion/test/content-views/details/content-view-versions.controller.test.js
+++ b/engines/bastion/test/content-views/details/content-view-versions.controller.test.js
@@ -58,6 +58,23 @@ describe('Controller: ContentViewVersionsController', function() {
         expect($scope.hideProgress(version)).toBe(false);
     });
 
+    it("correctly returns task in progress", function() {
+        var version = {};
+        expect($scope.taskInProgress(version)).toBe(false);
+
+        version = {task: {state: 'running'}};
+        expect($scope.taskInProgress(version)).toBe(true);
+
+        version = {task: {state: 'pending'}};
+        expect($scope.taskInProgress(version)).toBe(true);
+
+        version = {task: {state: 'error'}};
+        expect($scope.taskInProgress(version)).toBe(false);
+
+        version = {task: {state: 'stopped'}};
+        expect($scope.taskInProgress(version)).toBe(false);
+    });
+
     it("determines what history text to display", function() {
         var version = {active_history: [],
             last_event: {environment: {name: 'test'},


### PR DESCRIPTION
This commit addresses 2 issues:
1. when a version is being published, disable the promote/remove links on that version
2. when a version is being promoted, disable the promote/remove links on that version
