### PR TITLE
Fixes #6097,bz1120427 - repository.feed -> repository.url

### DIFF
--- a/app/assets/javascripts/katello/providers/repo_discovery.js
+++ b/app/assets/javascripts/katello/providers/repo_discovery.js
@@ -287,7 +287,7 @@ KT.repo_discovery.new_page = (function(){
                 url = repo_div.find('input[type=hidden]').val(),
                 id = '#' + repo_div.attr('id'),
                 unprotected = $('#unprotected').find('input[type=checkbox]:checked').val() === '1';
-            repos.push({name:name, label:label, feed:url, id:id, unprotected:unprotected});
+            repos.push({name:name, label:label, url:url, id:id, unprotected:unprotected});
         });
         $(window).trigger('repo.create', [create_url, repos]);
     },

--- a/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
@@ -38,7 +38,7 @@ module Katello
     api :POST, "/repositories/bulk/sync", N_("Synchronize repository")
     param :ids, Array, :desc => N_("List of repository ids"), :required => true
     def sync_repositories
-      syncable_repositories = @repositories.syncable.has_feed
+      syncable_repositories = @repositories.syncable.has_url
       syncable_repositories.each do |repo|
         async_task(::Actions::Katello::Repository::Sync, repo)
       end
@@ -54,7 +54,7 @@ module Katello
         :success    => _("Successfully started sync for %s repositories, you are free to leave this page."),
         :error      => _("Repository %s does not have a feed url."),
         :models     => @repositories,
-        :authorized => @repositories.has_feed
+        :authorized => @repositories.has_url
       )
 
       messages2[:error] += messages1[:error]

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -30,7 +30,7 @@ module Actions
                                         content_type: repository.content_type,
                                         pulp_id: repository.pulp_id,
                                         name: repository.name,
-                                        feed: repository.feed,
+                                        feed: repository.url,
                                         ssl_ca_cert: repository.feed_ca,
                                         ssl_client_cert: repository.feed_cert,
                                         ssl_client_key: repository.feed_key,

--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -75,7 +75,7 @@ class Candlepin::Content
                                 :relative_path => relative_path,
                                 :name => name,
                                 :label => label,
-                                :feed => feed_url,
+                                :url => feed_url,
                                 :feed_ca => ca,
                                 :feed_cert => product.certificate,
                                 :feed_key => product.key,

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -81,7 +81,7 @@ module Glue::Pulp::Repo
     end
 
     def pulp_update_needed?
-      ((self.respond_to?(:feed) && self.feed_changed?) ||
+      ((self.respond_to?(:url) && self.url_changed?) ||
        (self.respond_to?(:unprotected) && self.unprotected_changed?)) &&
       !self.product.provider.redhat_provider?
     end
@@ -150,15 +150,15 @@ module Glue::Pulp::Repo
         Runcible::Models::YumImporter.new(:ssl_ca_cert => self.feed_ca,
                                           :ssl_client_cert => self.feed_cert,
                                           :ssl_client_key => self.feed_key,
-                                          :feed => self.feed)
+                                          :feed => self.url)
       when Repository::FILE_TYPE
         Runcible::Models::IsoImporter.new(:ssl_ca_cert => self.feed_ca,
                                           :ssl_client_cert => self.feed_cert,
                                           :ssl_client_key => self.feed_key,
-                                          :feed => self.feed)
+                                          :feed => self.url)
       when Repository::PUPPET_TYPE
         options = {}
-        options[:feed] = self.feed if self.respond_to?(:feed)
+        options[:feed] = self.url if self.respond_to?(:url)
         Runcible::Models::PuppetImporter.new(options)
       else
         fail _("Unexpected repo type %s") % self.content_type

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -302,7 +302,7 @@ module Glue::Pulp::Repos
                      :arch => arch,
                      :name => name,
                      :label => label,
-                     :feed => url,
+                     :url => url,
                      :gpg_key => gpg,
                      :unprotected => unprotected,
                      :content_type => repo_type,

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -64,7 +64,7 @@ class Product < Katello::Model
 
   scope :engineering, where(:type => "Katello::Product")
   scope :marketing, where(:type => "Katello::MarketingProduct")
-  scope :syncable_content, joins(:repositories).where(Katello::Repository.arel_table[:feed].not_eq(nil))
+  scope :syncable_content, joins(:repositories).where(Katello::Repository.arel_table[:url].not_eq(nil))
 
   before_create :assign_unique_label
 
@@ -105,7 +105,7 @@ class Product < Katello::Model
     @repo_cache[env.id] ||= content_view.repos_in_product(env, self)
 
     repositories = @repo_cache[env.id]
-    repositories = repositories.has_feed if !include_feedless
+    repositories = repositories.has_url if !include_feedless
     repositories
   end
 
@@ -223,7 +223,7 @@ class Product < Katello::Model
   end
 
   def syncable_content?
-    repositories.any?(&:feed?)
+    repositories.any?(&:url?)
   end
 
   def available_content

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -71,7 +71,7 @@ class Repository < Katello::Model
   validates_with Validators::RepositoryUniqueAttributeValidator, :attributes => :label
   validates_with Validators::RepositoryUniqueAttributeValidator, :attributes => :name
   validates_with Validators::KatelloUrlFormatValidator,
-    :attributes => :feed, :nil_allowed => proc { |o| o.custom? }, :field_name => :url,
+    :attributes => :url, :nil_allowed => proc { |o| o.custom? }, :field_name => :url,
     :if => proc { |o| o.in_default_view? }
   validates :content_type, :inclusion => {
       :in => TYPES,
@@ -80,7 +80,7 @@ class Repository < Katello::Model
   }
 
   default_scope order("#{Katello::Repository.table_name}.name ASC")
-  scope :has_feed, where('feed IS NOT NULL')
+  scope :has_url, where('url IS NOT NULL')
   scope :in_default_view, joins(:content_view_version => :content_view).
     where("#{Katello::ContentView.table_name}.default" => true)
 
@@ -90,8 +90,6 @@ class Repository < Katello::Model
   scope :non_puppet, where("content_type != ?", PUPPET_TYPE)
   scope :non_archived, where('environment_id is not NULL')
   scope :archived, where('environment_id is NULL')
-
-  alias_attribute :url, :feed
 
   def organization
     if self.environment
@@ -406,8 +404,8 @@ class Repository < Katello::Model
     search.in_content_views([view])
   end
 
-  def feed?
-    feed.present?
+  def url?
+    url.present?
   end
 
   def name_conflicts

--- a/db/migrate/20140716211853_repo_rename_feed_to_url.rb
+++ b/db/migrate/20140716211853_repo_rename_feed_to_url.rb
@@ -1,0 +1,9 @@
+class RepoRenameFeedToUrl < ActiveRecord::Migration
+  def up
+    rename_column :katello_repositories, :feed, :url
+  end
+
+  def down
+    rename_column :katello_repositories, :url, :feed
+  end
+end

--- a/spec/helpers/product_helper_methods.rb
+++ b/spec/helpers/product_helper_methods.rb
@@ -42,7 +42,7 @@ module ProductHelperMethods
     repo = Repository.new(:environment => env, :product => @p, :name=>"FOOREPO" + suffix,
                           :label=>"FOOREPO" + suffix, :pulp_id=>RepoTestData::REPO_ID,
                           :content_id=> "1234", :content_view_version=>env.default_content_view_version,
-                          :relative_path=>'/foo/', :feed => 'https://localhost.com/foo')
+                          :relative_path=>'/foo/', :url => 'https://localhost.com/foo')
     repo.stubs(:create_pulp_repo).returns([])
     repo.save!
 
@@ -73,7 +73,7 @@ module ProductHelperMethods
     repo.stubs(:pulp_repo_facts).returns({'distributors' => []})
     repo.stubs(:content => {:id => "123"})
     Repository.where(:environment_id => environment, :product_id => repo.product).first.tap do |promoted|
-        promoted.stubs(:feed => repo.feed)
+        promoted.stubs(:url => repo.url)
     end
   end
 end

--- a/spec/helpers/repo_test_data.rb
+++ b/spec/helpers/repo_test_data.rb
@@ -33,7 +33,7 @@ module RepoTestData
     :arch => 'architecture',
     :relative_path => "ACME_Corporation/Library/zoo/base",
     :content_id=>'123234',
-    :feed => 'https://localhost',
+    :url => 'https://localhost',
     "distributors" => [
        {'config' => {'relative_url'=>"ACME_Corporation/Library/zoo/base"}}
     ],
@@ -47,7 +47,7 @@ module RepoTestData
     :label => REPO_LABEL,
     :arch => 'architecture',
     :relative_path => "ACME_Corporation/Dev/zoo/base",
-    :feed => 'https://localhost',
+    :url => 'https://localhost',
     "distributors" => [
        {'config' => {'relative_url'=>"ACME_Corporation/Library/zoo/base"}}
     ]

--- a/spec/helpers/repository_helper_methods.rb
+++ b/spec/helpers/repository_helper_methods.rb
@@ -24,7 +24,7 @@ module RepositoryHelperMethods
                           :relative_path => path, :pulp_id => "pulp-id-#{random_id}",
                           :content_id => "content-id-#{random_id}",
                           :content_view_version=>env.content_view_versions.first,
-                          :feed=>'http://localhost.com/foo')
+                          :url=>'http://localhost.com/foo')
     repo.library_instance = library_instance if library_instance
     repo.stubs(:create_pulp_repo).returns([])
     repo.save!

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -192,7 +192,7 @@ describe Product, :katello => true do
                                  :content_id=>"123",
                                  :relative_path => "#{@organization.name}/library/Prod/Repo",
                                  :content_view_version=>@organization.library.default_content_view_version,
-                                 :feed => 'https://localhost')
+                                 :url => 'https://localhost')
       @repo.stubs(:product).returns(@product)
       @repo.stubs(:promoted?).returns(false)
       @repo.stubs(:update_content).returns(Candlepin::Content.new)
@@ -254,7 +254,7 @@ describe Product, :katello => true do
       2.times do
         create(:katello_repository, product: product, environment: @organization.library,
                content_view_version: @organization.library.default_content_view_version,
-               feed: "http://something")
+               url: "http://something")
       end
       product.repositories.length.must_equal(2)
       product.repositories.map(&:environment).length.must_be(:>, product.environments.length)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -249,7 +249,7 @@ describe Provider do
                              :relative_path=>'/foo',
                              :content_id=>'asdfasdf',
                              :content_view_version=>product.organization.library.default_content_view_version,
-                             :feed => 'https://localhost')
+                             :url => 'https://localhost')
           repo.stubs(:create_pulp_repo).returns({})
           repo.save!
 

--- a/test/factories/repository_factory.rb
+++ b/test/factories/repository_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     sequence(:pulp_id) { |n| "pulp-#{n}" }
     sequence(:content_id)
     sequence(:relative_path) {|n| "/ACME_Corporation/DEV/Repo#{n}"}
-    feed "http://localhost/foo"
+    url "http://localhost/foo"
 
     ignore do
       stubbed = true

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -7,7 +7,7 @@ fedora_17_x86_64:
   environment_id:       <%= ActiveRecord::Fixtures.identify(:library) %>
   product_id:           <%= ActiveRecord::Fixtures.identify(:fedora) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
-  feed:                 "http://myrepo.com"
+  url:                 "http://myrepo.com"
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
 
 fedora_17_x86_64_dev:
@@ -21,7 +21,7 @@ fedora_17_x86_64_dev:
   product_id:           <%= ActiveRecord::Fixtures.identify(:fedora) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:dev_default_version) %>
-  feed:                 "http://myrepo.com"
+  url:                 "http://myrepo.com"
 
 
 feedless_fedora_17_x86_64:
@@ -44,12 +44,11 @@ rhel_6_x86_64:
   minor:                6Server
   label:                rhel_6_x86_64_label
   relative_path:        '/ACME_Corporation/library/rhel_6_label'
-  feed:                 'https://cdn.example.com/rhel/6/os'
   environment_id:       <%= ActiveRecord::Fixtures.identify(:library) %>
   product_id:           <%= ActiveRecord::Fixtures.identify(:redhat) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
-  feed:                 http://www.validurl.com
+  url:                 'https://cdn.example.com/rhel/6/os'
 
 rhel_6_x86_64_dev:
   name:                 RHEL 6 x86_64
@@ -59,12 +58,12 @@ rhel_6_x86_64_dev:
   minor:                6Server
   label:                rhel_6_x86_64_label
   relative_path:        '/ACME_Corporation/library/rhel_6_label'
-  feed:                 'https://cdn.example.com/rhel/6/os'
+  url:                 'https://cdn.example.com/rhel/6/os'
   environment_id:       <%= ActiveRecord::Fixtures.identify(:dev) %>
   product_id:           <%= ActiveRecord::Fixtures.identify(:redhat) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:dev_default_version) %>
-  feed:                 http://www.validurl.com
+  url:                 'https://cdn.example.com/rhel/6/os'
 
 p_forge:
   name:                 P Forge
@@ -125,7 +124,7 @@ fedora_17_x86_64_library_view_2_library:
   product_id:           <%= ActiveRecord::Fixtures.identify(:fedora) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_view_version_2) %>
-  feed:                  "http://www.pleaseack.com"
+  url:                  "http://www.pleaseack.com"
 
 fedora_17_unpublished:
   name:                 Fedora 17 x86_64
@@ -137,7 +136,7 @@ fedora_17_unpublished:
   product_id:           <%= ActiveRecord::Fixtures.identify(:fedora) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
-  feed:                  "http://www.pleaseack.com"
+  url:                  "http://www.pleaseack.com"
 
 fedora_17_unpublished_2:
   name:                 Fedora 17 x86_64 2
@@ -149,4 +148,4 @@ fedora_17_unpublished_2:
   product_id:           <%= ActiveRecord::Fixtures.identify(:fedora) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
-  feed:                  "http://www.pleaseack.com"
+  url:                  "http://www.pleaseack.com"

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -29,7 +29,7 @@ class GluePulpRepoTestBase < ActiveSupport::TestCase
 
     @@fedora_17_x86_64 = Repository.find(@loaded_fixtures['katello_repositories']['fedora_17_x86_64']['id'])
     @@fedora_17_x86_64.relative_path = '/test_path/'
-    @@fedora_17_x86_64.feed = "file:///var/www/test_repos/zoo"
+    @@fedora_17_x86_64.url = "file:///var/www/test_repos/zoo"
   end
 
   def self.delete_repo(repo)
@@ -49,7 +49,7 @@ class GluePulpRepoTestBase < ActiveSupport::TestCase
                             content_type: repository.content_type,
                             pulp_id: repository.pulp_id,
                             name: repository.name,
-                            feed: repository.feed,
+                            feed: repository.url,
                             ssl_ca_cert: repository.feed_ca,
                             ssl_client_cert: repository.feed_cert,
                             ssl_client_key: repository.feed_key,
@@ -194,7 +194,7 @@ class GluePulpChangeFeedTest < GluePulpRepoTestBase
 
   def test_feed_change
     new_feed = "http://foo.com/foo"
-    @@fedora_17_x86_64.feed = new_feed
+    @@fedora_17_x86_64.url = new_feed
     @@fedora_17_x86_64.save!
     pulps_feed = Repository.find(@@fedora_17_x86_64.id).pulp_repo_facts['importers'].first['config']['feed']
     assert_equal new_feed, pulps_feed
@@ -210,7 +210,7 @@ class GluePulpPuppetRepoTest < GluePulpRepoTestBase
     VCR.insert_cassette('pulp/repository/puppet')
     @@p_forge = Repository.find(@loaded_fixtures['katello_repositories']['p_forge']['id'])
     @@p_forge.relative_path = '/test_path/'
-    @@p_forge.feed = "http://davidd.fedorapeople.org/repos/random_puppet/"
+    @@p_forge.url = "http://davidd.fedorapeople.org/repos/random_puppet/"
     create_repo(@@p_forge)
   end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -234,19 +234,20 @@ class RepositoryInstanceTest < RepositoryTestBase
     new_custom_repo
   end
 
-  def test_nil_feed_url
+  def test_nil_url_url
     new_repo = new_custom_repo
-    new_repo.feed = nil
+    new_repo.url = nil
     assert new_repo.save
     assert new_repo.persisted?
-    assert_equal nil, new_repo.reload.feed
-    refute new_repo.feed?
+    assert_equal nil, new_repo.reload.url
+    refute new_repo.url?
   end
 
-  def test_blank_feed_url
+  def test_blank_url_url
     new_repo = new_custom_repo
+
     original_url = new_repo.url
-    new_repo.feed = ""
+    new_repo.url = ""
     refute new_repo.save
     refute new_repo.errors.empty?
     assert_equal original_url, new_repo.reload.url
@@ -254,7 +255,7 @@ class RepositoryInstanceTest < RepositoryTestBase
 
   def test_nil_rhel_url
     rhel = Repository.find(katello_repositories(:rhel_6_x86_64))
-    rhel.feed = nil
+    rhel.url = nil
     refute rhel.valid?
     refute rhel.save
     refute_empty rhel.errors

--- a/test/support/pulp/repository_support.rb
+++ b/test/support/pulp/repository_support.rb
@@ -40,13 +40,13 @@ module RepositorySupport
   def self.create_repo(repo_id)
     @repo = Repository.find(repo_id)
     @repo.relative_path = '/test_path/'
-    @repo.feed = @repo.content_type == 'puppet' ? @puppet_repo_url : @repo_url
+    @repo.url = @repo.content_type == 'puppet' ? @puppet_repo_url : @repo_url
 
     ::ForemanTasks.sync_task(::Actions::Pulp::Repository::Create,
                              content_type: @repo.content_type,
                              pulp_id: @repo.pulp_id,
                              name: @repo.name,
-                             feed: @repo.feed,
+                             feed: @repo.url,
                              ssl_ca_cert: @repo.feed_ca,
                              ssl_client_cert: @repo.feed_cert,
                              ssl_client_key: @repo.feed_key,


### PR DESCRIPTION
Migrating a repository data model attribute from feed to url. The word
feed applies to the feed url used by pulp, but in katello UI, CLI and
API we consistently use url for feed. To mitigate this confusion it was
deemed to rename feed to url.
