### PR TITLE
Fixes #5948/BZ1077886: tell alch-alert to track by index instead of value.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/incubator/views/alch-alert.html
+++ b/engines/bastion/app/assets/javascripts/bastion/incubator/views/alch-alert.html
@@ -1,5 +1,5 @@
 <div ng-repeat="type in types">
-  <div alert ng-repeat="alert in alerts[type]" type="type" close="closeAlert(type, $index)">
+  <div alert ng-repeat="alert in alerts[type] track by $index" type="type" close="closeAlert(type, $index)">
     {{ alert }}
   </div>
 </div>


### PR DESCRIPTION
The items in ng-repeat are tracked by value by default.  This causes
the error mentioned in the bugs if there are two items with the same
value in the array.  This commit tells alch-alert to track the values
in the DOM by array index instead of value.

http://projects.theforeman.org/issues/5948
https://bugzilla.redhat.com/show_bug.cgi?id=1077886
