### PR TITLE
Fixes #6664/BZ1103169: remove incorrect usages of control-width.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -46,7 +46,7 @@
   </div>
 
   <div alch-table="addSubscriptionsTable" class="nutupane">
-    <div alch-container-scroll control-width="addSubscriptionsTable" alch-infinite-scroll="addSubscriptionsTable.nextPage()">
+    <div alch-container-scroll alch-infinite-scroll="addSubscriptionsTable.nextPage()">
 
       <div class="loading-mask icon-3x" ng-show="addSubscriptionsTable.working && addSubscriptionsTable.rows.length == 0">
         <i class="icon-spinner icon-spin"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-host-collections-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-host-collections-table.html
@@ -43,7 +43,7 @@
   </div>
 
   <div alch-table="hostCollectionsTable" class="nutupane">
-    <div alch-container-scroll control-width="hostCollectionsTable" alch-infinite-scroll="hostCollectionsTable.nextPage()">
+    <div alch-container-scroll alch-infinite-scroll="hostCollectionsTable.nextPage()">
 
       <div ng-show="hostCollectionsTable.rows.length == 0">
         <div class="loading-mask" ng-show="hostCollectionsTable.working">

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -46,7 +46,7 @@
   </div>
 
   <div alch-table="subscriptionsTable" class="nutupane">
-    <div alch-container-scroll control-width="subscriptionsTable" alch-infinite-scroll="subscriptionsTable.nextPage()">
+    <div alch-container-scroll alch-infinite-scroll="subscriptionsTable.nextPage()">
 
       <div class="loading-mask icon-3x" ng-show="subscriptionsTable.working && subscriptionsTable.rows.length == 0">
         <i class="icon-spinner icon-spin"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-errata.html
@@ -32,7 +32,7 @@
 
 <div alch-table="errataTable">
   <p class="alert alert-info" translate>Please note katello-agent is required to be installed on the Content Host for Errata reporting.</p>
-  <div alch-container-scroll control-width="table" alch-infinite-scroll="errataTable.nextPage()" data="errataTable.rows">
+  <div alch-container-scroll alch-infinite-scroll="errataTable.nextPage()" data="errataTable.rows">
     <table ng-class="{'table-mask': errataTable.working}" class="table table-striped">
       <thead>
         <tr alch-table-head row-select>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-add-subscriptions.html
@@ -45,7 +45,7 @@
   </div>
 
   <div alch-table="addSubscriptionsTable" class="nutupane">
-    <div alch-container-scroll control-width="addSubscriptionsTable" alch-infinite-scroll="addSubscriptionsTable.nextPage()">
+    <div alch-container-scroll alch-infinite-scroll="addSubscriptionsTable.nextPage()">
 
       <div class="loading-mask icon-3x" ng-show="addSubscriptionsTable.working && addSubscriptionsTable.rows.length == 0">
         <i class="icon-spinner icon-spin"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
@@ -44,7 +44,7 @@
   </div>
 
   <div alch-table="subscriptionsTable" class="nutupane">
-    <div alch-container-scroll control-width="subscriptionsTable" alch-infinite-scroll="subscriptionsTable.nextPage()">
+    <div alch-container-scroll alch-infinite-scroll="subscriptionsTable.nextPage()">
 
       <div class="loading-mask icon-3x" ng-show="subscriptionsTable.working && subscriptionsTable.rows.length == 0">
         <i class="icon-spinner icon-spin"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/host-collections-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/host-collections-table.html
@@ -43,7 +43,7 @@
   </div>
 
   <div alch-table="hostCollectionsTable" class="nutupane">
-    <div alch-container-scroll control-width="hostCollectionsTable" alch-infinite-scroll="hostCollectionsTable.nextPage()">
+    <div alch-container-scroll alch-infinite-scroll="hostCollectionsTable.nextPage()">
 
       <div ng-show="hostCollectionsTable.rows.length == 0">
         <div class="loading-mask" ng-show="hostCollectionsTable.working">

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-add-content-hosts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-add-content-hosts.html
@@ -46,7 +46,7 @@
   </div>
 
   <div alch-table="addContentHostsTable" class="nutupane">
-    <div alch-container-scroll control-width="addContentHostsTable" alch-infinite-scroll="addContentHostsTable.nextPage()" data="addContentHostsTable.rows">
+    <div alch-container-scroll alch-infinite-scroll="addContentHostsTable.nextPage()" data="addContentHostsTable.rows">
 
       <div class="loading-mask" ng-show="addContentHostsTable.working && addContentHostsTable.rows.length == 0">
         <i class="icon-spinner icon-spin"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-content-hosts-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-content-hosts-list.html
@@ -45,7 +45,7 @@
   </div>
 
   <div alch-table="contentHostsTable" class="nutupane">
-    <div alch-container-scroll control-width="contentHostsTable" alch-infinite-scroll="contentHostsTable.nextPage()" data="contentHostsTable.rows">
+    <div alch-container-scroll alch-infinite-scroll="contentHostsTable.nextPage()" data="contentHostsTable.rows">
 
       <div class="loading-mask" ng-show="contentHostsTable.working && contentHostsTable.rows.length == 0">
         <i class="icon-spinner icon-spin"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -53,7 +53,7 @@
 
   <div class="nutupane" alch-table="detailsTable" nutupane-table>
 
-    <div alch-container-scroll control-width="detailsTable" alch-infinite-scroll="detailsTable.nextPage()" 
+    <div alch-container-scroll alch-infinite-scroll="detailsTable.nextPage()" 
          data="detailsTable.rows" skip-initial-load="!detailsTable.initialLoad">
 
       <div class="nutupane-select-all" ng-show="detailsTable.selectAllResultsEnabled && detailsTable.allSelected() && !detailsTable.allResultsSelected">

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
@@ -41,7 +41,7 @@
   </div>
 
   <div alch-table="productsTable" class="nutupane">
-    <div alch-container-scroll control-width="productsTable" alch-infinite-scroll="productsTable.nextPage()">
+    <div alch-container-scroll alch-infinite-scroll="productsTable.nextPage()">
 
       <div ng-show="productsTable.rows.length == 0">
         <div class="loading-mask" ng-show="productsTable.working">


### PR DESCRIPTION
The attribute control-width for the directive alch-container-scroll
was being used incorrectly in many cases.  This attribute should be
used for ensuring the element is the full width of the window and is
really only applicable for full width tables.  This commit removes
the incorrect usages of control-width.

http://projects.theforeman.org/issues/6664
https://bugzilla.redhat.com/show_bug.cgi?id=1103169
