### PR TITLE
fixes #6617 - create join table between System and Host for content_view and lifecycle environment

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -21,10 +21,41 @@ module Katello
                 :dependent => :destroy, :inverse_of => :foreman_host
         belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hosts
         scoped_search :in => :content_source, :on => :name, :complete_value => true, :rename => :content_source
+
+        has_one :system_host_join, :class_name => "Katello::SystemHostJoin", :dependent => :nullify, :foreign_key => :host_id
+        has_one :content_view, :through => :system_host_join, :source => :content_view, :dependent => :nullify
+        has_one :kt_environment, :through => :system_host_join, :source => :kt_environment, :dependent => :nullify
       end
 
       def validate_media_with_capsule?
         content_source_id.blank? && validate_media_without_capsule?
+      end
+
+      def content_view_id
+        build_system_host_join.content_view_id if new_record?
+        system_host_join.try(:content_view_id)
+      end
+      def content_view_id=(int)
+        return false unless (int)
+        if (cv = Katello::ContentView.find_by_id(int))
+          self.content_view = cv
+        else
+          # nullify didn't work in association
+          self.system_host_join.update_attribute(:content_view_id, nil) if self.system_host_join
+        end
+      end
+
+      def kt_environment_id
+        build_system_host_join.kt_environment_id if new_record?
+        system_host_join.try(:kt_environment_id)
+      end
+      def kt_environment_id=(int)
+        if (env = Katello::KTEnvironment.find_by_id(int))
+          self.kt_environment = env
+        else
+          # nullify didn't work in association
+          self.system_host_join.update_attribute(:kt_environment_id, nil) if self.system_host_join
+        end
       end
 
     end

--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -69,6 +69,38 @@ class System < Katello::Model
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :organization_id, :complete_value => true, :ext_method => :search_by_environment
 
+  has_one :system_host_join, :class_name => "Katello::SystemHostJoin", :dependent => :nullify, :foreign_key => :system_id
+  has_one :content_view, :through => :system_host_join, :source => :content_view, :dependent => :nullify
+  has_one :kt_environment, :through => :system_host_join, :source => :kt_environment, :dependent => :nullify
+
+  def content_view_id
+    build_system_host_join.content_view_id if new_record?
+    system_host_join.try(:content_view_id)
+  end
+  def content_view_id=(int)
+    return false unless (int)
+    if (cv = Katello::ContentView.find_by_id(int))
+      self.content_view = cv
+    else
+      # nullify didn't work in association
+      self.system_host_join.update_attribute(:content_view_id, nil) if self.system_host_join
+    end
+  end
+
+  def kt_environment_id
+    build_system_host_join.kt_environment_id if new_record?
+    system_host_join.try(:kt_environment_id)
+  end
+  def kt_environment_id=(int)
+    if (env = Katello::KTEnvironment.find_by_id(int))
+      self.kt_environment = env
+    else
+      # nullify didn't work in association
+      self.system_host_join.update_attribute(:kt_environment_id, nil) if self.system_host_join
+    end
+  end
+
+
   def self.search_by_environment(key, operator, value)
     conditions = "environment_id IN (#{::Organization.find(value).kt_environments.pluck(:id).join(',')})"
     {:conditions => conditions}

--- a/app/models/katello/system_host_join.rb
+++ b/app/models/katello/system_host_join.rb
@@ -1,0 +1,10 @@
+module Katello
+  class SystemHostJoin < ActiveRecord::Base
+
+    belongs_to :host, :class_name => "::Host::Managed", :foreign_key => :host_id
+    belongs_to :system, :class_name => "Katello::System", :foreign_key => :system_id
+    belongs_to :kt_environment, :class_name => "Katello::KTEnvironment", :foreign_key => :kt_environment_id
+    belongs_to :content_view, :class_name => "Katello::ContentView", :foreign_key => :content_view_id
+
+  end
+end

--- a/db/migrate/20140715143818_create_system_host_joins.rb
+++ b/db/migrate/20140715143818_create_system_host_joins.rb
@@ -1,0 +1,12 @@
+class CreateSystemHostJoins < ActiveRecord::Migration
+  def change
+    create_table :katello_system_host_joins do |t|
+      t.integer :host_id
+      t.integer :system_id
+      t.integer :kt_environment_id
+      t.integer :content_view_id
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
To allow a host to be created before a system (content host) is created and vice versa and to prevent the data from being stored in 2 places, both systems and hosts.

Currently, this information is only retrievable by parsing the puppet environment name connected to the content view / life-cycle environment
