### PR TITLE
Refs #5720: Proper resource scoping including authorization.

### DIFF
--- a/app/controllers/katello/api/api_controller.rb
+++ b/app/controllers/katello/api/api_controller.rb
@@ -85,8 +85,10 @@ class Api::ApiController < ::Api::BaseController
     controller_name
   end
 
-  def resource_name
-    controller_name.singularize
+  def get_class(model_name)
+    "Katello::#{model_name.classify}".constantize
+  rescue NameError
+    super(model_name)
   end
 
   def respond(options = {})

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -99,6 +99,12 @@ module Katello
       }
     end
 
+    def get_class(model_name)
+      "Katello::#{model_name.classify}".constantize
+    rescue NameError
+      super(model_name)
+    end
+
     protected
 
     def is_database_id?(num)


### PR DESCRIPTION
I am opening this initial PR (which has a corresponding Foreman update) in order to get some feedback from Foreman and Katello developers on the approach and the implications. 

The backstory is that in Katello we need to properly scope all resource lookups across our controllers. Foreman uses some common methods in their base_controller to centralize that scoping and data lookup. For Katello to take advantage of this (and other plugins as well in my opinion) there are a few changes on the Foreman side (https://github.com/theforeman/foreman/pull/1596).

I have created this initial PR as an example of the Katello implications and changes if we attempt to better align with Foreman methods and take advantage of them for our scoping. Further, I have chosen a nested resource (i.e. repositories get their permissions from their product) to show a full example of what is required. If this was a first class controller (one that has a direct permission) all that would need declaring is the `action_permissions`. For a nested resource, you'll note that `resource_scope` is overriden in order to account for the nested permission and that for all related objects (product, organization, gpg_key) the use of find_nested_object is used.
