### PR TITLE
fixes #5096 - fail gracefully on pulp repo creation failure

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -26,18 +26,20 @@ module Actions
           path = repository.relative_path unless repository.puppet?
 
           sequence do
-            plan_action(Actions::Pulp::Repository::Create,
-                        content_type: repository.content_type,
-                        pulp_id: repository.pulp_id,
-                        name: repository.name,
-                        feed: repository.feed,
-                        ssl_ca_cert: repository.feed_ca,
-                        ssl_client_cert: repository.feed_cert,
-                        ssl_client_key: repository.feed_key,
-                        unprotected: repository.unprotected,
-                        checksum_type: repository.checksum_type,
-                        path: path,
-                        with_importer: true)
+            create_action = plan_action(Actions::Pulp::Repository::CreateInPlan,
+                                        content_type: repository.content_type,
+                                        pulp_id: repository.pulp_id,
+                                        name: repository.name,
+                                        feed: repository.feed,
+                                        ssl_ca_cert: repository.feed_ca,
+                                        ssl_client_cert: repository.feed_cert,
+                                        ssl_client_key: repository.feed_key,
+                                        unprotected: repository.unprotected,
+                                        checksum_type: repository.checksum_type,
+                                        path: path,
+                                        with_importer: true)
+
+            return if create_action.error
 
             if repository.environment
               concurrence do

--- a/app/lib/actions/pulp/repository/create_in_plan.rb
+++ b/app/lib/actions/pulp/repository/create_in_plan.rb
@@ -1,0 +1,43 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Pulp
+    module Repository
+      class CreateInPlan < Create
+
+        alias_method :perform_run, :run
+
+        def plan(input)
+          plan_self(input)
+          pulp_extensions.repository.create_with_importer_and_distributors(input[:pulp_id],
+                                                                                      importer,
+                                                                                      distributors,
+                                                                                      display_name: input[:name])
+        rescue => e
+          raise error_message(e.http_body) || e
+        end
+
+        def error_message(body)
+          JSON.parse(body)['error_message']
+        rescue JSON::ParserError
+          nil
+        end
+
+        def run
+          self.output = input
+        end
+
+      end
+    end
+  end
+end

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/new/new-repository.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/new/new-repository.controller.js
@@ -53,6 +53,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
         }
 
         function error(response) {
+            var foundError = false;
             $scope.working = false;
 
             angular.forEach($scope.repositoryForm, function (value, field) {
@@ -64,10 +65,15 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
 
             angular.forEach(response.data.errors, function (errors, field) {
                 if ($scope.repositoryForm.hasOwnProperty(field)) {
+                    foundError = true;
                     $scope.repositoryForm[field].$setValidity('server', false);
                     $scope.repositoryForm[field].$error.messages = errors;
                 }
             });
+
+            if (!foundError) {
+                $scope.errorMessages = [response.data.displayMessage];
+            }
         }
 
     }]

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/new/views/repository-new.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/new/views/repository-new.html
@@ -9,6 +9,8 @@
     </h5>
   </header>
 
+  <div alch-alert error-messages="errorMessages" success-messages="successMessages"></div>
+
   <form name="repositoryForm" class="form-horizontal" novalidate role="form">
 
     <div alch-form-group label="{{ 'Name' | translate }}">

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -12,6 +12,13 @@
 
 require 'katello_test_helper'
 
+class Dynflow::Testing::DummyPlannedAction
+
+  attr_accessor :error
+
+end
+
+
 module ::Actions::Katello::Repository
 
   class TestBase < ActiveSupport::TestCase
@@ -34,6 +41,18 @@ module ::Actions::Katello::Repository
         content_create.stubs(input: { content_id: 123 })
       end
       plan_action action, repository
+    end
+  end
+
+  class CreateFailTest < TestBase
+    let(:action_class) { ::Actions::Katello::Repository::Create }
+    before do
+      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:error).returns("ERROR")
+    end
+
+
+    it 'fails to plan' do
+      repository.expects(:save!).never
     end
   end
 


### PR DESCRIPTION
The goal is to run the action creation in the plan phase
and error out if its not valid.  A similar approach is taken
with Content Host Creation.  However in that case, content hosts
are not created in other situations.  Repositories are created during
publish/promote of content views as well and in that situation we do not
want to perform pulp creation in the plan phase.  As a result I have created
a new action CreateImmediate that does the creation in the plan phase.
It attempts to use as much from Create as possible (there is a lot of code there)

Note: this also fixes non-rails validation errors not showing up on repo creation
