### PR TITLE
fixes #6686 - remove extraneous alch-alert div from CV filters index

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filters.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filters.html
@@ -1,6 +1,8 @@
 <span page-title ng-model="contentView">{{ 'Filters for Content View:' | translate }} {{ contentView.name }}</span>
 
 <div data-extend-template="layouts/details-nutupane.html">
+   
+  <div data-block="messages"></div>
 
   <div data-block="header">
     <h3 translate>Filters</h3>


### PR DESCRIPTION
Both the Content View and Content View Filters views have an alch-alert
div, which causes alerts to be shown twice in some situations.  The
Content View filters duplicate alch-alert is provided through the nutupane details
layout, and this PR provides a way to hide it.
