### PR TITLE
Fixes #6682: Move the katello-debug.sh script instead of linking it

### DIFF
--- a/deploy/script/katello-debug.sh
+++ b/deploy/script/katello-debug.sh
@@ -1,3 +1,10 @@
+# error out if called directly
+if [ $BASH_SOURCE == $0 ]
+then
+  echo "This script should not be executed directly, use foreman-debug instead."
+  exit 1
+fi
+
 # General stuff
 add_files "/var/log/audit/audit.log"
 


### PR DESCRIPTION
I have not been able to test this.. but I think it should work :)
