### PR TITLE
fixes #6719 / BZ 1079953 - Content Notices - fix deletion and list by org

### DIFF
--- a/app/assets/javascripts/katello/common/vendor.js
+++ b/app/assets/javascripts/katello/common/vendor.js
@@ -11,6 +11,7 @@
 */
 
 //= require "bastion/underscore/underscore"
+//= require "jquery.ui.dialog"
 //= require "jquery.ui.sortable"
 //= require "jquery.ui.tabs"
 //= require "jquery.ui.progressbar"

--- a/app/controllers/katello/notices_controller.rb
+++ b/app/controllers/katello/notices_controller.rb
@@ -38,11 +38,10 @@ class NoticesController < Katello::ApplicationController
   end
 
   def show
-    # TODO: search by organization
     # currently doesn't handle pagination
+    ids = Katello::Notice.readable(current_user).for_org(current_organization).select("#{Katello::Notice.table_name}.id")
     @notices = render_panel_direct(Notice, { }, params[:search], 0, [sort_column, sort_direction],
-                                   { :filter      => { :user_ids => [current_user.id] },
-                                     #:organization_id => [current_organization.id] },
+                                   { :filter      => { :_id => ids },
                                      :skip_render => true,
                                      :page_size   => 100 })
     retain_search_history
@@ -76,7 +75,7 @@ class NoticesController < Katello::ApplicationController
 
   def destroy_all
     # destroy all notices for the user
-    Katello::Notice.for_user(current_user).for_org(current_organization).read.each do |notice|
+    Katello::Notice.for_user(current_user).for_org(current_organization).each do |notice|
       notice.users.delete(current_user)
       notice.destroy unless notice.users.any?
     end

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -69,10 +69,10 @@ describe NoticesController do
     end
 
     it 'should allow all notices to be destroyed for a single user (katello)' do #TODO headpin
-      pre_count = UserNotice.count
+      !UserNotice.where(:user_id => @user.id).count.wont_equal(0)
       delete :destroy_all
       must_respond_with(:success)
-      UserNotice.count.must_equal(pre_count - 10)
+      UserNotice.where(:user_id => @user.id).count.must_equal(0)
     end
   end
 


### PR DESCRIPTION
This commit addresses 2 issues w/ the content notices page:
1. list only the notices associated with the current org
2. update so that clicking 'Delete All' will render the confirmation dialog
