### PR TITLE
Fixes #5985/bz1102120 - Marked content_view_id as required param

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -24,6 +24,7 @@ class Api::V2::ContentViewFiltersController < Api::V2::ApiController
   param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true
   param :name, String, :desc => N_("Filter content view filters by name")
   def index
+    params.require(:content_view_id)
     options = sort_params
     options[:load_records?] = true
     options[:filters] = [{ :terms => { :id => @view.filter_ids } }]


### PR DESCRIPTION
Content VIew id is marked as required param in the docs
for the cv filters index call but nothing is enforcing that.
This commit handles that enforcement aspect
