### PR TITLE
fixes #6737 - correct 'automatic' amount for subscriptions

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -211,7 +211,7 @@ module Resources
 
         def consume_entitlement(uuid, pool, quantity = nil)
           uri = join_path(path(uuid), 'entitlements') + "?pool=#{pool}"
-          uri += "&quantity=#{quantity}" if quantity
+          uri += "&quantity=#{quantity}" if quantity && quantity > 0
           response = self.post(uri, "", self.default_headers).body
           response.blank? ? [] : JSON.parse(response)
         end
@@ -795,9 +795,7 @@ module Resources
         def add_pools(id, pool_id, quantity)
           cppath = join_path(path(id), "pools/#{pool_id}")
           quantity = Integer(quantity) rescue nil
-          if quantity && quantity > 0
-            cppath += "?quantity=#{quantity}" if quantity
-          end
+          cppath += "?quantity=#{quantity}" if quantity && quantity > 0
           pool = self.post(cppath, {}, self.default_headers)
           JSON.parse(pool).with_indifferent_access
         end

--- a/app/models/katello/glue/candlepin/consumer.rb
+++ b/app/models/katello/glue/candlepin/consumer.rb
@@ -434,9 +434,9 @@ module Glue::Candlepin::Consumer
       self.entitlements.collect do |entitlement|
         pool = self.get_pool(entitlement['pool']['id'])
         entitlement_pool = Katello::Pool.new(pool)
-        entitlement_pool['cp_id'] = entitlement['id']
-        entitlement_pool['subscription_id'] = entitlement['pool']['id']
-        entitlement_pool['quantity'] = entitlement['quantity']
+        entitlement_pool.cp_id = entitlement['id']
+        entitlement_pool.subscription_id = entitlement['pool']['id']
+        entitlement_pool.amount = entitlement['quantity']
         entitlement_pool
       end
     end

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -168,7 +168,7 @@ module Glue::Candlepin::Pool
     end
 
     def products
-      Product.where(:cp_id => provided_products.map { |prod| prod[:productId] })
+      Katello::Product.where(:cp_id => provided_products.map { |prod| prod[:productId] })
     end
 
     def systems

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -23,6 +23,9 @@ class Pool < Katello::Model
   attr_accessor :cp_provider_id
   alias_method :provider_id, :cp_provider_id
   alias_method :provider_id=, :cp_provider_id=
+  attr_accessor :cp_id
+  attr_accessor :subscription_id
+  attr_accessor :amount
 
   DAYS_EXPIRING_SOON = 120
   DAYS_RECENTLY_EXPIRED = 30

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -29,7 +29,7 @@
 angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsController',
     ['$scope', '$location', 'translate', 'CurrentOrganization', 'Subscription', 'ContentHost', 'SubscriptionsHelper',
     function ($scope, $location, translate, CurrentOrganization, Subscription, ContentHost, SubscriptionsHelper) {
-        
+
         $scope.addSubscriptionsTable = $scope.addSubscriptionsPane.table;
         $scope.isAdding  = false;
         $scope.addSubscriptionsTable.closeItem = function () {};
@@ -62,7 +62,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsC
         };
 
         $scope.amountSelectorValues = function (subscription) {
-            // TODO: should the logic for step go here since content host is known whether phys or virt?
             var step, value, values;
 
             step = subscription['instance_multiplier'];


### PR DESCRIPTION
Corrects handling of quantity zero, which is used to indicate automatic.
Fixes regression of adding amount back to json.
