### PR TITLE
fixes #6702 - use a subscriptions derived provided products

### DIFF
--- a/app/controllers/katello/providers_controller.rb
+++ b/app/controllers/katello/providers_controller.rb
@@ -33,8 +33,9 @@ class ProvidersController < Katello::ApplicationController
 
     subscriptions = Resources::Candlepin::Subscription.get_for_owner(current_organization.label)
     subscriptions.each do |sub|
-      subscription_product_ids << sub["product"]["id"] if sub["product"]["id"]
-      subscription_product_ids += sub["providedProducts"].map{|p| p["id"]}
+      subscription_product_ids << sub['product']['id'] if sub['product']['id']
+      subscription_product_ids += sub['providedProducts'].map{|p| p['id']} if sub['providedProducts']
+      subscription_product_ids += sub['derivedProvidedProducts'].map{|p| p['id']} if sub['derivedProvidedProducts']
     end
 
     orphaned_product_ids = current_organization.redhat_provider.products.engineering.

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -659,7 +659,8 @@ module Resources
 
           product_subscription = subscriptions.find do |sub|
             sub["product"]["id"] == id ||
-              sub["providedProducts"].any? { |provided| provided["id"] == id }
+              sub["providedProducts"].any? { |provided| provided["id"] == id } ||
+              sub["derivedProvidedProducts"].any? { |provided| provided["id"] == id }
           end
 
           if product_subscription

--- a/app/models/katello/glue/candlepin/consumer.rb
+++ b/app/models/katello/glue/candlepin/consumer.rb
@@ -408,7 +408,7 @@ module Glue::Candlepin::Consumer
         end
 
         provided_products = []
-        pool["providedProducts"].each do |cp_product|
+        pool['providedProducts'].each do |cp_product|
           product = Katello::Product.where(:cp_id => cp_product["productId"]).first
           if product
             provided_products << product


### PR DESCRIPTION
Including the derived products in the list of a subscriptions products allows the repos to be enabled and sync'ed from cdn
