### PR TITLE
Fixes #6759/BZ1108928: using #content as topbar.js expects.

### DIFF
--- a/app/assets/stylesheets/katello/katello.scss
+++ b/app/assets/stylesheets/katello/katello.scss
@@ -1350,7 +1350,7 @@ footer a {
   @extend .clearfix;
 }
 
-#maincontent section.maincontent {
+#content section.maincontent {
   box-shadow: none !important;
   background: white;
   margin: 40px auto;
@@ -1383,7 +1383,7 @@ footer a {
   }
 }
 
-#maincontent {
+#content {
   padding-bottom: 51px;
 }
 

--- a/app/views/katello/layouts/katello.haml
+++ b/app/views/katello/layouts/katello.haml
@@ -25,7 +25,7 @@
     - title = "Katello"
 
 = content_for(:content) do
-  %article#maincontent
+  %article#content
     %section.maincontent.container_16{:id => section_id}
       = yield
 


### PR DESCRIPTION
Foreman's topbar.js expects an element with an id of "content"
that it adds top padding the size of the header to in order for
there to be sufficient room for the floating header.  This commit
renames #maincontent to #content so Foreman's topbar.js works for
katello pages.

http://projects.theforeman.org/issues/6759
https://bugzilla.redhat.com/show_bug.cgi?id=1108928
