### PR TITLE
Refs #6696 - Fixing test that doesn't work with content-type json

### DIFF
--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -81,7 +81,8 @@ class Api::V2::ProductsControllerTest < ActionController::TestCase
   end
 
   def test_create_fail_without_product
-    post :create, :organization_id => @organization.id
+    Organization.stubs(:current).returns(@organization)
+    post :create
 
     assert_response :bad_request
   end


### PR DESCRIPTION
Due to [a change in foreman](https://github.com/theforeman/foreman/pull/1600), we're using json for all api requests (which is the
only supported content-type for the api) and this triggers wrap_parameters.
With wrap_parameters, since organization_id is a product attribute, we no
longer hit the bad request. If we remove organization_id though, then we hit
404. So basically, there's no way to hit a 400 error. An alternative would be
to remove this test.
