### PR TITLE
Systems/Hosts: The Katello Systems API should exist but be documented as unsupported.

### DIFF
--- a/app/controllers/katello/api/v1/system_packages_controller.rb
+++ b/app/controllers/katello/api/v1/system_packages_controller.rb
@@ -16,7 +16,6 @@ class Api::V1::SystemPackagesController < Api::V1::ApiController
     param :system_id, :identifier, :desc => N_("system identifier"), :required => true
 
     api_version 'v1'
-    api_version 'v2'
   end
 
   respond_to :json

--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -39,9 +39,9 @@ module Katello
     end
 
     api :GET, "/host_collections", N_("List host collections")
-    api :GET, "/organizations/:organization_id/host_collections"
-    api :GET, "/activation_keys/:activation_key_id/host_collections"
-    api :GET, "/systems/:system_id/host_collections"
+    api :GET, "/organizations/:organization_id/host_collections", N_("List host collections within an organization")
+    api :GET, "/activation_keys/:activation_key_id/host_collections", N_("List host collections in an activation key")
+    api :GET, "/systems/:system_id/host_collections", N_("List host collections containing a content host"), :deprecated => true
     param_group :search, Api::V2::ApiController
     param :organization_id, :number, :desc => N_("organization identifier"), :required => true
     param :name, String, :desc => N_("host collection name to filter by")
@@ -81,7 +81,7 @@ module Katello
     end
 
     # TODO: switch to systems controller index w/ @adprice pull-request
-    api :GET, "/host_collections/:id/systems", N_("List content hosts in the host collection")
+    api :GET, "/host_collections/:id/systems", N_("List content hosts in the host collection"), :deprecated => true
     param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     def systems
       options = {
@@ -91,7 +91,7 @@ module Katello
       respond_for_index(:collection => item_search(System, params, options))
     end
 
-    api :PUT, "/host_collections/:id/add_systems", N_("Add content host to the host collection")
+    api :PUT, "/host_collections/:id/add_systems", N_("Add content host to the host collection"), :deprecated => true
     param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     param :system_ids, Array, :desc => N_("Array of content host ids")
     def add_systems
@@ -113,7 +113,7 @@ module Katello
                        :resource => { 'displayMessages' => messages }
     end
 
-    api :PUT, "/host_collections/:id/remove_systems", N_("Remove content hosts from the host collection")
+    api :PUT, "/host_collections/:id/remove_systems", N_("Remove content hosts from the host collection"), :deprecated => true
     param :id, :identifier, :desc => N_("Id of the host collection"), :required => true
     param :system_ids, Array, :desc => N_("Array of content host ids")
     def remove_systems

--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -30,7 +30,7 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
   end
 
   api :GET, "/organizations/:organization_id/subscriptions", N_("List organization subscriptions")
-  api :GET, "/systems/:system_id/subscriptions", N_("List a system's subscriptions")
+  api :GET, "/systems/:system_id/subscriptions", N_("List a system's subscriptions"), :deprecated => true
   api :GET, "/activation_keys/:activation_key_id/subscriptions", N_("List an activation key's subscriptions")
   param :organization_id, :number, :desc => N_("Organization ID"), :required => true
   param :system_id, String, :desc => N_("UUID of the system"), :required => false
@@ -68,7 +68,7 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
   end
 
   api :POST, "/subscriptions/:id", N_("Add a subscription to a resource")
-  api :POST, "/systems/:system_id/subscriptions", N_("Add a subscription to a system")
+  api :POST, "/systems/:system_id/subscriptions", N_("Add a subscription to a system"), :deprecated => true
   api :POST, "/activation_keys/:activation_key_id/subscriptions", N_("Add a subscription to an activation key")
   param :id, String, :desc => N_("Subscription Pool uuid"), :required => false
   param :system_id, String, :desc => N_("UUID of the system"), :required => false
@@ -101,7 +101,7 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
   end
 
   api :DELETE, "/subscriptions/:id", N_("Unattach a subscription")
-  api :DELETE, "/systems/:system_id/subscriptions/:id", N_("Unattach a subscription")
+  api :DELETE, "/systems/:system_id/subscriptions/:id", N_("Unattach a subscription"), :deprecated => true
   api :DELETE, "/activation_keys/:activation_key_id/subscriptions/:id", N_("Unattach a subscription")
   param :id, String, :desc => N_("Subscription ID"), :required => false
   param :system_id, String, :desc => N_("UUID of the system")
@@ -257,7 +257,7 @@ class Api::V2::SubscriptionsController < Api::V2::ApiController
     return subscriptions
   end
 
-  api :GET, "/systems/:system_id/subscriptions/available", N_("List available subscriptions")
+  api :GET, "/systems/:system_id/subscriptions/available", N_("List available subscriptions"), :deprecated => true
   param :system_id, String, :desc => N_("UUID of the system"), :required => true
   param :match_system, :bool, :desc => N_("Return subscriptions that match system")
   param :match_installed, :bool, :desc => N_("Return subscriptions that match installed")

--- a/app/controllers/katello/api/v2/system_errata_controller.rb
+++ b/app/controllers/katello/api/v2/system_errata_controller.rb
@@ -20,7 +20,7 @@ class Api::V2::SystemErrataController < Api::V2::ApiController
     api_base_url "#{Katello.config.url_prefix}/api"
   end
 
-  api :PUT, "/systems/:system_id/errata/apply", N_("Schedule errata for installation")
+  api :PUT, "/systems/:system_id/errata/apply", N_("Schedule errata for installation"), :deprecated => true
   param :system_id, :identifier, :desc => N_("System UUID"), :required => true
   param :errata_ids, Array, :desc => N_("List of Errata ids to install"), :required => true
   def apply
@@ -28,7 +28,7 @@ class Api::V2::SystemErrataController < Api::V2::ApiController
     respond_for_async :resource => task
   end
 
-  api :GET, "/systems/:system_id/errata/:id", N_("Retrieve a single errata for a system")
+  api :GET, "/systems/:system_id/errata/:id", N_("Retrieve a single errata for a system"), :deprecated => true
   param :system_id, :identifier, :desc => N_("System UUID"), :required => true
   param :id, String, :desc => N_("Errata id of the erratum (RHSA-2012:108)"), :required => true
   def show

--- a/app/controllers/katello/api/v2/system_packages_controller.rb
+++ b/app/controllers/katello/api/v2/system_packages_controller.rb
@@ -27,7 +27,7 @@ class Api::V2::SystemPackagesController < Api::V2::ApiController
     param :groups, Array, :desc => N_("List of package group names"), :required => false
   end
 
-  api :PUT, "/systems/:system_id/packages/install", N_("Install packages remotely")
+  api :PUT, "/systems/:system_id/packages/install", N_("Install packages remotely"), :deprecated => true
   param :system_id, :identifier, :required => true, :desc => N_("UUID of the content-host")
   param_group :packages_or_groups
   def install
@@ -46,7 +46,7 @@ class Api::V2::SystemPackagesController < Api::V2::ApiController
 
   end
 
-  api :PUT, "/systems/:system_id/packages/upgrade", N_("Update packages remotely")
+  api :PUT, "/systems/:system_id/packages/upgrade", N_("Update packages remotely"), :deprecated => true
   param :system_id, :identifier, :required => true, :desc => N_("UUID of the content-host")
   param :packages, Array, :desc => N_("list of packages names"), :required => true
   def upgrade
@@ -57,14 +57,14 @@ class Api::V2::SystemPackagesController < Api::V2::ApiController
     end
   end
 
-  api :PUT, "/systems/:system_id/packages/upgrade_all", N_("Update packages remotely")
+  api :PUT, "/systems/:system_id/packages/upgrade_all", N_("Update packages remotely"), :deprecated => true
   param :system_id, :identifier, :required => true, :desc => N_("UUID of the content-host")
   def upgrade_all
     task     = async_task(::Actions::Katello::System::Package::Update, @system, [])
     respond_for_async :resource => task
   end
 
-  api :PUT, "/systems/:system_id/packages/remove", N_("Uninstall packages remotely")
+  api :PUT, "/systems/:system_id/packages/remove", N_("Uninstall packages remotely"), :deprecated => true
   param :system_id, :identifier, :required => true, :desc => N_("UUID of the content-host")
   param_group :packages_or_groups
   def remove

--- a/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
@@ -52,7 +52,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
   end
 
   api :PUT, "/systems/bulk/add_host_collections",
-      N_("Add one or more host collections to one or more content hosts")
+      N_("Add one or more host collections to one or more content hosts"), :deprecated => true
   param_group :bulk_params
   param :host_collection_ids, Array, :desc => N_("List of host collection ids"), :required => true
   def bulk_add_host_collections
@@ -75,7 +75,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
   end
 
   api :PUT, "/systems/bulk/remove_host_collections",
-      N_("Remove one or more host collections from one or more content hosts")
+      N_("Remove one or more host collections from one or more content hosts"), :deprecated => true
   param_group :bulk_params
   param :host_collection_ids, Array, :desc => N_("List of host collection ids"), :required => true
   def bulk_remove_host_collections
@@ -98,7 +98,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
   end
 
   api :POST, "/systems/bulk/applicable_errata",
-      N_("Fetch applicable errata for a system.")
+      N_("Fetch applicable errata for a system."), :deprecated => true
   param_group :bulk_params
   def applicable_errata
     @search_service = nil #reload search service after systems are loaded
@@ -111,7 +111,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
     respond_for_index(:collection => results)
   end
 
-  api :PUT, "/systems/bulk/install_content", N_("Install content on one or more systems")
+  api :PUT, "/systems/bulk/install_content", N_("Install content on one or more systems"), :deprecated => true
   param_group :bulk_params
   param :content_type, String,
         :desc => N_("The type of content.  The following types are supported: 'package', 'package_group' and 'errata'."),
@@ -121,7 +121,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
     content_action
   end
 
-  api :PUT, "/systems/bulk/update_content", N_("Update content on one or more systems")
+  api :PUT, "/systems/bulk/update_content", N_("Update content on one or more systems"), :deprecated => true
   param_group :bulk_params
   param :content_type, String,
         :desc => N_("The type of content.  The following types are supported: 'package' and 'package_group."),
@@ -131,7 +131,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
     content_action
   end
 
-  api :PUT, "/systems/bulk/remove_content", N_("Remove content on one or more systems")
+  api :PUT, "/systems/bulk/remove_content", N_("Remove content on one or more systems"), :deprecated => true
   param_group :bulk_params
   param :content_type, String,
         :desc => N_("The type of content.  The following types are supported: 'package' and 'package_group."),
@@ -141,7 +141,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
     content_action
   end
 
-  api :PUT, "/systems/bulk/destroy", N_("Destroy one or more systems")
+  api :PUT, "/systems/bulk/destroy", N_("Destroy one or more systems"), :deprecated => true
   param_group :bulk_params
   def destroy_systems
     @systems.each { |system| sync_task(::Actions::Katello::System::Destroy, system) }
@@ -150,7 +150,7 @@ class Api::V2::SystemsBulkActionsController < Api::V2::ApiController
                      :resource => { 'displayMessages' => [display_message] }
   end
 
-  api :PUT, "/systems/bulk/environment_content_view", N_("Assign the environment and content view to one or more systems")
+  api :PUT, "/systems/bulk/environment_content_view", N_("Assign the environment and content view to one or more systems"), :deprecated => true
   param_group :bulk_params
   param :environment_id, Integer
   param :content_view_id, Integer

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -25,9 +25,9 @@ class Api::V2::SystemsController < Api::V2::ApiController
                                         :available_host_collections,
                                         :refresh_subscriptions, :tasks, :content_override, :events]
   before_filter :find_environment, :only => [:index, :report]
-  before_filter :find_optional_organization, :only => [:create, :index, :activate, :report]
+  before_filter :find_optional_organization, :only => [:create, :index, :report]
   before_filter :find_host_collection, :only => [:index]
-  before_filter :find_default_organization_and_or_environment, :only => [:create, :index, :activate]
+  before_filter :find_default_organization_and_or_environment, :only => [:create, :index]
   before_filter :find_only_environment, :only => [:create]
 
   before_filter :find_environment_and_content_view, :only => [:create]
@@ -52,10 +52,10 @@ class Api::V2::SystemsController < Api::V2::ApiController
     param :environment_id, :identifier
   end
 
-  api :GET, "/systems", N_("List content hosts")
-  api :GET, "/organizations/:organization_id/systems", N_("List content hosts in an organization")
-  api :GET, "/environments/:environment_id/systems", N_("List content hosts in environment")
-  api :GET, "/host_collections/:host_collection_id/systems", N_("List content hosts in a host collection")
+  api :GET, "/systems", N_("List content hosts"), :deprecated => true
+  api :GET, "/organizations/:organization_id/systems", N_("List content hosts in an organization"), :deprecated => true
+  api :GET, "/environments/:environment_id/systems", N_("List content hosts in environment"), :deprecated => true
+  api :GET, "/host_collections/:host_collection_id/systems", N_("List content hosts in a host collection"), :deprecated => true
   param :name, String, :desc => N_("Filter content host by name")
   param :pool_id, String, :desc => N_("Filter content host by subscribed pool")
   param :uuid, String, :desc => N_("Filter content host by uuid")
@@ -92,9 +92,9 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index(:collection => item_search(System, params, options))
   end
 
-  api :POST, "/systems", N_("Register a content host")
-  api :POST, "/environments/:environment_id/systems", N_("Register a content host in environment")
-  api :POST, "/host_collections/:host_collection_id/systems", N_("Register a content host in environment")
+  api :POST, "/systems", N_("Register a content host"), :deprecated => true
+  api :POST, "/environments/:environment_id/systems", N_("Register a content host in environment"), :deprecated => true
+  api :POST, "/host_collections/:host_collection_id/systems", N_("Register a content host in environment"), :deprecated => true
   param :name, String, :desc => N_("Name of the content host"), :required => true, :action_aware => true
   param :description, String, :desc => N_("Description of the content host")
   param :location, String, :desc => N_("Physical location of the content host")
@@ -119,7 +119,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_create
   end
 
-  api :PUT, "/systems/:id", N_("Update content host information")
+  api :PUT, "/systems/:id", N_("Update content host information"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   param :name, String, :desc => N_("Name of the content host"), :required => true, :action_aware => true
   param :description, String, :desc => N_("Description of the content host")
@@ -142,7 +142,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_update
   end
 
-  api :GET, "/systems/:id", N_("Show a content host")
+  api :GET, "/systems/:id", N_("Show a content host"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   def show
     @host_collections = @system.host_collections
@@ -150,7 +150,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond
   end
 
-  api :GET, "/systems/:id/available_host_collections", N_("List host collections the content host does not belong to")
+  api :GET, "/systems/:id/available_host_collections", N_("List host collections the content host does not belong to"), :deprecated => true
   param_group :search, Api::V2::ApiController
   param :name, String, :desc => N_("host collection name to filter by")
   def available_host_collections
@@ -166,14 +166,14 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index(:collection => host_collections)
   end
 
-  api :DELETE, "/systems/:id", N_("Unregister a content host")
+  api :DELETE, "/systems/:id", N_("Unregister a content host"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   def destroy
     sync_task(::Actions::Katello::System::Destroy, @system)
     respond :message => _("Deleted content host '%s'") % params[:id], :status => 204
   end
 
-  api :GET, "/systems/:id/packages", N_("List packages installed on the content host")
+  api :GET, "/systems/:id/packages", N_("List packages installed on the content host"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   def package_profile
     packages = @system.simple_packages.sort { |a, b| a.name.downcase <=> b.name.downcase }
@@ -185,14 +185,14 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index :collection => response
   end
 
-  api :PUT, "/systems/:id/refresh_subscriptions", N_("Trigger a refresh of subscriptions, auto-attaching if enabled")
+  api :PUT, "/systems/:id/refresh_subscriptions", N_("Trigger a refresh of subscriptions, auto-attaching if enabled"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   def refresh_subscriptions
     @system.refresh_subscriptions
     respond_for_show(:resource => @system)
   end
 
-  api :GET, "/systems/:id/errata", N_("List errata available for the content host")
+  api :GET, "/systems/:id/errata", N_("List errata available for the content host"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   def errata
     errata = @system.errata
@@ -206,8 +206,8 @@ class Api::V2::SystemsController < Api::V2::ApiController
   end
 
   # TODO: break this mehtod up
-  api :GET, "/environments/:environment_id/systems/report", N_("Get content host reports for the environment")
-  api :GET, "/organizations/:organization_id/systems/report", N_("Get content host reports for the organization")
+  api :GET, "/environments/:environment_id/systems/report", N_("Get content host reports for the environment"), :deprecated => true
+  api :GET, "/organizations/:organization_id/systems/report", N_("Get content host reports for the organization"), :deprecated => true
   def report # rubocop:disable MethodLength
     data = @environment.nil? ? @organization.systems.readable : @environment.systems.readable
 
@@ -237,7 +237,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
     end
   end
 
-  api :GET, "/systems/:id/pools", N_("List pools a content host is subscribed to")
+  api :GET, "/systems/:id/pools", N_("List pools a content host is subscribed to"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   param :match_system, [true, false], :desc => N_("Match pools to content host")
   param :match_installed, [true, false], :desc => N_("Match pools to installed")
@@ -255,7 +255,7 @@ class Api::V2::SystemsController < Api::V2::ApiController
     respond_for_index :collection => response
   end
 
-  api :GET, "/systems/:id/releases", N_("Show releases available for the content host")
+  api :GET, "/systems/:id/releases", N_("Show releases available for the content host"), :deprecated => true
   param :id, String, :desc => N_("UUID of the content host"), :required => true
   desc <<-DESC
     A hint for choosing the right value for the releaseVer param

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -102,9 +102,6 @@ Katello::Engine.routes.draw do
           api_resources :systems, :only => system_onlies do
             get :report, :on => :collection
           end
-          scope :constraints => Katello::RegisterWithActivationKeyConstraint.new do
-            match '/systems' => 'systems#activate', :via => :post
-          end
         end
 
         api_resources :errata, :only => [:index, :show]
@@ -148,9 +145,6 @@ Katello::Engine.routes.draw do
           end
           api_resources :systems, :only => system_onlies do
             get :report, :on => :collection
-          end
-          scope :constraints => Katello::RegisterWithActivationKeyConstraint.new do
-            match '/systems' => 'systems#activate', :via => :post
           end
         end
 
@@ -224,9 +218,6 @@ Katello::Engine.routes.draw do
               put :add_products
               put :remove_products
             end
-          end
-          scope :constraints => Katello::RegisterWithActivationKeyConstraint.new do
-            match '/systems' => 'systems#activate', :via => :post
           end
           api_resources :systems, :only => [:create] do
             get :report, :on => :collection

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "i18n_data", ">= 0.2.6"
 
   # Documentation
-  gem.add_dependency "apipie-rails", ">= 0.1.0"
   gem.add_dependency "maruku"
 
   # Pulp


### PR DESCRIPTION
added annotations to the apidoc to display deprecated routes

~~this pull-request depends on Apipie/apipie-rails#268~~
