### PR TITLE
Ref #6800 - add qpid-cpp-client-devel to comps

### DIFF
--- a/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
@@ -63,6 +63,7 @@
        <packagereq type="default">python-semantic-version</packagereq>
        <packagereq type="default">python-webpy</packagereq>
        <packagereq type="default">qpid-cpp-client</packagereq>
+       <packagereq type="default">qpid-cpp-client-devel</packagereq>
        <packagereq type="default">qpid-cpp-server</packagereq>
        <packagereq type="default">qpid-cpp-server-store</packagereq>
        <packagereq type="default">qpid-proton-c</packagereq>


### PR DESCRIPTION
add qpid-cpp-client-devel to pulp fedora and rhel comps which is needed
by qpid_messaging gem. The gem allows katello to receive candlepin event
messages.
