### PR TITLE
Fixes #6801: Make tipsy's on content search page visible again.

### DIFF
--- a/app/assets/stylesheets/katello/content_search.scss
+++ b/app/assets/stylesheets/katello/content_search.scss
@@ -56,12 +56,14 @@ $grid_cell_hover_link-color:                lighten($primary_color, 40%);
 }
 
 .view_tipsy {
-  &:hover { background: $details_icon_black; }
+  &:hover { color: black; }
   vertical-align: top;
   margin-top: 4px;
+  color: grey;
 }
 
-.browse_tipsy:hover { background: $details_icon_black; }
+.browse_tipsy { color: grey; }
+.browse_tipsy:hover { color: black; }
 
 .tipsify-errata {
   &:hover {

--- a/app/views/katello/content_search/_browser_box.html.haml
+++ b/app/views/katello/content_search/_browser_box.html.haml
@@ -35,7 +35,7 @@
         #repo_search
           = radio_button_tag :repos, :search_radio, true
           = text_field_tag :repo_search_input, nil, :placeholder=>_('Search repositories')
-          %span.browse_tipsy.details_icon-grey
+          %span.browse_tipsy.icon-info-sign
             %span.hidden-text.hidden
               .la.content-tipsy
                 = _('Example Searches:')
@@ -69,7 +69,7 @@
         = label_tag :packages, _("Packages")
         #package_search
           = text_field_tag :search, nil, :placeholder=>_('Search packages'), :size=>19
-          %span.browse_tipsy.details_icon-grey
+          %span.browse_tipsy.icon-info-sign
             %span.hidden-text.hidden
               .la.content-tipsy
                 = _('Example Searches:')
@@ -101,7 +101,7 @@
         #errata_search
           = radio_button_tag :errata, :search, true
           = text_field_tag :search, '', :size=>19, :placeholder=>_('Search Errata')
-          %span.browse_tipsy.details_icon-grey
+          %span.browse_tipsy.icon-info-sign
             %span.hidden-text.hidden
               .la.content-tipsy
                 = _('Example Searches:')
@@ -129,7 +129,7 @@
         #puppet_modules_search
           = radio_button_tag :puppet_modules, :search, true
           = text_field_tag :search, '', :size=>19, :placeholder=>_('Search modules')
-          %span.browse_tipsy.details_icon-grey
+          %span.browse_tipsy.icon-info-sign
             %span.hidden-text.hidden
               .la.content-tipsy
                 = _('Example Searches:')

--- a/app/views/katello/content_search/_grid.html.haml
+++ b/app/views/katello/content_search/_grid.html.haml
@@ -15,7 +15,7 @@
         %label
           = _("View")
         %select
-        %i.view_tipsy.details_icon-grey
+        %i.view_tipsy.icon-info-sign
           %span.hidden-text.hidden
             .la.content-tipsy
               %ul


### PR DESCRIPTION
The tipsy's on content search were lost at some point due to missing
fonts or CSS declarations. This changes those over to FontAwesome
which is used more widely throughout the application.
