### PR TITLE
fixes #6803 / BZ 1115308 - content search - fix sql errors on product/repo auto-complete

### DIFF
--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -49,7 +49,7 @@ class ProductsController < Katello::ApplicationController
 
     readable_ids = []
     readable_ids += Product.readable.pluck(:id) if Product.readable?
-    readable_ids += ContentView.readable_products.pluck(:id)
+    readable_ids += ContentView.readable_products.pluck("#{Katello::Product.table_name}.id")
     readable_ids.uniq
 
     products = Product.search do

--- a/app/controllers/katello/repositories_controller.rb
+++ b/app/controllers/katello/repositories_controller.rb
@@ -20,7 +20,7 @@ class RepositoriesController < Katello::ApplicationController
     query = "name_autocomplete:#{params[:term]}"
 
     ids = []
-    ids += Product.readable_repositories.pluck(:id) if Product.readable?
+    ids += Product.readable_repositories.pluck("#{Katello::Repository.table_name}.id") if Product.readable?
     ids += ContentView.readable_repositories.pluck(:library_instance_id)
     ids.uniq!
 


### PR DESCRIPTION
The sql used for auto-complete was generating 'ambiguous' errors in the
production configuration.

E.g.
    PGError: ERROR: column reference "id" is ambiguous LINE 1: SELECT id FROM "katello_repositories" INNER JOIN "katello_pr... ^ : SELECT id FROM "katello_repositories" INNER JOIN "katello_products" ON "katello_products"."id" = "katello_repositories"."product_id" INNER JOIN "katello_content_view_versions" ON "katello_content_view_versions"."id" = "katello_repositories"."content_view_version_id" WHERE "katello_content_view_versions"."content_view_id" IN (1) AND "katello_repositories"."product_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95) ORDER BY katello_repositories.name ASC (ActiveRecord::StatementInvalid)
