### PR TITLE
fixes #6811 - install katello-agent during kickstart

### DIFF
--- a/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
+++ b/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
@@ -5,7 +5,13 @@ rpm -ivh <%= subscription_manager_configuration_url %>
 
 echo "Registering the System"
 subscription-manager register --org="<%= @host.params['kt_org']%>" --name="<%= @host.name %>" --activationkey="<%= @host.params['kt_activation_keys'] %>"
-<% end %>
+
 <% if @host.content_source %>
   subscription-manager config --rhsm.baseurl=https://<%= @host.content_source.hostname %>/pulp/repos
+<% end %>
+
+echo "Installing Katello Agent"
+yum -t -y -e 0 install katello-agent
+chkconfig goferd on
+service goferd start
 <% end %>


### PR DESCRIPTION
This ensures that katello-agent is automatically installed on new hosts.
