### PR TITLE
Fixes #6821/BZ1117636: fix link to activation keys on CV delete page.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
@@ -71,7 +71,7 @@ angular.module('Bastion.content-views').controller('ContentViewVersionDeletionAc
 
         $scope.activationKeyLink = function () {
             var search = $scope.searchString($scope.contentView, $scope.deleteOptions.environments);
-            return $scope.$state.href('activation-keys.index').url + '?search=' + search;
+            return $scope.$state.href('activation-keys.index') + '?search=' + search;
         };
 
         $scope.toggleKeys = function () {

--- a/engines/bastion/test/content-views/details/deletion/content-view-version-deletion-activation-keys.controller.test.js
+++ b/engines/bastion/test/content-views/details/deletion/content-view-version-deletion-activation-keys.controller.test.js
@@ -36,7 +36,7 @@ describe('Controller: ContentViewVersionDeletionActivationKeysController', funct
         $scope.version = ContentViewVersion.get({id: 1});
         $scope.initEnvironmentWatch = function() {};
         $scope.validateEnvironmentSelection = function() {};
-        $scope.deleteOptions = {activationKeys: {}};
+        $scope.deleteOptions = {activationKeys: {}, environments: {}};
 
         spyOn(Organization, 'readableEnvironments').andCallThrough();
         spyOn($scope, 'validateEnvironmentSelection').andCallThrough();
@@ -84,4 +84,13 @@ describe('Controller: ContentViewVersionDeletionActivationKeysController', funct
         expect($scope.transitionToNext).toHaveBeenCalled();
     });
 
+    it('should construct the activation key link', function () {
+        $scope.searchString = function (contentView, environments) {};
+        spyOn($scope, 'searchString').andReturn('search');
+        spyOn($scope.$state, 'href').andReturn('activationKeys');
+
+        expect($scope.activationKeyLink()).toBe('activationKeys?search=search');
+        expect($scope.searchString).toHaveBeenCalledWith($scope.contentView, $scope.deleteOptions.environments);
+        expect($scope.$state.href).toHaveBeenCalledWith('activation-keys.index');
+    });
 });


### PR DESCRIPTION
The link to manage individual activation keys was incorrectly using
$state.href().  This commit fixes the usage of $state.href() when
constructing the activation keys link.

http://projects.theforeman.org/issues/6821
https://bugzilla.redhat.com/show_bug.cgi?id=1117636
