### PR TITLE
Fixes 6807/bz1103033 - Host Collection UI rows refresh code

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-add-content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-add-content-hosts.controller.js
@@ -74,9 +74,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionAddContentH
 
                 $scope.isAdding = false;
                 addContentHostsPane.refresh();
-                $scope.hostCollection.$get().then(function (hostCollection) {
-                    $scope.hostCollection = hostCollection;
-                });
+                $scope.refreshHostCollection();
             }, function (response) {
                 $scope.$parent.errorMessages.push(response.data.displayMessage);
                 $scope.isAdding  = false;

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-content-hosts.controller.js
@@ -57,6 +57,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionContentHost
                 angular.forEach(data.displayMessages.error, function (error) {
                     $scope.$parent.errorMessages.push(error);
                 });
+                $scope.refreshHostCollection();
 
                 $scope.isRemoving = false;
             }, function (response) {

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-details.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/host-collection-details.controller.js
@@ -42,6 +42,12 @@ angular.module('Bastion.host-collections').controller('HostCollectionDetailsCont
             $scope.panel.loading = false;
         });
 
+        $scope.refreshHostCollection = function () {
+            $scope.hostCollection.$get().then(function (hostCollection) {
+                $scope.$emit("updateContentHostCollection", hostCollection);
+            });
+        };
+
         $scope.save = function (hostCollection) {
             var deferred = $q.defer();
 

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/host-collections.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/host-collections.controller.js
@@ -47,5 +47,9 @@ angular.module('Bastion.host-collections').controller('HostCollectionsController
             $scope.transitionTo('host-collections.index');
         };
 
+        $scope.$on("updateContentHostCollection", function (event, hostCollectionRow) {
+            $scope.table.replaceRow(hostCollectionRow);
+        });
+
     }]
 );

--- a/engines/bastion/test/host-collections/details/host-collection-details.controller.test.js
+++ b/engines/bastion/test/host-collections/details/host-collection-details.controller.test.js
@@ -83,4 +83,14 @@ describe('Controller: HostCollectionDetailsController', function() {
         expect($scope.table.addRow).toHaveBeenCalledWith(newHostCollection)
     });
 
+    it("should be able to raise the host collection event on the .", function() {
+        var eventRaised = false;
+        $scope.$on("updateContentHostCollection", function (event, hostCollectionRow) {
+             eventRaised = true;
+        });
+        $scope.refreshHostCollection();
+        expect(eventRaised).toBe(true);
+    });
+
+
 });

--- a/engines/bastion/test/test-mocks.module.js
+++ b/engines/bastion/test/test-mocks.module.js
@@ -60,7 +60,11 @@ angular.module('Bastion.test-mocks').factory('MockResource', function () {
             label: '',
             failed: false,
             readonly: false,
-            $get: function() {},
+            $get: function() {
+                return {then: function(callback) {
+                    callback(mockResource);
+                }};
+            },
             $save: function(params, success, error) {
                 if (typeof(params) === "function") {
                     error = success;


### PR DESCRIPTION
Previously the content host counts in the rows of host collection index table
would not get updated. So for example if the host collection had 5 CH's and 6 th on got added
the updated CH count would not get reflected in the Host Collection index page. This
commit fixes that
