### PR TITLE
Fixes #6080/BZ1124058: fixing permissions of product buttons.

### DIFF
--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -51,7 +51,11 @@ end
 attributes :published_content_views
 
 node :readonly do |product|
-  product.redhat? || product.published_content_views.length > 0
+  product.redhat? 
+end
+
+node :can_remove do |product|
+  !product.redhat? && product.published_content_views.length == 0
 end
 
 extends 'katello/api/v2/common/timestamps'

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
@@ -13,7 +13,7 @@
 
       <button class="btn btn-default"
               ng-hide="denied('delete_products', product)"
-              ng-disabled="removingRepositories || repositoriesTable.numSelected == 0"
+              ng-disabled="removingRepositories || repositoriesTable.numSelected == 0 || !product.can_remove"
               ng-click="openModal()">
         <span ng-show="removingRepositories">
           <i class="icon-spinner inline-icon icon-spin"></i>

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
@@ -29,6 +29,7 @@
 
     <button class="btn btn-default"
             ng-click="openModal()"
+            ng-disabled="product.can_remove"
             ng-hide="denied('delete_products', product)">
       {{ "Remove Repository" | translate }}
     </button>


### PR DESCRIPTION
Several product buttons were using the incorrect permission
in determining whether to disable the buttons.  This commit
fixes these incorrect permissions.

http://projects.theforeman.org/issues/6808
https://bugzilla.redhat.com/show_bug.cgi?id=1124058
