### PR TITLE
Fixes #6826 - finish templ unable to render var

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -15,6 +15,7 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
+        include ::Katello::KatelloUrlsHelper
         alias_method_chain :validate_media?, :capsule
 
         has_one :content_host, :class_name => "Katello::System", :foreign_key => :host_id,


### PR DESCRIPTION
Finish templates are unable to render the view helper,
'subscriptions_manager_configuration_url'. Adding the helper to
Host::Managed so that the view helper can be rendered.
