### PR TITLE
Fixes #6808/BZ1124058: fixing permissions of product buttons.

### DIFF
--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -51,7 +51,7 @@ end
 attributes :published_content_views
 
 node :readonly do |product|
-  product.redhat? || product.published_content_views.length > 0
+  product.redhat? 
 end
 
 extends 'katello/api/v2/common/timestamps'

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-details.html
@@ -35,7 +35,7 @@
       </span>
 
       <button class="btn btn-default"
-              ng-hide="denied('delete_products', product) || product.readonly"
+              ng-hide="denied('delete_products', product) || product.readonly || product.published_content_views.length > 0"
               ng-click="openModal()">
         <i class="icon-trash"></i>
         {{ "Remove Product" | translate }}


### PR DESCRIPTION
Several product buttons were using the incorrect permission
in determining whether to disable the buttons.  This commit
fixes these incorrect permissions.

http://projects.theforeman.org/issues/6808
https://bugzilla.redhat.com/show_bug.cgi?id=1124058
