### PR TITLE
Fixes #6827/BZ1124607: hide CH Product tab if you lack permission.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content-hosts.module.js
@@ -102,7 +102,7 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
     })
     .state('content-hosts.details.products', {
         url: '/products',
-        permission: 'view_content_hosts',
+        permission: 'view_products',
         collapsed: true,
         controller: 'ContentHostProductsController',
         templateUrl: 'content-hosts/details/views/content-host-products.html'

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-details.html
@@ -70,7 +70,7 @@
           Errata
         </a>
       </li>
-      <li ng-class="{active: isState('content-hosts.details.products')}">
+      <li ng-hide="denied('view_products')" ng-class="{active: isState('content-hosts.details.products')}">
         <a translate
            ui-sref="content-hosts.details.products">
           Product Content


### PR DESCRIPTION
The Content Host Product tab was being shown even if you did not
have the correct permissions to view that page.  This commit hides
the tab if you cannot view the page.

http://projects.theforeman.org/issues/6827
https://bugzilla.redhat.com/show_bug.cgi?id=1124607
