### PR TITLE
Fixes #6828/BZ1104636: show correct version of puppet module.

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -110,7 +110,7 @@ module Katello
         search_filters << { :not => { :terms => { :id => current_ids } } }
       end
       search_filters << { :term => { :name => params[:name] } } if params[:name]
-      options = { :filters => search_filters }
+      options = { :filters => search_filters, :sort_by => 'sortable_version', :sort_order => 'DESC' }
 
       collection = item_search(PuppetModule, params, options)
       collection[:results] = collection[:results].map{|i| PuppetModule.new(i.as_json) }

--- a/app/models/katello/glue/elastic_search/puppet_module.rb
+++ b/app/models/katello/glue/elastic_search/puppet_module.rb
@@ -24,7 +24,7 @@ module Glue::ElasticSearch::PuppetModule
       "name_sort"         => name.downcase,
       "name_autocomplete" => name,
       "author_autocomplete" => author,
-      "sortable_version"  => sortable_version
+      "sortable_version_sort"  => sortable_version
     }
   end
 
@@ -49,6 +49,7 @@ module Glue::ElasticSearch::PuppetModule
             :name             => { :type => 'string', :analyzer => :kt_name_analyzer },
             :name_sort        => { :type => 'string', :index    => :not_analyzed },
             :sortable_version => { :type => 'string', :index    => :not_analyzed },
+            :sortable_version_sort => { :type => 'string', :index    => :not_analyzed },
             :repoids          => { :type => 'string', :index    => :not_analyzed }
           }
         }

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/content-view.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/content-view.factory.js
@@ -43,10 +43,10 @@ angular.module('Bastion.content-views').factory('ContentView',
                         var response = angular.fromJson(data);
 
                         angular.forEach(_.groupBy(response.results, 'author'), function (puppetModules) {
-                            var latest = angular.copy(puppetModules[puppetModules.length - 1]);
+                            var latest = angular.copy(puppetModules[0]);
                             latest.version = translate('Use Latest (currently %s)').replace('%s', latest.version);
                             latest.useLatest = true;
-                            response.results.unshift(latest);
+                            response.results.push(latest);
                         });
 
                         return response;

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
@@ -43,7 +43,7 @@
     </thead>
 
     <tbody>
-      <tr alch-table-row ng-repeat="item in versions.results | filter:filterTerm | orderBy:'author'">
+      <tr alch-table-row ng-repeat="item in versions.results | filter:filterTerm | orderBy: ['author', '-version']">
         <td alch-table-cell >{{ item.author }}</td>
         <td alch-table-cell >{{ item.version }}</td>
         <td alch-table-cell >{{ item.summary }}</td>


### PR DESCRIPTION
The latest version of puppet modules was being incorrectly
calculated, based on an incorrect assumption that the last
item in the array was the latest version.  This commit
explicitly sorts the puppet modules by the version such that
the latest version is correct.

http://projects.theforeman.org/issues/6828
https://bugzilla.redhat.com/show_bug.cgi?id=1104636
