### PR TITLE
fixes #6846 - correct link to hypervisor's content hosts

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-details-info.controller.js
@@ -64,7 +64,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
         $scope.cancelReleaseVersionUpdate = function () {
             $scope.showVersionAlert = false;
         };
-        
+
         $scope.cancelContentViewUpdate = function () {
             if ($scope.editContentView) {
                 $scope.editContentView = false;

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-info.html
@@ -37,10 +37,10 @@
       <div ng-show="contentHost.virtual_guests" class="detail">
         <span class="info-label" translate>Virtual Guests</span>
         <div class="info-value">
-          <a ng-href="/products?search={{ virtualGuestIds(contentHost) }}"
+          <a ng-href="/content_hosts?search={{ virtualGuestIds(contentHost) }}"
                  translate translate-n="contentHost.virtual_guests.length"
-                 translate-plural="{{ contentHost.virtual_guests.length }} Hosts">
-             1 Host
+                 translate-plural="{{ contentHost.virtual_guests.length }} Content Hosts">
+             1 Content Host
           </a>
         </div>
       </div>


### PR DESCRIPTION
Also changed wording from "1 Host" to "1 Content Host" since it seemed odd for a hypervisor to host a host.
