### PR TITLE
fixes #4922 - Fixes issue with not being able to update system facts, BZ 1103860

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -357,9 +357,10 @@ class Api::V2::SystemsController < Api::V2::ApiController
 
   def system_params(params)
     system_params = params.require(:system).permit(:name, :description, :location, :owner, :type,
-                                                   :service_level, :autoheal, {:facts => []},
+                                                   :service_level, :autoheal,
                                                    :guest_ids, {:host_collection_ids => []})
 
+    system_params[:facts] = params[:system][:facts].permit! if params[:system][:facts]
     system_params[:cp_type] = params[:type] ? params[:type] : ::Katello::System::DEFAULT_CP_TYPE
     system_params.delete(:type) if params[:system].key?(:type)
 


### PR DESCRIPTION
As the fix stands, it will replace all facts with the ones supplied in the change request.  It cannot be passed in strong parameters, as you have to explicitly title each permitted parameter, and the facts hash does are not explicit.
