### PR TITLE
Fixes #6354,bz1112717 - AK available_release perm

### DIFF
--- a/lib/katello/permissions/activation_key_permissions.rb
+++ b/lib/katello/permissions/activation_key_permissions.rb
@@ -4,7 +4,7 @@ Foreman::Plugin.find(:katello).security_block :activation_keys do
   permission :view_activation_keys,
              {
               'katello/activation_keys' => [:all, :index],
-              'katello/api/v2/activation_keys' => [:index, :show, :available_host_collections]
+              'katello/api/v2/activation_keys' => [:index, :show, :available_host_collections, :available_releases]
              },
              :resource_type => 'Katello::ActivationKey'
   permission :create_activation_keys,


### PR DESCRIPTION
Allow acess to available_release if user has permissions to
view_activation_key.
