### PR TITLE
fixes #6550 / BZ 1117952 - fix issues with changing org name which affected running db:seed

### DIFF
--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -76,11 +76,11 @@ module Katello
 
         # Ensure that the name and label namespaces do not overlap
         def unique_name_and_label
-          if new_record? && Organization.where("name = ? OR label = ?", label, name).any?
+          if new_record? && Organization.where("name = ? OR label = ?", name, label).any?
             errors.add(:organization, _("Names and labels must be unique across all organizations"))
-          elsif label_changed? && Organization.where("id != ? AND name = ?", id, label).any?
+          elsif label_changed? && Organization.where("id != ? AND label = ?", id, label).any?
             errors.add(:label, _("Names and labels must be unique across all organizations"))
-          elsif name_changed? && Organization.where("id != ? AND label = ?", id, name).any?
+          elsif name_changed? && Organization.where("id != ? AND name = ?", id, name).any?
             errors.add(:name, _("Names and labels must be unique across all organizations"))
           else
             true

--- a/app/models/katello/ext/label_from_name.rb
+++ b/app/models/katello/ext/label_from_name.rb
@@ -22,6 +22,9 @@ module Ext
     def setup_label_from_name
       unless label.present?
         self.label = Util::Model.labelize(name)
+        if self.class.where(:label => self.label).any?
+          self.label = Util::Model.uuid
+        end
       end
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -67,17 +67,7 @@ describe Organization do
     end
     it "should complain on duplicate label" do
       lambda{
-        Organization.create!(:name => @organization.name + "_changed", :label =>@organization.name)
-      }.must_raise(ActiveRecord::RecordInvalid)
-    end
-    it "should complain on duplicate name when label is taken" do
-      lambda{
-        Organization.create!(:name => @organization.label)
-      }.must_raise(ActiveRecord::RecordInvalid)
-    end
-    it "should complain on duplicate label when name is taken" do
-      lambda{
-        Organization.create!(:label => @organization.name)
+        Organization.create!(:name => @organization.name + "_changed", :label => @organization.label)
       }.must_raise(ActiveRecord::RecordInvalid)
     end
     it "should complain if the label is invalid" do
@@ -98,8 +88,8 @@ describe Organization do
     end
     it "can update label" do
       new_label = @organization.label + "_changed"
-      @organization = Organization.update(@organization.id, {:name => new_label})
-      @organization.name.must_equal(new_label)
+      @organization = Organization.update(@organization.id, {:label => new_label})
+      @organization.label.must_equal(new_label)
     end
     it "name update is ok for overlapping label from the same org" do
       @organization = Organization.update(@organization.id, {:name => @organization.label})
@@ -111,13 +101,31 @@ describe Organization do
     end
     it "name update should fail when already taken for different org" do
       lambda{
-        @organization.update_attributes!({:name => @organization2.label})
+        @organization.update_attributes!({:name => @organization2.name})
       }.must_raise(ActiveRecord::RecordInvalid)
     end
     it "label update should fail when already taken for different org" do
       lambda{
-        @organization.update_attributes!({:label => @organization2.name})
+        @organization.update_attributes!({:label => @organization2.label})
       }.must_raise(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe "update existing org name and create a new org using the original org name" do
+    it "allows user to perform scenario" do
+      original_org_name = "original org name"
+      new_org_name = "new org name"
+
+      @organization1 = Organization.create!(:name => original_org_name)
+      assert_equal @organization1.name, original_org_name
+
+      @organization1.name = new_org_name
+      @organization1.save!
+      assert_equal @organization1.name, new_org_name
+
+      @organization2 = Organization.create!(:name => original_org_name)
+      assert_equal @organization2.name, original_org_name
+      refute_equal @organization1.label, @organization2.label
     end
   end
 
@@ -182,7 +190,7 @@ describe Organization do
   end
 
   describe "it can retrieve manifest history" do
-    test 'test manifest history should be successful' do 
+    test 'test manifest history should be successful' do
       @organization = @organization.reload
       @organization.expects(:imports).returns([{'foo' => 'bar' },{'foo' => 'bar'}])
       assert @organization.manifest_history[0].foo == 'bar'


### PR DESCRIPTION
Without these changes, the user cannot change the default organization
name and re-run 'rake db:seed'.  The reason being, it would attempt
to create an organization with a label that was already in use and
the seed would fail.

In order to address this, this commit does a couple of things:
1. when creating an org, if a label is automatically generated
   and it is already in use, re-generate the label using a uuid.
2. fix an existing validation which was incorrectly comparing
   name=label, label=name, etc. during org create and update.
