### PR TITLE
fixes #6913 / BZ 1092143 - content view version - disable promote/remove on failed task

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-versions.controller.js
@@ -85,6 +85,14 @@ angular.module('Bastion.content-views').controller('ContentViewVersionsControlle
             return inProgress;
         };
 
+        $scope.taskFailed = function (version) {
+            var failed = false;
+            if (version.task && (version.task.result === 'error')) {
+                failed = true;
+            }
+            return failed;
+        };
+
         function findTaskTypes(activeHistory, taskType) {
             return _.filter(activeHistory, function (history) {
                 return history.task.label === taskType;

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
@@ -69,7 +69,7 @@
           <button class="btn btn-default"
                   ui-sref="content-views.details.promotion({contentViewId: contentView.id, versionId: version.id})"
                   ng-hide="denied('promote_or_remove_content_views', contentView)"
-                  ng-disabled="taskInProgress(version)">
+                  ng-disabled="taskInProgress(version) || taskFailed(version)">
             <i class="icon-share-alt"></i>
             <span translate>
               Promote
@@ -78,7 +78,7 @@
           <button class="btn btn-default"
                   ui-sref="content-views.details.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})"
                   ng-hide="denied('promote_or_remove_content_views', contentView)"
-                  ng-disabled="taskInProgress(version)">
+                  ng-disabled="taskInProgress(version) || taskFailed(version)">
             <i class="icon-trash"></i>
             <span translate>
               Remove

--- a/engines/bastion/app/assets/javascripts/bastion/tasks/aggregate-task.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/tasks/aggregate-task.factory.js
@@ -37,6 +37,7 @@ angular.module('Bastion.tasks').factory('AggregateTask',
                 taskSearches = {},
                 taskRepresentation = {
                     state: undefined,
+                    result: undefined,
                     progressbar: {}
                 };
 
@@ -90,6 +91,21 @@ angular.module('Bastion.tasks').factory('AggregateTask',
                 });
                 return found;
             },
+            greatestResult = function () {
+                var found = 'success',
+                    weights = {
+                        error: 4,
+                        warning: 3,
+                        pending: 2,
+                        success: 1
+                    };
+                _.each(taskMap, function (task) {
+                    if (weights[task.result] > weights[found]) {
+                        found = task.result;
+                    }
+                });
+                return found;
+            },
             updateProgress = function () {
                 var total = 0;
                 _.each(taskMap, function (task) {
@@ -98,6 +114,7 @@ angular.module('Bastion.tasks').factory('AggregateTask',
                 taskRepresentation.progressbar.value = total / _.size(taskMap);
                 taskRepresentation.progressbar.type = greatestType();
                 taskRepresentation.state = greatestState();
+                taskRepresentation.result = greatestResult();
             };
 
             taskRepresentation.unregisterAll = unregisterAll;

--- a/engines/bastion/test/content-views/details/content-view-versions.controller.test.js
+++ b/engines/bastion/test/content-views/details/content-view-versions.controller.test.js
@@ -75,6 +75,23 @@ describe('Controller: ContentViewVersionsController', function() {
         expect($scope.taskInProgress(version)).toBe(false);
     });
 
+    it("correctly returns task failed", function() {
+        var version = {};
+        expect($scope.taskFailed(version)).toBe(false);
+
+        version = {task: {result: 'success'}};
+        expect($scope.taskFailed(version)).toBe(false);
+
+        version = {task: {result: 'pending'}};
+        expect($scope.taskFailed(version)).toBe(false);
+
+        version = {task: {result: 'warning'}};
+        expect($scope.taskFailed(version)).toBe(false);
+
+        version = {task: {result: 'error'}};
+        expect($scope.taskFailed(version)).toBe(true);
+    });
+
     it("determines what history text to display", function() {
         var version = {active_history: [],
             last_event: {environment: {name: 'test'},


### PR DESCRIPTION
This commit will disable the promote/remove buttons for a content view version,
if the current task being executed resulted in an error.  Once the error
has been resolved and the task completes, the buttons will be re-enabled.
