### PR TITLE
Fixes #6918,BZ1125999 - Removing dupe products in sync widget

### DIFF
--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -64,7 +64,8 @@ class Product < Katello::Model
 
   scope :engineering, where(:type => "Katello::Product")
   scope :marketing, where(:type => "Katello::MarketingProduct")
-  scope :syncable_content, joins(:repositories).where(Katello::Repository.arel_table[:url].not_eq(nil))
+  scope :syncable_content, uniq.where(Katello::Repository.arel_table[:url].not_eq(nil))
+    .joins(:repositories)
 
   before_create :assign_unique_label
 

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -76,7 +76,7 @@ module Katello
 
     def test_syncable_content
       products = Katello::Product.syncable_content
-      refute_empty products
+      assert_equal 2, products.length
       products.each { |prod| assert prod.syncable_content? }
     end
   end


### PR DESCRIPTION
Products were getting returned twice from the DB due to the join.
