### PR TITLE
fixes #6919 / BZ 1113588 - host - show validation error if no puppet environment

### DIFF
--- a/app/overrides/foreman/activation_keys/_host_environment_select.html.erb
+++ b/app/overrides/foreman/activation_keys/_host_environment_select.html.erb
@@ -38,11 +38,11 @@
     });
 </script>
 
-<%= field(f, _("Lifecycle Environment"), { :include_blank => true }) do
+<%= field(f, :kt_environment_id, { :include_blank => true, :label => _("Lifecycle Environment") }) do
   select_tag :kt_environment_id, grouped_env_options, :class => 'form-control', :onchange => 'update_environment_label(this);'
 end %>
 
-<%= field(f, _("Puppet Environment"), { :include_blank => true }) do
+<%= field(f, :environment_id, { :include_blank => true, :label => _("Puppet Environment") }) do
   f.select :environment_id,
            content_view_options,
            { :include_blank => true },


### PR DESCRIPTION
This commit contains a small change so that if the user doesn't provide
a puppet environment, they'll see the validation error sent by the server.

E.g. Puppet Environment: [] can't be blank

The code change is to ensure that the html rendered includes
'for="environment_id"', which is used to support displaying
the error associated with that attribute.
