### PR TITLE
fixes #6330 - using pulp & pulp_node features of smart proxy

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -71,7 +71,7 @@ module Katello
     protected
 
     def find_capsule
-      @capsule = SmartProxy.authorized(:manage_capsule_content).find(params[:id])
+      @capsule = SmartProxy.authorized(:manage_capsule_content).with_features(SmartProxy::PULP_NODE_FEATURE).find(params[:id])
     end
 
     def find_environment

--- a/app/controllers/katello/api/v2/capsules_controller.rb
+++ b/app/controllers/katello/api/v2/capsules_controller.rb
@@ -20,7 +20,9 @@ module Katello
     api :GET, '/capsules', 'List all capsules'
     param_group :search, Api::V2::ApiController
     def index
-      super
+      @smart_proxies = SmartProxy.with_content.authorized(:view_smart_proxies).includes(:features).
+                search_for(*search_options).paginate(paginate_options)
+      @total = SmartProxy.with_content.authorized(:view_smart_proxies).includes(:features).count
     end
 
     api :GET, '/capsules/:id', 'Show the capsule details'

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -61,8 +61,7 @@ module Katello
     end
 
     def self.default_capsule
-      server_fqdn = Facter.value(:fqdn) || SETTINGS[:fqdn]
-      proxy = SmartProxy.where(name: server_fqdn).first
+      proxy = SmartProxy.with_features(SmartProxy::PULP_FEATURE).first
       self.new(proxy) if proxy
     end
   end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -16,6 +16,9 @@ module Katello
     module SmartProxyExtensions
       extend ActiveSupport::Concern
 
+      PULP_FEATURE = "Pulp"
+      PULP_NODE_FEATURE = "Pulp Node"
+
       included do
         before_create :associate_organizations
         before_create :associate_default_location
@@ -37,11 +40,13 @@ module Katello
                  :inverse_of => :content_source
         has_many :hostgroups, :class_name => "::Hostgroup",     :foreign_key => :content_source_id,
                  :inverse_of => :content_source
+
+        scope :with_content, with_features(PULP_FEATURE, PULP_NODE_FEATURE)
+
       end
 
       def default_capsule?
-        server_fqdn = Facter.value(:fqdn) || SETTINGS[:fqdn]
-        self.name == server_fqdn
+        self.features.pluck(:name).include?(PULP_FEATURE)
       end
 
       def associate_organizations

--- a/app/overrides/foreman/activation_keys/_host_environment_select.html.erb
+++ b/app/overrides/foreman/activation_keys/_host_environment_select.html.erb
@@ -52,7 +52,7 @@ end %>
              :class => 'form-control' }
 end %>
 
-<% proxies = SmartProxy.unscoped.with_taxonomy_scope(@location,@organization,:path_ids) %>
+<% proxies = SmartProxy.with_content.unscoped.with_taxonomy_scope(@location,@organization,:path_ids) %>
 <% if proxies.count > 0 %>
     <%= select_f f, :content_source_id, proxies, :id, :name,
              { :include_blank => blank_or_inherit_f(f, :content_source) },

--- a/app/overrides/foreman/smart_proxies/_environment_tab.html.erb
+++ b/app/overrides/foreman/smart_proxies/_environment_tab.html.erb
@@ -1,4 +1,4 @@
-<% unless @smart_proxy.new_record? -%>
+<% if !@smart_proxy.new_record? && @smart_proxy.features.pluck(:name).include?(SmartProxy::PULP_NODE_FEATURE) -%>
   <li id="kt_environments_tab">
     <a href="#kt_environments" data-toggle="tab"><%= _('Lifecyle Environments') %></a>
   </li>

--- a/app/overrides/foreman/smart_proxies/_environment_tab_pane.html.erb
+++ b/app/overrides/foreman/smart_proxies/_environment_tab_pane.html.erb
@@ -1,4 +1,4 @@
-<% unless @smart_proxy.new_record? -%>
+<% if !@smart_proxy.new_record? && @smart_proxy.features.pluck(:name).include?(SmartProxy::PULP_NODE_FEATURE) -%>
   <div class="tab-pane" id="kt_environments">
     <%= multiple_selects f, :lifecycle_environments, Katello::KTEnvironment.completer_scope(:organization_id => ::Organization.current.try(:id)), @smart_proxy.lifecycle_environment_ids, {:label => _('Lifecyle Environments')}, @smart_proxy.default_capsule? ? {:disabled => :disabled } : {}  %>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,3 +125,8 @@ Role.without_auditing do
 end
 
 Setting.find_by_name("dynflow_enable_console").update_attributes!(:value => true) if Rails.env.development?
+
+["Pulp", "Pulp Node"].each do |input|
+  f = Feature.find_or_create_by_name(input)
+  fail "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
+end

--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -14,7 +14,7 @@ module Support
 module CapsuleSupport
 
   def pulp_feature
-    @pulp_feture ||= Feature.create(name: "Pulp")
+    @pulp_feture ||= Feature.create(name: SmartProxy::PULP_NODE_FEATURE)
   end
 
   def proxy_with_pulp


### PR DESCRIPTION
- to determine the default smart proxy
- to determine whether to show the lifecycle env selection screen
- to determine which proxies to show under the content source selection on host(group) page

Depends on 
- [x] https://github.com/theforeman/smart-proxy-pulp/pull/1
- [x] https://github.com/Katello/puppet-capsule/pull/13
- [x] https://github.com/Katello/katello-installer/pull/95
