### PR TITLE
Refs #6777: Add organization association validator to models.

### DIFF
--- a/app/lib/actions/katello/environment/library_create.rb
+++ b/app/lib/actions/katello/environment/library_create.rb
@@ -26,6 +26,7 @@ module Actions
             v.version = 1
           end
 
+          library_view.reload
           version = library_view.versions.first
 
           plan_action(Katello::ContentView::Create, library_view)

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -51,6 +51,7 @@ class ActivationKey < Katello::Model
     end
   end
   validates_with Validators::ContentViewEnvironmentValidator
+  validates_with OrganizationAssociationValidator
 
   scope :in_environment, lambda { |env| where(:environment_id => env) }
 

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -65,6 +65,7 @@ class ContentView < Katello::Model
 
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
+  validates_with OrganizationAssociationValidator
 
   scope :default, where(:default => true)
   scope :non_default, where(:default => false)

--- a/app/models/katello/gpg_key.rb
+++ b/app/models/katello/gpg_key.rb
@@ -31,6 +31,7 @@ class GpgKey < Katello::Model
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates_with Validators::ContentValidator, :attributes => :content
   validates_with Validators::GpgKeyContentValidator, :attributes => :content, :if => proc { Katello.config.gpg_strict_validation }
+  validates_with OrganizationAssociationValidator
 
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :organization_id, :complete_value => true

--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -39,6 +39,7 @@ class HostCollection < Katello::Model
                                                    :greater_than_or_equal_to => 1,
                                                    :less_than_or_equal_to => 2_147_483_647,
                                                    :message => N_("must be a positive integer value.")}
+  validates_with OrganizationAssociationValidator
 
   alias_attribute :content_host_limit, :max_content_hosts
   validate :validate_max_content_hosts

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -65,6 +65,7 @@ class KTEnvironment < Katello::Model
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_with Validators::PriorValidator
   validates_with Validators::PathDescendentsValidator
+  validates_with OrganizationAssociationValidator
 
   has_many :capsule_lifecycle_environments, :foreign_key => :lifecycle_environment_id,
            :dependent => :destroy, :inverse_of => :lifecycle_environment

--- a/app/models/katello/notice.rb
+++ b/app/models/katello/notice.rb
@@ -27,6 +27,7 @@ class Notice < Katello::Model
   validates :user_notices, :length => {:minimum => 1}
   validates :level, :length => {:maximum => 255}
   validates :request_type, :length => {:maximum => 255}
+  validates_with OrganizationAssociationValidator
 
   before_validation :set_default_notice_level
   before_validation :trim_text

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -44,6 +44,7 @@ class Product < Katello::Model
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_with Validators::ProductUniqueAttributeValidator, :attributes => :name
   validates_with Validators::ProductUniqueAttributeValidator, :attributes => :label
+  validates_with OrganizationAssociationValidator
 
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :organization_id, :complete_value => true
@@ -111,10 +112,6 @@ class Product < Katello::Model
 
   def enabled?
     !self.provider.redhat_provider? || self.repositories.present?
-  end
-
-  def organization
-    provider.organization
   end
 
   def library

--- a/app/models/katello/provider.rb
+++ b/app/models/katello/provider.rb
@@ -42,6 +42,7 @@ class Provider < Katello::Model
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
   validates_with Validators::KatelloUrlFormatValidator, :if => :redhat_provider?,
                                                         :attributes => :repository_url
+  validates_with OrganizationAssociationValidator
 
   before_destroy :prevent_redhat_deletion
   before_validation :sanitize_repository_url

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -37,6 +37,7 @@ class SyncPlan < Katello::Model
   validate :validate_sync_date
   validates_with Validators::KatelloNameFormatValidator, :attributes => :name
   validates_with Validators::KatelloDescriptionFormatValidator, :attributes => :description
+  validates_with OrganizationAssociationValidator
 
   before_save :reassign_sync_plan_to_products
 

--- a/spec/helpers/organization_helper_methods.rb
+++ b/spec/helpers/organization_helper_methods.rb
@@ -45,7 +45,7 @@ module OrganizationHelperMethods
     if !attrs[:content_view]
         find_or_create_content_view(env)
     end
-    env
+    env.reload
   end
 
   def find_or_create_content_view(env)
@@ -85,6 +85,7 @@ module OrganizationHelperMethods
     cv.repositories = repos
     cv.save!
     cv.publish(:async => false)
+    cv.reload
     cv
   end
 

--- a/spec/models/gpg_key_spec.rb
+++ b/spec/models/gpg_key_spec.rb
@@ -40,7 +40,7 @@ describe GpgKey, :katello => true do
     it 'should be destroyable' do
       gpg_key = GpgKey.create!(:name => "Gpg Key 1", :content => @test_gpg_content, :organization => @organization)
       disable_product_orchestration
-      create(:katello_product, :fedora, provider: create(:katello_provider), organization: organization).tap do |product|
+      create(:katello_product, :fedora, provider: create(:katello_provider, :organization => @organization), organization: @organization).tap do |product|
         product.gpg_key = gpg_key
         product.save!
       end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -155,7 +155,7 @@ describe Organization do
       @organization.kt_environments << @env1
       @env1.save!
 
-      @env2 = KTEnvironment.new(:name=>env_name, :label=> env_name, :organization => @org2, :prior => @organization.library)
+      @env2 = KTEnvironment.new(:name=>env_name, :label=> env_name, :organization => @org2, :prior => @org2.library)
       @org2.kt_environments << @env2
       @env2.save!
 
@@ -182,7 +182,7 @@ describe Organization do
   end
 
   describe "it can retrieve manifest history" do
-    test 'test manifest history should be successful' do 
+    test 'test manifest history should be successful' do
       @organization = @organization.reload
       @organization.expects(:imports).returns([{'foo' => 'bar' },{'foo' => 'bar'}])
       assert @organization.manifest_history[0].foo == 'bar'


### PR DESCRIPTION
This adds the use of the organization association validator from
Foreman to models with a belongs_to relationship to organization.
This validator ensures that when two resources with belongs_to
relationships to organization are associated that they belong
to the same organization.