### PR TITLE
Fixes #6971,bz1085417 - api handle nonexistent id

### DIFF
--- a/app/controllers/katello/api/v2/capsules_controller.rb
+++ b/app/controllers/katello/api/v2/capsules_controller.rb
@@ -29,14 +29,14 @@ module Katello
       super
     end
 
+    def resource_name
+      :smart_proxy
+    end
+
     protected
 
     def resource_class
       SmartProxy
-    end
-
-    def resource_name
-      :smart_proxy
     end
 
     def authorized

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -109,7 +109,8 @@ module Katello
     protected
 
     def find_product
-      @product = Product.find_by_id(params[:id]) if params[:id]
+      @product = Product.find_by_id(params[:id])
+      fail HttpErrors::NotFound, _("Couldn't find product '%s'") % params[:id] unless @product
     end
 
     def find_activation_key


### PR DESCRIPTION
In capsule and product APIs, the show action for a nonexistant id fails
to give a proper 404.

for example /api/products/123123 where product 123132 does not exist
product gives 500 no resource loaded

capsule gives protected method `resource_name' called for
