### PR TITLE
Fixes #6985,BZ1127747 - Reusing CVEnv action in org destroy

### DIFF
--- a/app/lib/actions/katello/content_view_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_environment/destroy.rb
@@ -15,7 +15,8 @@ module Actions
     module ContentViewEnvironment
       class Destroy < Actions::Base
 
-        def plan(cv_env)
+        def plan(cv_env, options = {})
+          skip_cp_update = options.fetch(:skip_candlepin_update, false)
           content_view = cv_env.content_view
           environment = cv_env.environment
           content_view.check_remove_from_environment!(environment)
@@ -33,10 +34,10 @@ module Actions
                 plan_action(ContentViewPuppetEnvironment::Destroy, puppet_env)
               end
             end
-            plan_action(Candlepin::Environment::Destroy, cp_id: cv_env.cp_id)
+            plan_action(Candlepin::Environment::Destroy, cp_id: cv_env.cp_id) unless skip_cp_update
 
             cv_env.reload
-            cv_env.destroy
+            cv_env.destroy!
           end
         end
 

--- a/app/lib/actions/katello/organization/destroy.rb
+++ b/app/lib/actions/katello/organization/destroy.rb
@@ -69,21 +69,7 @@ module Actions
         end
 
         def remove_content_view_environment(cv_env)
-          content_view = cv_env.content_view
-          environment = cv_env.environment
-
-          concurrence do
-            content_view.repos(environment).each do |repo|
-              plan_action(Repository::Destroy, repo, skip_environment_update: true)
-            end
-
-            if puppet_env = content_view.puppet_env(environment)
-              plan_action(ContentViewPuppetEnvironment::Destroy, puppet_env)
-            end
-          end
-
-          cv_env.reload
-          cv_env.destroy!
+          plan_action(ContentViewEnvironment::Destroy, cv_env, skip_candlepin_update: true)
         end
 
         def remove_content_views(organization)


### PR DESCRIPTION
We also have a bug open against Product::Destroy not being used:

http://projects.theforeman.org/issues/6654
