### PR TITLE
Fixes #6993: Allow repo-discovery through a proxy.

### DIFF
--- a/app/lib/actions/katello/repository/discover.rb
+++ b/app/lib/actions/katello/repository/discover.rb
@@ -28,7 +28,7 @@ module Actions
         end
 
         def run
-          repo_discovery = ::Katello::RepoDiscovery.new(input[:url])
+          repo_discovery = ::Katello::RepoDiscovery.new(input[:url], proxy)
           output[:repo_urls] = []
           found = lambda { |path| output[:repo_urls] << path }
           # TODO: implement task cancelling
@@ -45,6 +45,19 @@ module Actions
         def task_output
           output[:repo_urls] || []
         end
+
+        def proxy
+          proxy = {}
+
+          config = ::Katello.config.cdn_proxy
+          proxy[:proxy_host] = URI.parse(config.host).host if config.respond_to?(:host)
+          proxy[:proxy_port] = config.port if config.respond_to?(:port)
+          proxy[:proxy_user] = config.user if config.respond_to?(:user)
+          proxy[:proxy_password] = config.password if config.respond_to?(:password)
+
+          proxy
+        end
+
       end
     end
   end

--- a/app/lib/katello/repo_discovery.rb
+++ b/app/lib/katello/repo_discovery.rb
@@ -15,13 +15,14 @@ class RepoDiscovery
 
   attr_reader :found
 
-  def initialize(url)
+  def initialize(url, options = {})
     #add a / on the end, as directories require it or else
     #  They will get double slahes on them
     url += '/' if !url.ends_with?('/')
     @uri = URI(url)
     @found = []
     @crawled = []
+    @options = options
   end
 
   def run(found_lambda, continue_lambda)
@@ -37,7 +38,7 @@ class RepoDiscovery
   private
 
   def http_crawl(found_lambda, continue_lambda)
-    Anemone.crawl(@uri) do |anemone|
+    Anemone.crawl(@uri, @options) do |anemone|
 
       anemone.focus_crawl do |page|
         return false if !continue_lambda.call

--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -33,6 +33,7 @@ require "delayed_job"
 
 require File.expand_path("../engines/bastion/lib/bastion", File.dirname(__FILE__))
 require "monkeys/string_to_bool"
+require "monkeys/anemone"
 
 module Katello
 

--- a/lib/monkeys/anemone.rb
+++ b/lib/monkeys/anemone.rb
@@ -1,0 +1,35 @@
+# Provides a patch to https://github.com/chriskite/anemone/blob/next/lib/anemone/http.rb#L162
+# to allow providing proxy user and password
+
+module Anemone
+  class HTTP
+
+    #
+    # The proxy user string
+    #
+    def proxy_user
+      @opts[:proxy_user]
+    end
+
+    #
+    # The proxy password
+    #
+    def proxy_password
+      @opts[:proxy_password]
+    end
+
+    def refresh_connection(url)
+      http = Net::HTTP.new(url.host, url.port, proxy_host, proxy_port, proxy_user, proxy_password)
+
+      http.read_timeout = read_timeout if !!read_timeout
+
+      if url.scheme == 'https'
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end
+
+      @connections[url.host][url.port] = http.start
+    end
+
+  end
+end


### PR DESCRIPTION
Note that the Anemone gem allows the passing of proxy_host and proxy_port
by default but does not currently support proxy user and password.
In order to get around this, a monkey patch is applied to anemone
to allow passing user and port.
