### PR TITLE
fixes #6992 - ensure rhel 5 repos can be used by el5 clients

### DIFF
--- a/app/lib/actions/katello/repository/correct_checksum.rb
+++ b/app/lib/actions/katello/repository/correct_checksum.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module Repository
+      class CorrectChecksum < Actions::Base
+
+        def plan(repo)
+         plan_self(:repo_id => repo.id)
+        end
+
+        def finalize
+          ::User.current = ::User.hidden.first
+          repo = ::Katello::Repository.find(input[:repo_id])
+          found_checksum = repo.pulp_checksum_type
+
+          if found_checksum && repo.checksum_type != found_checksum
+            repo.checksum_type = found_checksum
+            repo.save!
+          end
+        ensure
+          ::User.current = nil
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -62,7 +62,11 @@ module Actions
                 plan_action(ContentView::UpdateEnvironment, org.default_content_view,
                             org.library, content_create.input[:content_id])
               end
-              plan_action(Katello::Repository::MetadataGenerate, repository) unless repository.puppet?
+
+              #skip metadata generation until https://bugzilla.redhat.com/show_bug.cgi?id=1127793 is resolved
+              if !repository.puppet? && !repository.redhat?
+                plan_action(Katello::Repository::MetadataGenerate, repository)
+              end
               plan_action(ElasticSearch::Reindex, repository)
             end
           end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -36,6 +36,7 @@ module Actions
             end
             plan_action(ElasticSearch::Reindex, repo)
             plan_action(Katello::Foreman::ContentUpdate, repo.environment, repo.content_view)
+            plan_action(Katello::Repository::CorrectChecksum, repo)
           end
         end
 


### PR DESCRIPTION
We can not publish the repos prior to syncing as this will cause
pulp to set the checksum on the repos to sha256.  See https://bugzilla.redhat.com/show_bug.cgi?id=1127793
We also need to pull the checksum after sync and add it to the repo
to ensure that clones use the same checksum
