### PR TITLE
Fixes #6995: restore pulp_celerybeat to list of services to restart.

### DIFF
--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -5,7 +5,7 @@ namespace :katello do
     service_start = "sudo /sbin/service %s start"
 
     task :pulp do
-      SERVICES = %w(httpd pulp_workers pulp_resource_manager)
+      SERVICES = %w(httpd pulp_workers pulp_resource_manager pulp_celerybeat)
       system(service_stop.gsub("%s", "mongod"))
 
       SERVICES.each{|s| system(service_stop.gsub("%s", s)) }


### PR DESCRIPTION
The service pulp_celerybeat was removed from the list of services
restarted with a katello:reset during the pulp 2.4 upgrade. Restarting
the service is working fine now so this commit restores pulp_celerybeat
to the list of services to start/stop during katello:reset.

http://projects.theforeman.org/issues/6995
