### PR TITLE
Error message fix when organizations disabled

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -99,6 +99,10 @@ module Katello
         })
       FastGettext.default_text_domain = 'katello'
 
+      unless SETTINGS[:organizations_enabled]
+        fail Foreman::Exception.new(N_("Organizations disabled, try allowing them in foreman/config/settings.yaml"))
+      end
+
       # Model extensions
       ::Environment.send :include, Katello::Concerns::EnvironmentExtensions
       ::Host::Managed.send :include, Katello::Concerns::HostManagedExtensions


### PR DESCRIPTION
When :oragnizations_enable in foreman/config/settings.yaml is set to false, we get corresponding error message instead of 'undefined method for nil:NilClass'

cc @pitr-ch 
