### PR TITLE
fixes #6981 - handle non-yum sync statuses

### DIFF
--- a/app/lib/actions/pulp/repository/presenters/iso_presenter.rb
+++ b/app/lib/actions/pulp/repository/presenters/iso_presenter.rb
@@ -1,0 +1,71 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Pulp
+    module Repository
+      module Presenters
+
+        class IsoPresenter < Helpers::Presenter::Base
+          include ActionView::Helpers::NumberHelper
+
+          def humanized_output
+            if action.external_task
+              humanized_details
+            end
+          end
+
+          def progress
+            total_bytes == 0 ? 0.01 : finished_bytes.to_f / total_bytes
+          end
+
+          private
+
+          def humanized_details
+            ret = []
+            ret << _("Cancelled.") if cancelled?
+            ret << _("New ISOs: %s") % num_isos
+            ret.join("\n")
+          end
+
+          def sync_task
+            action.external_task.select{ |task| task['tags'].include?("pulp:action:sync") }.first
+          end
+
+          def cancelled?
+            sync_task['state'] == 'canceled'
+          end
+
+          def num_isos
+            task_progress_details['num_isos'] || 0
+          end
+
+          def total_bytes
+            task_progress_details['total_bytes'] || 0
+          end
+
+          def finished_bytes
+            task_progress_details['finished_bytes'] || 0
+          end
+
+          def task_progress_details
+            task_progress && task_progress['iso_importer']
+          end
+
+          def task_progress
+            sync_task['progress_report']
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/presenters/puppet_presenter.rb
+++ b/app/lib/actions/pulp/repository/presenters/puppet_presenter.rb
@@ -1,0 +1,96 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Pulp
+    module Repository
+      module Presenters
+
+        class PuppetPresenter < Helpers::Presenter::Base
+
+          include ActionView::Helpers::NumberHelper
+
+          def humanized_output
+            if action.external_task
+              humanized_details
+            end
+          end
+
+          def progress
+            #TODO: Add proper progress reporting
+            # Requires https://bugzilla.redhat.com/show_bug.cgi?id=1128274 to be fixed
+            0
+          end
+
+          private
+
+          def humanized_details
+            ret = []
+            ret << _("Cancelled.") if cancelled?
+
+            if total_count > 0
+              ret << (_("Total module count: %s.") % [total_count])
+            end
+
+            if error_count > 0
+              ret << n_("Failed to download %s module.", "Failed to download %s modules.",
+                        error_count) % error_count
+            end
+            ret.join("\n")
+          end
+
+          def added_count
+            task_result['added_count']
+          end
+
+          def updated_count
+            task_result['updated_count']
+          end
+
+          def total_count
+            task_progress_details['modules']['total_count'] || 0
+          end
+
+          def error_count
+            task_result_details['error_count'] || 0
+          end
+
+          def sync_task
+            action.external_task.select{ |task| task['tags'].include?("pulp:action:sync") }.first
+          end
+
+          def cancelled?
+            sync_task['state'] == 'canceled'
+          end
+
+          def task_result
+            sync_task['result']
+          end
+
+          def task_result_details
+            task_result ? task_result['details'] : {}
+          end
+
+          def task_progress
+            sync_task['progress_report']
+          end
+
+          def task_progress_details
+            task_progress && task_progress['puppet_importer']
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/presenters/yum_presenter.rb
+++ b/app/lib/actions/pulp/repository/presenters/yum_presenter.rb
@@ -1,0 +1,166 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Pulp
+    module Repository
+      module Presenters
+
+        class YumPresenter < Helpers::Presenter::Base
+
+          # TODO: in Rails 4.0, the logic is possible to use from ActiveSupport
+          include ActionView::Helpers::NumberHelper
+
+          def humanized_output
+           if action.external_task
+             humanized_details
+           end
+          end
+
+          def progress
+           if sync_task && size_total > 0
+             size_done.to_f / size_total
+           else
+             0.01
+           end
+          end
+
+          private
+
+          def humanized_details
+           ret = []
+           ret << _("Cancelled.") if cancelled?
+
+           if pending?
+             ret << _("Pending")
+           elsif content_started?
+             if items_total > 0
+               ret << (_("New packages: %s (%s).") % [count_summary, size_summary])
+             else
+               #if there are no new packages, it could just mean that they have not started downloading yet
+               # so only tell the user no new packages if errata have been processed
+               if errata_details && errata_details['state'] != 'NOT_STARTED'
+                 ret << _("No new packages.")
+               else
+                 ret << _("Processing metadata.")
+               end
+             end
+           elsif metadata_in_progress?
+             ret << _("Processing metadata")
+           end
+
+           ret << metadata_error if metadata_error
+
+           if error_details.any?
+             ret << n_("Failed to download %s package.", "Failed to download %s packages.",
+                       error_details.count) % error_details.count
+           end
+           ret.join("\n")
+          end
+
+          def count_summary
+           if content_details[:state] == "IN_PROGRESS"
+             "#{items_done}/#{items_total}"
+           else
+             items_done
+           end
+          end
+
+          def size_summary
+           if content_details[:state] == "IN_PROGRESS"
+             "#{number_to_human_size(size_done)}/#{number_to_human_size(size_total)}"
+           else
+             number_to_human_size(size_total)
+           end
+          end
+
+          def sync_task
+           action.external_task.select{ |task| task['tags'].include?("pulp:action:sync") }.first
+          end
+
+          def task_result
+           sync_task[:result]
+          end
+
+          def task_result_details
+           task_result && task_result[:details]
+          end
+
+          def task_progress
+           sync_task[:progress_report]
+          end
+
+          def task_progress_details
+           task_progress && task_progress[:yum_importer]
+          end
+
+          def task_details
+           task_result_details || task_progress_details
+          end
+
+          def content_details
+           task_details && task_details[:content]
+          end
+
+          def error_details
+           content_details.nil? ? [] : content_details[:error_details]
+          end
+
+          def metadata_details
+           task_details && task_details[:metadata]
+          end
+
+          def errata_details
+           task_details && task_details[:errata]
+          end
+
+          def items_done
+           items_total - content_details[:items_left]
+          end
+
+          def items_total
+           content_details[:items_total].to_i
+          end
+
+          def size_done
+           size_total - content_details[:size_left]
+          end
+
+          def size_total
+           (content_details && content_details[:size_total]).to_i
+          end
+
+          def cancelled?
+           task_details.nil? ? false : task_details.values.map{|item| item['state']}.include?('CANCELLED')
+          end
+
+          def content_started?
+           content_details && content_details[:state] != 'NOT_STARTED'
+          end
+
+          def metadata_in_progress?
+           metadata_details && metadata_details[:state] == 'IN_PROGRESS'
+          end
+
+          def metadata_error
+           metadata_details && metadata_details[:error]
+          end
+
+          def pending?
+           metadata_details.nil? || metadata_details['state'] == 'NOT_RUNNING'
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -118,7 +118,7 @@ module ::Actions::Katello::Repository
         end
       end
 
-      let(:pulp_action) { fixture_action(pulp_action_class, output: fixture_variant) }
+      let(:pulp_action) { fixture_action(pulp_action_class, input: {pulp_id: repository.pulp_id}, output: fixture_variant) }
 
       describe 'successfully synchronized' do
         let(:fixture_variant) { :success }

--- a/test/actions/pulp/repository_test.rb
+++ b/test/actions/pulp/repository_test.rb
@@ -26,6 +26,7 @@ module ::Actions::Pulp::Repository
 
     before do
       stub_remote_user
+      @repo = Katello::Repository.find(katello_repositories(:fedora_17_x86_64))
     end
 
     it 'runs' do
@@ -35,7 +36,7 @@ module ::Actions::Pulp::Repository
       task3         = task1.merge(task_progress_hash 0, 8).merge(task_finished_hash)
       pulp_response =  { 'spawned_tasks' => [{'task_id' => 'other' }]}
 
-      plan_action action, pulp_id: 'pulp-id'
+      plan_action action, pulp_id: @repo.pulp_id
       action = run_action action do |action|
         runcible_expects(action, :resources, :repository, :sync).
             returns(pulp_response)

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -2,6 +2,7 @@ fedora_17_x86_64:
   name:                 Fedora 17 x86_64
   pulp_id:              1
   content_id:           1
+  content_type:         yum
   label:                fedora_17_x86_64_label
   relative_path:        '/ACME_Corporation/library/fedora_17_label'
   environment_id:       <%= ActiveRecord::Fixtures.identify(:library) %>
@@ -14,6 +15,7 @@ fedora_17_x86_64_dev:
   name:                 Fedora 17 x86_64
   pulp_id:              2
   content_id:           1
+  content_type:         yum
   library_instance:     fedora_17_x86_64
   label:                fedora_17_dev_label
   relative_path:        '/ACME_Corporation/dev/fedora_17_dev_label'
@@ -28,6 +30,7 @@ feedless_fedora_17_x86_64:
   name:                 Feedless Fedora 17 x86_64
   pulp_id:              feedless_1
   content_id:           1
+  content_type:         yum
   label:                feedless_fedora_17_x86_64_label
   relative_path:        '/ACME_Corporation/library/fedora_17_label'
   environment_id:       <%= ActiveRecord::Fixtures.identify(:library) %>
@@ -42,6 +45,7 @@ rhel_6_x86_64:
   content_id:           1
   major:                6
   minor:                6Server
+  content_type:         yum
   label:                rhel_6_x86_64_label
   relative_path:        '/ACME_Corporation/library/rhel_6_label'
   environment_id:       <%= ActiveRecord::Fixtures.identify(:library) %>
@@ -56,6 +60,7 @@ rhel_6_x86_64_dev:
   content_id:           1
   major:                6
   minor:                6Server
+  content_type:         yum
   label:                rhel_6_x86_64_label
   relative_path:        '/ACME_Corporation/library/rhel_6_label'
   url:                 'https://cdn.example.com/rhel/6/os'


### PR DESCRIPTION
Splitting out the sync presenter into a few different files
depending on the type as each type is fairly different.
