### PR TITLE
fixes #7005 / BZ 1122736 - content host - change registration behavior with foreman host

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -197,6 +197,8 @@ module Katello
       content_view_environment = find_content_view_environment
       foreman_host = find_foreman_host(content_view_environment.environment.organization)
 
+      sync_task(::Actions::Katello::System::Destroy, foreman_host.content_host) if foreman_host.content_host
+
       @system = System.new(system_params.merge(:environment  => content_view_environment.environment,
                                                :content_view => content_view_environment.content_view,
                                                :serviceLevel => params[:service_level],
@@ -223,6 +225,8 @@ module Katello
       User.current    = User.hidden.first
       activation_keys = find_activation_keys
       foreman_host    = find_foreman_host(activation_keys.first.organization)
+
+      sync_task(::Actions::Katello::System::Destroy, foreman_host.content_host) if foreman_host.content_host
 
       @system = System.new(system_params.merge(:host_id => foreman_host.try(:id)))
       sync_task(::Actions::Katello::System::Create, @system, activation_keys)
@@ -349,7 +353,13 @@ module Katello
 
     def find_foreman_host(organization)
       if params[:facts].present? && params[:facts]['network.hostname'].present?
-        foreman_host = Host.where(:name => params[:facts]['network.hostname'], :organization_id => organization.id).first
+        mac_addresses =  System.interfaces(params[:facts]).
+                                map{ |interface| interface[:mac].downcase if interface[:mac] }.
+                                reject{ |mac| mac.nil? }
+
+        foreman_host = Host.where(:name => params[:facts]['network.hostname'],
+                                  :organization_id => organization.id,
+                                  :mac => mac_addresses).first
       end
       foreman_host
     end


### PR DESCRIPTION
This commit alters the behavior of registering a content host
(with or without an activation key) that is to be associated
with a foreman host to do the following:
1. identify the foreman host that this content host will be
   associated with by both name and mac address (previously
   it was only by name)
2. if the foreman host identified is already associated with a
   content host, delete it and then create/associate a new one.
   (This will avoid there becoming duplicate content hosts with
   the same name.)
