### PR TITLE
new sync plan requires interval field

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-details-info.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-details-info.controller.js
@@ -29,7 +29,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
         function ($scope, $q, translate, SyncPlan, MenuExpander) {
             $scope.successMessages = [];
             $scope.errorMessages = [];
-            $scope.intervals = ['none', 'hourly', 'daily', 'weekly'];
+            $scope.intervals = ['disabled', 'hourly', 'daily', 'weekly'];
 
             $scope.menuExpander = MenuExpander;
             $scope.panel = $scope.panel || {loading: false};

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/new-sync-plan.controller.js
@@ -24,12 +24,11 @@
  */
 angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
     ['$scope', 'translate', 'SyncPlan', function ($scope, translate, SyncPlan) {
-        $scope.intervals = [translate('none'), translate('hourly'), translate('daily'), translate('weekly')];
+        $scope.intervals = [translate('hourly'), translate('daily'), translate('weekly')];
         $scope.successMessages = [];
 
         $scope.syncPlan = new SyncPlan();
         $scope.syncPlan.startDate = new Date();
-        $scope.syncPlan.interval = $scope.intervals[0];
 
         function success(syncPlan) {
             $scope.working = false;

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/views/new-sync-plan-form.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/views/new-sync-plan-form.html
@@ -23,7 +23,9 @@
            name="interval"
            ng-model="syncPlan.interval"
            ng-options="interval for interval in intervals"
-           tabindex="3">
+           tabindex="3"
+           required>
+      <option value="">{{ 'disabled' | translate }}</option>     
    </select>
  </div>
 


### PR DESCRIPTION
Interval is now required field on creating a new sync plan
'none' in interval dropdown changed to 'disabled'
user cannot create new sync plan with 'disabled' selected
user can select 'disabled' on sync plan edit
