### PR TITLE
fixes #7019 / BZ 1128473 - content search - change to eliminate errors with ambiguous 'id'

### DIFF
--- a/app/controllers/katello/content_search_controller.rb
+++ b/app/controllers/katello/content_search_controller.rb
@@ -672,7 +672,7 @@ class ContentSearchController < Katello::ApplicationController
   # parent_repo    the library repo instance (or the parent row)
   # spanned_repos  all other instances of repos across all environments
   def spanning_content_rows(view, content_list, id_prefix, parent_repo, spanned_repos)
-    env_ids = KTEnvironment.content_readable(current_organization).pluck(:id)
+    env_ids = KTEnvironment.content_readable(current_organization).pluck("#{Katello::KTEnvironment.table_name}.id")
     to_ret = []
     content_list.each do |item|
 
@@ -744,8 +744,8 @@ class ContentSearchController < Katello::ApplicationController
 
     # repos were searched by string
     if repo_ids.is_a? Array
-      ids = ContentView.readable_repositories(repo_ids).pluck(:id)
-      ids += Product.readable_repositories(repo_ids).pluck(:id)
+      ids = ContentView.readable_repositories(repo_ids).pluck("#{Katello::Repository.table_name}.id")
+      ids += Product.readable_repositories(repo_ids).pluck("#{Katello::Repository.table_name}.id")
       repo_ids = ids
     else
       search_string = repo_ids


### PR DESCRIPTION
This commit is to update a few queries that use 'pluck' to be explicit
on the table that the attribute (id) is being plucked from.  Without them
the user can experience errors like:

Processing by Katello::ContentSearchController#packages as _/_
  Parameters: {"repos"=>{"autocomplete"=>[{"id"=>"13", "name"=>"samrepo"}]}, "packages"=>{"search"=>""}, "content_type"=>"packages", "mode"=>"all", "environments"=>[2], "content_search"=>{"repos"=>{"autocomplete"=>[{"id"=>"13", "name"=>"samrepo"}]}, "packages"=>{"search"=>""}, "content_type"=>"packages", "mode"=>"all", "environments"=>[2]}}
PGError: ERROR:  column reference "id" is ambiguous
LINE 1: SELECT id FROM "katello_repositories" INNER JOIN "katello_co...
               ^
: SELECT id FROM "katello_repositories" INNER JOIN "katello_content_view_versions" ON "katello_content_view_versions"."id" = "katello_repositories"."content_view_version_id" WHERE "katello_content_view_versions"."content_view_id" IN (1, 2, 3, 4, 6) ORDER BY katello_repositories.name ASC (ActiveRecord::StatementInvalid)
