### PR TITLE
Fixes #6175 - Handle new status icon that was added

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -54,6 +54,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsC
                     $scope.successMessages.push(translate("Successfully added %s subscriptions.").replace('%s', selected.length));
                     $scope.isAdding = false;
                     $scope.addSubscriptionsPane.refresh();
+                    $scope.subscriptionsPane.refresh();
+                    $scope.nutupane.refresh();
                 });
             }, function (response) {
                 $scope.$parent.errorMessages = response.data.displayMessage;

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-subscriptions.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/content-host-subscriptions.controller.js
@@ -54,6 +54,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostSubscriptionsCont
                     $scope.subscriptionsPane.refresh();
                     $scope.successMessages.push(translate("Successfully removed %s subscriptions.").replace('%s', selected.length));
                     $scope.isRemoving = false;
+                    $scope.nutupane.refresh();
                 });
             }, function (response) {
                 $scope.isRemoving = false;


### PR DESCRIPTION
In the following commit, a new status icon was added but we didn't check to make
sure that it was properly refreshed so [#6175](http://projects.theforeman.org/issues/6175) was reopened to deal with this.

https://github.com/Katello/katello/commit/7e86b53e#diff-8d1fe504fb4c8c0ff058edda520089f9R17
