### PR TITLE
Fixes #7024 - fixes delete cv from environment

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -151,7 +151,7 @@ module Katello
     param :id, :number, :desc => N_("content view numeric identifier"), :required => true
     param :environment_id, :number, :desc => N_("environment numeric identifier"), :required => true
     def remove_from_environment
-      unless @view.environments.include?(@environments)
+      unless @view.environments.include?(@environment)
         fail HttpErrors::BadRequest, _("Content view '%{view}' is not in lifecycle environment '%{env}'.") %
               {view: @view.name, env: @environment.name}
       end


### PR DESCRIPTION
In the cv api, this fixes the guard that checks that cv is in environment prior to removal.
