### PR TITLE
Fixes #7025 - replace default_environment in sys

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -319,8 +319,8 @@ class Api::V2::SystemsController < Api::V2::ApiController
       # the single env of the org or throw an error if more than one.
       #
       if @organization.kt_environments.size > 1
-        if current_user.default_environment && current_user.default_environment.organization == @organization
-          @environment = current_user.default_environment
+        if current_user.default_organization && current_user.default_organization == @organization
+          @environment = current_user.library
         else
           fail HttpErrors::BadRequest, _("Organization %s has more than one environment. Please specify target environment for content host registration.") % @organization.name
         end


### PR DESCRIPTION
In System api, default_environment is still being retrieved from the
User (which is no longer being defined there). This fix obtains the
environment from the user's default_organization.
