### PR TITLE
Fixes #7026/BZ1128471: fix error on updating errata date range filter.

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -79,9 +79,12 @@ module Katello
     param :types, Array, :desc => N_("erratum: types (enhancement, bugfix, security)")
     def update
       update_params = rule_params
-      update_params[:version] = "" unless rule_params[:version]
-      update_params[:min_version] = "" unless rule_params[:min_version]
-      update_params[:max_version] = "" unless rule_params[:max_version]
+
+      if @rule.filter.content_type == 'package'
+        update_params[:version] = "" unless rule_params[:version]
+        update_params[:min_version] = "" unless rule_params[:min_version]
+        update_params[:max_version] = "" unless rule_params[:max_version]
+      end
 
       @rule.update_attributes!(update_params)
       respond :resource => @rule

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
@@ -59,7 +59,6 @@ angular.module('Bastion.content-views').controller('DateTypeErrataFilterControll
 
         function success() {
             $scope.successMessages = [translate('Updated errata filter - ' + $scope.filter.name)];
-            $scope.transitionTo('content-views.details.filters.list', {contentViewId: $scope.filter['content_view'].id});
         }
 
         function failure(response) {

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/date-type-errata.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/date-type-errata.html
@@ -1,3 +1,5 @@
+<div data-block="messages" alch-alert success-messages="successMessages" error-messages="errorMessages"></div>
+
 <div alch-form-group label="{{ 'Errata Type' | translate }}">
 
   <label class="checkbox-inline">

--- a/engines/bastion/test/content-views/details/filters/date-type-errata-filter.controller.test.js
+++ b/engines/bastion/test/content-views/details/filters/date-type-errata-filter.controller.test.js
@@ -46,11 +46,9 @@ describe('Controller: DateTypeErrataFilterController', function() {
     });
 
     it("should provide a method to add errata to the filter", function () {
-        spyOn($scope, 'transitionTo');
         $scope.save($scope.rule, $scope.filter);
 
         expect($scope.successMessages.length).toBe(1);
-        expect($scope.transitionTo).toHaveBeenCalled();
     });
 
 });


### PR DESCRIPTION
There was an error when updating an errata data range filter.  This
commit fixes the error as well as displays error messages on the form
in the event of a legitimate error.

http://projects.theforeman.org/issues/7026
https://bugzilla.redhat.com/show_bug.cgi?id=1128471
