### PR TITLE
Fixes #7047/BZ1128467: get full result of product's repositories.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/products/details/product-repositories.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/product-repositories.controller.js
@@ -32,7 +32,8 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
             'product_id': $scope.$stateParams.productId,
             'library': true,
             'organization_id': CurrentOrganization,
-            'enabled': true
+            'enabled': true,
+            'full_result': true
         });
 
         $scope.successMessages = [];


### PR DESCRIPTION
We were only getting the (default) first 20 results for a product's
repositories.  This commit ensures we fetch all of a product's
repositories for display.

http://projects.theforeman.org/issues/7047
https://bugzilla.redhat.com/show_bug.cgi?id=1128467
