### PR TITLE
Fixes #7000/BZ1080172: paginate content host packages.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/content-host-packages.controller.js
@@ -26,6 +26,7 @@
 angular.module('Bastion.content-hosts').controller('ContentHostPackagesController',
     ['$scope', 'ContentHostPackage', 'translate', 'Nutupane',
     function ($scope, ContentHostPackage, translate, Nutupane) {
+        const PACKAGES_PER_PAGE = 50;
         var packagesNutupane, packageActions, openEventInfo;
 
         openEventInfo = function (event) {
@@ -80,6 +81,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
         };
 
         packagesNutupane = new Nutupane(ContentHostPackage, { 'id': $scope.$stateParams.contentHostId }, 'get');
+        packagesNutupane.load();
         $scope.currentPackagesTable = packagesNutupane.table;
         $scope.currentPackagesTable.openEventInfo = openEventInfo;
         $scope.currentPackagesTable.contentHost = $scope.contentHost;
@@ -97,6 +99,13 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
                         arch: pkg.arch, release: pkg.release}]
                 }, openEventInfo, errorHandler);
             }
+        };
+
+        $scope.currentPackagesTable.limit = PACKAGES_PER_PAGE;
+        $scope.currentPackagesTable.loadMorePackages = function () {
+            $scope.$evalAsync(function (scope) {
+                scope.currentPackagesTable.limit = scope.currentPackagesTable.limit + PACKAGES_PER_PAGE;
+            });
         };
     }
 ]);

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
@@ -56,7 +56,7 @@
   </div>
 
   <div alch-table="currentPackagesTable">
-    <div alch-container-scroll control-width="table" alch-infinite-scroll="currentPackagesTable.nextPage()" data="currentPackagesTable.rows">
+    <div alch-container-scroll control-width="table" alch-infinite-scroll="currentPackagesTable.loadMorePackages()" data="currentPackagesTable.rows">
       <table ng-class="{'table-mask': currentPackagesTable.working}" class="table table-striped">
         <thead>
           <tr alch-table-head>
@@ -66,7 +66,8 @@
         </thead>
 
         <tbody>
-          <tr alch-table-row ng-repeat="package in currentPackagesTable.rows | filter:currentPackagesTable.filter" >
+
+            <tr alch-table-row ng-repeat="package in currentPackagesTable.rows | filter: currentPackagesTable.filter | limitTo: currentPackagesTable.limit" >
             <td alch-table-cell>{{ package.nvrea }}</td>
             <td alch-table-cell ng-hide="currentPackagesTable.contentHost.readonly">
 

--- a/engines/bastion/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion/test/content-hosts/content/content-host-packages.controller.test.js
@@ -23,6 +23,7 @@ describe('Controller: ContentHostPackagesController', function() {
                 showColumns: function() {}
             };
             this.get = function() {};
+            this.load = function() {};
         };
         ContentHost = {
             tasks: function() {return []}
@@ -129,4 +130,16 @@ describe('Controller: ContentHostPackagesController', function() {
         expect($scope.working).toBe(true);
     });
 
+    it("sets the default number of packages limit to 20", function() {
+        expect($scope.currentPackagesTable.limit).toBe(50);
+    });
+
+    it("provides a way to load more packages", function() {
+        expect($scope.currentPackagesTable.limit).toBe(50);
+
+        $scope.currentPackagesTable.loadMorePackages();
+        $scope.$digest();
+
+        expect($scope.currentPackagesTable.limit).toBe(100);
+    })
 });


### PR DESCRIPTION
Rendering hundreds of content host package rows was taxing the CPU,
especially in Firefox.  This commit uses client side pagination to
limit the number of package rows rendered.

http://projects.theforeman.org/issues/7000
https://bugzilla.redhat.com/show_bug.cgi?id=1080172
