### PR TITLE
Fixes #6773 - Host inherits Content Source from Hostgroup

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -19,6 +19,7 @@ module Katello
         before_update :update_content_host, :if => :environment_id_changed?
 
         alias_method_chain :validate_media?, :capsule
+        alias_method_chain :set_hostgroup_defaults, :content_source
 
         has_one :content_host, :class_name => "Katello::System", :foreign_key => :host_id,
                 :dependent => :destroy, :inverse_of => :foreman_host
@@ -45,6 +46,10 @@ module Katello
         end
       end
 
+      def set_hostgroup_defaults_with_content_source
+        assign_hostgroup_attributes(%w{content_source_id}) if hostgroup.present?
+        set_hostgroup_defaults_without_content_source
+      end
     end
   end
 end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -21,7 +21,11 @@ module Katello
 
       # instead of calling nested_attribute_for(:content_source_id) in Foreman, define the methods explictedly
       def inherited_content_source_id
-        self[:inherited_content_source_id] || self.class.sort_by_ancestry(ancestors.where("content_source_id is not NULL")).last.try(:content_source_id) if ancestry.present?
+        if ancestry.present?
+          read_attribute(:content_source_id) || self.class.sort_by_ancestry(ancestors.where("content_source_id is not NULL")).last.try(:content_source_id)
+        else
+          self.content_source_id
+        end
       end
 
       def content_source

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module Katello
+  class HostgroupExtensionsTest < ActiveSupport::TestCase
+    def inherited_content_source_id_with_ancestry
+      root = Hostgroup.new(:name => 'AHostgroup', :content_source => smart_proxies(:puppetmaster))
+      root.save
+
+      child = Hostgroup.new(:name => 'AChild', :parent => root)
+      child.save
+
+      assert_equal smart_proxies(:puppetmaster).id, child.inherited_content_source_id
+    end
+
+    def inherited_content_source_id_without_ancestry
+      root = Hostgroup.new(:name => 'AHostgroup', :content_source => smart_proxies(:puppetmaster))
+      root.save
+
+      assert_equal smart_proxies(:puppetmaster).id, root.inherited_content_source_id
+    end
+  end
+end


### PR DESCRIPTION
To reproduce -

Create a host group, and assign it a content source
Create a host, and change the host group to the previously created host group. 
It should populate the content source attribute as well as other inherited attributes from host group.
