### PR TITLE
Fixes #5229 - Messages for empty tables in Bastion.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-full.html
@@ -1,4 +1,8 @@
-<table class="table table-striped" ng-class="{'table-mask': table.working}">
+<p class="alert alert-info" ng-show="table.rows.length === 0" translate>
+  You currently don't have any Activation keys, you can add activation keys using the button on the right.
+</p>
+
+<table class="table table-striped" ng-class="{'table-mask': table.working}" ng-show="table.rows.length > 0">
   <thead>
     <tr alch-table-head>
       <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-products.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-products.html
@@ -5,7 +5,8 @@
          placeholder="{{ 'Filter' | translate }}"
          ng-model="productSearch"/>
 
-  <table alch-table="table" class="table table-striped">
+  
+  <table alch-table="table" class="table table-striped" ng-show="gpgKey.products.length > 0">
     <thead>
       <tr alch-table-head>
         <th alch-table-column="name" sortable translate>Name</th>
@@ -25,3 +26,7 @@
     </tbody>
   </table>
 </section>
+
+<p class="alert alert-info" ng-show="gpgKey.products.length === 0" translate>
+  You currently don't have any Products associated with this Gpg Key.
+</p>

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-repositories.html
@@ -6,7 +6,7 @@
          placeholder="{{ 'Filter' | translate }}"
          ng-model="repositorySearch"/>
 
-  <table class="table table-striped">
+  <table class="table table-striped" ng-show="gpgKey.repositories.length > 0">
     <thead>
       <tr>
         <th translate>Name</th>
@@ -31,3 +31,7 @@
   </table>
 
 </section>
+
+<p class="alert alert-info" ng-show="gpgKey.repositories.length === 0" translate>
+  You currently don't have any Repositories associated with this Gpg Key.
+</p>

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-full.html
@@ -1,4 +1,10 @@
-<table alch-table="table" class="table table-striped" ng-class="{'table-mask': table.working}">
+<p class="alert alert-info" ng-show="table.rows.length === 0" translate>
+      You currently don't have any Gpg Keys, you can add gpg keys using the button on the right.
+</p>
+<table alch-table="table"
+       class="table table-striped"
+       ng-class="{'table-mask': table.working}"
+       ng-show="table.rows.length > 0">
   <thead>
     <tr alch-table-head>
       <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
@@ -61,11 +61,12 @@
             ui-sref="products.details.repositories.new({productId: product.id})">
       Create Repository
     </button>
-  </span>
-
+  </span> 
+  
   <table alch-table="repositoriesTable"
          class="table table-striped"
-         ng-class="{'table-mask': repositoriesTable.working}">
+         ng-class="{'table-mask': repositoriesTable.working}"
+         ng-show="repositoriesTable.rows.length > 0">
     <thead>
       <tr alch-table-head row-select>
         <th alch-table-column="name" translate>Name</th>
@@ -119,5 +120,8 @@
       </tr>
     </tbody>
   </table>
-
 </section>
+
+<p class="alert alert-info" ng-show="repositoriesTable.rows.length === 0" translate>
+  You currently don't have any Repositories included in this Product, you can add repositories using the button on the right.
+</p>

--- a/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-full.html
@@ -1,4 +1,8 @@
-<table class="table table-striped" ng-class="{'table-mask': productTable.working}">
+<p class="alert alert-info" ng-show="productTable.rows.length === 0" translate>
+  You currently don't have any Products, you can add products using the button on the right.
+</p>
+
+<table class="table table-striped" ng-class="{'table-mask': productTable.working}" ng-show="productTable.rows.length > 0">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
@@ -49,7 +49,10 @@
           {{ "Loading..." | translate }}
         </div>
 
-        <p ng-hide="productsTable.working" translate>No Products to show.</p>
+        <p class="alert alert-info" 
+           ng-hide="productsTable.working" 
+           translate>No Products to show. You can add products after selecting 'Add' tab. 
+        </p>
       </div>
 
       <table ng-show="productsTable.rows.length > 0"

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
@@ -1,4 +1,9 @@
-<table class="table table-striped" ng-class="{'table-mask': syncPlanTable.working}">
+<p class="alert alert-info" ng-show="syncPlanTable.rows.length === 0" translate>
+      You currently don't have any Sync Plan, you can add sync plans using the button on the right.
+    </p>
+<table class="table table-striped" 
+       ng-class="{'table-mask': syncPlanTable.working}" 
+       ng-show="syncPlanTable.rows.length > 0">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>


### PR DESCRIPTION
When there is an empty table in Activation keys, Gpg keys, Products and Sync plans, message with hint will be displayed.
