### PR TITLE
Fixes #5229 - Added messages for empty tables in Bastion

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-full.html
@@ -1,4 +1,8 @@
-<table class="table table-striped" ng-class="{'table-mask': table.working}">
+<p class="alert alert-info" ng-show="table.rows.length === 0" translate>
+  You currently don't have any Activation Keys, you can add Activation Keys using the button on the right.
+</p>
+
+<table class="table table-striped" ng-class="{'table-mask': table.working}" ng-show="table.rows.length > 0">
   <thead>
     <tr alch-table-head>
       <th alch-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-errata.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-errata.html
@@ -38,40 +38,51 @@
         <i class="icon-plus"></i>
         {{ "Install Selected" | translate }}
       </button>
-   </div>
+    </div>
 
-    <table data-block="table"  class="table table-striped" ng-class="{'table-mask': detailsTable.working}">
-     <thead>
-       <tr alch-table-head row-select>
-         <th class="small" alch-table-column="type" translate>Type</th>
-         <th class="small" alch-table-column="errata_id" translate>Id</th>
-         <th alch-table-column="title" translate>Title</th>
-         <th class="small" alch-table-column="issued" translate>Issued</th>
-         <th class="small" alch-table-column="content_host_affected" translate>Affected Content Hosts</th>
-       </tr>
-     </thead>
 
-     <tbody>
-       <tr alch-table-row ng-repeat="erratum in detailsTable.rows" row-select="erratum">
-         <td class="small" alch-table-cell>
-             {{ erratum.type }}
-         </td>
-         <td class="small" alch-table-cell>
-           <a ng-click="transitionToErrata(erratum)">
-             {{ erratum.errata_id }}
-           </a>
-         </td>
+    <div data-block="table">
+      <p class="alert alert-info" ng-show="detailsTable.rows.length === 0">
+        There are no Errata associated with this Content Host to display.
+      </p>
 
-         <td alch-table-cell>{{ erratum.title }}</td>
-         <td class="small" alch-table-cell>{{ erratum.issued }}</td>
-         <td class="small" alch-table-cell class="number-cell">
-           <a ng-click="transitionToErrataContentHosts(erratum)">
-            {{ erratum.applicable_consumers.length }}
-           </a>
-         </td>
-       </tr>
-     </tbody>
-    </table>
+      <table class="table table-striped"
+             ng-class="{'table-mask': detailsTable.working}"
+             ng-show="detailsTable.rows.length > 0">
+       <thead>
+         <tr alch-table-head row-select>
+           <th class="small" alch-table-column="type" translate>Type</th>
+           <th class="small" alch-table-column="errata_id" translate>Id</th>
+           <th alch-table-column="title" translate>Title</th>
+           <th class="small" alch-table-column="issued" translate>Issued</th>
+           <th class="small" alch-table-column="content_host_affected" translate>Affected Content Hosts</th>
+         </tr>
+       </thead>
 
-  </div>
+       <tbody>
+         <tr alch-table-row ng-repeat="erratum in detailsTable.rows" row-select="erratum">
+           <td class="small" alch-table-cell>
+               {{ erratum.type }}
+           </td>
+           <td class="small" alch-table-cell>
+             <a ng-click="transitionToErrata(erratum)">
+               {{ erratum.errata_id }}
+             </a>
+           </td>
+
+           <td alch-table-cell>{{ erratum.title }}</td>
+           <td class="small" alch-table-cell>{{ erratum.issued }}</td>
+           <td class="small" alch-table-cell class="number-cell">
+             <a ng-click="transitionToErrataContentHosts(erratum)">
+              {{ erratum.applicable_consumers.length }}
+             </a>
+           </td>
+         </tr>
+       </tbody>
+      </table>
+    </div>
+
+  </div>  
 </section>
+
+

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-host-collections.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-host-collections.html
@@ -41,32 +41,38 @@
       </button>
     </div>
 
-    <table data-block="table"  class="table table-striped" ng-class="{'table-mask': state.working}">
-      <thead>
-        <tr alch-table-head row-select>
-          <th alch-table-column="name"><span translate>Name</span></th>
-          <th alch-table-column="content_hosts"><span translate>Content Hosts</span></th>
-          <th alch-table-column="limit"><span translate>Limit</span></th>
-        </tr>
-      </thead>
+    <div data-block="table">
+      <p class="alert alert-info" ng-show="detailsTable.rows.length === 0">
+        There are no Host Collections available. You can create new Host Collections after selecting 'Host Collections' under 'Hosts' in main menu.
+      </p>
 
-      <tbody>
-        <tr alch-table-row ng-repeat="hostCollection in detailsTable.rows" row-select="hostCollection">
-          <td alch-table-cell>
-            <a class="clickable" ui-sref="host-collections.details.info({hostCollectionId: hostCollection.id})">
-              {{ hostCollection.name }}
-            </a>
-          </td>
-          <td alch-table-cell>
-            <a class="clickable" ui-sref="host-collections.details.content-hosts({hostCollectionId: hostCollection.id})">
-              {{ hostCollection.total_content_hosts }}
-            </a>
-          </td>
-          <td alch-table-cell>{{ hostCollection.max_content_hosts | unlimitedFilter:hostCollection.unlimited_content_hosts }}</td>
-        </tr>
-      </tbody>
-    </table>
 
+      <table data-block="table"  class="table table-striped" ng-class="{'table-mask': state.working}">
+        <thead>
+          <tr alch-table-head row-select>
+            <th alch-table-column="name"><span translate>Name</span></th>
+            <th alch-table-column="content_hosts"><span translate>Content Hosts</span></th>
+            <th alch-table-column="limit"><span translate>Limit</span></th>
+          </tr>
+        </thead>      
+
+        <tbody>
+          <tr alch-table-row ng-repeat="hostCollection in detailsTable.rows" row-select="hostCollection">
+            <td alch-table-cell>
+              <a class="clickable" ui-sref="host-collections.details.info({hostCollectionId: hostCollection.id})">
+                {{ hostCollection.name }}
+              </a>
+            </td>
+            <td alch-table-cell>
+              <a class="clickable" ui-sref="host-collections.details.content-hosts({hostCollectionId: hostCollection.id})">
+                {{ hostCollection.total_content_hosts }}
+              </a>
+            </td>
+            <td alch-table-cell>{{ hostCollection.max_content_hosts | unlimitedFilter:hostCollection.unlimited_content_hosts }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 
 </section>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-errata.html
@@ -36,7 +36,14 @@
     Please install the katello-agent package to manage errata on
     {{ contentHost.name }}.
   </p>
-  <div alch-container-scroll alch-infinite-scroll="errataTable.nextPage()" data="errataTable.rows">
+
+  <p class="alert alert-info" ng-show="errataTable.rows.length === 0">There are no Errata to display.</p>
+
+  <div alch-container-scroll 
+       alch-infinite-scroll="errataTable.nextPage()"
+       data="errataTable.rows" 
+       ng-show="errataTable.rows.length > 0">
+       
     <table ng-class="{'table-mask': errataTable.working}" class="table table-striped">
       <thead>
         <tr alch-table-head row-select>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/content/views/content-host-packages.html
@@ -61,8 +61,13 @@
     </div>
   </div>
 
-  <div alch-table="currentPackagesTable">
+  <p class="alert alert-info" ng-show="currentPackagesTable.rows.length === 0">
+    You currently do not have any Packages installed. You can use Package Actions above this message to install new Packages. 
+  </p>
+
+  <div alch-table="currentPackagesTable" ng-show="currentPackagesTable.rows.length > 0">
     <div alch-container-scroll control-width="table" alch-infinite-scroll="currentPackagesTable.loadMorePackages()" data="currentPackagesTable.rows">
+
       <table ng-class="{'table-mask': currentPackagesTable.working}" class="table table-striped">
         <thead>
           <tr alch-table-head>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-add-subscriptions.html
@@ -52,7 +52,13 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <table ng-class="{'table-mask': addSubscriptionsTable.working}" class="table table-full table-striped">
+      <p class="alert alert-info" ng-show="addSubscriptionsTable.rows.length === 0" translate>
+        You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu.
+      </p>
+
+      <table ng-class="{'table-mask': addSubscriptionsTable.working}"
+             class="table table-full table-striped" 
+             ng-show="addSubscriptionsTable.rows.length > 0" >
         <thead>
           <tr alch-table-head row-select>
             <th alch-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
@@ -51,7 +51,13 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <table ng-class="{'table-mask': subscriptionsTable.working}" class="table table-full table-striped">
+      <p class="alert alert-info" ng-show="subscriptionsTable.rows.length === 0" translate>
+        You currently don't have any Subscriptions associated with this Content Host, you can add Subscriptions after selecting the 'Add' tab.
+      </p>
+
+      <table ng-class="{'table-mask': subscriptionsTable.working}" 
+             class="table table-full table-striped"
+             ng-show="subscriptionsTable.rows.length > 0">
         <thead>
           <tr alch-table-head row-select>
             <th alch-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/host-collections-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/host-collections-table.html
@@ -51,7 +51,18 @@
           {{ "Loading..." | translate }}
         </div>
 
-        <p ng-hide="hostCollectionsTable.working" translate>No Host Collections to show.</p>
+        <p class="alert alert-info" 
+           ng-if="isState('content-hosts.details.host-collections.list')"
+           ng-hide="hostCollectionsTable.working"
+           translate>No Host Collections to show, you can add Host Collections after selecting the 'Add' tab.
+        </p>
+
+        <p class="alert alert-info" 
+           ng-if="isState('content-hosts.details.host-collections.add')"
+           ng-hide="hostCollectionsTable.working"
+           translate>No Host Collections to show, you can add Host Collections after selecting 'Host Collections'
+                     under 'Hosts' in main menu.
+        </p>
       </div>
 
       <table ng-show="hostCollectionsTable.rows.length > 0"

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-full.html
@@ -1,4 +1,9 @@
-<table class="table table-striped" ng-class="{'table-mask': contentHostTable.working}">
+<p class="alert alert-info" ng-show="contentHostTable.rows.length === 0" translate>
+      You currently don't have any Content Hosts, you can register Content Hosts using the button on the right.
+</p>
+<table class="table table-striped" 
+       ng-class="{'table-mask': contentHostTable.working}"
+       ng-show="contentHostTable.rows.length > 0">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-modules.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-modules.html
@@ -23,7 +23,7 @@
 
   <div data-block="table">
     <p class="alert alert-info" ng-show="detailsTable.rows.length === 0" translate>
-      You currently don't have any Puppet Modules included in this Content View, you can add puppet modules using the button on the right.
+      You currently don't have any Puppet Modules included in this Content View, you can add Puppet Modules using the button on the right.
     </p>
 
     <table class="table table-striped table-bordered" ng-show="detailsTable.rows.length > 0">

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-full.html
@@ -1,4 +1,11 @@
-<table class="table table-striped table-bordered"  alch-table="table" ng-class="{'table-mask': table.working}">
+<p class="alert alert-info" ng-show="table.rows.length === 0" translate>
+  You currently don't have any Content Views, you can create Content View using the button on the right.
+</p>
+
+<table class="table table-striped table-bordered"  
+       alch-table="table" 
+       ng-class="{'table-mask': table.working}"
+       ng-show="table.rows.length > 0">
 
   <thead>
     <tr alch-table-head row-select>

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-products.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-products.html
@@ -5,7 +5,8 @@
          placeholder="{{ 'Filter' | translate }}"
          ng-model="productSearch"/>
 
-  <table alch-table="table" class="table table-striped">
+  
+  <table alch-table="table" class="table table-striped" ng-show="gpgKey.products.length > 0">
     <thead>
       <tr alch-table-head>
         <th alch-table-column="name" sortable><span translate>Name</span></th>
@@ -25,3 +26,7 @@
     </tbody>
   </table>
 </section>
+
+<p class="alert alert-info" ng-show="gpgKey.products.length === 0" translate>
+  You currently don't have any Products associated with this Gpg Key.
+</p>

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-repositories.html
@@ -6,7 +6,7 @@
          placeholder="{{ 'Filter' | translate }}"
          ng-model="repositorySearch"/>
 
-  <table class="table table-striped">
+  <table class="table table-striped" ng-show="gpgKey.repositories.length > 0">
     <thead>
       <tr>
         <th translate>Name</th>
@@ -31,3 +31,7 @@
   </table>
 
 </section>
+
+<p class="alert alert-info" ng-show="gpgKey.repositories.length === 0" translate>
+  You currently don't have any Repositories associated with this Gpg Key.
+</p>

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-full.html
@@ -1,4 +1,10 @@
-<table alch-table="table" class="table table-striped" ng-class="{'table-mask': table.working}">
+<p class="alert alert-info" ng-show="table.rows.length === 0" translate>
+      You currently don't have any Gpg keys, you can add Gpg keys using the button on the right.
+</p>
+<table alch-table="table"
+       class="table table-striped"
+       ng-class="{'table-mask': table.working}"
+       ng-show="table.rows.length > 0">
   <thead>
     <tr alch-table-head>
       <th alch-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-add-content-hosts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-add-content-hosts.html
@@ -53,7 +53,13 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <table ng-class="{'table-mask': addContentHostsTable.working}" class="table table-full table-striped">
+      <p class="alert alert-info" ng-show="addContentHostsTable.rows.length === 0" translate>
+        You currently don't have any Content Hosts, you can create new Content Hosts by selecting Contents Host from main menu and then clicking the button on the right.
+      </p>
+
+      <table ng-class="{'table-mask': addContentHostsTable.working}"
+             class="table table-full table-striped"
+             ng-show="addContentHostsTable.rows.length > 0">
         <thead>
           <tr alch-table-head row-select>
             <th alch-table-column="name" translate>Name</th>

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-content-hosts-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-content-hosts-list.html
@@ -52,7 +52,13 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <table ng-class="{'table-mask': contentHostsTable.working}" class="table table-full table-striped">
+      <p class="alert alert-info" ng-show="contentHostsTable.rows.length === 0" translate>
+        You currently don't have any Content Hosts in this Host Group, you can add Content Hosts after selecting the 'Add' tab.
+      </p>
+
+      <table ng-class="{'table-mask': contentHostsTable.working}" 
+             class="table table-full table-striped"
+             ng-show="contentHostTable.rows.length > 0">
         <thead>
           <tr alch-table-head row-select>
             <th alch-table-column="name" translate>Name</th>

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-full.html
@@ -1,4 +1,9 @@
-<table class="table table-striped" ng-class="{'table-mask': table.working}">
+<p class="alert alert-info" ng-show="table.rows.length === 0" translate>
+  You currently don't have any Host Collections, you can add Host Collections using the button on the right.
+</p>
+<table class="table table-striped" 
+       ng-class="{'table-mask': table.working}"
+       ng-show="table.rows.length > 0">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
@@ -61,11 +61,12 @@
             ui-sref="products.details.repositories.new({productId: product.id})">
       Create Repository
     </button>
-  </span>
-
+  </span> 
+  
   <table alch-table="repositoriesTable"
          class="table table-striped"
-         ng-class="{'table-mask': repositoriesTable.working}">
+         ng-class="{'table-mask': repositoriesTable.working}"
+         ng-show="repositoriesTable.rows.length > 0">
     <thead>
       <tr alch-table-head row-select>
         <th alch-table-column="name" translate>Name</th>
@@ -119,5 +120,8 @@
       </tr>
     </tbody>
   </table>
-
 </section>
+
+<p class="alert alert-info" ng-show="repositoriesTable.rows.length === 0" translate>
+  You currently don't have any Repositories included in this Product, you can add Repositories using the button on the right.
+</p>

--- a/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-full.html
@@ -1,4 +1,8 @@
-<table class="table table-striped" ng-class="{'table-mask': productTable.working}">
+<p class="alert alert-info" ng-show="productTable.rows.length === 0" translate>
+  You currently don't have any Products, you can add Products using the button on the right.
+</p>
+
+<table class="table table-striped" ng-class="{'table-mask': productTable.working}" ng-show="productTable.rows.length > 0">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
@@ -49,7 +49,10 @@
           {{ "Loading..." | translate }}
         </div>
 
-        <p ng-hide="productsTable.working" translate>No Products to show.</p>
+        <p class="alert alert-info" 
+           ng-hide="productsTable.working" 
+           translate>No Products to show. 
+        </p>
       </div>
 
       <table ng-show="productsTable.rows.length > 0"

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
@@ -1,4 +1,9 @@
-<table class="table table-striped" ng-class="{'table-mask': syncPlanTable.working}">
+<p class="alert alert-info" ng-show="syncPlanTable.rows.length === 0" translate>
+  You currently don't have any Sync Plan, you can add Sync Plans using the button on the right.
+</p>
+<table class="table table-striped" 
+       ng-class="{'table-mask': syncPlanTable.working}" 
+       ng-show="syncPlanTable.rows.length > 0">
   <thead>
     <tr alch-table-head row-select>
       <th alch-table-column="name" sortable><span translate>Name</span></th>


### PR DESCRIPTION
When there is an empty table in Activation keys, Gpg keys, Products or Sync plans, message with hint will be displayed. 
