### PR TITLE
Fixes #7068/bz1129775 - Fix repo sync checksum error

### DIFF
--- a/app/lib/actions/katello/repository/correct_checksum.rb
+++ b/app/lib/actions/katello/repository/correct_checksum.rb
@@ -20,7 +20,7 @@ module Actions
         end
 
         def finalize
-          ::User.current = ::User.hidden.first
+          ::User.current = ::User.anonymous_admin
           repo = ::Katello::Repository.find(input[:repo_id])
           found_checksum = repo.pulp_checksum_type
 


### PR DESCRIPTION
When one synced a repo priori to this commit, we got an error that
looked like

Error
undefined method `hidden' for #<Class:0x0000000d6beab0> (NoMethodError)
gems/ruby-2.0.0-p481/gems/activerecord-3.2.18/lib/active_record/dynamic_matchers.rb:55:in
`method_missing'
/katello/app/lib/actions/katello/repository/correct_checksum.rb:23:in
`finalize'

Basically after the commit for #6870/BZ1075523, all instance of the
User.hidden was replaced with User.anonymous_admin in katello code.
Sounds like there was a missed spot in this file
/katello/app/lib/actions/katello/repository/correct_checksum.rb.

this commit fixes this.
"
