### PR TITLE
Fixes #7071/BZ1125391: add installer and pulp configs to katello-debug.

### DIFF
--- a/deploy/script/katello-debug.sh
+++ b/deploy/script/katello-debug.sh
@@ -39,6 +39,8 @@ add_files "/etc/cron.d/splice-sst-sync"
 # Katello
 add_files "/var/log/katello/*"
 add_files "/var/log/katello-installer/*"
+add_files "/etc/katello-installer/*"
+add_files "/etc/pulp/server/plugins.d/*"
 add_cmd "find /root/ssl-build -ls | sort -k 11" "katello_ssl_build_dir"
 add_files "/etc/foreman/plugins/katello.yaml"
 add_files "/var/lib/pgsql/data/pg_log/*"


### PR DESCRIPTION
We do not include katello-installer and pulp proxy configs when running
katello-debug.  This commit adds these configs.

http://projects.theforeman.org/issues/7071
https://bugzilla.redhat.com/show_bug.cgi?id=1125391
