### PR TITLE
Fixes #7088/BZ1130224: reload filter after saving date range errata.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/date-type-errata-filter.controller.js
@@ -53,8 +53,8 @@ angular.module('Bastion.content-views').controller('DateTypeErrataFilterControll
 
         $scope.save = function (rule, filter) {
             var params = {filterId: filter.id, ruleId: rule.id};
-
             rule.$update(params, success, failure);
+            $scope.filter = $scope.filter.$get();
         };
 
         function success() {


### PR DESCRIPTION
After saving the rule it was being replaced by the previous value
that was stored in the fitler.  This commit reloads the filter so
that the rule is current.

http://projects.theforeman.org/issues/7088
https://bugzilla.redhat.com/show_bug.cgi?id=1130224
