### PR TITLE
fixes #7069 / BZ 1123959 - host<->content host - improve behavior when puppet env, lifecycle env or content view change

### DIFF
--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -68,6 +68,8 @@ class System < Katello::Model
   before_create  :fill_defaults
   after_create :init_default_custom_info
 
+  before_update :update_foreman_host, :if => proc { |r| r.environment_id_changed? || r.content_view_id_changed? }
+
   scope :in_environment, lambda { |env| where('environment_id = ?', env) unless env.nil?}
   scope :completer_scope, lambda { |options| readable(options[:organization_id])}
   scope :by_uuids, lambda { |uuids| where(:uuid => uuids)}
@@ -309,6 +311,26 @@ class System < Katello::Model
 
   def set_default_content_view
     self.content_view = self.environment.try(:default_content_view) unless self.content_view
+  end
+
+  def update_foreman_host
+    # If the lifecycle environment and/or content view are being changed for the content host
+    # (system), then we may also need to update the associated foreman host's puppet environment
+    if self.foreman_host &&
+       self.foreman_host.environment.lifecycle_environment &&
+       self.foreman_host.environment.content_view
+
+      if puppet_env = self.content_view.puppet_env(self.environment).try(:puppet_environment)
+        if puppet_env.id != self.foreman_host.environment_id
+          self.foreman_host.environment_id = puppet_env.id
+          self.foreman_host.save!
+        end
+      else
+        fail Errors::NotFound,
+             _("Couldn't find puppet environment associated with lifecycle environment '%{env}' and content view '%{view}'") %
+                 { :env => self.environment.name, :view => self.content_view.name }
+      end
+    end
   end
 
   # rubocop:disable SymbolName

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -1,0 +1,74 @@
+# encoding: UTF-8
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module Katello
+  class HostManagedExtensionsTest < ActiveSupport::TestCase
+
+    def self.before_suite
+      services  = ['Candlepin', 'Pulp', 'ElasticSearch', 'Foreman']
+      models    = ['User', 'KTEnvironment', 'Organization',
+                   "ContentView", "System"]
+      disable_glue_layers(services, models)
+
+      configure_runcible
+    end
+
+    def setup
+      disable_orchestration # disable foreman orchestration
+
+      content_host = Katello::System.find(katello_systems(:simple_server))
+      @foreman_host = Host.find(hosts(:one))
+      @foreman_host.puppetclasses = []
+      @foreman_host.content_host = content_host
+      @foreman_host.save!
+
+      new_puppet_environment = Environment.find(environments(:testing))
+
+      @foreman_host.environment = new_puppet_environment
+    end
+
+    def teardown
+      @foreman_host.destroy
+    end
+
+    def test_update_puppet_environment_updates_content_host
+      Environment.any_instance.stubs(:content_view_puppet_environment).returns(
+          ContentViewPuppetEnvironment.find(katello_content_view_puppet_environments(:dev_view_puppet_environment)))
+
+      # we are making an update to the foreman host that should result in a change to the content host
+      @foreman_host.content_host.expects(:save!)
+      @foreman_host.save!
+    end
+
+    def test_update_puppet_environment_does_not_update_content_host
+      # we are making an update to the foreman host that should NOT result in a change to the content host.
+      # this can happen if the user is only using puppet environments that they create within foreman
+      # vs those that automatically created as part of the katello content management
+      @foreman_host.content_host.expects(:save!).never
+      @foreman_host.save!
+    end
+
+    def test_update_does_not_update_content_host
+      content_host = System.find(katello_systems(:simple_server2))
+      @foreman_host2 = Host.find(hosts(:two))
+      @foreman_host2.content_host = content_host
+      @foreman_host2.save!
+
+      @foreman_host2.expects(:update_content_host).never
+      @foreman_host2.save!
+    end
+
+  end
+end


### PR DESCRIPTION
This commit is intended to improve the behavior between foreman host and
katello content host.  More specifically,
- if the foreman host puppet environment changes, we'll attempt to update the content
  host lifecycle environment and content view
- if the content host lifecycle environment and/or content view changes, we'll attempt
  to update the foreman host puppet environment
