### PR TITLE
Fixes #6726 - Actions that hit candlepin use username in cp-user oauth header

### DIFF
--- a/app/lib/actions/middleware/remote_action.rb
+++ b/app/lib/actions/middleware/remote_action.rb
@@ -18,7 +18,10 @@ module Actions
     # that triggered the action.
     class RemoteAction < Dynflow::Middleware
       def plan(*args)
-        pass(*args).tap { action.input[:remote_user] = User.current.remote_id }
+        pass(*args).tap do
+          action.input[:remote_user] = User.current.remote_id
+          action.input[:remote_cp_user] = User.current.login
+        end
       end
 
       def run(*args)
@@ -32,8 +35,8 @@ module Actions
       private
 
       def as_cp_user(&block)
-        fail 'missing :remote_user' unless remote_user
-        User.set_cp_config('cp-user' => remote_user, &block)
+        fail 'missing :remote_user' unless cp_user
+        User.set_cp_config('cp-user' => cp_user, &block)
       end
 
       def as_pulp_user(&block)
@@ -43,6 +46,10 @@ module Actions
 
       def remote_user
         action.input[:remote_user]
+      end
+
+      def cp_user
+        action.input[:remote_cp_user]
       end
 
       def as_remote_user

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -19,6 +19,8 @@ module ::Actions::Katello::CapsuleContent
     include Support::Actions::Fixtures
     include FactoryGirl::Syntax::Methods
     include Support::CapsuleSupport
+    include Support::Actions::RemoteAction
+
 
     let(:environment) do
       katello_environments(:dev)

--- a/test/actions/katello/foreman_test.rb
+++ b/test/actions/katello/foreman_test.rb
@@ -36,7 +36,8 @@ class Actions::Katello::Foreman::ContentUpdateTest < ActiveSupport::TestCase
     assert_finalize_phase(action)
     action.input.must_equal("environment_id" => environment.id,
                             "content_view_id" => content_view.id,
-                            "remote_user" => "user")
+                            "remote_user" => "user",
+                            "remote_cp_user" => "user")
   end
 
   it 'updates the foreman content' do

--- a/test/actions/katello/system_test.rb
+++ b/test/actions/katello/system_test.rb
@@ -53,6 +53,7 @@ module ::Actions::Katello::System
     it 'updates the uuid in finalize method' do
       ::Katello::System.stubs(:find).with(123).returns(system)
       action.input[:remote_user] = 'user'
+      action.input[:remote_cp_user] = 'user'
       action.input[:system] = { id:  123 }
       action.input[:uuid] = '123'
       system.expects(:save!)

--- a/test/support/actions/remote_action.rb
+++ b/test/support/actions/remote_action.rb
@@ -13,7 +13,8 @@ module Support
   module Actions
     module RemoteAction
       def stub_remote_user
-        User.stubs(:current).returns mock('user', remote_id: 'user')
+        usr = mock('user', remote_id: 'user', login: 'user')
+        User.stubs(:current).returns usr
       end
 
       # runcible_expects(action, :extensions, :consumer, :create).with('uuid')


### PR DESCRIPTION
instead of remote_id
