### PR TITLE
Fixes #7114: use the correct model for host-collection row select.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-collapsed.html
@@ -8,7 +8,7 @@
   <tbody>
     <tr alch-table-row
         ng-repeat="hostCollection in table.rows"
-        row-select="product"
+        row-select="hostCollection"
         active-row="stateIncludes('host-collections.details', {hostCollectionId: hostCollection.id})">
       <td alch-table-cell>
         <a ui-sref="host-collections.details.info({hostCollectionId: hostCollection.id})">


### PR DESCRIPTION
The model being used for host-collections collapsed table row
select was incorrect from a bad copy/paste.  This commit fixes the
model being used.

http://projects.theforeman.org/issues/7114
