### PR TITLE
fixes #7110 / BZ 1129424 - fix syncing of iso repos

### DIFF
--- a/app/lib/actions/katello/repository/node_metadata_generate.rb
+++ b/app/lib/actions/katello/repository/node_metadata_generate.rb
@@ -16,7 +16,8 @@ module Actions
       class NodeMetadataGenerate < Actions::Base
 
         def plan(repo, dependency = nil)
-          return unless repo.environment
+          return if (repo.content_type == ::Katello::Repository::FILE_TYPE) || !repo.environment
+
           sequence do
             unless repo.puppet? && repo.content_view.default?
               plan_action(Pulp::Repository::DistributorPublish,


### PR DESCRIPTION
Based on discussions, it seems that syncing an ISO
repo to a node/capsule is not all that useful;
therefore, this commit will disable the node meta
generation for ISO repos.  In addition, it would
increase sync times and the amount of storage required
on the node/capsule.

Without this change, syncing ISO repos will fail
since the node distributor is not being associated
with repos of that type (i.e. file).
