### PR TITLE
Fixes #7116/bz1130577- Adding install media after repo sync

### DIFF
--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -40,6 +40,7 @@ module Actions
             plan_action(ElasticSearch::Reindex, repo)
             plan_action(Katello::Foreman::ContentUpdate, repo.environment, repo.content_view)
             plan_action(Katello::Repository::CorrectChecksum, repo)
+            plan_action(Katello::Repository::UpdateMedia, repo)
           end
           plan_self(:sync_result => sync_task.output)
         end

--- a/app/lib/actions/katello/repository/update_media.rb
+++ b/app/lib/actions/katello/repository/update_media.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module Repository
+      class UpdateMedia < Actions::Base
+
+        def plan(repo)
+          plan_self(:repo_id => repo.id)
+        end
+
+        def finalize
+          repo = ::Katello::Repository.find(input[:repo_id])
+          Medium.update_media(repo)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this commit the installation media was missing after kickstart repo was synced,
This commit fixes that issue.
