### PR TITLE
Fixes #7138,BZ1030537 - Prevent file repos being added to views

### DIFF
--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -14,6 +14,8 @@ module Katello
   class ContentViewRepository < Katello::Model
     self.include_root_in_json = false
 
+    ALLOWED_REPOSITORY_TYPES = [Repository::YUM_TYPE]
+
     belongs_to :content_view, :inverse_of => :content_view_repositories,
       :class_name => "Katello::ContentView"
     belongs_to :repository, :inverse_of => :content_view_repositories,
@@ -21,7 +23,7 @@ module Katello
 
     validates :repository_id, :uniqueness => {:scope => :content_view_id}
     validate :content_view_composite
-    validate :non_puppet_repository
+    validate :ensure_repository_type
 
     private
 
@@ -31,9 +33,9 @@ module Katello
       end
     end
 
-    def non_puppet_repository
-      if repository.puppet?
-        errors.add(:base, _("Cannot add puppet repositories to a content view"))
+    def ensure_repository_type
+      unless ALLOWED_REPOSITORY_TYPES.include?(repository.content_type)
+        errors.add(:base, _("Cannot add %s repositories to a content view.") % repository.content_type)
       end
     end
   end

--- a/test/factories/repository_factory.rb
+++ b/test/factories/repository_factory.rb
@@ -31,5 +31,8 @@ FactoryGirl.define do
       content_type "puppet"
     end
 
+    trait :iso do
+      content_type "file"
+    end
   end
 end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -265,6 +265,14 @@ class ContentViewTest < ActiveSupport::TestCase
     end
   end
 
+  def test_puppet_repos
+    @file_repo = build_stubbed(:katello_repository, :iso)
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      @library_view.repositories << @file_repo
+    end
+  end
+
   def test_unique_environments
     3.times do |i|
       ContentViewVersion.create!(:version => i + 2,


### PR DESCRIPTION
Looks like we already have the UI covered:

https://github.com/Katello/katello/blob/master/engines/bastion/app/assets/javascripts/bastion/content-views/details/content-view-available-repositories.controller.js#L40

This prevents users from adding file repos to a content view via CLI or API.
