### PR TITLE
Fixes #7173: remove grunt bower:dev configuration.

### DIFF
--- a/engines/bastion/Gruntfile.js
+++ b/engines/bastion/Gruntfile.js
@@ -52,15 +52,6 @@ module.exports = function (grunt) {
                     },
                     clearBowerDir: true
                 }
-            },
-            dev: {
-                options: {
-                    targetDir: '.tmp/bower_components',
-                    copy: false,
-                    layout: 'byType',
-                    verbose: true,
-                    cleanTargetDir: true
-                }
             }
         },
         clean: {


### PR DESCRIPTION
We are no longer using grunt bower:dev.  This commit removes
the configuration.

http://projects.theforeman.org/issues/7173
