### PR TITLE
fixes #7162 / BZ 1102763 - capsule - treat task as failed if sync times times out

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -15,6 +15,10 @@ module Actions
     module CapsuleContent
       class Sync < ::Actions::EntryAction
 
+        def humanized_name
+          _("Sychronize capsule content")
+        end
+
         def plan(capsule_content, environment = nil)
           fail _("Action not allowed for the default capsule.") if capsule_content.default_capsule?
 

--- a/app/lib/actions/pulp/consumer/abstract_sync_node_task.rb
+++ b/app/lib/actions/pulp/consumer/abstract_sync_node_task.rb
@@ -1,0 +1,35 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Pulp
+    module Consumer
+      class AbstractSyncNodeTask <  ::Actions::Pulp::AbstractAsyncTask
+
+        private
+
+        def external_task=(external_task_data)
+          external_task_data = [external_task_data] if external_task_data.is_a?(Hash)
+          output[:pulp_tasks] = external_task_data.reject{ |task| task['task_id'].nil? }
+
+          output[:pulp_tasks].each do |pulp_task|
+            if pulp_task[:result] && pulp_task[:result].key?(:succeeded) && pulp_task[:result][:succeeded] == false
+              fail StandardError.new(_("Pulp task error.  Refer to task for more details."))
+            end
+          end
+          super(external_task_data)
+        end
+
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/consumer/sync_node.rb
+++ b/app/lib/actions/pulp/consumer/sync_node.rb
@@ -13,7 +13,7 @@
 module Actions
   module Pulp
     module Consumer
-      class SyncNode < ::Actions::Pulp::AbstractAsyncTask
+      class SyncNode < AbstractSyncNodeTask
 
         input_format do
           param :consumer_uuid, String
@@ -40,8 +40,14 @@ module Actions
           ret[:skip_content_update] = true if input[:skip_content]
           ret
         end
-      end
 
+        def rescue_strategy_for_self
+          # There are various reasons the syncing fails, not all of them are
+          # fatal: when fail on syncing, we continue with the task ending up
+          # in the warning state, but not locking further syncs
+          Dynflow::Action::Rescue::Skip
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Without this change, when an error (such as timeout) occurs attempting to
'capsule content synchronize' an environment, the synchronize task is reported
as successful.  E.g. from cli, this might look like:

hammer> capsule content synchronize --id 3 --environment-id 5
[.....................................................................] [100%]
Task 6c80df66-af10-44aa-9eca-c96992148811: success

With this change, if an error occurs that is reported back from pulp as
succeeded=false, we'll treat this as an error (because it is).  In
this scenario, the cli might look like:

hammer> capsule content synchronize --id 3 --environment-id 5
[..........................                                           ] [50%]
Task 2246bfb5-131f-4171-a7c3-6e16e3276ddd: error
