### PR TITLE
Fixes #7119/BZ1130645: double quote host collection name in search.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-actions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/details/views/host-collection-actions.html
@@ -8,26 +8,26 @@
 
   <ul class="bullet">
     <li>
-      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.packages') }}?select_all=true&search=host_collection:'{{ hostCollection.name }}'">
+      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.packages') }}?select_all=true&search=host_collection:&quot;{{ hostCollection.name }}&quot;">
         Package Installation, Removal, and Update
       </a>
     </li>
 
 
     <li>
-      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.errata.list') }}?select_all=true&search=host_collection:'{{ hostCollection.name }}'">
+      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.errata.list') }}?select_all=true&search=host_collection:&quot;{{ hostCollection.name }}&quot;">
         Errata Installation
       </a>
     </li>
 
     <li>
-      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.host-collections') }}?select_all=true&search=host_collection:'{{ hostCollection.name }}'">
+      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.host-collections') }}?select_all=true&search=host_collection:&quot;{{ hostCollection.name }}&quot;">
         Host Collection Membership
       </a>
     </li>
 
     <li>
-      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.environment') }}?select_all=true&search=host_collection:'{{ hostCollection.name }}'">
+      <a translate ng-href="{{ $state.href('content-hosts.bulk-actions.environment') }}?select_all=true&search=host_collection:&quot;{{ hostCollection.name }}&quot;">
         Change assigned Lifecycle Environment or Content View
       </a>
     </li>


### PR DESCRIPTION
The host collection search was using single quotes which search
isn't happy with.  This commit changes the host collection bulk
actions to use double quotes.

http://projects.theforeman.org/issues/7119
https://bugzilla.redhat.com/show_bug.cgi?id=1130645
