### PR TITLE
Fixes #7214: add !optional to @extends, required after sass update

### DIFF
--- a/app/assets/stylesheets/katello/contents.scss
+++ b/app/assets/stylesheets/katello/contents.scss
@@ -117,7 +117,7 @@ $container_width: ($static_width/2) - 36;
 
     }
     .locked_breadcrumb_filter {
-      @extend breadcrumb_filter;
+      @extend breadcrumb_filter !optional;
       background-color: $tree-locked-breadcrumb_color;
       color: $black_color;
       border: 1px solid $tree-border_color;

--- a/app/assets/stylesheets/katello/katello.scss
+++ b/app/assets/stylesheets/katello/katello.scss
@@ -1097,7 +1097,7 @@ fieldset {
   padding: 12px;
   border: 1px solid $helptip-border_color;
   margin: 10px auto 5px auto;
-  @extend .clearfix;
+  @extend .clearfix !optional;
 
   .helptip-close-button {
     position: relative;
@@ -1124,7 +1124,7 @@ fieldset {
     position: absolute;
 
     &:hover { background-position: -336px -16px; }
-    @extend .clearfix
+    @extend .clearfix !optional;
   }
 }
 /* end helptip */
@@ -1347,7 +1347,7 @@ footer a {
   padding: 12px;
   border: 1px solid $helptip-border_color;
   margin: 10px auto 5px auto;
-  @extend .clearfix;
+  @extend .clearfix !optional;
 }
 
 #content section.maincontent {


### PR DESCRIPTION
There were sass errors occurring on load after we upgraded sass.
This commit adds !optional to the @extends so we don't get an error.

http://projects.theforeman.org/issues/7214
