### PR TITLE
Fixes #7120/BZ980113: use BS3 on dashboard to make it responsive.

### DIFF
--- a/app/assets/stylesheets/katello/dashboard.scss
+++ b/app/assets/stylesheets/katello/dashboard.scss
@@ -2,10 +2,6 @@
 
 $col_width: (($static_width) * 0.5);
 .column {
-  float: left;
-  margin: 0 10px;
-  margin-left: 20px;
-  width: $col_width - 50;
   min-height: 650px;
 
   &.right {

--- a/app/assets/stylesheets/katello/katello.scss
+++ b/app/assets/stylesheets/katello/katello.scss
@@ -42,7 +42,6 @@
 
 body {
   background-color: white;
-  min-width: $static_width;
 }
 
 pre  { text-indent: 18px; }
@@ -1356,7 +1355,6 @@ footer a {
   margin: 40px auto;
   box-sizing: border-box;
   padding-bottom: 20px;
-  width: 1172px;
   padding-left: 20px;
   padding-right: 20px;
 }

--- a/app/helpers/katello/dashboard_helper.rb
+++ b/app/helpers/katello/dashboard_helper.rb
@@ -164,7 +164,7 @@ module DashboardHelper
   def render_dashboard
     output = ""
     dashboard_layout.columns.each do |col|
-      output += content_tag "div", class: "column" do
+      output += content_tag "div", class: "col-md-6 column" do
         render_column(col)
       end
     end

--- a/app/views/katello/dashboard/_subscriptions.haml
+++ b/app/views/katello/dashboard/_subscriptions.haml
@@ -7,7 +7,7 @@
                             {data:#{escape_javascript(owner_info.total_valid_compliance_consumers + owner_info.total_partial_compliance_consumers + owner_info.total_invalid_compliance_consumers == 0 ? "100" : owner_info.total_valid_compliance_consumers.to_s)}, color:"#9ccc50"}]; //green   valid
 
 #dashboard_subscriptions.widget
-  .right_side
+  .right_side.visible-sm.visible-lg
     #overlay
     #sub_graph
 

--- a/app/views/katello/dashboard/index.html.haml
+++ b/app/views/katello/dashboard/index.html.haml
@@ -1,17 +1,19 @@
 = javascript "katello/dashboard"
 
 - if current_user && current_user.organizations.length == 0
-  .grid_16.flash_hud
+  .flash_hud
     %ul.flash_messages.warning
       %li
         = _("You do not currently have access to any organizations.  Please contact an administrator to get permission to access an organization.")
 
-.center.dashboard-container
-  = help_tip_button
-  = help_tip((_('Your dashboard can be rearranged by clicking on a widget\'s title and dragging the widget ' + |
-                'to another position.'))) |
 
-  = render_dashboard
+  = help_tip_button
+  .col-md-12
+    = help_tip((_('Your dashboard can be rearranged by clicking on a widget\'s title and dragging the widget ' + |
+                  'to another position.'))) |
+
+  .row
+    = render_dashboard
 
   .dashboard_popout.hidden
     .popout_row.popout

--- a/app/views/katello/layouts/katello.haml
+++ b/app/views/katello/layouts/katello.haml
@@ -26,7 +26,7 @@
 
 = content_for(:content) do
   %article#content
-    %section.maincontent.container_16{:id => section_id}
+    %section.maincontent.container{:id => section_id}
       = yield
 
 = render :template => 'layouts/base'


### PR DESCRIPTION
The dashboard was displaying badly in smaller browsers.  This
commit reworks the dashboard to use bootstrap 3 classes and
thus makes it responsive.

http://projects.theforeman.org/issues/7120
https://bugzilla.redhat.com/show_bug.cgi?id=980113
