### PR TITLE
Fixes #7028 - fixing api docs for orgs

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -13,6 +13,8 @@
 module Katello
   class Api::V2::OrganizationsController < ::Api::V2::OrganizationsController
 
+    apipie_concern_subst(:a_resource => N_("an organization"), :resource => "organization")
+
     include Api::V2::Rendering
     include ForemanTasks::Triggers
 
@@ -51,6 +53,7 @@ module Katello
     param :id, :identifier, :desc => N_("organization ID"), :required => true
     param :description, String, :desc => N_("description of the organization"), :required => false
     param :redhat_repository_url, String, :desc => N_("Redhat CDN url")
+    param_group :resource, ::Api::V2::TaxonomiesController
     def update
       if params.key?(:redhat_repository_url)
         @organization.redhat_provider.update_attributes!(:repository_url => params[:redhat_repository_url])
@@ -62,6 +65,7 @@ module Katello
     param :name, String, :desc => N_("name"), :required => true
     param :label, String, :desc => N_("unique label")
     param :description, String, :desc => N_("description")
+    param_group :resource, ::Api::V2::TaxonomiesController
     def create
       super
     end


### PR DESCRIPTION
Adding all taxonomy parameters inherited from Foreman. Important for the CLI to build the parameters correctly.

Requires:
~~https://github.com/Apipie/apipie-rails/pull/280~~ MERGED; apipie-rails 0.2.5 built and released
https://github.com/theforeman/foreman/pull/1707
