### PR TITLE
Fixes #7241/bz1132790 - Enable rh common for ks template

### DIFF
--- a/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
+++ b/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
@@ -10,6 +10,11 @@ subscription-manager register --org="<%= @host.params['kt_org']%>" --name="<%= @
   subscription-manager config --rhsm.baseurl=https://<%= @host.content_source.hostname %>/pulp/repos
 <% end %>
 
+<% if @host.operatingsystem.name == "RedHat" %>
+  # add the rhel rpms to install katello agent
+  subscription-manager repos --enable=rhel-*-rh-common-rpms
+<% end %>
+
 echo "Installing Katello Agent"
 yum -t -y -e 0 install katello-agent
 chkconfig goferd on


### PR DESCRIPTION
Added code to enable rhel RH common repo before installing the katello-agent.
This needs to be enabled by default for katello-agent to install
