### PR TITLE
Fixes #7243 - CVV promotion out of sequence

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -46,9 +46,12 @@ module Katello
 
     api :POST, "/content_view_versions/:id/promote", N_("Promote a content view version")
     param :id, :identifier, :desc => N_("Content view version identifier"), :required => true
+    param :force, :bool, :desc => N_("force content view promotion and bypass lifecycle environment restriction")
     param :environment_id, :identifier
     def promote
-      task = async_task(::Actions::Katello::ContentView::Promote, @version, @environment)
+      is_force = params[:force].is_a?(String) ? params[:force].to_bool : params[:force]
+      task = async_task(::Actions::Katello::ContentView::Promote,
+                        @version, @environment, is_force)
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -15,9 +15,11 @@ module Actions
     module ContentView
       class Promote < Actions::EntryAction
 
-        def plan(version, environment)
+        def plan(version, environment, is_force = false)
           action_subject(version.content_view)
           version.check_ready_to_promote!
+
+          fail ::Katello::HttpErrors::BadRequest, _("Cannot promote environment out of sequence. Use force to bypass restriction.") if !is_force && !version.promotable?(environment)
 
           history = ::Katello::ContentViewHistory.create!(:content_view_version => version, :user => ::User.current.login,
                                                 :environment => environment, :task => self.task,

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -133,6 +133,10 @@ class ContentViewVersion < Katello::Model
         self.content_view.versions.in_environment(from_env).count > 1
   end
 
+  def promotable?(environment)
+    environments.include?(environment.prior) || environments.empty? && environment == organization.library
+  end
+
   def archive_puppet_environment
     content_view_puppet_environments.archived.first
   end

--- a/test/fixtures/models/katello_environment_priors.yml
+++ b/test/fixtures/models/katello_environment_priors.yml
@@ -2,6 +2,14 @@ dev_library_prior:
   prior_id: <%= ActiveRecord::Fixtures.identify(:library) %>
   environment_id: <%= ActiveRecord::Fixtures.identify(:dev) %>
 
+test_dev_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:dev) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:test) %>
+
+test_beta_prior:
+  prior_id: <%= ActiveRecord::Fixtures.identify(:test) %>
+  environment_id: <%= ActiveRecord::Fixtures.identify(:beta) %>
+
 staging_library_prior:
   prior_id: <%= ActiveRecord::Fixtures.identify(:library) %>
   environment_id: <%= ActiveRecord::Fixtures.identify(:staging) %>

--- a/test/fixtures/models/katello_environments.yml
+++ b/test/fixtures/models/katello_environments.yml
@@ -11,6 +11,18 @@ dev:
   label:          dev_label
   organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
 
+test:
+  name:           Test_env
+  description:    Test environment.
+  label:          test_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
+beta:
+  name:           Beta
+  description:    Beta environment.
+  label:          beta_label
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
 staging:
   name:           Staging
   description:    Staging environment.

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -1,0 +1,54 @@
+
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module Katello
+class ContentViewVersionTest < ActiveSupport::TestCase
+
+  def self.before_suite
+    models = ["Organization", "KTEnvironment", "User", "ContentViewEnvironment",
+              "Repository", "ContentView", "ContentViewVersion",
+              "System", "ActivationKey"]
+    services = ["Candlepin", "Pulp", "ElasticSearch"]
+    disable_glue_layers(services, models, true)
+  end
+
+  def setup
+    User.current = User.find(users(:admin))
+    @cvv = create(:katello_content_view_version)
+    @cvv.organization.kt_environments << Katello::KTEnvironment.find_by_name(:Library)
+    @dev = create(:katello_environment,  :organization => @cvv.organization, :prior => @cvv.organization.library,     :name=> 'dev' )
+    @beta = create(:katello_environment, :organization => @cvv.organization, :prior => @dev,                         :name=> 'beta' )
+  end
+
+  def test_promotable_in_sequence
+    @cvv.expects(:environments).returns([@cvv.organization.library]).at_least_once
+    assert @cvv.promotable?(@dev)
+  end
+
+  def test_promotable_out_of_sequence
+    @cvv.expects(:environments).returns([@cvv.organization.library]).at_least_once
+    refute @cvv.promotable?(@beta)
+  end
+
+  def test_promotoable_without_environments
+    @cvv.expects(:environments).returns([]).at_least_once
+    assert @cvv.promotable?(@cvv.organization.library)
+  end
+
+  def test_promotoable_without_environments2
+    @cvv.expects(:environments).returns([]).at_least_once
+    refute @cvv.promotable?(@dev)
+  end
+end
+end


### PR DESCRIPTION
This prevents content view versions from being promoted out of sequence.
promotion of content view versions can be forced to be promoted out of
sequence by passing the force param.
