### PR TITLE
Fixes #7251 - hammer org_id help text missing

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -38,6 +38,7 @@ module Katello
     end
 
     api :GET, '/organizations/:id', N_('Show organization')
+    param :id, :identifier, :desc => N_("organization ID"), :required => true
     def show
       @render_template = 'katello/api/v2/organizations/show'
       super


### PR DESCRIPTION
This fixes an issue in hammer where the --organization-id is missing
descriptions. Hammer uses the show action to determine the description
for the id param when building options for dependant resources.
