### PR TITLE
Fixes #6990 - No message for admin

### DIFF
--- a/app/views/katello/dashboard/index.html.haml
+++ b/app/views/katello/dashboard/index.html.haml
@@ -1,6 +1,6 @@
 = javascript "katello/dashboard"
 
-- if current_user && current_user.organizations.length == 0
+- if (current_user && current_user.organizations.length == 0) && !current_user.admin
   .flash_hud
     %ul.flash_messages.warning
       %li


### PR DESCRIPTION
Erroneous message about contacting administrator will not be displayed for admin user. 
