### PR TITLE
Fixes #7270/BZ1131661: remove GMT from new sync plan form.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/views/new-sync-plan-form.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/views/new-sync-plan-form.html
@@ -37,7 +37,7 @@
           required/>
  </div>
 
- <div alch-form-group label="{{ 'Start Time' | translate }} ({{ syncPlan.startTime | date:'Z' }} GMT)">
+ <div alch-form-group label="{{ 'Start Time' | translate }}">
    <timepicker type="time" show-meridian="false"
           id="startTime"
           name="startTime"


### PR DESCRIPTION
Sync plan start time was listed as being in GMT and this is not
the case.  This commit removes the timezone designation.

http://projects.theforeman.org/issues/7270
https://bugzilla.redhat.com/show_bug.cgi?id=1131661
