### PR TITLE
fixes #7273 - capsule sync puppet and rpm content together

### DIFF
--- a/app/lib/actions/katello/content_view/node_metadata_generate.rb
+++ b/app/lib/actions/katello/content_view/node_metadata_generate.rb
@@ -26,12 +26,16 @@ module Actions
         def plan(content_view, environment)
           action_subject(content_view)
 
-          sequence do
+          concurrence do
             ::Katello::Repository.in_content_views([content_view]).in_environment(environment).each do |repo|
               plan_action(Katello::Repository::NodeMetadataGenerate, repo)
-              plan_self(:environment_name => environment.name)
             end
+
+            cv_puppet_env = ::Katello::ContentViewPuppetEnvironment.in_environment(environment).
+                in_content_view(content_view).first
+            plan_action(Katello::Repository::NodeMetadataGenerate, cv_puppet_env)
           end
+          plan_self(:environment_name => environment.name)
         end
 
       end

--- a/app/lib/actions/katello/content_view_puppet_environment/clone_to_environment.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/clone_to_environment.rb
@@ -41,8 +41,6 @@ module Actions
                 ::Katello::CapsuleContent.with_environment(environment).each do |capsule_content|
                   plan_action(CapsuleContent::AddRepository, capsule_content, clone)
                 end
-
-                plan_action(Katello::Repository::NodeMetadataGenerate, clone)
               end
             end
           end

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -90,7 +90,6 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
         current_capsule_content.capsule.id == capsule_content.capsule.id &&
             dev_puppet_env == repo
       end
-      assert_action_planed_with action, ::Actions::Katello::Repository::NodeMetadataGenerate, dev_puppet_env
     end
 
     it 'plans without existing puppet environment' do


### PR DESCRIPTION
previously there was a task spawned to sync rpm content to the capsule
when puppet content sync to the capsule was added, it was not added in
this 2nd task.  This commit moves puppet syncing to that 2nd, spanwed task.
