### PR TITLE
Fixes #6993: Ensure repo discovery proxy setup is loaded in production.

### DIFF
--- a/config/initializers/monkeys.rb
+++ b/config/initializers/monkeys.rb
@@ -2,3 +2,4 @@
 require 'monkeys/multi_json_empty_fix'
 require 'monkeys/json_munging_patch'
 require 'monkeys/passenger_tee_input'
+require 'monkeys/anemone'


### PR DESCRIPTION
Without this change, repo discovery behind a proxy works within the
Rails development environment. However, the monkey patch to Anemone
to enable authenticated proxies is not loaded in production.
