### PR TITLE
Fixes #7283: using translate directive in <span> to avoid infinite loop.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-products.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/details/views/gpg-key-products.html
@@ -8,7 +8,7 @@
   <table alch-table="table" class="table table-striped">
     <thead>
       <tr alch-table-head>
-        <th alch-table-column="name" sortable translate>Name</th>
+        <th alch-table-column="name" sortable><span translate>Name</span></th>
         <th alch-table-column class="number-cell" translate>Repositories</th>
       </tr>
     </thead>


### PR DESCRIPTION
Changing this table header to use a child `<span>` with the translate
directive thus avoiding an infinite loop created by the interaction
between the translate and sortable directives.

http://projects.theforeman.org/issues/7283
