### PR TITLE
Fixes #7294: replace <th> translate filters with directives.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -56,13 +56,13 @@
       <table ng-class="{'table-mask': subscriptionsTable.working}" class="table table-full table-striped">
         <thead>
           <tr alch-table-head row-select>
-            <th alch-table-column="quantity" sortable class="align-center">{{ "Quantity" | translate }}</th>
-            <th alch-table-column="attached" sortable>{{ "Attached" | translate }}</th>
-            <th alch-table-column="startDate" sortable>{{ "Starts" | translate }}</th>
-            <th alch-table-column="endDate" sortable>{{ "Expires" | translate }}</th>
-            <th alch-table-column="supportLevel">{{ "Support Level" | translate }}</th>
-            <th alch-table-column="contractNumber" sortable>{{ "Contract" | translate }}</th>
-            <th alch-table-column="accountNumber" sortable>{{ "Account" | translate }}</th>
+            <th alch-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
+            <th alch-table-column="attached" sortable><span translate>Attached</span></th>
+            <th alch-table-column="startDate" sortable><span translate>Starts</span></th>
+            <th alch-table-column="endDate" sortable><span translate>Expires</span></th>
+            <th alch-table-column="supportLevel"><span translate>Support Level</span></th>
+            <th alch-table-column="contractNumber" sortable><span translate>Contract</span></th>
+            <th alch-table-column="accountNumber" sortable><span translate>Account</span></th>
           </tr>
         </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -9,14 +9,14 @@
   <table class="table table-striped" alch-table="table" ng-class="{'table-mask': table.working}">
     <thead>
       <tr alch-table-head>
-        <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
+        <th alch-table-column="name" sortable><span translate>Name</span></th>
         <th alch-table-column="status">
           {{ "Subscription Status" | translate }}
         </th>
-        <th alch-table-column="environment" sortable>{{ "Environment" | translate }}</th>
-        <th alch-table-column="contentView">{{ "Content View" | translate }}</th>
-        <th alch-table-column="serviceLevel">{{ "Service Level" | translate }}</th>
-        <th alch-table-column="releaseVersion">{{ "Release Version" | translate }}</th>
+        <th alch-table-column="environment" sortable><span translate>Environment</span></th>
+        <th alch-table-column="contentView"><span translate>Content View</span></th>
+        <th alch-table-column="serviceLevel"><span translate>Service Level</span></th>
+        <th alch-table-column="releaseVersion"><span translate>Release Version</span></th>
       </tr>
     </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -56,13 +56,13 @@
       <table ng-class="{'table-mask': subscriptionsTable.working}" class="table table-full table-striped">
         <thead>
           <tr alch-table-head row-select>
-            <th alch-table-column="quantity" sortable class="align-center">{{ "Quantity" | translate }}</th>
-            <th alch-table-column="attached" sortable>{{ "Attached" | translate }}</th>
-            <th alch-table-column="startDate" sortable>{{ "Starts" | translate }}</th>
-            <th alch-table-column="endDate" sortable>{{ "Expires" | translate }}</th>
-            <th alch-table-column="supportLevel">{{ "Support Level" | translate }}</th>
-            <th alch-table-column="contractNumber" sortable>{{ "Contract" | translate }}</th>
-            <th alch-table-column="accountNumber" sortable>{{ "Account" | translate }}</th>
+            <th alch-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
+            <th alch-table-column="attached" sortable><span translate>Attached</span></th>
+            <th alch-table-column="startDate" sortable><span translate>Starts</span></th>
+            <th alch-table-column="endDate" sortable><span translate>Expires</span></th>
+            <th alch-table-column="supportLevel"><span translate>Support Level</span></th>
+            <th alch-table-column="contractNumber" sortable><span translate>Contract</span></th>
+            <th alch-table-column="accountNumber" sortable><span translate>Account</span></th>
           </tr>
         </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-collapsed.html
@@ -1,7 +1,7 @@
 <table alch-table="table" class="table table-striped table-full" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head>
-      <th alch-table-column sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/activation-keys/views/activation-keys-table-full.html
@@ -1,10 +1,10 @@
 <table class="table table-striped" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head>
-      <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
-      <th alch-table-column="consumed">{{ "Consumed" | translate }}</th>
-      <th alch-table-column="environment">{{ "Environment" | translate }}</th>
-      <th alch-table-column="contentView">{{ "Content View" | translate }}</th>
+      <th alch-table-column="name" sortable><span translate>Name</span></th>
+      <th alch-table-column="consumed"><span translate>Consumed</span></th>
+      <th alch-table-column="environment"><span translate>Environment</span></th>
+      <th alch-table-column="contentView"><span translate>Content View</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-host-collections.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/bulk/views/bulk-actions-host-collections.html
@@ -44,9 +44,9 @@
     <table data-block="table"  class="table table-striped" ng-class="{'table-mask': state.working}">
       <thead>
         <tr alch-table-head row-select>
-          <th alch-table-column="name">{{ "Name" | translate }}</th>
-          <th alch-table-column="content_hosts">{{ "Content Hosts" | translate }}</th>
-          <th alch-table-column="limit">{{ "Limit" | translate }}</th>
+          <th alch-table-column="name"><span translate>Name</span></th>
+          <th alch-table-column="content_hosts"><span translate>Content Hosts</span></th>
+          <th alch-table-column="limit"><span translate>Limit</span></th>
         </tr>
       </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-add-subscriptions.html
@@ -55,13 +55,13 @@
       <table ng-class="{'table-mask': addSubscriptionsTable.working}" class="table table-full table-striped">
         <thead>
           <tr alch-table-head row-select>
-            <th alch-table-column="quantity" sortable class="align-center">{{ "Quantity" | translate }}</th>
-            <th alch-table-column="attached" sortable>{{ "Attached" | translate }}</th>
-            <th alch-table-column="startDate" sortable>{{ "Starts" | translate }}</th>
-            <th alch-table-column="endDate" sortable>{{ "Expires" | translate }}</th>
-            <th alch-table-column="supportLevel">{{ "Support Level" | translate }}</th>
-            <th alch-table-column="contractNumber" sortable>{{ "Contract" | translate }}</th>
-            <th alch-table-column="accountNumber" sortable>{{ "Account" | translate }}</th>
+            <th alch-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
+            <th alch-table-column="attached" sortable><span translate>Attached</span></th>
+            <th alch-table-column="startDate" sortable><span translate>Starts</span></th>
+            <th alch-table-column="endDate" sortable><span translate>Expires</span></th>
+            <th alch-table-column="supportLevel"><span translate>Support Level</span></th>
+            <th alch-table-column="contractNumber" sortable><span translate>Contract</span></th>
+            <th alch-table-column="accountNumber" sortable><span translate>Account</span></th>
           </tr>
         </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/details/views/content-host-subscriptions-list.html
@@ -54,13 +54,13 @@
       <table ng-class="{'table-mask': subscriptionsTable.working}" class="table table-full table-striped">
         <thead>
           <tr alch-table-head row-select>
-            <th alch-table-column="quantity" sortable class="align-center">{{ "Quantity" | translate }}</th>
-            <th alch-table-column="attached" sortable>{{ "Attached" | translate }}</th>
-            <th alch-table-column="startDate" sortable>{{ "Starts" | translate }}</th>
-            <th alch-table-column="endDate" sortable>{{ "Expires" | translate }}</th>
-            <th alch-table-column="supportLevel">{{ "Support Level" | translate }}</th>
-            <th alch-table-column="contractNumber" sortable>{{ "Contract" | translate }}</th>
-            <th alch-table-column="accountNumber" sortable>{{ "Account" | translate }}</th>
+            <th alch-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
+            <th alch-table-column="attached" sortable><span translate>Attached</span></th>
+            <th alch-table-column="startDate" sortable><span translate>Starts</span></th>
+            <th alch-table-column="endDate" sortable><span translate>Expires</span></th>
+            <th alch-table-column="supportLevel"><span translate>Support Level</span></th>
+            <th alch-table-column="contractNumber" sortable><span translate>Contract</span></th>
+            <th alch-table-column="accountNumber" sortable><span translate>Account</span></th>
           </tr>
         </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-collapsed.html
@@ -1,7 +1,7 @@
 <table class="table table-striped" ng-class="{'table-mask': contentHostTable.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-full.html
@@ -1,15 +1,15 @@
 <table class="table table-striped" ng-class="{'table-mask': contentHostTable.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column="name" sortable><span translate>Name</span></th>
       <th alch-table-column="status">
         {{ "Subscription Status" | translate }}
       </th>
-      <th alch-table-column="os">{{ "OS" | translate }}</th>
-      <th alch-table-column="environment" sortable>{{ "Environment" | translate }}</th>
-      <th alch-table-column="contentView">{{ "Content View" | translate }}</th>
-      <th alch-table-column="registered">{{ "Registered" | translate }}</th>
-      <th alch-table-column="lastCheckin" sortable>{{ "Last Checkin" | translate }}</th>
+      <th alch-table-column="os"><span translate>OS</span></th>
+      <th alch-table-column="environment" sortable><span translate>Environment</span></th>
+      <th alch-table-column="contentView"><span translate>Content View</span></th>
+      <th alch-table-column="registered"><span translate>Registered</span></th>
+      <th alch-table-column="lastCheckin" sortable><span translate>Last Checkin</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/version-deletion-activation-keys.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/version-deletion-activation-keys.html
@@ -76,8 +76,8 @@
         <table data-block="table" class="table table-striped table-bordered">
           <thead>
             <tr alch-table-head>
-              <th alch-table-column="name">{{ "Name" | translate }}</th>
-              <th alch-table-column="environment.name">{{ "Lifecycle Environments" | translate }}</th>
+              <th alch-table-column="name"><span translate>Name</span></th>
+              <th alch-table-column="environment.name"><span translate>Lifecycle Environments</span></th>
             </tr>
           </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/version-deletion-content-hosts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/views/version-deletion-content-hosts.html
@@ -67,8 +67,8 @@
         <table data-block="table"  class="table table-striped table-bordered">
           <thead>
             <tr alch-table-head>
-              <th alch-table-column="name">{{ "Name" | translate }}</th>
-              <th alch-table-column="name">{{ "Environment" | translate }}</th>
+              <th alch-table-column="name"><span translate>Name</span></th>
+              <th alch-table-column="name"><span translate>Environment</span></th>
             </tr>
           </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filters.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filters.html
@@ -34,11 +34,11 @@
 
       <thead>
         <tr alch-table-head row-select>
-          <th alch-table-column>{{ "Name" | translate }}</th>
-          <th alch-table-column>{{ "Description" | translate }}</th>
-          <th alch-table-column>{{ "Updated" | translate }}</th>
-          <th alch-table-column>{{ "Content Type" | translate }}</th>
-          <th alch-table-column>{{ "Type" | translate }}</th>
+          <th alch-table-column><span translate>Name</span></th>
+          <th alch-table-column><span translate>Description</span></th>
+          <th alch-table-column><span translate>Updated</span></th>
+          <th alch-table-column><span translate>Content Type</span></th>
+          <th alch-table-column><span translate>Type</span></th>
         </tr>
       </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter-details.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/package-group-filter-details.html
@@ -23,10 +23,10 @@
 
       <thead>
         <tr alch-table-head row-select>
-          <th alch-table-column>{{ "Name" | translate }}</th>
-          <th alch-table-column>{{ "Product" | translate }}</th>
-          <th alch-table-column>{{ "Repository" | translate }}</th>
-          <th alch-table-column>{{ "Description" | translate }}</th>
+          <th alch-table-column><span translate>Name</span></th>
+          <th alch-table-column><span translate>Product</span></th>
+          <th alch-table-column><span translate>Repository</span></th>
+          <th alch-table-column><span translate>Description</span></th>
         </tr>
       </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
@@ -34,8 +34,8 @@
     <table class="table table-striped table-bordered">
       <thead>
         <tr alch-table-head>
-          <th alch-table-column>{{ "Name" | translate }}</th>
-          <th alch-table-column>{{ "Actions" | translate }}</th>
+          <th alch-table-column><span translate>Name</span></th>
+          <th alch-table-column><span translate>Actions</span></th>
         </tr>
       </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
@@ -34,11 +34,11 @@
   <table class="table table-striped table-bordered" alch-table="table" ng-class="{'table-mask': table.working}">
     <thead>
       <tr alch-table-head>
-        <th alch-table-column>{{ "Author" | translate }}</th>
-        <th alch-table-column>{{ "Version" | translate }}</th>
-        <th alch-table-column>{{ "Summary" | translate }}</th>
-        <th alch-table-column>{{ "Repositories" | translate }}</th>
-        <th alch-table-column>{{ "Actions" | translate }}</th>
+        <th alch-table-column><span translate>Author</span></th>
+        <th alch-table-column><span translate>Version</span></th>
+        <th alch-table-column><span translate>Summary</span></th>
+        <th alch-table-column><span translate>Repositories</span></th>
+        <th alch-table-column><span translate>Actions</span></th>
       </tr>
     </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-modules.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-modules.html
@@ -29,10 +29,10 @@
     <table class="table table-striped table-bordered" ng-show="detailsTable.rows.length > 0">
       <thead>
         <tr alch-table-head>
-          <th alch-table-column>{{ "Name" | translate }}</th>
-          <th alch-table-column>{{ "Author" | translate }}</th>
-          <th alch-table-column>{{ "Version" | translate }}</th>
-          <th alch-table-column>{{ "Actions" | translate }}</th>
+          <th alch-table-column><span translate>Name</span></th>
+          <th alch-table-column><span translate>Author</span></th>
+          <th alch-table-column><span translate>Version</span></th>
+          <th alch-table-column><span translate>Actions</span></th>
         </tr>
       </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
@@ -16,12 +16,12 @@
   <table class="table table-striped table-bordered" alch-table="table" ng-class="{'table-mask': loadingVersions}">
     <thead>
       <tr alch-table-head>
-        <th alch-table-column>{{ "Version" | translate }}</th>
-        <th alch-table-column>{{ "Status" | translate }}</th>
-        <th alch-table-column>{{ "Environments" | translate }}</th>
-        <th alch-table-column>{{ "Content" | translate }}</th>
-        <th alch-table-column>{{ "Author" | translate }}</th>
-        <th class="col-sm-2" alch-table-column>{{ "Actions" | translate }}</th>
+        <th alch-table-column><span translate>Version</span></th>
+        <th alch-table-column><span translate>Status</span></th>
+        <th alch-table-column><span translate>Environments</span></th>
+        <th alch-table-column><span translate>Content</span></th>
+        <th alch-table-column><span translate>Author</span></th>
+        <th class="col-sm-2" alch-table-column><span translate>Actions</span></th>
       </tr>
     </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-collapsed.html
@@ -2,7 +2,7 @@
 
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/views/content-views-table-full.html
@@ -2,11 +2,11 @@
 
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column>{{ "Name" | translate }}</th>
-      <th alch-table-column>{{ "Composite View?" | translate }}</th>
-      <th alch-table-column>{{ "Last Published" | translate }}</th>
-      <th alch-table-column>{{ "Environments" | translate }}</th>
-      <th alch-table-column>{{ "Repositories" | translate }}</th>
+      <th alch-table-column><span translate>Name</span></th>
+      <th alch-table-column><span translate>Composite View?</span></th>
+      <th alch-table-column><span translate>Last Published</span></th>
+      <th alch-table-column><span translate>Environments</span></th>
+      <th alch-table-column><span translate>Repositories</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-collapsed.html
@@ -1,7 +1,7 @@
 <table alch-table="table" class="table table-striped" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head>
-      <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column="name" sortable><span translate>Name</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/gpg-keys/views/gpg-keys-table-full.html
@@ -1,10 +1,10 @@
 <table alch-table="table" class="table table-striped" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head>
-      <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
-      <th alch-table-column="organization">{{ "Organization" | translate }}</th>
-      <th alch-table-column="products" class="number-cell">{{ "Product Count" | translate }}</th>
-      <th alch-table-column class="number-cell">{{ "Repository Count" | translate }}</th>
+      <th alch-table-column="name" sortable><span translate>Name</span></th>
+      <th alch-table-column="organization"><span translate>Organization</span></th>
+      <th alch-table-column="products" class="number-cell"><span translate>Product Count</span></th>
+      <th alch-table-column class="number-cell"><span translate>Repository Count</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-collapsed.html
@@ -1,7 +1,7 @@
 <table alch-table="table" class="table table-striped table-full" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/host-collections/views/host-collections-table-full.html
@@ -1,9 +1,9 @@
 <table class="table table-striped" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
-      <th alch-table-column="content-hosts">{{ "Content Hosts" | translate }}</th>
-      <th alch-table-column="limit">{{ "Limit" | translate }}</th>
+      <th alch-table-column="name" sortable><span translate>Name</span></th>
+      <th alch-table-column="content-hosts"><span translate>Content Hosts</span></th>
+      <th alch-table-column="limit"><span translate>Limit</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-collapsed.html
@@ -1,7 +1,7 @@
 <table class="table table-striped" ng-class="{'table-mask': productTable.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/views/products-table-full.html
@@ -1,11 +1,11 @@
 <table class="table table-striped" ng-class="{'table-mask': productTable.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
-      <th alch-table-column="description">{{ "Description" | translate }}</th>
-      <th alch-table-column="sync_status">{{ "Sync Status" | translate }}</th>
-      <th alch-table-column="sync_plan">{{ "Sync Plan" | translate }}</th>
-      <th alch-table-column class="number-cell">{{ "Repositories" | translate }}</th>
+      <th alch-table-column="name" sortable><span translate>Name</span></th>
+      <th alch-table-column="description"><span translate>Description</span></th>
+      <th alch-table-column="sync_status"><span translate>Sync Status</span></th>
+      <th alch-table-column="sync_plan"><span translate>Sync Plan</span></th>
+      <th alch-table-column class="number-cell"><span translate>Repositories</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-manage-packages.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-manage-packages.html
@@ -44,7 +44,7 @@
 
       <thead ng-hide="detailsTable.working">
         <tr alch-table-head row-select>
-          <th alch-table-column>{{ "Name" | translate }}</th>
+          <th alch-table-column><span translate>Name</span></th>
         </tr>
       </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/details/views/subscription-associations-activation-keys.html
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/details/views/subscription-associations-activation-keys.html
@@ -9,11 +9,11 @@
   <table class="table table-striped" alch-table="table" ng-class="{'table-mask': working}">
     <thead>
       <tr alch-table-head>
-        <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
-        <th alch-table-column="environment">{{ "Environment" | translate }}</th>
-        <th alch-table-column="contentView">{{ "Content View" | translate }}</th>
-        <th alch-table-column="contentView">{{ "Service Level" | translate }}</th>
-        <th alch-table-column="contentView">{{ "Release Version" | translate }}</th>
+        <th alch-table-column="name" sortable><span translate>Name</span></th>
+        <th alch-table-column="environment"><span translate>Environment</span></th>
+        <th alch-table-column="contentView"><span translate>Content View</span></th>
+        <th alch-table-column="contentView"><span translate>Service Level</span></th>
+        <th alch-table-column="contentView"><span translate>Release Version</span></th>
       </tr>
     </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/details/views/subscription-associations-content-hosts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/details/views/subscription-associations-content-hosts.html
@@ -9,17 +9,17 @@
   <table class="table table-striped" alch-table="table" ng-class="{'table-mask': working}">
     <thead>
       <tr alch-table-head>
-        <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
+        <th alch-table-column="name" sortable><span translate>Name</span></th>
         <th alch-table-column="status">
           {{ "Subscription Status" | translate }}
         </th>
-        <th alch-table-column="virtual">{{ "Virtual" | translate }}</th>
-        <th alch-table-column="environment" sortable>{{ "Environment" | translate }}</th>
-        <th alch-table-column="contentView">{{ "Content View" | translate }}</th>
-        <th alch-table-column="serviceLevel">{{ "Service Level" | translate }}</th>
-        <th alch-table-column="sockets">{{ "Sockets" | translate }}</th>
-        <th alch-table-column="cores">{{ "Cores per Socket" | translate }}</th>
-        <th alch-table-column="memory">{{ "RAM (GB)" | translate }}</th>
+        <th alch-table-column="virtual"><span translate>Virtual</span></th>
+        <th alch-table-column="environment" sortable><span translate>Environment</span></th>
+        <th alch-table-column="contentView"><span translate>Content View</span></th>
+        <th alch-table-column="serviceLevel"><span translate>Service Level</span></th>
+        <th alch-table-column="sockets"><span translate>Sockets</span></th>
+        <th alch-table-column="cores"><span translate>Cores per Socket</span></th>
+        <th alch-table-column="memory"><span translate>RAM (GB)</span></th>
       </tr>
     </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/views/subscriptions-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/views/subscriptions-table-collapsed.html
@@ -1,7 +1,7 @@
 <table class="table table-striped table-full" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head>
-      <th alch-table-column sortable>{{ "Consumed" | translate }}</th>
+      <th alch-table-column sortable><span translate>Consumed</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/views/subscriptions-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/views/subscriptions-table-full.html
@@ -1,13 +1,13 @@
 <table class="table table-striped" ng-class="{'table-mask': table.working}">
   <thead>
     <tr alch-table-head>
-      <th alch-table-column="consumed" class="align-center">{{ "Consumed" | translate }}</th>
-      <th alch-table-column="type">{{ "Type" | translate }}</th>
-      <th alch-table-column="startDate">{{ "Starts" | translate }}</th>
-      <th alch-table-column="endDate">{{ "Expires" | translate }}</th>
-      <th alch-table-column="supportLevel">{{ "Support Level" | translate }}</th>
-      <th alch-table-column="contractNumber">{{ "Contract" | translate }}</th>
-      <th alch-table-column="accountNumber">{{ "Account" | translate }}</th>
+      <th alch-table-column="consumed" class="align-center"><span translate>Consumed</span></th>
+      <th alch-table-column="type"><span translate>Type</span></th>
+      <th alch-table-column="startDate"><span translate>Starts</span></th>
+      <th alch-table-column="endDate"><span translate>Expires</span></th>
+      <th alch-table-column="supportLevel"><span translate>Support Level</span></th>
+      <th alch-table-column="contractNumber"><span translate>Contract</span></th>
+      <th alch-table-column="accountNumber"><span translate>Account</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-products-table.html
@@ -59,7 +59,7 @@
           <th alch-table-column="name" translate>Name</th>
           <th alch-table-column="description" translate>Description</th>
           <th alch-table-column="sync_status" translate>Sync Status</th>
-          <th alch-table-column class="number-cell">{{ "Repositories" | translate }}</th>
+          <th alch-table-column class="number-cell"><span translate>Repositories</span></th>
         </tr>
         </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-collapsed.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-collapsed.html
@@ -1,7 +1,7 @@
 <table class="table table-striped" ng-class="{'table-mask': syncPlanTable.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column sortable>{{ "Name" | translate }}</th>
+      <th alch-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
 

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
@@ -1,11 +1,11 @@
 <table class="table table-striped" ng-class="{'table-mask': syncPlanTable.working}">
   <thead>
     <tr alch-table-head row-select>
-      <th alch-table-column="name" sortable>{{ "Name" | translate }}</th>
-      <th alch-table-column="description">{{ "Description" | translate }}</th>
-      <th alch-table-column="syncDate">{{ "Original Sync Date" | translate }}</th>
-      <th alch-table-column="interval">{{ "Interval" | translate }}</th>
-      <th alch-table-column="nextSync">{{ "Next Sync" | translate }}</th>
+      <th alch-table-column="name" sortable><span translate>Name</span></th>
+      <th alch-table-column="description"><span translate>Description</span></th>
+      <th alch-table-column="syncDate"><span translate>Original Sync Date</span></th>
+      <th alch-table-column="interval"><span translate>Interval</span></th>
+      <th alch-table-column="nextSync"><span translate>Next Sync</span></th>
     </tr>
   </thead>
 


### PR DESCRIPTION
We were using translate filters in our table headers because
of a clash between the translate directive and other directives.
This commit updates the text in the `<th>`s to be wrapped in a
span that includes the translate directive instead.  Directives
are more performant than filters so this should speed up the
application ever so slightly.

http://projects.theforeman.org/issues/7294
