### PR TITLE
fixes #7309 / BZ 1093483 - Repo sync status - update UI cross-links and status based on dynflow task

### DIFF
--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -3,7 +3,6 @@ object @resource
 extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 extends 'katello/api/v2/common/timestamps'
-extends 'katello/api/v2/common/syncable'
 
 attributes :content_type
 attributes :unprotected, :full_path
@@ -48,3 +47,14 @@ end
 child :gpg_key do
   attributes :id, :name
 end
+
+child :latest_dynflow_sync => :last_sync do |object|
+  attributes :id, :username, :started_at, :ended_at, :state, :result, :progress
+end
+
+node :last_sync_words do |object|
+  if (object.latest_dynflow_sync.respond_to?('ended_at') && object.latest_dynflow_sync.ended_at)
+    time_ago_in_words(Time.parse(object.latest_dynflow_sync.ended_at.to_s))
+  end
+end
+

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/filters/views/filter-repositories.html
@@ -94,8 +94,8 @@
                   Not Synced
                 </span>
                 <span ng-hide="repository.last_sync == null">
-                  <a href="/katello/sync_management">{{ repository.sync_state | capitalize}}</a>
-                  ({{ repository.last_sync | date:"short" }})
+                  <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize}}</a>
+                  ({{ repository.last_sync.ended_at | date:"short" }})
                 </span>
               </span>
             <span ng-hide="repository.url" translate>N/A</span>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-repositories.html
@@ -101,13 +101,13 @@
             <td alch-table-cell>{{ repository.product.name }}</td>
             <td alch-table-cell>
               <span ng-show="repository.url">
-                {{ repository.last_sync | date:"short" }}
+                {{ repository.last_sync.ended_at | date:"short" }}
               </span>
               <span ng-hide="repository.url" translate>N/A</span>
             </td>
             <td alch-table-cell>
               <span ng-show="repository.url">
-                <a href="/katello/sync_management">{{ repository.sync_state | capitalize }}</a>
+                <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
               </span>
               <span ng-hide="repository.url" translate>N/A</span>
             </td>

--- a/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/views/product-repositories.html
@@ -89,7 +89,7 @@
               Not Synced
             </span>
             <span ng-hide="repository.last_sync == null">
-              <a href="/katello/sync_management">{{ repository.sync_state | capitalize}}</a>
+              <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize}}</a>
               <span translate>{{ repository.last_sync_words }} ago</span>
             </span>
           </span>

--- a/engines/bastion/app/assets/javascripts/bastion/products/products.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/products/products.controller.js
@@ -62,7 +62,11 @@ angular.module('Bastion.products').controller('ProductsController',
         watch = $scope.$watch('productTable.rows', function (rows) {
             if (_.isArray(rows) && !_.isEmpty(rows)) {
                 angular.forEach(rows, function (row) {
-                    row.repositoriesByState = _.groupBy(row.repositories, 'sync_state');
+                    row.repositoriesByState = _.groupBy(row.repositories, function (repository) {
+                        if (repository['last_sync'] !== null) {
+                            return repository['last_sync']['result'];
+                        }
+                    });
                 });
                 watch();
             }

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/repository-details-info.controller.js
@@ -101,8 +101,12 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
             }
         };
 
-        $scope.syncInProgress = function (state) {
-            return (state === 'running' || state === 'waiting');
+        $scope.syncInProgress = function (task) {
+            var inProgress = false;
+            if (task && (task.state === 'pending' || task.state === 'running')) {
+                inProgress = true;
+            }
+            return inProgress;
         };
 
         $scope.syncRepository = function (repository) {

--- a/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/repositories/details/views/repository-info.html
@@ -18,7 +18,7 @@
     <button class="btn btn-default"
             ng-click="syncRepository(repository); working = true"
             ng-hide="!repository.url || denied('sync_products', product)"
-            ng-disabled="syncInProgress(repository.sync_state)">
+            ng-disabled="syncInProgress(repository.last_sync)">
       <i class="icon-refresh"></i>
       <span translate>Sync Now</span>
     </button>
@@ -135,7 +135,7 @@
     <div class="detail">
       <span class="info-label" translate>Last Sync</span>
       <span class="info-value" translate>
-        {{ repository.last_sync_words }} Ago ({{ repository.last_sync | date:'medium' }} Local Time)
+        {{ repository.last_sync_words }} Ago ({{ repository.last_sync.ended_at | date:'medium' }} Local Time)
       </span>
     </div>
 
@@ -152,7 +152,7 @@
     <div class="detail">
       <span class="info-label" translate>Sync State</span>
       <span class="info-value">
-        <a href="sync_management">{{ repository.sync_state }}</a>
+        <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result }}</a>
       </span>
     </div>
   </section>

--- a/engines/bastion/test/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion/test/repositories/details/repository-details-info.controller.test.js
@@ -121,7 +121,8 @@ describe('Controller: RepositoryDetailsInfoController', function() {
     });
 
     it('should provide a method to determine if a repository is currently being syncd', function() {
-        expect($scope.syncInProgress('running')).toBe(true);
+        var lastSync = {state: 'running'};
+        expect($scope.syncInProgress(lastSync)).toBe(true);
     });
 
     it("provides a way to sync a repository", function() {


### PR DESCRIPTION
The Sync Status page was recently updated to sync repositories
using dynflow tasks.  With this, all syncs whether they are
initiated by Sync Status, Product or Repository pages should
be executed through dynflow.

That said, the API (which is used for showing sync status on
the Products, Repositories, Content Views and Content View
Filter pages) is currently reporting the status using
pulp; however, that does not provide a true indication of
whether or not the sync process has completed successfully.

This commit will address 2 things:
1. Update the API to return the 'last sync' information using the
   dynflow task (vs pulp). This information is then used for displaying
   sync time, status...etc.
2. Update the cross-linking for individual repositories on the various
   pages to go directly to the dynflow task versus sending the user to the
   sync status page.  This will allow the user to see
   any errors that may have occured without having to search for
   the repo once landing on Sync Status and then having to click
   again to get to the dynflow task.
