### PR TITLE
Fixes #7284 - BooleanValidator set expected_type

### DIFF
--- a/lib/katello/apipie/validators.rb
+++ b/lib/katello/apipie/validators.rb
@@ -93,6 +93,10 @@ module Katello
         def description
           "boolean"
         end
+
+        def expected_type
+          'boolean'
+        end
       end
     end
   end


### PR DESCRIPTION
this changes  the apiapie BooleanValidator to provide 'boolean' for expected_type so that
in hammer, the correct normalizer is set for for all :bool params.
