### PR TITLE
Fixes #6821/BZ1117636: fix link to content hosts on CV delete page.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-content-hosts.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/deletion/content-view-version-deletion-content-hosts.controller.js
@@ -71,7 +71,7 @@ angular.module('Bastion.content-views').controller('ContentViewVersionDeletionCo
 
         $scope.contentHostsLink = function () {
             var search = $scope.searchString($scope.contentView, $scope.deleteOptions.environments);
-            return $scope.$state.href('content-hosts.index').url + '?search=' + search;
+            return $scope.$state.href('content-hosts.index') + '?search=' + search;
         };
 
         $scope.toggleHosts = function () {


### PR DESCRIPTION
The link to manage individual content hosts was incorrectly using
$state.href(). This commit fixes the usage of $state.href() when
constructing the content hosts link.

http://projects.theforeman.org/issues/6821
https://bugzilla.redhat.com/show_bug.cgi?id=1117636
