### PR TITLE
fixes #7343 / BZ 1132576 - iso sync - fix issue where progress report not available yet

### DIFF
--- a/app/lib/actions/pulp/repository/presenters/iso_presenter.rb
+++ b/app/lib/actions/pulp/repository/presenters/iso_presenter.rb
@@ -31,15 +31,15 @@ module Actions
           end
 
           def num_isos
-            task_progress_details['num_isos'] || 0
+            task_progress_details && task_progress_details['num_isos'] || 0
           end
 
           def total_bytes
-            task_progress_details['total_bytes'] || 0
+            task_progress_details && task_progress_details['total_bytes'] || 0
           end
 
           def finished_bytes
-            task_progress_details['finished_bytes'] || 0
+            task_progress_details && task_progress_details['finished_bytes'] || 0
           end
 
           def task_progress_details


### PR DESCRIPTION
This is to address the issue where 'task_progress_details' returned
nil due to the pulp response not yet containing the progress report.
