### PR TITLE
fixes #7360 / BZ 1120595 - UI: Product: fix Sync Now behavior

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/products/details/product-details-info.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/products/details/product-details-info.controller.js
@@ -80,17 +80,23 @@ angular.module('Bastion.products').controller('ProductDetailsInfoController',
         });
 
         $scope.syncProduct = function () {
+            var success, error;
             $scope.productSyncing = true;
-            $scope.product.$sync(function () {
-                $scope.productSyncing = false;
+
+            success = function () {
                 $scope.successMessages.push(translate("Successfully started sync for %s products, you are free to leave this page.")
                     .replace('%s', $scope.product.name));
-            }, function (response) {
                 $scope.productSyncing = false;
+            };
+
+            error = function (response) {
                 _.each(response.data.errors, function (errorMessage) {
                     $scope.errorMessages.push(translate("An error occurred saving the Product: ") + errorMessage);
                 });
-            });
+                $scope.productSyncing = false;
+            };
+
+            Product.sync({id: $scope.$stateParams.productId}, success, error);
         };
     }]
 );

--- a/engines/bastion/test/products/details/product-details-info.controller.test.js
+++ b/engines/bastion/test/products/details/product-details-info.controller.test.js
@@ -22,9 +22,11 @@ describe('Controller: ProductDetailsInfoController', function() {
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller'),
             $q = $injector.get('$q'),
-            Product = $injector.get('MockResource').$new(),
             SyncPlan = $injector.get('MockResource').$new();
             GPGKey = $injector.get('MockResource').$new();
+
+        Product = $injector.get('MockResource').$new();
+        Product.sync = function() {};
 
         $scope = $injector.get('$rootScope').$new();
         $scope.$stateParams = {productId: 1};
@@ -88,11 +90,10 @@ describe('Controller: ProductDetailsInfoController', function() {
     });
 
     it('provides a way to sync a product', function() {
-        $scope.product.$sync = function () {};
-        spyOn($scope.product, '$sync');
+        spyOn(Product, 'sync');
 
         $scope.syncProduct();
 
-        expect($scope.product.$sync).toHaveBeenCalled();
+        expect(Product.sync).toHaveBeenCalledWith({id: $scope.$stateParams.productId}, jasmine.any(Function), jasmine.any(Function));
     });
 });


### PR DESCRIPTION
This commit addresses 2 small issues related to the 'Sync Now' button
on a the Product -> Details pane.  After the user clicks the button
and a response is received from the server:
1. switch the button back from 'Syncing...' to 'Sync Now'
2. display a notification to the user to indicate that the sync has
   been scheduled
