### PR TITLE
Fixes #7358/BZ1138411: correct empty org message logic on dashboard.

### DIFF
--- a/app/views/katello/dashboard/index.html.haml
+++ b/app/views/katello/dashboard/index.html.haml
@@ -7,6 +7,7 @@
         = _("You do not currently have access to any organizations.  Please contact an administrator to get permission to access an organization.")
 
 
+- else
   = help_tip_button
   .col-md-12
     = help_tip((_('Your dashboard can be rearranged by clicking on a widget\'s title and dragging the widget ' + |


### PR DESCRIPTION
The dashboard was not displaying in the case of not having a default
org selected if you were admin.  This is because we wanted to prevent
showing the error message to admins in #4611 and because of spacing
being important in haml we ended up not showing anything at all. This
commit fixes the dashboard display in the case of an admin without any
default organizations.

http://projects.theforeman.org/issues/7358
https://bugzilla.redhat.com/show_bug.cgi?id=1138411
