### PR TITLE
Fixes #7389: Prevent undefined method error from root controller.

### DIFF
--- a/app/controllers/katello/api/v2/root_controller.rb
+++ b/app/controllers/katello/api/v2/root_controller.rb
@@ -23,7 +23,7 @@ class Api::V2::RootController < Api::V2::ApiController
 
   def resource_list
     all_routes = Engine.routes.routes
-    all_routes.collect! { |r| r.path.spec.to_s }
+    all_routes = all_routes.collect { |r| r.path.spec.to_s }
 
     api_root_routes = all_routes.select do |path|
       path =~ %r{^/katello/api(\(/:api_version\))?/[^/]+/:id\(\.:format\)$}


### PR DESCRIPTION
This error was introduced while removing the V1 API and leads to
and undefined method error whenever RHSM attempts to get a list
of routes.
