### PR TITLE
Fixes #6946: Update organization to disallow modifying label

### DIFF
--- a/app/models/katello/ext/label_from_name.rb
+++ b/app/models/katello/ext/label_from_name.rb
@@ -16,6 +16,7 @@ module Ext
     def self.included(base)
       base.class_eval do
         before_validation :setup_label_from_name
+        validate :label_not_changed, :on => :update
       end
     end
 
@@ -25,6 +26,12 @@ module Ext
         if self.class.where(:label => self.label).any?
           self.label = Util::Model.uuid
         end
+      end
+    end
+
+    def label_not_changed
+      if label_changed?
+        errors.add(:label, _("cannot be changed."))
       end
     end
   end

--- a/test/glue/candlepin/consumer_test.rb
+++ b/test/glue/candlepin/consumer_test.rb
@@ -37,7 +37,8 @@ class GlueCandlepinConsumerTestBase < ActiveSupport::TestCase
 
     @@org      = Organization.find(@loaded_fixtures['taxonomies']['organization2']['id'])
     @@org.setup_label_from_name
-    @@org.save
+    @@org.stubs(:label_not_changed).returns(true)
+    @@org.save!
 
     @@dev_cv   = ContentView.find(@loaded_fixtures['katello_content_views']['candlepin_library_dev_cv']['id'])
     @@dev_cve  = ContentViewEnvironment.find(@loaded_fixtures['katello_content_view_environments']['candlepin_library_dev_cve']['id'])

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -153,6 +153,7 @@ class ActiveSupport::TestCase
     User.current = User.find(users(:admin))
     org = org.nil? ? :empty_organization : org
     organization = Organization.find(taxonomies(org.to_sym))
+    organization.stubs(:label_not_changed).returns(true)
     organization.setup_label_from_name
     organization.save!
     User.current = saved_user

--- a/test/models/label_from_name_test.rb
+++ b/test/models/label_from_name_test.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module Katello
+  class LabelFromNameTest < ActiveSupport::TestCase
+
+    def self.before_suite
+      services  = ['Candlepin', 'Pulp', 'ElasticSearch', 'Foreman']
+      models    = ['Repository', 'KTEnvironment', 'ContentView', 'ContentViewVersion',
+                   'ContentViewEnvironment', 'Organization', 'Product',
+                   'Provider']
+      disable_glue_layers(services, models, true)
+    end
+
+    def test_create_wtih_empty_label
+      org = get_organization
+      library = KTEnvironment.find(katello_environments(:library).id)
+      env = KTEnvironment.create!(:name => "justin11", :organization => org, :prior => library)
+      refute_nil env.label
+    end
+
+    def test_update_label
+      org = get_organization
+      staging = KTEnvironment.find(katello_environments(:staging).id)
+      assert_raises ActiveRecord::RecordInvalid do
+        staging.update_attributes!(:label => "crazy")
+      end
+    end
+
+  end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -228,6 +228,7 @@ class RepositoryInstanceTest < RepositoryTestBase
 
   def new_custom_repo
     new_custom_repo = @fedora_17_x86_64.clone
+    new_custom_repo.stubs(:label_not_changed).returns(true)
     new_custom_repo.name = "new_custom_repo"
     new_custom_repo.label = "new_custom_repo"
     new_custom_repo.pulp_id = "new_custom_repo"


### PR DESCRIPTION
Changed code to disallow updating an org label at the model level
