### PR TITLE
Fixes #7394: Stop blocking plugin routes from being loaded properly.

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -132,7 +132,7 @@ module Katello
       ::PuppetClassImporter.send :include, Katello::Services::PuppetClassImporterExtensions
     end
 
-    initializer 'katello.register_plugin', :after => :disable_dependency_loading do
+    initializer 'katello.register_plugin', :after => :finisher_hook do
       require 'katello/plugin'
       require 'katello/permissions'
     end


### PR DESCRIPTION
Prior to tis change, if a Foreman plugin was declared via bundler
after Katello in load order, the routes would not get properly loaded
within the application. This meant that these routes were in-accessible,
and could lead to intermittent and un-expected behaviors.
