### PR TITLE
Fixes #7446/bz1140653 - Host delete dynflowed

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Concerns
+    module Api::V2::HostsControllerExtensions
+      extend ActiveSupport::Concern
+      include ForemanTasks::Triggers
+
+      included do
+        def destroy
+          sync_task(::Actions::Katello::System::HostDestroy, @host)
+          process_response(:object => @host)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -1,0 +1,28 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Concerns
+    module HostsControllerExtensions
+      extend ActiveSupport::Concern
+      include ForemanTasks::Triggers
+      included do
+        def destroy
+          sync_task(::Actions::Katello::System::HostDestroy, @host)
+          process_success(:object => @host)
+        rescue StandardError => ex
+          process_error(:object => @host, :error_msg => ex.message)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/system/host_destroy.rb
+++ b/app/lib/actions/katello/system/host_destroy.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module System
+      class HostDestroy < Actions::EntryAction
+
+        def plan(host)
+          action_subject(host)
+          sequence do
+            if host.content_host
+              plan_action(Katello::System::Destroy, host.content_host)
+            end
+            unless host.reload.destroy
+              fail host.errors.full_messages.join('; ')
+            end
+          end
+        end
+
+        def humanized_name
+          _("Destroy Host")
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -14,6 +14,7 @@ module Katello
     module HostManagedExtensions
       extend ActiveSupport::Concern
       include Katello::KatelloUrlsHelper
+      include ForemanTasks::Concerns::ActionSubject
 
       included do
         before_update :update_content_host, :if => :environment_id_changed?
@@ -22,7 +23,7 @@ module Katello
         alias_method_chain :set_hostgroup_defaults, :content_source
 
         has_one :content_host, :class_name => "Katello::System", :foreign_key => :host_id,
-                :dependent => :destroy, :inverse_of => :foreman_host
+                :dependent => :restrict, :inverse_of => :foreman_host
         belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hosts
         scoped_search :in => :content_source, :on => :name, :complete_value => true, :rename => :content_source
       end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -109,6 +109,7 @@ module Katello
 
       #Controller extensions
       ::OperatingsystemsController.send :include, Katello::Concerns::OperatingsystemsControllerExtensions
+      ::HostsController.send :include, Katello::Concerns::HostsControllerExtensions
 
       #Handle Smart Proxy items separately
       begin
@@ -130,6 +131,9 @@ module Katello
       require_dependency "#{Katello::Engine.root}/app/controllers/katello/api/api_controller"
       require_dependency "#{Katello::Engine.root}/app/controllers/katello/api/v2/api_controller"
       ::PuppetClassImporter.send :include, Katello::Services::PuppetClassImporterExtensions
+
+      #Api controller extensions
+      ::Api::V2::HostsController.send :include, Katello::Concerns::Api::V2::HostsControllerExtensions
     end
 
     initializer 'katello.register_plugin', :after => :finisher_hook do

--- a/lib/katello/tasks/clean_backend_objects.rake
+++ b/lib/katello/tasks/clean_backend_objects.rake
@@ -1,36 +1,58 @@
 namespace :katello do
   desc "Cleans backend objects (systems) that are missing in one or more backend systems"
   task :clean_backend_objects => ["environment"] do
-    User.current = User.anonymous_admin
-    Katello::System.find_each do |system|
-      cp_fail = false
-      pulp_fail = false
-      begin
-        system.facts 
-      rescue  RestClient::ResourceNotFound => e
-        cp_fail = true
-      rescue  RestClient::Gone => e
-        cp_fail = true
-      end
+    def cleanup_systems
+      Katello::System.find_each do |system|
+        next if system.is_a? Katello::Hypervisor
 
-      begin
-        system.pulp_facts
-      rescue  RestClient::ResourceNotFound => e
-        pulp_fail = true
-      rescue  RestClient::Gone => e
-        pulp_fail = true
-      rescue  RestClient::Conflict => e
-        pulp_fail = true
-      end
+        cp_fail = false
+        pulp_fail = false
+        begin
+          system.facts
+        rescue  RestClient::ResourceNotFound => e
+          cp_fail = true
+        rescue  RestClient::Gone => e
+          cp_fail = true
+        end
 
-      if cp_fail || pulp_fail
-        print "System #{system.id} #{system.name} #{system.uuid} is partially missing.  Cleaning.\n"
-        system.del_candlepin_consumer unless cp_fail        
-        system.del_pulp_consumer unless pulp_fail
-        Katello::System.index.remove system
-        system.system_activation_keys.destroy_all
-        system.delete
-      end      
+        begin
+          system.pulp_facts
+        rescue  RestClient::ResourceNotFound => e
+          pulp_fail = true
+        rescue  RestClient::Gone => e
+          pulp_fail = true
+        rescue  RestClient::Conflict => e
+          pulp_fail = true
+        end
+
+        if cp_fail || pulp_fail
+          print "System #{system.id} #{system.name} #{system.uuid} is partially missing.  Cleaning.\n"
+          system.del_candlepin_consumer unless cp_fail
+          system.del_pulp_consumer unless pulp_fail
+          Katello::System.index.remove system
+          system.system_activation_keys.destroy_all
+          system.delete
+        end
+      end
     end
+
+    def cleanup_host_delete_artifacts
+      # clean up dirty consumer data in candleplin,
+      # that did not get cleared by host delete.
+      # look at https://bugzilla.redhat.com/show_bug.cgi?id=1140653
+      # for more information
+      cp_consumers = ::Katello::Resources::Candlepin::Consumer.get({})
+      cp_consumer_ids = cp_consumers.map {|cons| cons["uuid"]}
+      katello_consumer_ids = ::Katello::System.pluck(:uuid)
+      deletable_ids = cp_consumer_ids - katello_consumer_ids
+      deletable_ids.each do |consumer_id|
+        Katello::Resources::Candlepin::Consumer.destroy(consumer_id)
+        Katello.pulp_server.extensions.consumer.delete(consumer_id)
+      end
+    end
+
+    User.current = User.anonymous_admin
+    cleanup_systems
+    cleanup_host_delete_artifacts
   end
 end

--- a/test/actions/katello/system_test.rb
+++ b/test/actions/katello/system_test.rb
@@ -77,6 +77,23 @@ module ::Actions::Katello::System
     end
   end
 
+  class HostDestroyTest < TestBase
+    let(:action_class) { ::Actions::Katello::System::HostDestroy }
+    it 'plans' do
+      host = mock()
+      content_host = mock()
+      host.expects(:content_host).at_least(1).returns(content_host)
+      host.expects(:reload).returns(host)
+      host.expects(:destroy).returns(true)
+
+      action.stubs(:action_subject).with(host)
+
+      plan_action(action, host)
+      assert_action_planed_with(action, ::Actions::Katello::System::Destroy, content_host)
+    end
+  end
+
+
   class ActivationKeyTest < TestBase
     let(:action_class) { ::Actions::Katello::System::ActivationKeys }
 

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -40,7 +40,8 @@ module Katello
     end
 
     def teardown
-      @foreman_host.destroy
+      @foreman_host.content_host.destroy
+      @foreman_host.reload.destroy
     end
 
     def test_update_puppet_environment_updates_content_host


### PR DESCRIPTION
Previously when a host got deleted in foreman either via UI or API
the content_host active record would get deleted but NOT the backend
like candlepin or pulp consumer information. This commit aims to fix that
by making foreman's delete host call use katello's consumer delete dynflow.
