### PR TITLE
fixes #7481 - fix taxonomy association on smart proxy create

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -46,7 +46,8 @@ module Katello
       end
 
       def default_capsule?
-        self.features.pluck(:name).include?(PULP_FEATURE)
+        # use map instead of pluck in case the features aren't saved yet during create
+        self.features.map(&:name).include?(PULP_FEATURE)
       end
 
       def associate_organizations


### PR DESCRIPTION
during the create using .pluck would not work since the model had not been saved yet
and would return no features
