### PR TITLE
fixes #7621 - treat a nil minor OS version as empty string

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -27,6 +27,7 @@ module Katello
         def find_or_create_operating_system(distribution)
           os_name = construct_name(distribution.family)
           major, minor = distribution.version.split('.')
+          minor ||= '' # treat minor versions as empty string to not confuse with nil
 
           os = ::Redhat.where(:name => os_name, :major => major, :minor => minor).first
           os = create_operating_system(os_name, major, minor) unless os

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -31,6 +31,15 @@ module Katello
       refute_nil ::Redhat.find_or_create_operating_system(@my_distro)
     end
 
+    def test_find_or_create_os_without_minor
+      other_distro = OpenStruct.new(:name => 'RedHat', :family => 'Red Hat Enterprise Linux', :version => '9')
+      os_count = Operatingsystem.count
+      created = ::Redhat.find_or_create_operating_system(other_distro)
+      created2 = ::Redhat.find_or_create_operating_system(other_distro)
+      assert_equal created, created2
+      assert_equal os_count + 1, Operatingsystem.count
+    end
+
     def test_create_operating_system
       assert_nil ::Redhat.where(:name => @my_distro.name).first
 


### PR DESCRIPTION
other wise we will forever create operating systems in foreman
