### PR TITLE
fixes #7627 - handle cases where this code is ran outside of rails

### DIFF
--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -27,8 +27,10 @@ require 'jquery-ui-rails'
 
 require "uuidtools"
 
-# to make Foreman#in_rake? helper available
-require File.expand_path('lib/foreman', Rails.root)
+# to make Foreman#in_rake? helper available if Foreman's lib is available
+lib_foreman = File.expand_path('lib/foreman', Rails.root)
+require lib_foreman unless !Dir.exist?(lib_foreman)
+
 require File.expand_path("../engines/bastion/lib/bastion", File.dirname(__FILE__))
 require "monkeys/string_to_bool"
 require "monkeys/anemone"


### PR DESCRIPTION
When running katello ruby code outside of rails the Rails.root
is incorrectly set (katello-disconnected)
