### PR TITLE
refs #7124 - docker - downcase pulp_id when creating docker repository

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -15,6 +15,7 @@ class Repository < Katello::Model
   self.include_root_in_json = false
 
   before_destroy :assert_deletable
+  before_create :downcase_pulp_id
 
   include ForemanTasks::Concerns::ActionSubject
   include Glue::Candlepin::Content if (Katello.config.use_cp && Katello.config.use_pulp)
@@ -442,6 +443,14 @@ class Repository < Katello::Model
 
         return false
       end
+    end
+  end
+
+  def downcase_pulp_id
+    # Docker doesn't support uppercase letters in repository names.  Since the pulp_id
+    # is currently being used for the name, it will be downcased for this content type.
+    if self.content_type == Repository::DOCKER_TYPE
+      self.pulp_id = self.pulp_id.downcase
     end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -72,6 +72,28 @@ class RepositoryCreateTest < RepositoryTestBase
     assert @repo.save
     assert_equal "puppet", Repository.find(@repo.id).content_type
   end
+
+  def test_docker_pulp_id
+    # for docker repos, the pulp_id should be downcased
+    @repo.pulp_id = 'PULP-ID'
+    @repo.content_type = Repository::DOCKER_TYPE
+    assert @repo.save
+    assert @repo.pulp_id.ends_with?('pulp-id')
+  end
+
+  def test_yum_type_pulp_id
+    @repo.pulp_id = 'PULP-ID'
+    @repo.content_type = Repository::YUM_TYPE
+    assert @repo.save
+    assert @repo.pulp_id.ends_with?('PULP-ID')
+  end
+
+  def test_puppet_type_pulp_id
+    @repo.pulp_id = 'PULP-ID'
+    @repo.content_type = Repository::PUPPET_TYPE
+    assert @repo.save
+    assert @repo.pulp_id.ends_with?('PULP-ID')
+  end
 end
 
 class RepositoryInstanceTest < RepositoryTestBase


### PR DESCRIPTION
Unfortunately, docker requires that repository names do not contain capital
letters.  More specifically, it currently requires that they consist of [a-z0-9-_.]+.

The pulp_id is currently constructed of the labels from org, env, view and
repo.  The label follows the rule, with the exception that capital
letters are supported; therefore, this commit will downcase the pulp_id
for docker repos.
