### PR TITLE
Fixes #7704: show applicable Errata count for Content Host list.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-hosts/views/content-hosts-table-full.html
@@ -10,6 +10,9 @@
       <th alch-table-column="status">
         {{ "Subscription Status" | translate }}
       </th>
+      <th alch-table-column="status">
+        <span translate>Applicable Errata</span>
+      </th>
       <th alch-table-column="os"><span translate>OS</span></th>
       <th alch-table-column="environment" sortable><span translate>Environment</span></th>
       <th alch-table-column="contentView"><span translate>Content View</span></th>
@@ -31,6 +34,9 @@
       <td alch-table-cell>
         <span class="icon-circle" ng-class="contentHostTable.getStatusColor(contentHost.entitlementStatus)">
         </span>
+      </td>
+      <td>
+        <span errata-counts="contentHost.errata_counts"></span>
       </td>
       <td alch-table-cell>{{ contentHost.distribution }}</td>
       <td alch-table-cell>{{ contentHost.environment.name }}</td>

--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/views/content-view-versions.html
@@ -52,14 +52,8 @@
           <div translate>
             {{ version.package_count || 0 }} Packages
           </div>
-          <div translate>
-            {{ version.errata_count || 0 }} Errata
-            <span>(</span>
-            <span><i class="icon-warning-sign inline-icon" title="{{ 'Security' | translate }}"></i>{{ version.errata_counts.security || 0 }}</span>
-            <span><i class="icon-bug inline-icon" title="{{ 'Bug Fix' | translate }}"></i>{{ version.errata_counts.bugfix || 0 }}</span>
-            <span><i class="icon-plus-sign-alt inline-icon" title="{{ 'Enhancement' | translate }}"></i>{{ version.errata_counts.enhancement || 0 }}</span>
-            <span>)</span>
-          </div>
+	  <span translate>{{ errataCounts.total || 0 }} Errata</span>
+          (<span errata-counts="version.errata_counts"></span>)
           <div translate>
             {{ version.puppet_modules.length || 0 }} Puppet Modules
           </div>

--- a/engines/bastion/app/assets/javascripts/bastion/errata/errata-counts.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/errata/errata-counts.directive.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+/**
+ * @ngdoc directive
+ * @name bastion.errata:errataCounts
+ *
+ * @description
+ *   Directive for displaying the counts of the various types of errata.
+ *
+ * @example
+ * <div errata-counts="contentViewVersion.errata_counts"></div>
+ */
+angular.module('Bastion.errata').directive('errataCounts', function () {
+    return {
+        restrict: 'AE',
+        replace: true,
+        templateUrl: 'errata/views/errata-counts.html',
+        scope: {
+            errataCounts: '='
+        }
+    };
+});

--- a/engines/bastion/app/assets/javascripts/bastion/errata/views/errata-counts.html
+++ b/engines/bastion/app/assets/javascripts/bastion/errata/views/errata-counts.html
@@ -1,0 +1,5 @@
+<span>
+  <span><i class="icon-warning-sign inline-icon" title="{{ 'Security' | translate }}"></i>{{ errataCounts.security || 0 }}</span>
+  <span><i class="icon-bug inline-icon" title="{{ 'Bug Fix' | translate }}"></i>{{ errataCounts.bugfix || 0 }}</span>
+  <span><i class="icon-plus-sign-alt inline-icon" title="{{ 'Enhancement' | translate }}"></i>{{ errataCounts.enhancement || 0 }}</span>
+</span>

--- a/engines/bastion/test/errata/errata-counts.directive.test.js
+++ b/engines/bastion/test/errata/errata-counts.directive.test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+describe('Directive: errataCounts', function() {
+    var $scope, $compile, element;
+
+    beforeEach(module(
+        'Bastion.errata',
+        'errata/views/errata-counts.html'
+    ));
+
+    beforeEach(inject(function(_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        $scope = _$rootScope_;
+    }));
+
+    beforeEach(function() {
+        $scope.errataCounts = {bufix: 1, enhancement: 2, security: 3, total: 6};
+        element = '<span errata-counts="errataCounts"></span>';
+        element = $compile(element)($scope);
+        $scope.$digest();
+    });
+
+    it("displays totals for each type of errata", function() {
+        expect(element.find('[title="Security"]').length).toBe(1);
+        expect(element.find('[title="Bug Fix"]').length).toBe(1);
+        expect(element.find('[title="Enhancement"]').length).toBe(1);
+    });
+
+    it("displays icons for each type of errata", function() {
+        expect(element.find('.icon-warning-sign').length).toBe(1);
+        expect(element.find('.icon-bug').length).toBe(1);
+        expect(element.find('.icon-plus-sign-alt').length).toBe(1);
+    });
+});


### PR DESCRIPTION
Add Errata counts to the Content hHost list and refactor into a
directive.  Also update usage in Content View Versions.

http://projects.theforeman.org/issues/7704

Note that these totals will always show 0 until http://projects.theforeman.org/issues/7705 is completed.
