### PR TITLE
Fixes #7798 - Upload manifest containing docker items

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -53,11 +53,17 @@ module Katello
     # to the inclusion of a modules.
     param :id, :identifier, :desc => N_("organization ID"), :required => true
     param :description, String, :desc => N_("description of the organization"), :required => false
-    param :redhat_repository_url, String, :desc => N_("Redhat CDN url")
+    param :redhat_repository_url, String, :desc => N_("Red Hat CDN URL")
+    param :redhat_docker_registry_url,  String, :desc => N_("Red Hat Docker Registry URL")
     param_group :resource, ::Api::V2::TaxonomiesController
     def update
       if params.key?(:redhat_repository_url)
         @organization.redhat_provider.update_attributes!(:repository_url => params[:redhat_repository_url])
+      end
+
+      if params.key?(:redhat_docker_registry_url)
+        @organization.redhat_provider.update_attributes!(:docker_registry_url =>
+                                                          params[:redhat_docker_registry_url])
       end
       super
     end

--- a/app/helpers/katello/providers_helper.rb
+++ b/app/helpers/katello/providers_helper.rb
@@ -22,6 +22,7 @@ module ProvidersHelper
       {:id => :debug, :name => _('Debug RPMs'), :products => {}},
       {:id => :beta, :name => _('Beta'), :products => {}},
       {:id => :isos, :name => _('ISOs'), :products => {}},
+      {:id => :docker_images, :name => _('Docker Images'), :products => {}},
       {:id => :other, :name => _('Other'), :products => {}}
     ]
   end
@@ -33,7 +34,9 @@ module ProvidersHelper
     provider.products.engineering.each do |product|
       product.productContent.each do |prod_content|
         name = prod_content.content.name
-        if name.include?(" Beta ")
+        if prod_content.content.type == "containerImage"
+          key = :docker_images
+        elsif name.include?(" Beta ")
           key = :beta
         elsif name.include?("(Source RPMs)")
           key = :srpms

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -140,6 +140,10 @@ module Katello
           redhat_provider.repository_url
         end
 
+        def redhat_docker_registry_url
+          redhat_provider.docker_registry_url
+        end
+
         def being_deleted?
           ForemanTasks::Task::DynflowTask.for_action(::Actions::Katello::Organization::Destroy).
             for_resource(self).active.any?

--- a/app/views/katello/api/v2/organizations/show.json.rabl
+++ b/app/views/katello/api/v2/organizations/show.json.rabl
@@ -4,4 +4,4 @@ extends "api/v2/taxonomies/show"
 
 attributes :task_id, :label, :description, :service_levels,
   :service_level, :system_info_keys, :distributor_info_keys, :default_info,
-  :owner_details, :redhat_repository_url
+  :owner_details, :redhat_repository_url, :redhat_docker_registry_url

--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -67,6 +67,7 @@ common:
   simple_search_tokens: [":", " and\\b", " or\\b", " not\\b"]
 
   redhat_repository_url: https://cdn.redhat.com
+  redhat_docker_registry_url: http://registry.access.redhat.com
 
   consumer_cert_rpm: 'katello-ca-consumer-latest.noarch.rpm'
 

--- a/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
+++ b/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
@@ -1,0 +1,12 @@
+class AddDockerContainerRegistryUrlToProviders < ActiveRecord::Migration
+  def up
+    add_column :katello_providers, :docker_registry_url, :string
+    ::Katello::Provider.redhat.update_all(:docker_registry_url =>
+                                          Katello.config.redhat_docker_registry_url)
+  end
+
+  def down
+    remove_column :katello_providers, :docker_registry_url
+  end
+
+end

--- a/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion/app/assets/javascripts/bastion/subscriptions/manifest/views/manifest-import.html
@@ -3,13 +3,23 @@
     <h4 translate>Red Hat Provider Details</h4>
 
     <div class="detail">
-      <span class="info-label" translate>Repository URL</span>
+      <span class="info-label" translate>Red Hat CDN URL</span>
       <span class="info-value"
         alch-edit-text="organization.redhat_repository_url"
         on-save="saveCdnUrl(organization)"
         readonly="organization.readonly">
       </span>
     </div>
+
+    <div class="detail">
+      <span class="info-label" translate>Red Hat Docker Registry URL</span>
+      <span class="info-value"
+        alch-edit-text="organization.redhat_docker_registry_url"
+        on-save="saveCdnUrl(organization)"
+        readonly="organization.readonly">
+      </span>
+    </div>
+
   </div>
 </section>
 

--- a/test/fixtures/models/katello_providers.yml
+++ b/test/fixtures/models/katello_providers.yml
@@ -15,6 +15,8 @@ redhat:
   description: Provider of all your red hat needs
   provider_type: 'Red Hat'
   repository_url: 'https://cds.example.com'
+  docker_registry_url: 'https://docker.example.com'
+
   organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
 
 candlepin_redhat:


### PR DESCRIPTION
Has code to upload manifest and then list it in the Red Hat
Repositories tab.

Also includes code that lets you update the Redhat Docker Registry URL
in the manage manifest page.
