### PR TITLE
refs #7818 - render permissions to fix oj 2.10.3 error

### DIFF
--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -13,7 +13,9 @@ attributes :gpg_key_id
 attributes :redhat? => :redhat
 
 attributes :productContent => :product_content
-attributes :available_content
+
+child :available_content => :available_content, :object_root => false do
+end
 
 node :repository_count do |product|
   if product.library_repositories.to_a.any?
@@ -48,10 +50,11 @@ node :permissions do |product|
   }
 end
 
-attributes :published_content_views
+child :published_content_views => :published_content_views, :object_root => false do
+end
 
 node :readonly do |product|
-  product.redhat? 
+  product.redhat?
 end
 
 extends 'katello/api/v2/common/timestamps'


### PR DESCRIPTION
oj 2.10.3 is causing a few errors in Foreman and Katello API views, https://github.com/theforeman/foreman/pull/1821 fixes the Foreman side, this should fix a few errors on the products API controller.
