### PR TITLE
Fixes #7900: Bastion pages couldn't load due to unparseable User.to_json

### DIFF
--- a/engines/bastion/app/views/bastion/layouts/application.html.haml
+++ b/engines/bastion/app/views/bastion/layouts/application.html.haml
@@ -16,7 +16,7 @@
       angular.module('Bastion').value('currentLocale', '#{I18n.locale}');
       angular.module('Bastion').value('CurrentOrganization', "#{current_organization.id if current_organization}");
       angular.module('Bastion').value('Permissions', angular.fromJson('#{ current_user.roles.collect { |role| role.permissions }.flatten.to_json }'));
-      angular.module('Bastion').value('CurrentUser', angular.fromJson('#{current_user.to_json}').user);
+      angular.module('Bastion').value('CurrentUser', {id: "#{User.current.id}", admin: "#{User.current.admin}"});
       angular.module('Bastion').value('markActiveMenu', mark_active_menu);
       angular.module('Bastion').constant('BastionConfig', {
           consumerCertRPM: "#{Katello.config.consumer_cert_rpm}",


### PR DESCRIPTION
A change to the User model led some fields to be unparseable when
User.current.to_json is done within the layout. This reduces the fields
to only those specifically needed by the UI.
