### PR TITLE
Fixes #7919/BZ1151633: fix translations of sync plan intervals.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/incubator/alch-edit.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/incubator/alch-edit.directive.js
@@ -243,6 +243,7 @@ angular.module('alchemy')
             scope: {
                 model: '=alchEditSelect',
                 displayValueDefault: '=displayValueDefault',
+                formatter: '@formatter',
                 readonly: '=',
                 selector: '=',
                 handleOptions: '&options',

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-details-info.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/sync-plan-details-info.controller.js
@@ -29,7 +29,11 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
         function ($scope, $q, translate, SyncPlan, MenuExpander) {
             $scope.successMessages = [];
             $scope.errorMessages = [];
-            $scope.intervals = ['hourly', 'daily', 'weekly'];
+            $scope.intervals = [
+                {id: 'hourly', value: translate('hourly')},
+                {id: 'daily', value: translate('daily')},
+                {id: 'weekly', value: translate('weekly')}
+            ];
 
             $scope.menuExpander = MenuExpander;
             $scope.panel = $scope.panel || {loading: false};

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-info.html
@@ -49,10 +49,11 @@
       <span class="info-label" translate>Interval</span>
       <span class="info-value"
             alch-edit-select="syncPlan.interval"
+            formatter="translate"
             readonly="denied('edit_sync_plans', syncPlan)"
             selector="syncPlan.interval"
             options="intervals"
-            options-format="value for value in options"
+            options-format="value.id as value.value for value in options"
             on-save="save(syncPlan)">
       </span>
     </div>

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/new-sync-plan.controller.js
@@ -24,10 +24,16 @@
  */
 angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
     ['$scope', 'translate', 'SyncPlan', function ($scope, translate, SyncPlan) {
-        $scope.intervals = [translate('hourly'), translate('daily'), translate('weekly')];
+        $scope.intervals = [
+            {id: 'hourly', value: translate('hourly')},
+            {id: 'daily', value: translate('daily')},
+            {id: 'weekly', value: translate('weekly')}
+        ];
+
         $scope.successMessages = [];
 
         $scope.syncPlan = new SyncPlan();
+        $scope.syncPlan.interval = $scope.intervals[0].id;
         $scope.syncPlan.startDate = new Date();
 
         function success(syncPlan) {

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/views/new-sync-plan-form.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/views/new-sync-plan-form.html
@@ -17,12 +17,11 @@
    </textarea>
  </div>
 
-
  <div alch-form-group label="{{ 'Interval' | translate }}">
    <select id="interval"
            name="interval"
            ng-model="syncPlan.interval"
-           ng-options="interval for interval in intervals"
+           ng-options="interval.id as interval.value for interval in intervals"
            tabindex="3"
            required>
       <option value="" translate>-- select an interval --</option>

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
@@ -27,7 +27,7 @@
       <td alch-table-cell>{{ syncPlan.description }}</td>
       <td alch-table-cell>{{ syncPlan.sync_date | date:'medium' }}</td>
       <td alch-table-cell>{{ syncPlan.enabled }}</td>
-      <td alch-table-cell>{{ syncPlan.interval | capitalize }}</td>
+      <td alch-table-cell>{{ syncPlan.interval | translate | capitalize }}</td>
       <td alch-table-cell>{{ syncPlan.next_sync | date:'medium' }}</td>
     </tr>
   </tbody>


### PR DESCRIPTION
The sync plan interval strings were being translated in the UI
and thus would fail when creating/editing a new sync plan in
another language.  This commit fixes the issue by differentiating
between interval display value and stored value and also fixes
an issue where you had to select an already populated interval
in order to create a sync plan.

http://projects.theforeman.org/issues/7919
https://bugzilla.redhat.com/show_bug.cgi?id=1151633
