### PR TITLE
Fixes #7923: fix display of sync plan start date.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-info.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/details/views/sync-plan-info.html
@@ -26,7 +26,7 @@
 
     <div class="detail">
       <span class="info-label" translate>Start Date</span>
-      <span class="info-value">{{ syncPlan.sync_date | date:'medium' }}</span>
+      <span class="info-value">{{ syncPlan.sync_date.time | date:'medium' }}</span>
     </div>
 
     <div class="detail">

--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/views/sync-plans-table-full.html
@@ -25,7 +25,7 @@
         </a>
       </td>
       <td alch-table-cell>{{ syncPlan.description }}</td>
-      <td alch-table-cell>{{ syncPlan.sync_date | date:'medium' }}</td>
+      <td alch-table-cell>{{ syncPlan.sync_date.time | date:'medium' }}</td>
       <td alch-table-cell>{{ syncPlan.enabled }}</td>
       <td alch-table-cell>{{ syncPlan.interval | capitalize }}</td>
       <td alch-table-cell>{{ syncPlan.next_sync | date:'medium' }}</td>


### PR DESCRIPTION
The sync plan start date was displaying the entire object instead
of just the time.  This commit fixes the display.

http://projects.theforeman.org/issues/7923
