### PR TITLE
Fixes #7939/BZ1148488: increase prominence of nutupane loading display.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-modules.html
+++ b/engines/bastion/app/assets/javascripts/bastion/content-views/details/puppet-modules/views/content-view-puppet-modules.html
@@ -22,7 +22,7 @@
   </div>
 
   <div data-block="table">
-    <p class="alert alert-info" ng-show="detailsTable.rows.length === 0" translate>
+    <p class="alert alert-info" ng-show="detailsTable.rows.length === 0 && !detailsTable.working" translate>
       You currently don't have any Puppet Modules included in this Content View, you can add Puppet Modules using the button on the right.
     </p>
 

--- a/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
+++ b/engines/bastion/app/assets/javascripts/bastion/layouts/details-nutupane.html
@@ -25,11 +25,6 @@
       <span class="nutupane-info" data-block="result-count" translate>Showing {{ detailsTable.rows.length }} of {{ detailsTable.resource.subtotal }} ({{ detailsTable.resource.total }} Total)</span>
     </div>
 
-    <div class="col-sm-2" ng-show="detailsTable.working">
-      <i class="icon-spinner icon-spin"></i>
-      <span translate>Working...</span>
-    </div>
-
     <div class="col-sm-4 fr">
       <div class="fr">
         <span class="nutupane-info fl" data-block="selection-summary">
@@ -67,6 +62,11 @@
       </div>
 
       <div data-block="table"></div>
+
+      <div class="text-center col-md-12 loading-indicator icon-3x" ng-show="detailsTable.working">
+        <i class="icon-spinner icon-spin"></i>
+        <span class="h1" translate>Working...</span>
+      </div>
     </div>
   </div>
 

--- a/engines/bastion/app/assets/stylesheets/bastion/nutupane.less
+++ b/engines/bastion/app/assets/stylesheets/bastion/nutupane.less
@@ -39,6 +39,10 @@ td.row-select {
 }
 
 .nutupane {
+  .loading-indicator {
+    margin-top: 30px;
+    width: 100%;
+  }
 
   td {
     word-wrap: break-word;


### PR DESCRIPTION
The nutupane-details loading indicator was small and not noticeable.  This
commit increases the prominence of the loading indicator
