### PR TITLE
Fixes #7942: redirect to correct place after creating a sync plan.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion/app/assets/javascripts/bastion/sync-plans/new/new-sync-plan.controller.js
@@ -35,10 +35,11 @@ angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
             $scope.successMessages = [translate('New sync plan successfully created.')];
             if ($scope.product) {
                 $scope.product['sync_plan_id'] = syncPlan.id;
+                $scope.$state.go('products.details.info', {productId: $scope.product.id});
             } else if ($scope.syncPlanTable) {
                 $scope.syncPlanTable.rows.unshift(syncPlan);
+                $scope.$state.go('sync-plans.details.info', {syncPlanId: syncPlan.id});
             }
-            $scope.transitionBack();
         }
 
         function error(response) {

--- a/engines/bastion/test/sync-plans/new-sync-plan.controller.test.js
+++ b/engines/bastion/test/sync-plans/new-sync-plan.controller.test.js
@@ -24,10 +24,15 @@ describe('Controller: NewSyncPlanController', function() {
 
         SyncPlan = $injector.get('MockResource').$new()
         $scope = $injector.get('$rootScope').$new();
-        $scope.transitionBack = function () {};
-        $scope.product = {};
+        $scope.$state = {go: function () {}};
 
         translate = function (string) { return string; };
+
+        $scope.syncPlanTable = {
+            rows: {
+                unshift: function () {}
+            }
+        };
 
         $controller('NewSyncPlanController', {
             $scope: $scope,
@@ -41,17 +46,34 @@ describe('Controller: NewSyncPlanController', function() {
         expect($scope.syncPlan).toBeDefined();
     });
 
-    it('should save a new sync plan resource', function() {
-        var syncPlan = {startDate: '11/17/1982', endDate: '14:40'};
+    it('should save a new sync plan resource and transform to the newly created sync plan', function() {
+        var syncPlan = {id: 1, startDate: '11/17/1982', endDate: '14:40'};
         syncPlan.$save = new SyncPlan().$save;
 
-        spyOn($scope, 'transitionBack');
+        spyOn($scope.$state, 'go');
         spyOn(syncPlan, '$save').andCallThrough();
+        spyOn($scope.syncPlanTable.rows, 'unshift');
 
         $scope.createSyncPlan(syncPlan);
 
         expect($scope.working).toBe(false);
         expect($scope.successMessages.length).toBe(1);
-        expect($scope.transitionBack).toHaveBeenCalled();
+        expect($scope.syncPlanTable.rows.unshift).toHaveBeenCalledWith(syncPlan);
+        expect($scope.$state.go).toHaveBeenCalledWith('sync-plans.details.info', {syncPlanId: syncPlan.id});
+    });
+
+    it('should save a new sync plan resource and transform to the product if called from there', function() {
+        var syncPlan = {startDate: '11/17/1982', endDate: '14:40'};
+        syncPlan.$save = new SyncPlan().$save;
+
+        spyOn($scope.$state, 'go');
+        spyOn(syncPlan, '$save').andCallThrough();
+
+        $scope.product = {id: 1};
+        $scope.createSyncPlan(syncPlan);
+
+        expect($scope.working).toBe(false);
+        expect($scope.successMessages.length).toBe(1);
+        expect($scope.$state.go).toHaveBeenCalledWith('products.details.info', {productId: $scope.product.id});
     });
 });


### PR DESCRIPTION
After creating a new sync plan the controller was attempting to
transition back to the previous state instead of going to a known
state.  This commit fixes the behavior.

http://projects.theforeman.org/issues/7942
