### PR TITLE
Code to promote/publish content views with docker repos

### DIFF
--- a/app/lib/actions/katello/repository/clone_docker_content.rb
+++ b/app/lib/actions/katello/repository/clone_docker_content.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module Repository
+      class CloneDockerContent < Actions::Base
+        def plan(source_repo, target_repo)
+          sequence do
+            plan_action(Pulp::Repository::CopyDockerImage,
+                        source_pulp_id: source_repo.pulp_id,
+                        target_pulp_id: target_repo.pulp_id)
+            plan_action(Pulp::Repository::CopyDockerTag,
+                        source_pulp_id: source_repo.pulp_id,
+                        target_pulp_id: target_repo.pulp_id)
+            plan_action(Katello::Repository::MetadataGenerate, target_repo)
+            plan_action(ElasticSearch::Repository::IndexContent, id: target_repo.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/clone_to_environment.rb
+++ b/app/lib/actions/katello/repository/clone_to_environment.rb
@@ -25,7 +25,12 @@ module Actions
             else
               plan_action(Repository::Clear, clone)
             end
-            plan_action(Repository::CloneContent, repository, clone, [], false)
+
+            if repository.yum?
+              plan_action(Repository::CloneYumContent, repository, clone, [], false)
+            elsif repository.docker?
+              plan_action(Repository::CloneDockerContent, repository, clone)
+            end
           end
         end
 

--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -24,7 +24,11 @@ module Actions
                                                        version: content_view_version)
           sequence do
             plan_action(Repository::Create, new_repository, true)
-            plan_action(Repository::CloneContent, repository, new_repository, filters, true)
+            if new_repository.yum?
+              plan_action(Repository::CloneYumContent, repository, new_repository, filters, true)
+            elsif new_repository.docker?
+              plan_action(Repository::CloneDockerContent, repository, new_repository)
+            end
           end
         end
       end

--- a/app/lib/actions/katello/repository/clone_yum_content.rb
+++ b/app/lib/actions/katello/repository/clone_yum_content.rb
@@ -13,7 +13,7 @@
 module Actions
   module Katello
     module Repository
-      class CloneContent < Actions::Base
+      class CloneYumContent < Actions::Base
         # rubocop:disable MethodLength
         def plan(source_repo, target_repo, filters, purge_empty_units)
           copy_clauses = nil

--- a/app/lib/actions/pulp/repository/copy_docker_image.rb
+++ b/app/lib/actions/pulp/repository/copy_docker_image.rb
@@ -1,0 +1,23 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Pulp
+    module Repository
+      class CopyDockerImage < Pulp::Repository::AbstractCopyContent
+        def content_extension
+          pulp_extensions.docker_image
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/copy_docker_tag.rb
+++ b/app/lib/actions/pulp/repository/copy_docker_tag.rb
@@ -1,0 +1,30 @@
+
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Pulp
+    module Repository
+      class CopyDockerTag  < Pulp::Abstract
+        input_format do
+          param :source_pulp_id
+          param :target_pulp_id
+        end
+
+        def run
+          repo = ::Katello::Repository.find_by_pulp_id(input[:source_pulp_id])
+          output[:response] = pulp_extensions.repository.update_docker_tags(input[:target_pulp_id], repo.docker_image_tag_hash)
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -157,6 +157,20 @@ module Katello
       Package.package_count(self.repositories.archived)
     end
 
+    def docker_image_count
+      image_counts = repositories.archived.docker_type.map do |repo|
+        repo.docker_images.count
+      end
+      image_counts.sum
+    end
+
+    def docker_tag_count
+      tag_counts = repositories.archived.docker_type.map do |repo|
+        repo.docker_tags.count
+      end
+      tag_counts.sum
+    end
+
     def errata(errata_type = nil)
       errata = Erratum.in_repositories(self.repositories.archived).uniq
       errata = errata.of_type(errata_type) if errata_type

--- a/app/views/katello/api/v2/content_view_versions/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/show.json.rabl
@@ -8,6 +8,8 @@ attributes :content_view_id
 attributes :default
 attributes :description
 attributes :package_count
+attributes :docker_image_count
+attributes :docker_tag_count
 
 node :errata_counts do |version|
   partial('katello/api/v2/errata/counts', :object => Katello::RelationPresenter.new(version.errata))

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -59,6 +59,13 @@
           <div translate>
             {{ version.puppet_modules.length || 0 }} Puppet Modules
           </div>
+          <div translate>
+            {{ version.docker_image_count || 0 }} Docker Images
+          </div>
+          <div translate>
+            {{ version.docker_tag_count || 0 }} Docker Tags
+          </div>
+
         </td>
         <td bst-table-cell>{{ version.user }}</td>
         <td class="col-sm-2">

--- a/test/fixtures/models/katello_content_view_repositories.yml
+++ b/test/fixtures/models/katello_content_view_repositories.yml
@@ -5,3 +5,11 @@ library_view_fedora_17_x86_64:
 library_view_rhel_6_x86_64:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:acme_default) %>
   repository_id:   <%= ActiveRecord::Fixtures.identify(:rhel_6_x86_64) %>
+
+library_view_docker:
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:library_view) %>
+  repository_id:   <%= ActiveRecord::Fixtures.identify(:docker) %>
+
+library_view_docker2:
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:library_view) %>
+  repository_id:   <%= ActiveRecord::Fixtures.identify(:docker2) %>

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -204,3 +204,39 @@ docker:
   product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
+
+docker2:
+  name:                 redis2
+  pulp_id:              "Default_Organization-Test-redis2"
+  content_id:           1
+  content_type:         docker
+  label:                redis2
+  relative_path:        '/ACME_Corporation/library/redis2'
+  environment_id:       <%= ActiveRecord::Fixtures.identify(:library) %>
+  product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
+  gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
+
+docker2_view1:
+  name:                 redis2
+  pulp_id:              "Default_Organization-Test-redis2"
+  content_id:           1
+  content_type:         docker
+  label:                redis2
+  relative_path:        '/ACME_Corporation/library/redis2'
+  environment_id:
+  product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
+  gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_view_version_1) %>
+
+docker2_view2:
+  name:                 redis2
+  pulp_id:              "Default_Organization-Test-redis2"
+  content_id:           1
+  content_type:         docker
+  label:                redis2
+  relative_path:        '/ACME_Corporation/library/redis2'
+  environment_id:
+  product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
+  gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_view_version_2) %>

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -230,11 +230,11 @@ module Katello
       composite = ContentView.find(katello_content_views(:composite_view))
       v1 = ContentViewVersion.find(katello_content_view_versions(:library_view_version_1))
       composite.update_attributes(:component_ids => [v1.id])
-      repo_ids = composite.repositories_to_publish.map(&:library_instance_id)
-      assert_equal v1.content_view.repository_ids, repo_ids
+      repo_ids = composite.repositories_to_publish.map(&:id)
+      assert_equal v1.repositories.archived.pluck(:id), repo_ids
 
       repo = Repository.find(katello_repositories(:fedora_17_x86_64))
-      assert_equal [repo.id], @library_view.repositories_to_publish.map(&:id)
+      assert_includes @library_view.repositories_to_publish.map(&:id), repo.id
     end
 
     def test_repo_conflicts

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -49,5 +49,25 @@ module Katello
       @cvv.expects(:environments).returns([]).at_least_once
       refute @cvv.promotable?(@dev)
     end
+
+    def test_docker_count
+      cv = katello_content_views(:library_view)
+      cvv = cv.versions.first
+      assert cvv.repositories.archived.docker_type.count > 0
+      image_count = 0
+      tag_count = 0
+      cvv.repositories.archived.docker_type.each do |repo|
+        image = repo.docker_images.create!({:image_id => "abc123", :katello_uuid => "123"},
+                                             :without_protection => true
+                                            )
+        repo.docker_tags.create!(:tag => "wat", :image => image)
+        image_count += repo.docker_images.count
+        tag_count += repo.docker_tags.count
+      end
+
+      assert cvv.repositories.archived.docker_type.count > 0
+      assert_equal image_count, cvv.docker_image_count
+      assert_equal tag_count, cvv.docker_tag_count
+    end
   end
 end


### PR DESCRIPTION
Right now  we do not have a way to add docker repositories in the UI and you will have to use hammer cli. Here is a sample set of steps.

```
$ hammer repository list --organization-id=3 --content-type=docker

---|-------------------------|------------------------|--------------|------------------------------------------------------------------
ID | NAME                    | PRODUCT                | CONTENT TYPE | URL                                                              
---|-------------------------|------------------------|--------------|------------------------------------------------------------------
29 | fedora/rabbitmq         | great                  | docker       | https://registry.hub.docker.com/repos                            
---|-------------------------|------------------------|--------------|------------------------------------------------------------------

$ hammer content-view create --name=test-pub --organization-id=3
$ hammer content-view add-repository  --name=test-pub --organization-id=3  --repository-id=29
$ hammer content-view publish --name=test-pub --organization-id=3

```
