### PR TITLE
 fixes #7979 - adding better error reporting for repo enable ui

### DIFF
--- a/app/assets/javascripts/katello/providers/provider_redhat.js
+++ b/app/assets/javascripts/katello/providers/provider_redhat.js
@@ -67,6 +67,7 @@ KT.redhat_provider_page = (function($) {
 
         $(checkbox).hide();
         $('#spinner_'+id).removeClass('hidden').show();
+        checkbox.parent().parent().siblings().first().find('.errors').remove();
         $.ajax({
             type: "PUT",
             url: url,
@@ -80,6 +81,11 @@ KT.redhat_provider_page = (function($) {
               else {
                 set_checkbox.attr('disabled','disabled');
               }
+            },
+            error: function(data) {
+                checkbox.parent().parent().siblings().first().append(data.responseText);
+                $(checkbox).removeClass('hidden').show().attr('checked', false);
+                $('#spinner_'+id).addClass('hidden').hide();
             }
         });
         return false;

--- a/app/assets/stylesheets/katello/contents.scss
+++ b/app/assets/stylesheets/katello/contents.scss
@@ -569,6 +569,9 @@ $container_width: ($static_width/2) - 36;
       }
     }
     tbody {
+      a {
+        color: $linkfg_color
+      }
       tr {
         background: $white_color;
       }

--- a/app/assets/stylesheets/katello/widgets/tabs.scss
+++ b/app/assets/stylesheets/katello/widgets/tabs.scss
@@ -17,6 +17,26 @@
   padding: 0px;
   .ui-tabs-nav {
     background: $lightergrey_color;
+    a {
+      cursor: pointer;
+      text-transform: none;
+      text-decoration: none;
+      @include text-shadow(0 1px 0 rgba($white_color, 1));
+      display: block;
+      margin: 0;
+      padding: 8px 16px 6px;
+      color: $taboff_color;
+      float: left;
+      font-weight: bold;
+      &.selected {
+        color: $tabon_color;
+        font-weight: bold;
+        border-bottom: 3px solid $kselected_color;
+        padding-bottom: 3px;
+      }
+
+      &:hover { color: lighten($kselected_color,10%); }
+    }
   }
   .ui-tabs-panel {
     padding: 0px;
@@ -36,26 +56,6 @@
     float: left;
     color: $tabon_color;
     font-weight: bold;
-  }
-  a {
-    cursor: pointer;
-    text-transform: none;
-    text-decoration: none;
-    @include text-shadow(0 1px 0 rgba($white_color, 1));
-    display: block;
-    margin: 0;
-    padding: 8px 16px 6px;
-    color: $taboff_color;
-    float: left;
-    font-weight: bold;
-    &.selected {
-      color: $tabon_color;
-      font-weight: bold;
-      border-bottom: 3px solid $kselected_color;
-      padding-bottom: 3px;
-    }
-
-    &:hover { color: lighten($kselected_color,10%); }
   }
 
   .icon_wrap {

--- a/app/views/katello/providers/redhat/_enable_errors.haml
+++ b/app/views/katello/providers/redhat/_enable_errors.haml
@@ -1,0 +1,9 @@
+%span.errors
+  %br
+  %i.icon-exclamation-sign
+  = _("There was an error attempting to enable or disable this repository:")
+  %pre
+    = error_message
+  = _("For more information see ")
+  %a{:href => main_app.foreman_tasks_tasks_path}
+    = _("the related failed task.")

--- a/app/views/katello/providers/redhat/_errors.html.haml
+++ b/app/views/katello/providers/redhat/_errors.html.haml
@@ -1,0 +1,13 @@
+%table.repo_table{:style=>'display: none;'}
+  %thead
+    %th
+      = _('Errors')
+  %tbody
+    %td
+      %i.icon-exclamation-sign
+      = _("There was an error attempting to retrieve the repository list:")
+      %pre
+        = error_message
+      = _("For more information see ")
+      %a{:href => main_app.foreman_tasks_task_path(task.id)}
+        = _("the failed task.")


### PR DESCRIPTION
This adds better messages for:
- Fetching the list of available repositories for a repo set
- Enabling a repo
