### PR TITLE
Refs #7733: Remove usage of Host fixtures in favor of Host factories.

### DIFF
--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -27,6 +27,7 @@ module Katello
 
     describe "GET 'index'" do
       it "should be successful" do
+        FactoryGirl.create(:host) # Dashboard needs a host or it renders differently
         @controller.expects(:render)
         get 'index'
         must_respond_with(:success)

--- a/test/actions/foreman/environment_test.rb
+++ b/test/actions/foreman/environment_test.rb
@@ -35,6 +35,7 @@ module ::Actions::Foreman::Environment
     end
 
     it 'fails to destroy when there are hosts' do
+      FactoryGirl.create(:host, :environment => @production)
       assert @production.hosts.count > 0
 
       @production.hostgroups = []

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -48,7 +48,7 @@ module Katello
     describe "register with activation key" do
 
       before do
-        @foreman_host = Host.find(hosts(:one))
+        @foreman_host = FactoryGirl.create(:host, :organization => @organization)
         @facts = { 'network.hostname' => @foreman_host.name }
 
         @activation_key = ActivationKey.create!(:name => "key 1", :organization => @foreman_host.organization)
@@ -82,7 +82,7 @@ module Katello
 
     describe "register with a lifecycle environment" do
       before do
-        @foreman_host = Host.find(hosts(:one))
+        @foreman_host = FactoryGirl.create(:host, :organization => @organization)
         @facts = { 'network.hostname' => @foreman_host.name }
 
         @content_view_environment = ContentViewEnvironment.find(katello_content_view_environments(:library_default_view_environment))

--- a/test/katello_test_runner.rb
+++ b/test/katello_test_runner.rb
@@ -27,6 +27,7 @@ module KatelloMiniTestRunner
 
     def _run_suite(suite, type)
       User.current = nil  #reset User.current
+      puts suite
       suite.before_suite if suite.respond_to?(:before_suite)
       super(suite, type)
     ensure

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -29,7 +29,7 @@ module Katello
       disable_orchestration # disable foreman orchestration
 
       content_host = Katello::System.find(katello_systems(:simple_server))
-      @foreman_host = Host.find(hosts(:one))
+      @foreman_host = FactoryGirl.create(:host)
       @foreman_host.puppetclasses = []
       @foreman_host.content_host = content_host
       @foreman_host.save!
@@ -63,7 +63,7 @@ module Katello
 
     def test_update_does_not_update_content_host
       content_host = System.find(katello_systems(:simple_server2))
-      @foreman_host2 = Host.find(hosts(:two))
+      @foreman_host2 = FactoryGirl.create(:host)
       @foreman_host2.content_host = content_host
       @foreman_host2.save!
 

--- a/test/models/foreman/location_test.rb
+++ b/test/models/foreman/location_test.rb
@@ -34,7 +34,7 @@ module Katello
       loc = Location.default_location
       loc.katello_default = false
 
-      assert_raises(ActiveRecord::RecordInvalid) do
+      assert_raises(RuntimeError) do
         loc.save!
       end
     end

--- a/test/models/system_test.rb
+++ b/test/models/system_test.rb
@@ -89,7 +89,7 @@ module Katello
   class SystemUpdateTest < SystemTestBase
     def setup
       super
-      foreman_host = Host.find(hosts(:one))
+      foreman_host = FactoryGirl.create(:host)
       @system.host_id = foreman_host.id
       @system.save!
 
@@ -140,7 +140,7 @@ module Katello
     end
 
     def test_update_does_not_update_foreman_host
-      foreman_host = Host.find(hosts(:one))
+      foreman_host = FactoryGirl.create(:host)
       @system2 = System.find(katello_systems(:simple_server2))
       @system2.host_id = foreman_host.id
       @system2.save!


### PR DESCRIPTION
Foreman is moving to the use of factories for testing and removing
the host fixtures from usage. Here we change out our reliance on
those host fixtures in favor of the factories.
