### PR TITLE
fixes #8087 - Locations - update to allow proper use of nested locations

### DIFF
--- a/app/overrides/add_organization_attributes.rb
+++ b/app/overrides/add_organization_attributes.rb
@@ -1,12 +1,14 @@
 # Remove Parent select box from org
 Deface::Override.new(:virtual_path => "taxonomies/_step1",
                      :name => "remove_parent_organization_on_create",
-                     :remove => 'code[erb-loud]:contains("select_f"):contains(":parent")'
+                     :surround => 'code[erb-loud]:contains("select_f"):contains(":parent")',
+                     :text => '<% if taxonomy.is_a?(Location) %><%= render_original %><% end %>'
                      )
 
 Deface::Override.new(:virtual_path => "taxonomies/_form",
                      :name => "remove_parent_organization_on_edit",
-                     :remove => 'code[erb-loud]:contains("select_f"):contains(":parent")'
+                     :surround => 'code[erb-loud]:contains("select_f"):contains(":parent")',
+                     :text => '<% if taxonomy.is_a?(Location) %><%= render_original %><% end %>'
                      )
 
 # Add organization attributes to org creation


### PR DESCRIPTION
Without this commit, the user can click 'Nest' to created a nested
location; however, they cannot actually assign a parent location.
As a result, nesting really isn't functional.

This commit will conditionally remove the 'parent' for organization
taxonomies, but leave them in place on the location taxonomies.

This can be tested using the following:
- new & edit org - confirm there is no 'parent'
- new, edit, nest location - confirm that user can select a 'parent'
