### PR TITLE
fixes #8094 - Content Host - fix the host collection capacity

### DIFF
--- a/app/views/katello/api/v2/systems/show.json.rabl
+++ b/app/views/katello/api/v2/systems/show.json.rabl
@@ -44,7 +44,7 @@ child :foreman_host => :host do
 end
 
 child :host_collections => :hostCollections do
-  attributes :id, :name, :description, :max_content_hosts, :total_content_hosts
+  attributes :id, :name, :description, :max_content_hosts, :unlimited_content_hosts, :total_content_hosts
 end
 
 child :custom_info => :customInfo do


### PR DESCRIPTION
Currently, if host collection is set for 'unlimited' the capacity
will show as 'N / '; however, it should be 'N / Unlimited'
