### PR TITLE
Fixes #7688: add a content hosts tab to the errata details.

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -63,6 +63,10 @@ module Katello
         where("#{Katello::SystemRepository.table_name}.repository_id = #{Katello::RepositoryErratum.table_name}.repository_id")
     end
 
+    def systems_unavailable
+      self.systems_applicable.where("#{Katello::System.table_name}.id not in (#{self.systems_available.select("#{Katello::System.table_name}.id").to_sql})")
+    end
+
     def self.available_for_systems(systems)
       Katello::Erratum.joins(:system_errata).joins(:repository_errata).joins("INNER JOIN #{Katello::SystemRepository.table_name} on \
         #{Katello::SystemRepository.table_name}.system_id = #{Katello::SystemErratum.table_name}.system_id").

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+/**
+ * @ngdoc object
+ * @name  Bastion.errata.controller:ErrataContentHostsController
+ *
+ * @requires $scope
+ * @requires Nutupane
+ * @requires ContentHost
+ * @requires ContentHostBulkAction
+ * @requires CurrentOrganization
+ *
+ * @description
+ *   Provides the functionality for the available host collection details action pane.
+ */
+angular.module('Bastion.errata').controller('ErrataContentHostsController',
+    ['$scope', 'translate', 'Nutupane', 'ContentHost', 'ContentHostBulkAction', 'CurrentOrganization',
+    function ($scope, translate, Nutupane, ContentHost, ContentHostBulkAction, CurrentOrganization) {
+        var nutupane, params;
+
+        $scope.successMessages = [];
+        $scope.errorMessages = [];
+
+        params = {
+            'erratum_id': $scope.$stateParams.errataId,
+            'organization_id': CurrentOrganization
+        };
+
+        nutupane = new Nutupane(ContentHost, params);
+        nutupane.table.closeItem = function () {};
+        nutupane.enableSelectAllResults();
+
+        $scope.nutupane = nutupane;
+        $scope.detailsTable = nutupane.table;
+
+        $scope.toggleAvailable = function () {
+            nutupane.table.params['erratum_restrict_available'] = $scope.errata.showAvailable;
+            nutupane.refresh();
+        };
+        
+        $scope.applyErrata = function () {
+            var params = $scope.nutupane.getAllSelectedResults(),
+                success, error;
+
+            params['content_type'] = 'errata';
+            params.content = [$scope.errata['errata_id']];
+            params['organization_id'] = CurrentOrganization;
+
+            success = function () {
+                $scope.successMessages = [translate("Successfully scheduled installation of errata")];
+                $scope.nutupane.refresh();
+            };
+
+            error = function (data) {
+                $scope.errorMessages = data.errors;
+            };
+
+            ContentHostBulkAction.installContent(params, success, error);
+        };
+    }
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-details.controller.js
@@ -19,10 +19,9 @@
  * @requires Errata
  *
  * @description
- *   Provides the functionality for the host collection details action pane.
+ *   Provides the functionality for the errata details action pane.
  */
-angular.module('Bastion.errata').controller('ErrataDetailsController',
-    ['$scope', 'Erratum',
+angular.module('Bastion.errata').controller('ErrataDetailsController', ['$scope', 'Erratum',
     function ($scope, Erratum) {
         if ($scope.errata) {
             $scope.panel = {loading: false};
@@ -30,11 +29,8 @@ angular.module('Bastion.errata').controller('ErrataDetailsController',
             $scope.panel = {loading: true};
         }
 
-        $scope.errata = Erratum.get({id: $scope.$stateParams.errataId}, function (errata) {
-            $scope.$broadcast('errata.loaded', errata);
+        $scope.errata = Erratum.get({id: $scope.$stateParams.errataId}, function () {
             $scope.panel.loading = false;
         });
-
-
-    }]
-);
+    }
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -1,0 +1,59 @@
+<span page-title>{{ 'Apply Errata to Content Hosts' | translate }}</span>
+
+<div data-extend-template="layouts/details-nutupane.html">
+
+  <div data-block="header">
+    <h3 translate>Apply to Content Hosts</h3>
+  </div>
+
+  <div data-block="actions"></div>
+
+  <div data-block="filters">
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" ng-model="errata.showAvailable" ng-change="toggleAvailable()"/>
+        <span translate>Only show content hosts where {{ errata.title }} is currently available in the host's Lifecycle Environment.</span>
+
+      </label>
+    </div>
+  </div>
+
+  <div data-block="table">
+    <p class="alert alert-warning" data-i18n
+       ng-show="detailsTable.rows.length > 0 && stateIncludes('errata.details.content-hosts.unavailable')">
+      The Content View or Lifecycle Environment needs to be updated in order to make errata available to these hosts.
+    </p>
+
+    <p class="alert alert-info" ng-show="detailsTable.rows.length === 0" translate>
+      No Content Hosts match this Erratum.
+    </p>
+
+    <table class="table table-striped table-bordered"
+           ng-class="{'table-mask': detailsTable.working}"
+           ng-show="detailsTable.rows.length > 0">
+      <thead>
+        <tr bst-table-head row-select>
+          <th bst-table-column="name"><span translate>Name</span></th>
+          <th bst-table-column="os"><span translate>OS</span></th>
+          <th bst-table-column="environment"><span translate>Environment</span></th>
+          <th bst-table-column="contentView"><span translate>Content View</span></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr bst-table-row ng-repeat="contentHost in detailsTable.rows" row-select="contentHost"
+            ng-controller="ContentHostStatusController">
+          <td bst-table-cell>
+            <a ui-sref="content-hosts.details.info({contentHostId: contentHost.uuid})">
+              {{ contentHost.name }}
+            </a>
+          </td>
+          <td bst-table-cell>{{ contentHost.distribution }}</td>
+          <td bst-table-cell>{{ contentHost.environment.name }}</td>
+          <td bst-table-cell>{{ contentHost.content_view.name || "" }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details.html
@@ -27,6 +27,14 @@
           </span>
         </a>
       </li>
+
+      <li ng-class="{active: isState('errata.details.content-hosts')}">
+        <a ui-sref="errata.details.content-hosts">
+          <span translate>
+            Content Hosts
+          </span>
+        </a>
+      </li>
     </ul>
   </nav>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
@@ -55,5 +55,12 @@ angular.module('Bastion.errata').config(['$stateProvider', function ($stateProvi
         collapsed: true,
         permission: 'view_errata',
         templateUrl: 'errata/details/views/errata-details-info.html'
+    })
+    .state('errata.details.content-hosts', {
+        url: '/content-hosts',
+        collapsed: true,
+        permission: 'view_errata',
+        controller: 'ErrataContentHostsController',
+        templateUrl: 'errata/details/views/errata-details-content-hosts.html'
     });
 }]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
@@ -26,7 +26,12 @@ angular.module('Bastion.errata').factory('Erratum',
         return BastionResource('/katello/api/v2/errata/:id/',
             {id: '@id', 'sort_by': 'issued', 'sort_order': 'DESC'},
             {
-                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
+                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
+                applicableContentHosts: {method: 'GET', transformResponse: function (data) {
+                    var erratum = angular.fromJson(data),
+                        systems = erratum['systems_applicable'];
+                    return {results: systems, subtotal: systems.length, total: systems.length};
+                }}
             }
         );
 

--- a/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+describe('Controller: ErrataContentHostsController', function() {
+    var $scope, translate, Nutupane, ContentHost, ContentHostBulkAction,
+        CurrentOrganization;
+
+    beforeEach(module('Bastion.errata', 'Bastion.test-mocks'));
+
+    beforeEach(inject(function($injector) {
+        var $controller = $injector.get('$controller');
+
+        translate = function (string) {
+            return string;
+        };
+
+        Nutupane = function() {
+            this.table = {
+                params: {},
+                showColumns: function () {}
+            };
+            this.enableSelectAllResults = function () {};
+            this.getAllSelectedResults = function () {
+                return {include: [1, 2, 3]};
+            };
+            this.refresh = function () {};
+        };
+
+        ContentHost = {};
+
+        ContentHostBulkAction = {
+            failed: false,
+            installContent: function (params, success, error) {
+                if (this.failed) {
+                    error({errors: ['error']});
+                } else {
+                    success();
+                }
+            }
+        };
+
+
+        CurrentOrganization = 'foo';
+        
+        $scope = $injector.get('$rootScope').$new();
+        $scope.$stateParams = {errataId: 1};
+
+        $controller('ErrataContentHostsController', {
+            $scope: $scope,
+            translate: translate,
+            Nutupane: Nutupane,
+            ContentHost: ContentHost,
+            ContentHostBulkAction: ContentHostBulkAction,
+            CurrentOrganization: CurrentOrganization                      
+        });
+    }));
+
+    it("puts the errata content hosts table object on the scope", function() {
+        expect($scope.detailsTable).toBeDefined();
+    });
+
+    it("allows the filtering of available errata only", function () {
+        $scope.errata = {
+            showAvailable: true
+        };
+        
+        $scope.toggleAvailable();
+        expect($scope.detailsTable.params['erratum_restrict_available']).toBe(true)
+    });
+
+    describe("can apply errata", function () {
+        var expectedParams;
+
+        beforeEach(function () {
+            $scope.errata = {'errata_id': 10},
+            expectedParams = {
+                include: [1, 2, 3],
+                'content_type': 'errata',
+                content: [$scope.errata['errata_id']],
+                'organization_id': CurrentOrganization
+
+            };
+            spyOn(ContentHostBulkAction, 'installContent').andCallThrough();
+        });
+
+        afterEach(function () {
+            expect(ContentHostBulkAction.installContent).toHaveBeenCalledWith(expectedParams, jasmine.any(Function),
+                jasmine.any(Function));
+        });
+
+        it("and succeed", function () {
+            $scope.applyErrata();
+
+            expect($scope.successMessages.length).toBe(1);
+            expect($scope.errorMessages.length).toBe(0);
+        });
+
+        it("and fail", function () {
+            ContentHostBulkAction.failed = true;
+            $scope.applyErrata();
+
+            expect($scope.successMessages.length).toBe(0);
+            expect($scope.errorMessages.length).toBe(1);
+            expect($scope.errorMessages[0]).toBe('error');
+        });
+    });
+});

--- a/engines/bastion_katello/test/errata/erratum.factory.test.js
+++ b/engines/bastion_katello/test/errata/erratum.factory.test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+describe('Factory: Erratum', function() {
+    var Erratum, erratum;
+
+    beforeEach(module('Bastion.errata'));
+
+    beforeEach(module(function($provide) {
+        $provide.value('CurrentOrganization', 'ACME');
+    }));
+
+    beforeEach(inject(function(_Erratum_) {
+        Erratum = _Erratum_;
+    }));
+
+    it("provides a way to update a content host", function() {
+        var applicable_systems = [2, 3, 4],
+            erratum = {
+                id: 1,
+                'systems_applicable': applicable_systems
+            };
+
+        $httpBackend.expectGET('/api/v2/errata/1').respond(erratum);
+
+        Erratum.applicableContentHosts({id: 1}, function (result) {
+            expect(result.results).toEqual(applicable_systems);
+            expect(result.subtotal).toBe(3);
+            expect(result.total).toBe(3);
+        });
+    });
+});

--- a/test/controllers/api/v2/errata_controller_test.rb
+++ b/test/controllers/api/v2/errata_controller_test.rb
@@ -42,6 +42,10 @@ module Katello
       @request.env['HTTP_ACCEPT'] = 'application/json'
       @request.env['CONTENT_TYPE'] = 'application/json'
       @fake_search_service = @controller.load_search_service(Support::SearchService::FakeSearchService.new)
+
+      Katello::Erratum.any_instance.stubs(:systems_applicable).returns([])
+      Katello::Erratum.any_instance.stubs(:systems_available).returns([])
+
       models
       permissions
     end


### PR DESCRIPTION
Adds a content host tab to the errata details page that allows
the listing and syncing of applicable content hosts.

http://projects.theforeman.org/issues/7688
