### PR TITLE
Fixes #7554 - Show user friendly error message on 413

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
@@ -76,7 +76,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
         };
 
         $scope.uploadContent = function (content) {
-            var returnData;
+            var returnData, error;
 
             if (content) {
                 try {
@@ -94,7 +94,12 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     $scope.repository.$get();
                     updateRepositoriesTable();
                 } else {
-                    $scope.uploadErrorMessages = [translate('Error during upload: ') + returnData.displayMessage];
+                    if (typeof(returnData) === "string" && returnData.indexOf("Request Entity Too Large")) {
+                        error = translate('File too large. Please use the CLI instead.');
+                    } else {
+                        error = returnData.displayMessage;
+                    }
+                    $scope.uploadErrorMessages = [translate('Error during upload: ') + error];
                 }
 
                 $scope.progress.uploading = false;

--- a/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
@@ -105,6 +105,23 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect($scope.uploadErrorMessages.length).toBe(1);
     });
 
+    it('should handle 413 (file too large) responses by showing an error', function() {
+        var text = '<html><head> \
+            <title>413 Request Entity Too Large</title> \
+            </head><body> \
+            <h1>Request Entity Too Large</h1> \
+            The requested resource<br />/katello/api/v2/repositories/1/upload_content<br /> \
+            does not allow request data with POST requests, or the amount of data provided in \
+            the request exceeds the capacity limit. \
+            </body></html>';
+
+        $scope.uploadContent(text, true);
+        expect($scope.uploadSuccessMessages.length).toBe(0);
+        expect($scope.uploadErrorMessages.length).toBe(1);
+        expect($scope.uploadErrorMessages[0]).toContain('File too large');
+
+    });
+
     it('should set the upload status to success and refresh the repository if a file upload status is success', function() {
         spyOn($scope.repositoriesTable, 'replaceRow');
         spyOn($scope.repository, '$get');


### PR DESCRIPTION
This is kind of tricky to test. You need to run the web server with passenger (no apache proxy either). Then just upload a file 10MB+. You should get "Error during upload: undefined" without this change. Some options:
1. Set up a nightly install. Turn off asset compilation and apply the patch.
2. Setup your dev install to use passenger
3. Hack the action to return the text you see in the js test.
