### PR TITLE
Fixes #8018 - Performs docker repository name validation on repo create

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -85,7 +85,6 @@ module Katello
       unless repo_params[:gpg_key_id].blank?
         gpg_key = @gpg_key
       end
-
       repo_params[:label] = labelize_params(repo_params)
       repo_params[:url] = nil if repo_params[:url].blank?
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -69,6 +69,10 @@ module Katello
     validates :product_id, :presence => true
     validates :pulp_id, :presence => true, :uniqueness => true, :if => proc { |r| r.name.present? }
     validates :checksum_type, :inclusion => {:in => CHECKSUM_TYPES, :allow_blank => true}
+    validates :name, :if => :docker?, :format => {
+      :with => /^([a-z0-9\-_]{4,30}\/)?[a-z0-9\-_\.]{3,30}$/,
+      :message => (_("must be a valid docker name"))
+    }
     #validates :content_id, :presence => true #add back after fixing add_repo orchestration
     validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -185,6 +185,7 @@ module Katello
 
     def test_create_without_label_or_name
       post :create, :product_id => @product.id
+      # TODO: fix this test, returns 500 because of undefined method add_repo for Katello::Product
       assert_response 500 # should be 400 but dynflow doesn't raise RecordInvalid
     end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -47,6 +47,32 @@ module Katello
       refute @repo2.valid?
     end
 
+    def test_docker_repository_name_format
+      @repo.content_type = 'docker'
+      @repo.name = 'valid'
+      assert @repo.valid?
+      @repo.name = 'Invalid'
+      refute @repo.valid?
+      @repo.name = '-_ok/valid'
+      assert @repo.valid?
+      @repo.name = 'Invalid/valid'
+      refute @repo.valid?
+      @repo.name = 'Invalid/Invalid'
+      refute @repo.valid?
+      @repo.name = 'abcd/.-_'
+      assert @repo.valid?
+      @repo.name = 'abc/valid'
+      refute @repo.valid?
+      @repo.name = 'abcd/ab'
+      refute @repo.valid?
+      @repo.name = '/valid'
+      refute @repo.valid?
+      @repo.name = 'thisisnotvalidbecauseitistoolong/valid'
+      refute @repo.valid?
+      @repo.name = 'valid/thisisnotvalidbecauseitistoolong'
+      refute @repo.valid?
+    end
+
     def test_unique_repository_label_per_product_and_environment
       @repo.save
       @repo2 = build(:katello_repository,
@@ -75,6 +101,7 @@ module Katello
 
     def test_docker_pulp_id
       # for docker repos, the pulp_id should be downcased
+      @repo.name = 'docker_repo'
       @repo.pulp_id = 'PULP-ID'
       @repo.content_type = Repository::DOCKER_TYPE
       assert @repo.save


### PR DESCRIPTION
Validation in UI could be done, but for CLI and API one would still have to validate it on the controller as far as i know.
