### PR TITLE
Fixes #8265/BZ1154380: remove deselect all link from tables.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -24,13 +24,6 @@
     <div class="pull-right">
       <div class="pull-left nutupane-info">
         <span translate>{{ addSubscriptionsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : addSubscriptionsTable.numSelected == 0 }"
-           ng-click="addSubscriptionsTable.selectAll(false)">
-          Deselect All
-        </a>
       </div>
 
       <div ng-hide="denied('edit_activation_keys', activationKey)" class="nutupane-actions pull-right">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
@@ -15,13 +15,6 @@
     <div class="fr select-action">
       <span class="nutupane-info">
         <span translate>{{ hostCollectionsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : hostCollectionsTable.numSelected == 0 }"
-           ng-click="hostCollectionsTable.selectAll(false)">
-          Deselect All
-        </a>
       </span>
 
       <button ng-if="isState('activation-keys.details.host-collections.list')"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -24,13 +24,6 @@
     <div class="pull-right">
       <div class="pull-left nutupane-info">
         <span translate>{{ subscriptionsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : subscriptionsTable.numSelected == 0 }"
-           ng-click="subscriptionsTable.selectAll(false)">
-          Deselect All
-        </a>
       </div>
 
       <div class="nutupane-actions pull-right">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -22,13 +22,6 @@
     <div class="fr">
       <div class="fl nutupane-info">
         <span translate>{{ addSubscriptionsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : addSubscriptionsTable.numSelected == 0 }"
-           ng-click="addSubscriptionsTable.selectAll(false)">
-          Deselect All
-        </a>
       </div>
 
       <div ng-hide="system.readonly" class="nutupane-actions fr">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -22,13 +22,6 @@
     <div class="fr">
       <div class="fl nutupane-info">
         <span translate>{{ subscriptionsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : subscriptionsTable.numSelected == 0 }"
-           ng-click="subscriptionsTable.selectAll(false)">
-          Deselect All
-        </a>
       </div>
 
       <div ng-hide="system.readonly" class="nutupane-actions fr">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/host-collections-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/host-collections-table.html
@@ -15,13 +15,6 @@
     <div class="fr select-action">
       <span class="nutupane-info">
         <span translate>{{ hostCollectionsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : hostCollectionsTable.numSelected == 0 }"
-           ng-click="hostCollectionsTable.selectAll(false)">
-          Deselect All
-        </a>
       </span>
 
       <button ng-if="isState('content-hosts.details.host-collections.list')"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-content-hosts.html
@@ -23,13 +23,6 @@
     <div class="fr">
       <div class="fl nutupane-info">
         <span translate>{{ addContentHostsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : addContentHostsTable.numSelected == 0 }"
-           ng-click="addContentHostsTable.selectAll(false)">
-          Deselect All
-        </a>
       </div>
 
       <div ng-hide="hostCollection.readonly" class="nutupane-actions fr">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-content-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-content-hosts-list.html
@@ -24,13 +24,6 @@
     <div class="fr">
       <div class="fl nutupane-info">
         <span translate>{{ contentHostsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : contentHostsTable.numSelected == 0 }"
-           ng-click="contentHostsTable.selectAll(false)">
-          Deselect All
-        </a>
       </div>
 
       <div ng-hide="denied('edit_content_hosts')" class="nutupane-actions fr">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -48,13 +48,6 @@
     <div class="fr">
       <div class="fl nutupane-info">
         <span translate>{{ discoveryTable.numSelected }} Selected</span>
-        <span>|</span>        
-          <a class="deselect-action"
-             translate
-             ng-class="{ 'disabled-link' : discoveryTable.numSelected == 0 }"
-             ng-click="discoveryTable.selectAll(false)">
-            Deselect All
-          </a>
       </div>   
 
       <div ng-hide="system.readonly" class="nutupane-actions fr">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products-table.html
@@ -13,13 +13,6 @@
     <div class="fr select-action">
       <span class="nutupane-info">
         <span translate>{{ productsTable.numSelected }} Selected</span>
-        <span>|</span>
-        <a class="deselect-action"
-           translate
-           ng-class="{ 'disabled-link' : productsTable.numSelected == 0 }"
-           ng-click="productsTable.selectAll(false)">
-          Deselect All
-        </a>
       </span>
 
       <button ng-if="isState('sync-plans.details.products.list')"


### PR DESCRIPTION
Remove the deselect all link from tables as the checkbox on the
left side of the table is the expected control for selecting and
deselecting.

http://projects.theforeman.org/issues/8265
https://bugzilla.redhat.com/show_bug.cgi?id=1154380
