### PR TITLE
Fixes #8263: Remove usage of to_sym on user input params.

### DIFF
--- a/app/controllers/katello/api/api_controller.rb
+++ b/app/controllers/katello/api/api_controller.rb
@@ -84,9 +84,9 @@ module Katello
     end
 
     def respond(options = {})
-      method_name = ('respond_for_' + params[:action].to_s).to_sym
+      method_name = 'respond_for_' + params[:action].to_s
       fail "automatic response method '%s' not defined" % method_name unless respond_to?(method_name, true)
-      return send(method_name, options)
+      return send(method_name.to_sym, options)
     end
 
     def format_bulk_action_messages(args = {})

--- a/app/controllers/katello/content_search_controller.rb
+++ b/app/controllers/katello/content_search_controller.rb
@@ -614,7 +614,7 @@ module Katello
       ContentSearch::SearchUtils.current_user = current_user
       ContentSearch::SearchUtils.env_ids = params[:environments]
       ContentSearch::SearchUtils.offset = params[:offset] || 0
-      @mode = params[:mode].try(:to_sym) || :all
+      @mode = params[:mode] || 'all'
     end
 
     def process_views(view_ids)

--- a/app/lib/katello/content_search/content_view_search.rb
+++ b/app/lib/katello/content_search/content_view_search.rb
@@ -52,9 +52,9 @@ module Katello
       def view_versions
         @view_versions ||= begin
           versions = views.map { |v| v.versions.in_environment(search_envs) }.flatten
-          if @mode == :unique
+          if @mode == 'unique'
             versions = versions.select { |v| !(search_envs - v.environments).empty? }
-          elsif @mode == :shared
+          elsif @mode == 'shared'
             versions = versions.select { |v| (search_envs - v.environments).empty? }
           end
           versions

--- a/app/lib/katello/content_search/search.rb
+++ b/app/lib/katello/content_search/search.rb
@@ -31,7 +31,7 @@ module Katello
       end
 
       def mode
-        @mode || :all
+        @mode || 'all'
       end
 
       def offset


### PR DESCRIPTION
Addresses CVE-2014-3712, whereby two locations in the code turn user
input into symbols and allow potential DoS attacks by an authenticated user.

The first location, content search params, was turned from symbol matching
into string matching to avoid the to_sym conversion. The second location
involves the use of the Rails action param. While this should be guarded
by the internals of Rails, the code was changed to only perform the to_sym
if the params[:action] parameter exists within the application by doing
the respond_to? check prior to the to_sym in the send.
