### PR TITLE
Fixes #8273/BZ1138868: fix JS error on content hosts page.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -359,7 +359,7 @@
     <div ng-show="showAdvanced" class="details fl">
       <section ng-show="showAdvanced" ng-repeat="(sectionName, subSection) in advancedInfoLeft">
         <h4>{{ sectionName }}</h4>
-        <div ng-repeat="(key, value) in subSection" >
+        <div ng-repeat="(key, value) in subSection track by $index" >
           <div ng-include="getTemplateForType(value)"></div>
         </div>
         <div class="divider" ng-show="!$last"></div>
@@ -368,7 +368,7 @@
     <div ng-show="showAdvanced" class="details fr">
       <section ng-show="showAdvanced" ng-repeat="(sectionName, subSection) in advancedInfoRight">
         <h4>{{ sectionName }}</h4>
-        <div ng-repeat="(key, value) in subSection" >
+        <div ng-repeat="(key, value) in subSection track by $index" >
           <div ng-include="getTemplateForType(value)"></div>
         </div>
         <div class="divider" ng-show="!$last"></div>


### PR DESCRIPTION
Use track by in ng-repeat to fix javascript error on the
content hosts page when visiting multiple content hosts
sequentially.

http://projects.theforeman.org/issues/8273
https://bugzilla.redhat.com/show_bug.cgi?id=1138868
