### PR TITLE
fixes #8318 - make errata indexing idempotent

### DIFF
--- a/test/fixtures/models/katello_errata.yml
+++ b/test/fixtures/models/katello_errata.yml
@@ -6,6 +6,8 @@ security:
   uuid: "partylikeits1999"
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+  issued: <%= 3.days.ago %>
+  updated: <%= 3.days.ago %>
 
 bugfix:
   errata_id:  "RHBA-2014-013"
@@ -13,6 +15,8 @@ bugfix:
   uuid: "100dividedby0"
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+  issued: <%= 3.days.ago %>
+  updated: <%= 3.days.ago %>
 
 enhancement:
   errata_id: "RHEA-2014-111"
@@ -20,3 +24,5 @@ enhancement:
   uuid: "wecanrebuildhim"
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+  issued: <%= 3.days.ago %>
+  updated: <%= 3.days.ago %>

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -54,6 +54,20 @@ module Katello
       assert_empty Erratum.applicable_to_systems([@simple_server])
     end
 
+    def test_update_from_json
+      errata = katello_errata(:security)
+      json = errata.attributes.merge('description' => 'an update', 'updated' => DateTime.now)
+      errata.update_from_json(json)
+      assert_equal Erratum.find(errata).description, json['description']
+    end
+
+    def test_update_from_json_is_idempotent
+      errata = katello_errata(:security)
+      last_updated = errata.updated_at
+      json = errata.attributes
+      errata.update_from_json(json)
+      assert_equal Erratum.find(errata).updated_at, last_updated
+    end
   end
 
   class ErratumAvailableTest < ErratumTestBase


### PR DESCRIPTION
Currently, every erratum's 'updated_at' field is updated on every sync.  This will only update an erratum if the issuer actually issued an update.
