### PR TITLE
Fixes #8322: display black icons if no errata needs to be applied.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -183,7 +183,7 @@
           <a ui-sref="content-hosts.details.errata.index({search: 'type:security'})">
             {{ contentHost.errata_counts.security || 0 }}
             <i class="icon-warning-sign inline-icon"
-               ng-class="{green: contentHost.errata_counts.security === 0, red: contentHost.errata_counts.security > 0}"
+               ng-class="{black: contentHost.errata_counts.security === 0, red: contentHost.errata_counts.security > 0}"
                title="{{ 'Security' | translate }}"></i>
           </a>
         </span>
@@ -195,7 +195,7 @@
           <a ui-sref="content-hosts.details.errata.index({search: 'type:bugfix'})">
             {{ contentHost.errata_counts.bugfix || 0 }}
             <i class="icon-bug inline-icon"
-               ng-class="{green: contentHost.errata_counts.bugfix === 0, yellow: contentHost.errata_counts.bugfix > 0}"
+               ng-class="{black: contentHost.errata_counts.bugfix === 0, yellow: contentHost.errata_counts.bugfix > 0}"
                title="{{ 'Bug Fix' | translate }}"></i>
           </a>
         </span>
@@ -207,7 +207,7 @@
           <a ui-sref="content-hosts.details.errata.index({search: 'type:enhancement'})">
             {{ errataCounts.enhancement || 0 }}
             <i class="icon-plus-sign-alt inline-icon"
-               ng-class="{green: contentHost.errata_counts.enhancement === 0, yellow: contentHost.errata_counts.enhancement > 0}"
+               ng-class="{black: contentHost.errata_counts.enhancement === 0, yellow: contentHost.errata_counts.enhancement > 0}"
                title="{{ 'Enhancement' | translate }}"></i>
           </a>
         </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-counts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-counts.html
@@ -2,19 +2,19 @@
   <span>
     {{ errataCounts.security || 0 }}
     <i class="icon-warning-sign inline-icon"
-       ng-class="{green: errataCounts.security === 0, red: errataCounts.security > 0}"
+       ng-class="{black: errataCounts.security === 0, red: errataCounts.security > 0}"
        title="{{ 'Security' | translate }}"></i>
   </span>
   <span>
     {{ errataCounts.bugfix || 0 }}
     <i class="icon-bug inline-icon"
-       ng-class="{green: errataCounts.bugfix === 0, yellow: errataCounts.bugfix > 0}"
+       ng-class="{black: errataCounts.bugfix === 0, yellow: errataCounts.bugfix > 0}"
        title="{{ 'Bug Fix' | translate }}"></i>
   </span>
   <span>
     {{ errataCounts.enhancement || 0 }}
     <i class="icon-plus-sign-alt inline-icon"
-       ng-class="{green: errataCounts.enhancement === 0, yellow: errataCounts.enhancement > 0}"
+       ng-class="{black: errataCounts.enhancement === 0, yellow: errataCounts.enhancement > 0}"
        title="{{ 'Enhancement' | translate }}"></i>
   </span>
 </span>


### PR DESCRIPTION
Simply show black errata icons instead of calling attention to
them with green icons if no action needs to be performed.

http://projects.theforeman.org/issues/8322
