### PR TITLE
fixes #8355 - remove ambigious column plucks for older rails

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -215,7 +215,7 @@ module Katello
         :total    => errata.count
       }
 
-      @available_errata_ids = @system.available_errata.pluck(:id)
+      @available_errata_ids = @system.available_errata.pluck("#{Katello::Erratum.table_name}.id")
       respond_for_index :collection => response
     end
 


### PR DESCRIPTION
Happens when listing errata for a content host on a production install on RHEL, due to the older version of Rails:

```
ActiveRecord::StatementInvalid: PGError: ERROR:  column reference "id" is ambiguous
LINE 1: SELECT id FROM "katello_errata" INNER JOIN "katello_reposito...
```

Foreman has dealt with a number of these issues too:
  https://github.com/theforeman/foreman/pulls?q=is%3Apr+pluck+is%3Aclosed
