### PR TITLE
fixes #7904 - adding autocomplete for errata

### DIFF
--- a/app/controllers/katello/concerns/filtered_auto_complete_search.rb
+++ b/app/controllers/katello/concerns/filtered_auto_complete_search.rb
@@ -1,0 +1,35 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Concerns
+    module FilteredAutoCompleteSearch
+      extend ActiveSupport::Concern
+
+      def auto_complete_search
+        begin
+          items = self.index_relation.complete_for(params[:search])
+          items = items.map do |item|
+            category = (['and', 'or', 'not', 'has'].include?(item.to_s.sub(/^.*\s+/, ''))) ? _('Operators') : ''
+            part = item.to_s.sub(/^.*\b(and|or)\b/i) { |match| match.sub(/^.*\s+/, '') }
+            completed = item.to_s.chomp(part)
+            {:completed => CGI.escapeHTML(completed), :part => CGI.escapeHTML(part), :label => item, :category => category}
+          end
+        rescue ScopedSearch::QueryNotSupported => e
+          items = [{:error => e.to_s}]
+        end
+        render :json => items
+      end
+
+    end
+  end
+end

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -32,7 +32,7 @@ module Katello
     has_many :cves, :class_name => "Katello::ErratumCve", :dependent => :destroy, :inverse_of => :erratum
     has_many :packages, :class_name => "Katello::ErratumPackage", :dependent => :destroy, :inverse_of => :erratum
 
-    scoped_search :on => :errata_id, :rename => :id
+    scoped_search :on => :errata_id, :rename => :id, :complete_value => true
     scoped_search :on => :title, :only_explicit => true
     scoped_search :on => :severity, :complete_value => true
     scoped_search :on => :errata_type, :rename => :type, :complete_value => true

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -110,6 +110,7 @@ Katello::Engine.routes.draw do
         api_resources :errata, :only => [:index, :show] do
           collection do
             get :compare
+            get :auto_complete_search
           end
         end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
@@ -25,7 +25,9 @@ angular.module('Bastion.errata').factory('Erratum',
 
         return BastionResource('/katello/api/v2/errata/:id/',
             {id: '@id', 'sort_by': 'issued', 'sort_order': 'DESC'},
-            {}
+            {
+                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
+            }
         );
 
     }]


### PR DESCRIPTION
should be on any nutupane page that has errata including:

Content > Errata
Lifecycle Environments > Library > Errata
Content Views > Click a View > Click A Version > Errata
