### PR TITLE
refs #7706 - extend errata in systems/erratum rabl

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -200,6 +200,7 @@ module Katello
     param :id, String, :desc => N_("UUID of the content host"), :required => true
     param :content_view_id, :number, :desc => N_("Calculate Applicable Errata based on a particular Content View"), :required => false
     param :environment_id, :number, :desc => N_("Calculate Applicable Errata based on a particular Environment"), :required => false
+    param_group :search, Api::V2::ApiController
     def errata
       if params[:content_view_id] && params[:environment_id]
         find_content_view

--- a/app/views/katello/api/v2/errata/show.json.rabl
+++ b/app/views/katello/api/v2/errata/show.json.rabl
@@ -2,7 +2,7 @@ object @resource
 
 attributes :uuid => :id
 attributes :title, :errata_id
-attributes :issued, :updated
+attributes :issued, :updated, :version, :status, :release
 attributes :severity, :description, :solution, :summary, :reboot_suggested
 attributes :_href
 attributes :cves

--- a/app/views/katello/api/v2/systems/erratum.json.rabl
+++ b/app/views/katello/api/v2/systems/erratum.json.rabl
@@ -1,11 +1,4 @@
-attributes :title, :version, :description, :status, :id, :errata_id
-attributes :reboot_suggested, :updated, :issued, :release, :solution
-
-node :packages do |e|
-  e.packages.pluck(:nvrea).sort
-end
-
-attributes :errata_type => :type
+extends("katello/api/v2/errata/show")
 
 node :available do |e|
   @available_errata_ids.include?(e.id) if @available_errata_ids


### PR DESCRIPTION
Makes the result returned consistent between the two API endpoints

For the hammer CLI tasks, I wanted to show the same view in `errata list` and `content-host errata list`, but the errata RABL was showing UUID as ID (which seems standard), but systems/erratum was using the database ID column.
