### PR TITLE
fixes #8306,8177,8180 - adding incremnetal update api

### DIFF
--- a/app/lib/actions/katello/content_view/incremental_updates.rb
+++ b/app/lib/actions/katello/content_view/incremental_updates.rb
@@ -1,0 +1,32 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module ContentView
+      class IncrementalUpdates < Actions::EntryAction
+        def plan(version_environments, content, dep_solve, description)
+          concurrence do
+            version_environments.each do |version_environment|
+              plan_action(ContentViewVersion::IncrementalUpdate, version_environment[:content_view_version],
+                          version_environment[:environments], content, dep_solve, description)
+            end
+          end
+        end
+
+        def humanized_name
+          _("Incremental Update")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view/node_metadata_generate.rb
+++ b/app/lib/actions/katello/content_view/node_metadata_generate.rb
@@ -19,7 +19,7 @@ module Actions
         end
 
         def humanized_name
-          _("Generate Capsule Metadata and Synchronize Capsules for %s") % input[:environment_name]
+          _("Generate and Synchronize Capsule Metadata for %s") % input[:environment_name]
         end
 
         def plan(content_view, environment)

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -32,7 +32,7 @@ module Actions
                 end
               end
 
-              plan_action(ContentViewPuppetEnvironment::CloneToEnvironment, version, environment)
+              plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => environment)
 
               repos_to_delete(version, environment).each do |repo|
                 plan_action(Repository::Destroy, repo)

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -35,7 +35,7 @@ module Actions
 
               sequence do
                 plan_action(ContentViewPuppetEnvironment::CreateForVersion, version)
-                plan_action(ContentViewPuppetEnvironment::CloneToEnvironment, version, library)
+                plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => library)
               end
 
               repos_to_delete(content_view).each do |repo|

--- a/app/lib/actions/katello/content_view_puppet_environment/clone.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/clone.rb
@@ -13,32 +13,50 @@
 module Actions
   module Katello
     module ContentViewPuppetEnvironment
-      class CloneToEnvironment < Actions::Base
-        def plan(version, environment)
-          source = version.content_view_puppet_environments.archived.first
-          clone = find_or_build_puppet_env(version, environment)
+      class Clone < Actions::Base
+        attr_accessor :new_puppet_environment
+
+        def plan(from_version, options)
+          environment = options[:environment]
+          new_version = options[:new_version]
+          source = from_version.content_view_puppet_environments.archived.first
+
+          if environment
+            clone = find_or_build_puppet_env(from_version, environment)
+          else
+            clone = find_or_build_puppet_archive(new_version)
+          end
 
           sequence do
             if clone.new_record?
               plan_action(ContentViewPuppetEnvironment::Create, clone, true)
             else
-              clone.content_view_version = version
+              clone.content_view_version = from_version
               clone.save!
               plan_action(ContentViewPuppetEnvironment::Clear, clone)
             end
 
+            self.new_puppet_environment = clone
             plan_action(Pulp::Repository::CopyPuppetModule,
                         source_pulp_id: source.pulp_id,
                         target_pulp_id: clone.pulp_id,
                         criteria: nil)
 
             concurrence do
-              plan_action(Katello::Repository::MetadataGenerate, clone)
+              plan_action(Katello::Repository::MetadataGenerate, clone) if environment
               plan_action(ElasticSearch::ContentViewPuppetEnvironment::IndexContent, id: clone.id)
-              sequence do
-                ::Katello::CapsuleContent.with_environment(environment).each do |capsule_content|
-                  plan_action(CapsuleContent::AddRepository, capsule_content, clone)
-                end
+              handle_capsule_content(environment, clone)
+            end
+          end
+        end
+
+        private
+
+        def handle_capsule_content(environment, clone)
+          sequence do
+            if environment
+              ::Katello::CapsuleContent.with_environment(environment).each do |capsule_content|
+                plan_action(CapsuleContent::AddRepository, capsule_content, clone)
               end
             end
           end
@@ -49,10 +67,13 @@ module Actions
         def find_or_build_puppet_env(version, environment)
           puppet_env = ::Katello::ContentViewPuppetEnvironment.in_content_view(version.content_view).
               in_environment(environment).scoped(:readonly => false).first
+          puppet_env = version.content_view.build_puppet_env(:environment => environment) unless puppet_env
+          puppet_env
+        end
 
-          unless puppet_env
-            puppet_env = version.content_view.build_puppet_env(:environment => environment)
-          end
+        def find_or_build_puppet_archive(new_version)
+          puppet_env = new_version.archive_puppet_environment
+          puppet_env = new_version.content_view.build_puppet_env(:version => new_version) unless puppet_env
           puppet_env
         end
       end

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -1,0 +1,123 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module ContentViewVersion
+      class IncrementalUpdate < Actions::EntryAction
+        def humanized_name
+          _("Incremental Update")
+        end
+
+        def plan(old_version, environments, content, dep_solve, description)
+          action_subject(old_version.content_view)
+
+          unless (environments - old_version.environments).empty?
+            fail _("Content View Version %{id} not in all specified environments %{envs}") %
+                     {:id => old_version.id, :envs => (environments - old_version.environments).map(&:name).join(',')}
+          end
+
+          new_minor = old_version.content_view.versions.where(:major => old_version.major).maximum(:minor) + 1
+          new_version = old_version.content_view.create_new_version(description, old_version.major, new_minor)
+          history = ::Katello::ContentViewHistory.create!(:content_view_version => new_version, :user => ::User.current.login,
+                                                          :status => ::Katello::ContentViewHistory::IN_PROGRESS, :task => self.task)
+
+          sequence do
+            concurrence do
+              old_version.archived_repos.each do |source_repo|
+                sequence do
+                  new_repo = plan_action(Repository::CloneToVersion, source_repo, new_version, true).new_repository
+
+                  copy_yum_content(new_repo, dep_solve, content[:package_ids], content[:errata_ids])
+                  plan_action(Katello::Repository::MetadataGenerate, new_repo, nil)
+                  plan_action(ElasticSearch::Repository::IndexContent, id: new_repo.id)
+                end
+              end
+
+              sequence do
+                new_puppet_environment = plan_action(Katello::ContentViewPuppetEnvironment::Clone, old_version,
+                                                   :new_version => new_version).new_puppet_environment
+                copy_puppet_content(new_puppet_environment, content[:puppet_module_ids])
+              end
+            end
+
+            plan_self(:content_view_id => old_version.content_view.id, :environment_ids => environments.map(&:id),
+                      :user_id => ::User.current.id, :history_id => history.id)
+
+          end
+          promote(new_version, environments)
+        end
+
+        def finalize
+          history = ::Katello::ContentViewHistory.find(input[:history_id])
+          history.status = ::Katello::ContentViewHistory::SUCCESSFUL
+          history.save!
+        end
+
+        private
+
+        def promote(new_version, environments)
+          concurrence do
+            environments.each do |environment|
+              plan_action(Katello::ContentView::Promote, new_version, environment, true)
+            end
+          end
+        end
+
+        def copy_yum_content(new_repo, dep_solve, package_uuids, errata_uuids)
+          if new_repo.content_type == ::Katello::Repository::YUM_TYPE
+            unless errata_uuids.blank?
+              plan_copy(Pulp::Repository::CopyErrata, new_repo.library_instance, new_repo,
+                        { :filters => {:association => {'unit_id' => {'$in' => errata_uuids}}}},
+                        :recursive => true, :resolve_dependencies => dep_solve)
+            end
+
+            unless package_uuids.blank?
+              plan_copy(Pulp::Repository::CopyRpm, new_repo.library_instance, new_repo,
+                        { :filters => {:association => {'unit_id' => {'$in' => package_uuids}}}},
+                        resolve_dependencies => dep_solve)
+            end
+          end
+        end
+
+        def puppet_module_names(uuids)
+          ::Katello::PuppetModule.id_search(uuids).map(&:name)
+        end
+
+        def remove_puppet_names(repo, names)
+          plan_action(Pulp::Repository::RemovePuppetModule, :pulp_id => repo.pulp_id, :clauses => {:unit => {:name => {'$in' => names}}})
+        end
+
+        def copy_puppet_content(new_repo, puppet_module_uuids)
+          unless puppet_module_uuids.blank?
+            remove_puppet_names(new_repo, puppet_module_names(puppet_module_uuids))
+            puppet_module_uuids.each { |uuid| copy_puppet_module(new_repo, uuid) }
+          end
+        end
+
+        def copy_puppet_module(new_repo, uuid)
+          possible_repos = ::Katello::PuppetModule.find(uuid).repositories.in_organization(new_repo.organization).in_default_view
+          plan_action(Pulp::Repository::CopyPuppetModule, :source_pulp_id => possible_repos.first.pulp_id,
+                    :target_pulp_id => new_repo.pulp_id, :clauses =>  {'unit_id' => uuid})
+        end
+
+        def plan_copy(action_class, source_repo, target_repo, clauses = nil, override_config = nil)
+          plan_action(action_class,
+                      :source_pulp_id => source_repo.pulp_id,
+                      :target_pulp_id => target_repo.pulp_id,
+                      :full_clauses => clauses,
+                      :override_config => override_config)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/environment/library_create.rb
+++ b/app/lib/actions/katello/environment/library_create.rb
@@ -22,7 +22,7 @@ module Actions
 
           ::Katello::ContentViewVersion.create! do |v|
             v.content_view = library_view
-            v.version = 1
+            v.major = 1
           end
 
           version = library_view.versions.first

--- a/app/lib/actions/pulp/repository/abstract_copy_content.rb
+++ b/app/lib/actions/pulp/repository/abstract_copy_content.rb
@@ -18,6 +18,8 @@ module Actions
           param :source_pulp_id
           param :target_pulp_id
           param :clauses
+          param :full_clauses
+          param :override_config
         end
 
         # @api override - pulp extension representing the content type to copy
@@ -26,13 +28,17 @@ module Actions
         end
 
         def invoke_external_task
+          optional = criteria
+          optional[:override_config] = input[:override_config] if input[:override_config]
           content_extension.copy(input[:source_pulp_id],
                                  input[:target_pulp_id],
                                  criteria)
         end
 
         def criteria
-          if input[:clauses]
+          if input[:full_clauses]
+            input[:full_clauses]
+          elsif input[:clauses]
             { filters: {:unit => input[:clauses] } }
           else
             {}

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -370,12 +370,13 @@ module Katello
       ContentViewEnvironment.where(:content_view_id => self, :environment_id => env).first.try(:cp_id)
     end
 
-    def create_new_version(description = "")
-      version = ContentViewVersion.create!(:version => next_version,
+    def create_new_version(description = '', major = next_version, minor = 0)
+      version = ContentViewVersion.create!(:major => major,
+                                           :minor => minor,
                                            :content_view => self,
                                            :description => description
                                           )
-      increment!(:next_version)
+      increment!(:next_version) if minor == 0
 
       version
     end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -47,6 +47,13 @@ module Katello
       joins(:repositories).where("#{Katello::Repository.table_name}.library_instance_id" => repo)
     end
 
+    def self.for_version(version)
+      major, minor = version.to_s.split('.')
+      query = where(:major => major)
+      query.where(:minor => minor) if minor
+      query
+    end
+
     def to_s
       name
     end
@@ -71,6 +78,10 @@ module Katello
 
     def available_releases
       self.repositories.pluck(:minor).compact.uniq.sort
+    end
+
+    def version
+      "#{major}.#{minor}"
     end
 
     def repos(env)

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -3,7 +3,7 @@ object @resource
 
 extends 'katello/api/v2/common/identifier'
 
-attributes :version
+attributes :version, :major, :minor
 attributes :composite_content_view_ids
 attributes :content_view_id
 attributes :default

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -94,6 +94,9 @@ Katello::Engine.routes.draw do
           member do
             post :promote
           end
+          collection do
+            post :incremental_update
+          end
         end
 
         api_resources :docker_images, :only => [:index, :show]

--- a/db/migrate/20141124182205_content_view_version_add_minor.rb
+++ b/db/migrate/20141124182205_content_view_version_add_minor.rb
@@ -1,0 +1,11 @@
+class ContentViewVersionAddMinor < ActiveRecord::Migration
+  def up
+    add_column :katello_content_view_versions, :minor, :integer, :null => false, :default => 0
+    rename_column :katello_content_view_versions, :version, :major
+  end
+
+  def down
+    rename_column :katello_content_view_versions, :major, :version
+    remove_column :katello_content_view_versions, :minor
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -36,7 +36,8 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
         $scope.taskTypes = {
             publish: "Actions::Katello::ContentView::Publish",
             promotion: "Actions::Katello::ContentView::Promote",
-            deletion:  "Actions::Katello::ContentView::Remove"
+            deletion:  "Actions::Katello::ContentView::Remove",
+            incrementalUpdate:  "Actions::Katello::ContentView::IncrementalUpdates"
         };
 
         $scope.copy = function (newName) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
@@ -57,7 +57,9 @@ angular.module('Bastion.content-views').controller('ContentViewPromotionControll
 
             if (!env.prior) {
                 env.prior = {};
-            } else if (envIds.indexOf(env.id) !== -1) {
+            }
+
+            if (envIds.indexOf(env.id) !== -1) {
                 //if version is already promoted to the environment
                 enabled = false;
             } else if (env.library) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
@@ -55,6 +55,8 @@ angular.module('Bastion.content-views').controller('ContentViewVersionsControlle
                 message = translate("Promoted to %s").replace('%s', version['last_event'].environment.name);
             } else if (taskType === taskTypes.publish) {
                 message = translate("Published");
+            } else if (taskType === taskTypes.incrementalUpdate) {
+                message = translate("Incremental Update");
             }
             return message;
         };

--- a/lib/katello/permissions/content_view_permissions.rb
+++ b/lib/katello/permissions/content_view_permissions.rb
@@ -63,7 +63,8 @@ Foreman::Plugin.find(:katello).security_block :content_views do
              :resource_type => 'Katello::ContentView'
   permission :publish_content_views,
              {
-               'katello/api/v2/content_views' => [:publish]
+               'katello/api/v2/content_views' => [:publish],
+               'katello/api/v2/content_view_versions' => [:incremental_update]
              },
              :resource_type => 'Katello::ContentView'
   permission :promote_or_remove_content_views,

--- a/spec/helpers/organization_helper_methods.rb
+++ b/spec/helpers/organization_helper_methods.rb
@@ -48,7 +48,7 @@ module Katello
                                    :organization => env.organization)
 
         version = ContentViewVersion.new(:content_view => view,
-                                         :version => 1)
+                                         :major => 1)
         view.add_environment(env, version)
         version.save!
         view.save!

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -60,7 +60,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
   end
 
   class CloneToEnvironmentTest < TestBase
-    let(:action_class) { ::Actions::Katello::ContentViewPuppetEnvironment::CloneToEnvironment }
+    let(:action_class) { ::Actions::Katello::ContentViewPuppetEnvironment::Clone }
     let(:action) { create_action action_class }
     let(:dev) { katello_environments(:dev) }
     let(:dev_puppet_env) { katello_content_view_puppet_environments(:dev_view_puppet_environment) }
@@ -69,7 +69,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
 
     it 'plans with existing puppet environment' do
 
-      plan_action action, puppet_env.content_view_version, dev
+      plan_action action, puppet_env.content_view_version, :environment => dev
 
       assert_action_planed_with action, ::Actions::Katello::ContentViewPuppetEnvironment::Clear, dev_puppet_env
       refute_action_planed action, ::Actions::Katello::ContentViewPuppetEnvironment::Create
@@ -84,7 +84,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
 
     it 'plans capsule related actions' do
       capsule_content.add_lifecycle_environment(dev)
-      plan_action action, puppet_env.content_view_version, dev
+      plan_action action, puppet_env.content_view_version, :environment => dev
       assert_action_planed_with action, ::Actions::Katello::CapsuleContent::AddRepository do |(current_capsule_content, repo)|
         current_capsule_content.capsule.id == capsule_content.capsule.id &&
             dev_puppet_env == repo
@@ -95,7 +95,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
       dev_puppet_env.delete
       action.execution_plan.stub_planned_action(::Actions::Katello::ContentViewPuppetEnvironment::Create)
 
-      plan_action action, puppet_env.content_view_version, dev
+      plan_action action, puppet_env.content_view_version, :environment => dev
 
       assert_action_planed action, ::Actions::Katello::ContentViewPuppetEnvironment::Create
       refute_action_planed action, ::Actions::Katello::ContentViewPuppetEnvironment::Clear

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -36,6 +36,7 @@ module Katello
       @create_permission = :create_content_views
       @update_permission = :edit_content_views
       @destroy_permission = :destroy_content_views
+      @publish_permission = :publish_content_views
       @env_promote_permission = :promote_or_remove_content_views_to_environments
       @cv_promote_permission = :promote_or_remove_content_views
 
@@ -80,7 +81,6 @@ module Katello
 
     def test_index_with_content_view_by_version
       expected_version = ContentViewVersion.find(katello_content_view_versions(:library_view_version_2))
-
       results = JSON.parse(get(:index, :content_view_id => @library_view.id, :version => 2).body)
 
       assert_response :success
@@ -182,9 +182,40 @@ module Katello
       assert_response 400
     end
 
+    def test_incremental_update
+      version = @library_dev_staging_view.versions.first
+      errata_id = Katello::Erratum.first.uuid
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
+                                            [{:content_view_version => version, :environments => [@beta]}],
+                                            {'errata_ids' => [errata_id]}, true, nil).returns({})
+
+      put :incremental_update, :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}],
+                               :add_content => {:errata_ids => [errata_id]}, :resolve_dependencies => true
+
+      assert_response :success
+    end
+
+    def test_incremental_update_protected
+      version = @library_dev_staging_view.versions.first
+      errata_id = Katello::Erratum.first.uuid
+
+      publish_permission = {:name => @publish_permission, :search => "name=\"#{version.content_view.name}\"" }
+      view_promote_permission = {:name => @cv_promote_permission, :search => "name=\"#{version.content_view.name}\""  }
+      environment_promote_permission = {:name => @env_promote_permission, :search => "name=\"#{@beta.name}\"" }
+
+      allowed_perms = [[publish_permission, view_promote_permission, environment_promote_permission]]
+      denied_perms =  [@view_permission, @create_permission, @update_permission, @cv_promote_permission,
+                       publish_permission, view_promote_permission, environment_promote_permission]
+
+      assert_protected_action(:incremental_update, allowed_perms, denied_perms) do
+        put :incremental_update, :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}],
+                                 :add_content => {:errata_ids => [errata_id], :resolve_dependencies => true}
+      end
+    end
+
     def test_destroy_protected
       diff_view = ContentView.find(katello_content_views(:candlepin_default_cv))
-      diff_view_destroy_permission = {:name => @destroy_permission, :search => "name=\"#{diff_view.name}\"" }
+      diff_view_destroy_permission = {:name => @destroy_permission, :search => "name=\"#{diff_view.name}\""}
 
       allowed_perms = [@destroy_permission]
 

--- a/test/factories/content_view_version_factory.rb
+++ b/test/factories/content_view_version_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :katello_content_view_version, :class => Katello::ContentViewVersion do
-    sequence(:version)
+    sequence(:major)
     association :content_view, :factory => :katello_content_view
   end
 end

--- a/test/fixtures/models/katello_content_view_versions.yml
+++ b/test/fixtures/models/katello_content_view_versions.yml
@@ -1,38 +1,38 @@
 library_default_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:acme_default) %>
-  version:   1
+  major:   1
 
 # TODO: REMOVE THESE TWO
 dev_default_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:acme_default) %>
-  version:  1
+  major:  1
 
 staging_default_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:acme_default) %>
-  version: 1
+  major: 1
 # END TODO: REMOVE THESE TWO
 
 library_view_version_1:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:library_view) %>
-  version: 1
+  major: 1
 
 library_view_version_2:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:library_view) %>
-  version: 2
+  major: 2
 
 library_dev_view_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:library_dev_view) %>
-  version: 1
+  major: 1
 
 library_dev_staging_view_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:library_dev_staging_view) %>
-  version: 3
+  major: 3
 
 candlepin_library_dev_cv_version:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:candlepin_library_dev_cv) %>
-  version: 1
+  major: 1
 
 composite_view_version_1:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:composite_view) %>
-  version: 1
+  major: 1
 

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -288,7 +288,7 @@ module Katello
 
     def test_unique_environments
       3.times do |i|
-        ContentViewVersion.create!(:version => i + 2,
+        ContentViewVersion.create!(:major => i + 2,
                                    :content_view => @library_dev_view)
       end
       @library_dev_view.add_environment(@library_dev_view.organization.library, ContentViewVersion.last)
@@ -325,12 +325,12 @@ module Katello
       assert_equal 1, cv.next_version
 
       assert_equal 2, @library_dev_view.next_version
-      assert_equal @library_dev_view.next_version - 1, @library_dev_view.versions.maximum(:version)
+      assert_equal @library_dev_view.next_version - 1, @library_dev_view.versions.maximum(:major)
 
       assert @library_dev_view.create_new_version
       @library_dev_view.reload
       assert_equal 3, @library_dev_view.next_version
-      assert_equal @library_dev_view.next_version - 1, @library_dev_view.versions.reload.maximum(:version)
+      assert_equal @library_dev_view.next_version - 1, @library_dev_view.versions.reload.maximum(:major)
     end
 
     def test_check_distribution_conflicts_conflict
@@ -421,7 +421,7 @@ module Katello
 
       ::Katello::ContentViewVersion.create! do |v|
         v.content_view = library_view
-        v.version = 1
+        v.major = 1
       end
 
       product = create(:katello_product, :organization => other_org, :provider => other_org.anonymous_provider)

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -24,7 +24,7 @@ module Katello
 
     def setup
       User.current = User.find(users(:admin))
-      @cvv = create(:katello_content_view_version)
+      @cvv = create(:katello_content_view_version, :major => 1, :minor => 0)
       @cvv.organization.kt_environments << Katello::KTEnvironment.find_by_name(:Library)
       @dev = create(:katello_environment,  :organization => @cvv.organization, :prior => @cvv.organization.library,     :name => 'dev')
       @beta = create(:katello_environment, :organization => @cvv.organization, :prior => @dev,                         :name => 'beta')
@@ -48,6 +48,14 @@ module Katello
     def test_promotoable_without_environments2
       @cvv.expects(:environments).returns([]).at_least_once
       refute @cvv.promotable?(@dev)
+    end
+
+    def test_of_version
+      version = @cvv
+      assert_equal [version], version.content_view.versions.for_version("1.0")
+      assert_equal [version], version.content_view.versions.for_version("1")
+      assert_equal [version], version.content_view.versions.for_version(1)
+      assert_equal [version], version.content_view.versions.for_version(1.0)
     end
 
     def test_docker_count

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -245,7 +245,7 @@ module Katello
                                         :version => @fedora_17_x86_64.content_view_version,
                                         :content_view => @fedora_17_x86_64.content_view
                                        )
-      assert_equal "/content_views/org_default_label/1/library/fedora_17_label", path
+      assert_equal "/content_views/org_default_label/1.0/library/fedora_17_label", path
 
       path = Repository.clone_repo_path(:repository => @fedora_17_x86_64,
                                         :environment => @fedora_17_x86_64.organization.library,
@@ -264,7 +264,7 @@ module Katello
                                                :version => @repo.content_view_version,
                                                :content_view => @repo.content_view
                                                )
-      assert_equal "empty_organization-org_default_label-1-fedora_label-dockeruser_repo", path
+      assert_equal "empty_organization-org_default_label-1.0-fedora_label-dockeruser_repo", path
       path = Repository.clone_docker_repo_path(:repository => @repo,
                                                :environment => @repo.organization.library,
                                                :content_view => @repo.content_view


### PR DESCRIPTION
example api call:

POST /katello/api/v2/content_view_versions/incremental_update

{
"content_view_version_environments": [{"content_view_version_id": 5, "environment_ids": [1,2,3]}],
"add_content": {"errata_ids": ["3068d8b3-5546-4ad7-90ea-8df0c0af5792"]  },
"resolve_dependencies": true
}

you may also want to test  'package_ids' & 'puppet_module_ids' as valid content
