### PR TITLE
Fixes #8387: Redirect users back to 403 page if no current organization.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/check-current-organization.run.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/check-current-organization.run.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the License (GPLv2) or (at your option) any later version.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+
+(function () {
+
+    /**
+     * @ngdoc run
+     * @name Bastion.run:CheckCurrentOrganization
+     *
+     * @description
+     *   Checks whether a page requires a current organization to be set and if it does
+     *   redirects the user to the Katello 403 page to instruct them to select an organization to proceed.
+     */
+    function CheckCurrentOrganization($rootScope, $window, CurrentOrganization) {
+        var fencedPages = [
+            'products',
+            'activation-keys',
+            'environments',
+            'subscriptions',
+            'gpg-keys',
+            'sync-plans',
+            'content-views',
+            'errata',
+            'content-hosts',
+            'host-collections'
+        ];
+
+        $rootScope.$on('$stateChangeStart', function (event, toState) {
+            if (CurrentOrganization === "" && fencedPages.indexOf(toState.name.split('.')[0]) !== -1) {
+                event.preventDefault();
+                $rootScope.transitionTo('organizations.select', {toState: toState.url});
+            }
+        });
+
+    }
+
+    angular
+        .module('Bastion.organizations')
+        .run(CheckCurrentOrganization);
+
+    CheckCurrentOrganization.$inject = ['$rootScope', '$window', 'CurrentOrganization'];
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization-selector.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization-selector.controller.js
@@ -1,0 +1,56 @@
+/**
+* Copyright 2015 Red Hat, Inc.
+*
+* This software is licensed to you under the GNU General Public
+* License as published by the Free Software Foundation; either version
+* 2 of the License (GPLv2) or (at your option) any later version.
+* There is NO WARRANTY for this software, express or implied,
+* including the implied warranties of MERCHANTABILITY,
+* NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+* have received a copy of GPLv2 along with this software; if not, see
+* http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+**/
+
+
+(function () {
+    'use strict';
+
+    /**
+    * @ngdoc controller
+    * @name Bastion.organizations.controller:OrganizationSelectorController
+    *
+    * @description
+    *     Selecting an organization
+    */
+    function OrganizationSelectorController($scope, Organization, CurrentOrganization, $window) {
+        var transitionState;
+
+        $scope.selectedOrganization = {};
+
+        Organization.queryUnpaged(function (response) {
+            $scope.organizations = response.results;
+        });
+
+        $scope.selectOrganization = function (organization) {
+            var label = organization.id + '-' + organization.name.replace("'", '').replace(".", '');
+
+            Organization.select({label: label}).$promise.catch(function () {
+                $window.location.href = transitionState;
+            });
+        };
+
+        $scope.$on('$stateChangeSuccess', function (event, toState, toParams) {
+            transitionState = toParams.toState;
+
+            if (CurrentOrganization) {
+                $window.location.href = transitionState;
+            }
+        });
+    }
+
+    angular
+        .module('Bastion.organizations')
+        .controller('OrganizationSelectorController', OrganizationSelectorController);
+
+    OrganizationSelectorController.$inject = ['$scope', 'Organization', 'CurrentOrganization', '$window'];
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization.factory.js
@@ -27,6 +27,10 @@ angular.module('Bastion.organizations').factory('Organization',
             {id: '@id'},
             {
                 update: { method: 'PUT'},
+                select: {
+                    method: 'GET',
+                    url: '/organizations/:label/select'
+                },
                 repoDiscover: { method: 'POST', params: {action: 'repo_discover'}},
                 cancelRepoDiscover: {method: 'POST', params: {action: 'cancel_repo_discover'}},
                 autoAttachSubscriptions: {method: 'POST', params: {action: 'autoattach_subscriptions'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.routes.js
@@ -1,0 +1,42 @@
+/**
+ Copyright 2014 Red Hat, Inc.
+
+ This software is licensed to you under the GNU General Public
+ License as published by the Free Software Foundation; either version
+ 2 of the License (GPLv2) or (at your option) any later version.
+ There is NO WARRANTY for this software, express or implied,
+ including the implied warranties of MERCHANTABILITY,
+ NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ have received a copy of GPLv2 along with this software; if not, see
+ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+(function () {
+
+    /**
+     * @ngdoc object
+     * @name Bastion.organizations.config
+     *
+     * @requires $stateProvider
+     *
+     * @description
+     *   State routes defined for the organizations module.
+     */
+    function OrganizationRoutes($stateProvider) {
+        $stateProvider.state('organizations', {
+            abstract: true,
+            template: '<div ui-view></div>'
+        })
+        .state('organizations.select', {
+            url: '/select_organization?toState',
+            permission: 'view_organizations',
+            controller: 'OrganizationSelectorController',
+            templateUrl: 'organizations/views/organization-selector.html'
+        });
+    }
+
+    angular.module('Bastion.organizations').config(OrganizationRoutes);
+
+    OrganizationRoutes.$inject = ['$stateProvider'];
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/views/organization-selector.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/views/organization-selector.html
@@ -1,0 +1,34 @@
+<div class="well col-sm-6 col-sm-offset-3">
+
+  <form name="organizationSelectorForm" class="form-horizontal" novalidate role="form">
+
+    <h1 class="center-header" translate>Select an Organization</h1>
+
+    <p class="center-paragraph" translate>
+      The page you are attempting to access requires selecting a specific organization.
+    </p>
+
+    <p class="center-paragraph" translate>
+      Please select one from the list below and you will be redirected.
+    </p>
+
+    <div class="form-group">
+      <div class="col-sm-5 col-sm-offset-3">
+        <select id="organization"
+                name="organization"
+                class="form-control"
+                ng-model="selectedOrganization.organization"
+                ng-options="organization as organization.name for organization in organizations"
+                tabindex="1">
+          <option value="">Select an Organization</option>
+        </select>
+      </div>
+
+      <div class="col-sm-4">
+        <button class="btn btn-primary" ng-disabled="!selectedOrganization.organization" ng-click="selectOrganization(selectedOrganization.organization)">Select</button>
+      </div>
+    </div>
+
+  </form>
+
+</div>

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.less
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.less
@@ -4,4 +4,12 @@
   @import "tasks";
   @import "environments";
   @import "errata";
+
+  .center-paragraph {
+    text-align: center;
+  }
+
+  .center-header {
+    text-align: center;
+  }
 }

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -32,6 +32,7 @@ module BastionKatello
           sync_plans
           host_collections
           katello_tasks
+          select_organization
         )
       )
     end

--- a/engines/bastion_katello/test/organizations/organization-selector.controller.test.js
+++ b/engines/bastion_katello/test/organizations/organization-selector.controller.test.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public
+ * License as published by the Free Software Foundation; either environment
+ * 2 of the License (GPLv2) or (at your option) any later environment.
+ * There is NO WARRANTY for this software, express or implied,
+ * including the implied warranties of MERCHANTABILITY,
+ * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+ * have received a copy of GPLv2 along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ **/
+
+describe('Controller: OrganizationSelectorController', function() {
+    var $scope,
+        $rootScope,
+        $state,
+        $window;
+
+    beforeEach(module('Bastion.organizations', 'Bastion.test-mocks'));
+
+    beforeEach(inject(function($injector) {
+        var $controller = $injector.get('$controller'),
+            Organization = $injector.get('MockResource').$new(),
+            CurrentOrganization = undefined;
+
+        $rootScope = $injector.get('$rootScope');
+        $scope = $rootScope.$new();
+        $state = $injector.get('$state');
+        $window = {location: {href: ''}};
+
+        Organization.select = function (params) {
+            return {'$promise': {catch: function (func) { func.call() } }};
+        };
+
+        $controller('OrganizationSelectorController', {
+            $scope: $scope,
+            Organization: Organization,
+            CurrentOrganization: CurrentOrganization,
+            $window: $window
+        });
+    }));
+
+    it("should query for a list of organizations", function() {
+        expect($scope.organizations).toBeDefined();
+    });
+
+    it("should provide selecting an organization in the backend", function () {
+        $scope.$broadcast('$stateChangeSuccess', {}, {toState: '/product'});
+        $scope.selectOrganization({id: 1, name: 'Default Organization'});
+
+        expect($window.location.href).toBeDefined();
+    });
+
+});
+


### PR DESCRIPTION
This functionality used to exist thanks to server side code that intercepted
pages. When Bastion was split and the logic that loads SPA pages updated the
server side check could no longer be relied on. This adds this logic to the
client side code and limits itself to declared pages as to not interrupt other
potential plugin pages.