### PR TITLE
Fixes #8552 - guard init of cp listending service

### DIFF
--- a/app/lib/actions/candlepin/listen_on_candlepin_events.rb
+++ b/app/lib/actions/candlepin/listen_on_candlepin_events.rb
@@ -32,6 +32,10 @@ module Actions
       def notify_not_connected(message)
         @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::NotConnected[message]
       end
+
+      def notify_finished
+        @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::Close
+      end
     end
 
     class ListenOnCandlepinEvents < Actions::Base
@@ -148,11 +152,22 @@ module Actions
         suspend
       end
 
+      def configured?
+        ::Katello.config.respond_to?(:qpid) &&
+          ::Katello.config.qpid.respond_to?(:url) &&
+          ::Katello.config.qpid.respond_to?(:subscriptions_queue_address)
+      end
+
       def initialize_listening_service(suspended_action)
-        CandlepinListeningService.initialize(world.logger,
+        if configured?
+          CandlepinListeningService.initialize(world.logger,
                                              ::Katello.config.qpid.url,
                                              ::Katello.config.qpid.subscriptions_queue_address)
-        suspended_action.notify_not_connected("initialized...have not connected yet")
+          suspended_action.notify_not_connected("initialized...have not connected yet")
+        else
+          action_logger.error("katello has not been configured for qpid.url and qpid.subscriptions_queue_address")
+          suspended_action.notify_finished
+        end
         rescue => e
           Rails.logger.error(e.message)
           Rails.logger.error(e.backtrace)


### PR DESCRIPTION
check that katello is configured prior to starting candlepin listending service
