### PR TITLE
fixes #8588 - make repo indexing idempotent

### DIFF
--- a/db/migrate/20141203123206_add_timestamps_to_repository_join_tables.rb
+++ b/db/migrate/20141203123206_add_timestamps_to_repository_join_tables.rb
@@ -1,0 +1,11 @@
+class AddTimestampsToRepositoryJoinTables < ActiveRecord::Migration
+  def change
+    change_table(:katello_repository_errata) do |t|
+      t.timestamps
+    end
+
+    change_table(:katello_repository_docker_images) do |t|
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This makes sure we don't touch the associations unless there's been a change, and it adds time stamps so that new items can be calculated for mail notifications in #4780 
