### PR TITLE
Fixes #8552 - guard init of cp listening service

### DIFF
--- a/app/lib/actions/candlepin/listen_on_candlepin_events.rb
+++ b/app/lib/actions/candlepin/listen_on_candlepin_events.rb
@@ -32,6 +32,10 @@ module Actions
       def notify_not_connected(message)
         @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::NotConnected[message]
       end
+
+      def notify_finished
+        @suspended_action << Actions::Candlepin::ListenOnCandlepinEvents::Close
+      end
     end
 
     class ListenOnCandlepinEvents < Actions::Base
@@ -128,6 +132,7 @@ module Actions
           begin
             initialize_listening_service(SuspendedAction.new(suspended_action))
           rescue => e
+            error!(e)
             raise e
           end
           at_exit do
@@ -148,11 +153,22 @@ module Actions
         suspend
       end
 
+      def configured?
+        ::Katello.config.respond_to?(:qpid) &&
+          ::Katello.config.qpid.respond_to?(:url) &&
+          ::Katello.config.qpid.respond_to?(:subscriptions_queue_address)
+      end
+
       def initialize_listening_service(suspended_action)
-        CandlepinListeningService.initialize(world.logger,
+        if configured?
+          CandlepinListeningService.initialize(world.logger,
                                              ::Katello.config.qpid.url,
                                              ::Katello.config.qpid.subscriptions_queue_address)
-        suspended_action.notify_not_connected("initialized...have not connected yet")
+          suspended_action.notify_not_connected("initialized...have not connected yet")
+        else
+          action_logger.error("katello has not been configured for qpid.url and qpid.subscriptions_queue_address")
+          suspended_action.notify_finished
+        end
         rescue => e
           Rails.logger.error(e.message)
           Rails.logger.error(e.backtrace)

--- a/test/actions/candlepin/listen_on_events_test.rb
+++ b/test/actions/candlepin/listen_on_events_test.rb
@@ -22,6 +22,23 @@ class Actions::Candlepin::ListenOnCandlepinEventsTest < ActiveSupport::TestCase
       create_and_plan_action action_class
     end
 
+    it 'initializes when configuration present' do
+      ::Actions::Candlepin::CandlepinListeningService.stubs(:new).at_least_once
+      action_class.stubs(:connect_listening_service)
+
+      Katello.config[:qpid] = {:url => 'url', :subscriptions_queue_address => 'addr'}
+      ::Actions::Candlepin::ListenOnCandlepinEvents.any_instance.stubs(:configured?).returns(true)
+      run_action planned_action
+    end
+
+    it 'does not intialize when configuration missing' do
+      ::Actions::Candlepin::CandlepinListeningService.stubs(:new).never
+      action_class.stubs(:connect_listening_service)
+
+      ::Actions::Candlepin::ListenOnCandlepinEvents.any_instance.stubs(:configured?).returns(false)
+      run_action planned_action
+    end
+
     it 'reindexes and acknowledges messages' do
       Actions::Candlepin::ListenOnCandlepinEvents.any_instance.stubs(:suspend)
       Actions::Candlepin::CandlepinListeningService.any_instance.stubs(:create_connection)


### PR DESCRIPTION
method_missing exception was produced when starting the candlepin
listening service without qpid configs set in the katello.yml or
katello_defaults.yml. This checks that configs are present before
starting candlepin listending service.