### PR TITLE
BuildRequires needs to be updated as well

### DIFF
--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -140,7 +140,7 @@ BuildRequires: %{?scl_prefix}rubygem-tire => 0.6.2
 BuildRequires: %{?scl_prefix}rubygem-tire < 0.7
 BuildRequires: %{?scl_prefix}rubygem-logging >= 1.8.0
 BuildRequires: %{?scl_prefix}rubygem-hooks
-BuildRequires: %{?scl_prefix}rubygem-foreman_docker >= 0.1.0
+BuildRequires: %{?scl_prefix}rubygem-foreman_docker >= 0.2.0
 BuildRequires: %{?scl_prefix}rubygem-foreman-tasks >= 0.6.0
 BuildRequires: %{?scl_prefix}rubygem-justified
 BuildRequires: %{?scl_prefix}rubygem-gettext_i18n_rails


### PR DESCRIPTION
The error this can cause during build is:
/usr/bin/ruby193-rake assets:precompile:katello RAILS_ENV=production --trace
rake aborted!
Don't know how to build task 'assets:precompile:katello'
/opt/rh/ruby193/root/usr/share/ruby/rake/task_manager.rb:49:in `[]'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:115:in`invoke_task'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:94:in `block (2 levels) in top_level'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:94:in`each'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:94:in `block in top_level'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:133:in`standard_exception_handling'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:88:in `top_level'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:66:in`block in run'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:133:in `standard_exception_handling'
/opt/rh/ruby193/root/usr/share/ruby/rake/application.rb:63:in`run'
/opt/rh/ruby193/root/usr/bin/rake:32:in `<main>'
Gem loading error: Unable to activate katello-2.1.0, because foreman_docker-0.1.0 conflicts with foreman_docker (>= 0.2.0)
error: Bad exit status from /var/tmp/rpm-tmp.EJsh3J (%install)
RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.EJsh3J (%install)
