### PR TITLE
Fixes #8615 - relax qpid_messaging dependency

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "justified"
   gem.add_dependency "strong_parameters", "~> 0.2.1" # remove after we upgrade to Rails 4
 
-  gem.add_dependency "qpid_messaging", ">= 0.26.1", '<= 0.28.1'
+  gem.add_dependency "qpid_messaging", ">= 0.22.0", '<= 0.28.1'
 
   gem.add_dependency "gettext_i18n_rails"
   gem.add_dependency "i18n_data", ">= 0.2.6"

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -129,7 +129,7 @@ Requires: %{?scl_prefix}rubygem-haml-rails
 Requires: %{?scl_prefix}rubygem-jquery-ui-rails
 Requires: %{?scl_prefix}rubygem-deface < 1.0.0
 Requires: %{?scl_prefix}rubygem-strong_parameters
-Requires: %{?scl_prefix}rubygem-qpid_messaging >= 0.26.1
+Requires: %{?scl_prefix}rubygem-qpid_messaging >= 0.22.0
 Requires: %{?scl_prefix}rubygem-qpid_messaging <= 0.28.1
 BuildRequires: foreman >= 1.3.0
 BuildRequires: foreman-assets >= 1.7.0
@@ -155,7 +155,7 @@ BuildRequires: %{?scl_prefix}rubygem-jquery-ui-rails
 BuildRequires: %{?scl_prefix}rubygem-deface < 1.0.0
 BuildRequires: %{?scl_prefix}rubygem(uglifier) >= 1.0.3
 BuildRequires: %{?scl_prefix}rubygem-strong_parameters
-BuildRequires: %{?scl_prefix}rubygem-qpid_messaging >= 0.26.1
+BuildRequires: %{?scl_prefix}rubygem-qpid_messaging >= 0.22.0
 BuildRequires: %{?scl_prefix}rubygem-qpid_messaging <= 0.28.1
 BuildRequires: %{?scl_prefix}rubygems
 BuildArch: noarch


### PR DESCRIPTION
This will allow downstream support more easily without having to edit the gempsec. It might actually be worth considering removing versions completely for this gem, if Katello will work with any version of qpid (or relaxing it even further if there is a wider range of versions it will work with) since rubygem-qpid_messaging is version locked with qpid.
