### PR TITLE
fixes #8606 - fixing puppet module index

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -43,7 +43,16 @@ module Katello
         options = filter_by_environment(@environment, options) if @environment
         options = filter_by_content_view_filter(@filter, options) if @filter
 
-        respond(:collection => item_search(resource_class, params, options))
+        results = item_search(resource_class, params, options)
+        results[:results] = results[:results].map do  |item|
+          if resource_class.respond_to?(:new_from_search)
+            resource_class.new_from_search(item.as_json)
+          else
+            resource_class.new(item.as_json)
+          end
+        end
+
+        respond(:collection => results)
       end
 
       api :GET, "/:resource_id/:id", N_("Show :a_resource")

--- a/app/models/katello/glue/elastic_search/package_group.rb
+++ b/app/models/katello/glue/elastic_search/package_group.rb
@@ -78,6 +78,14 @@ module Katello
           search.results
         end
 
+        def self.new_from_search(params)
+          group_name = params.delete('package_group_id')
+          id = params.delete('id')
+          params['id'] = group_name
+          params['_id'] = id
+          self.new(params)
+        end
+
         def self.legacy_search(query, start, page_size, repoid = nil, sort = [:name_sort, "asc"],
                                default_field = 'name')
           return Util::Support.array_with_total unless Tire.index(self.index).exists?


### PR DESCRIPTION
root cause was rabl calling a repositories function which did not exist on
the ES item object that was being sent to the templates.  This change now takes
the ES item objects and transform them to katello objects. This should only affect
Package, Package Groups, and Puppet Modules
