### PR TITLE
Fixes #8626: ensure errata icons line up, BZ 1171310.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -181,10 +181,10 @@
         <span class="info-label" translate>Security</span>
         <span class="info-value">
           <a ui-sref="content-hosts.details.errata.index({search: 'type:security'})">
-            {{ contentHost.errata_counts.security || 0 }}
             <i class="icon-warning-sign inline-icon"
                ng-class="{black: contentHost.errata_counts.security === 0, red: contentHost.errata_counts.security > 0}"
                title="{{ 'Security' | translate }}"></i>
+            {{ contentHost.errata_counts.security || 0 }}
           </a>
         </span>
       </div>
@@ -193,10 +193,10 @@
         <span class="info-label" translate>Bug Fix</span>
         <span class="info-value">
           <a ui-sref="content-hosts.details.errata.index({search: 'type:bugfix'})">
-            {{ contentHost.errata_counts.bugfix || 0 }}
             <i class="icon-bug inline-icon"
                ng-class="{black: contentHost.errata_counts.bugfix === 0, yellow: contentHost.errata_counts.bugfix > 0}"
                title="{{ 'Bug Fix' | translate }}"></i>
+            {{ contentHost.errata_counts.bugfix || 0 }}
           </a>
         </span>
       </div>
@@ -205,10 +205,10 @@
         <span class="info-label" translate>Enhancement</span>
         <span class="info-value">
           <a ui-sref="content-hosts.details.errata.index({search: 'type:enhancement'})">
-            {{ errataCounts.enhancement || 0 }}
             <i class="icon-plus-sign-alt inline-icon"
                ng-class="{black: contentHost.errata_counts.enhancement === 0, yellow: contentHost.errata_counts.enhancement > 0}"
                title="{{ 'Enhancement' | translate }}"></i>
+            {{ errataCounts.enhancement || 0 }}
           </a>
         </span>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-collapsed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-collapsed.html
@@ -1,4 +1,4 @@
-<table class="table table-striped" ng-class="{'table-mask': contentHostTable.working}">
+<table class="table table-striped table-bordered" ng-class="{'table-mask': contentHostTable.working}">
   <thead>
     <tr bst-table-head row-select>
       <th bst-table-column sortable><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-full.html
@@ -1,7 +1,7 @@
 <p class="alert alert-info" ng-show="contentHostTable.rows.length === 0" translate>
       You currently don't have any Content Hosts, you can register Content Hosts using the button on the right.
 </p>
-<table class="table table-striped" 
+<table class="table table-striped table-bordered"
        ng-class="{'table-mask': contentHostTable.working}"
        ng-show="contentHostTable.rows.length > 0">
   <thead>
@@ -37,7 +37,7 @@
       </td>
       <td>
         <a ui-sref="content-hosts.details.errata.index({contentHostId: contentHost.uuid})">
-          <span errata-counts="contentHost.errata_counts"></span>
+          <span class="aligned-errata-count" errata-counts="contentHost.errata_counts"></span>
         </a>
       </td>
       <td bst-table-cell>{{ contentHost.distribution }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-counts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-counts.html
@@ -1,18 +1,24 @@
 <span>
-  <span>
-    {{ errataCounts.security || 0 }}
+  <span class="errata-count">
+    <span>
+      {{ errataCounts.security || 0 }}
+    </span>
     <i class="icon-warning-sign inline-icon"
        ng-class="{black: errataCounts.security === 0, red: errataCounts.security > 0}"
        title="{{ 'Security' | translate }}"></i>
   </span>
-  <span>
-    {{ errataCounts.bugfix || 0 }}
+  <span class="errata-count">
+    <span>
+      {{ errataCounts.bugfix || 0 }}
+    </span>
     <i class="icon-bug inline-icon"
        ng-class="{black: errataCounts.bugfix === 0, yellow: errataCounts.bugfix > 0}"
        title="{{ 'Bug Fix' | translate }}"></i>
   </span>
-  <span>
-    {{ errataCounts.enhancement || 0 }}
+  <span class="errata-count">
+    <span>
+      {{ errataCounts.enhancement || 0 }}
+    </span>
     <i class="icon-plus-sign-alt inline-icon"
        ng-class="{black: errataCounts.enhancement === 0, yellow: errataCounts.enhancement > 0}"
        title="{{ 'Enhancement' | translate }}"></i>

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.less
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.less
@@ -3,4 +3,5 @@
   @import "systems";
   @import "tasks";
   @import "environments";
+  @import "errata";
 }

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/errata.less
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/errata.less
@@ -1,0 +1,5 @@
+.aligned-errata-count .errata-count {
+  display: inline-block;
+  text-align: right;
+  width: 55px;
+}


### PR DESCRIPTION
The errata icons were not lining up on the list and
details pages.  This commit ensures that they line up,
thus enhancing readability.

http://projects.theforeman.org/issues/8626
https://bugzilla.redhat.com/show_bug.cgi?id=1171310
