### PR TITLE
Fixes #8668: Hide 'Server' kickstart repositories from enablement.

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -47,10 +47,20 @@ module Katello
     param :product_id, :number, :required => true, :desc => N_("ID of a product to list repository sets from")
     def available_repositories
       scan_cdn = sync_task(::Actions::Katello::RepositorySet::ScanCdn, @product, @product_content.content.id)
+      repos = scan_cdn.output[:results]
+
+      repos = repos.select do |repo|
+        if repo[:path].include?('kickstart')
+          repo[:substitutions][:releasever].include?('Server') ? repo[:enabled] : true
+        else
+          true
+        end
+      end
+
       collection = {
-        :results  => scan_cdn.output[:results],
-        :subtotal => scan_cdn.output[:results].size,
-        :total    => scan_cdn.output[:results].size
+        :results  => repos,
+        :subtotal => repos.size,
+        :total    => repos.size
       }
       respond_for_index :collection => collection
     end

--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -32,7 +32,17 @@ module Katello
         if task.result == 'warning'
           render :partial => 'katello/providers/redhat/errors', :locals => { :error_message => task_error(task), :task => task}
         else
-          render :partial => 'katello/providers/redhat/repos', :locals => { :scan_cdn => task }
+          repos = task.output[:results]
+
+          repos = repos.select do |repo|
+            if repo[:path].include?('kickstart')
+              repo[:substitutions][:releasever].include?('Server') ? repo[:enabled] : true
+            else
+              true
+            end
+          end
+
+          render :partial => 'katello/providers/redhat/repos', :locals => {:scan_cdn => task, :repos => repos}
         end
       end
     end

--- a/app/helpers/katello/providers_helper.rb
+++ b/app/helpers/katello/providers_helper.rb
@@ -18,6 +18,7 @@ module Katello
     def redhat_repo_tabs
       [
         {:id => :rpms, :name => _('RPMs'), :products => {}},
+        {:id => :kickstarts, :name => _('Kickstarts'), :products => {}},
         {:id => :srpms, :name => _('Source RPMs'), :products => {}},
         {:id => :debug, :name => _('Debug RPMs'), :products => {}},
         {:id => :beta, :name => _('Beta'), :products => {}},
@@ -44,8 +45,10 @@ module Katello
             key = :debug
           elsif name.include?("(ISOs)") || name.include?("Source ISOs")
             key = :isos
-          elsif name.include?("(RPMs)") || name.include?("(Kickstart)")
+          elsif name.include?("(RPMs)")
             key = :rpms
+          elsif name.include?("(Kickstart)")
+            key = :kickstarts
           else
             key = :other
           end

--- a/app/views/katello/providers/redhat/_repos.html.haml
+++ b/app/views/katello/providers/redhat/_repos.html.haml
@@ -5,7 +5,7 @@
     %th
       = _('Repository')
   %tbody
-    - scan_cdn.output[:results].each do |result|
+    - repos.each do |result|
       %tr.repo{:id=>"repo_#{result[:pulp_id]}"}
         %td
           %label


### PR DESCRIPTION
This also moves kickstart repositories to their own tab similar to
other 'types' and to make them easier to locate.
