### PR TITLE
fixes #6637 - loosening url validation restrictions

### DIFF
--- a/app/helpers/katello/katello_url_helper.rb
+++ b/app/helpers/katello/katello_url_helper.rb
@@ -12,28 +12,27 @@
 
 module Katello
   module KatelloUrlHelper
-    include Rails.application.routes.url_helpers
-
     unless defined? CONSTANTS_DEFINED
-      PORT = /(([:]\d{1,5})?)/
-      PROTOCOLS = %r{(https?|ftp)://}ix
-      FILEPREFIX = %r{(^file://)|^/}ix # is this a file based url
-      # validation of hostname according to RFC952 and RFC1123
-      DOMAIN = /(?:(?:(?:(?:[a-z0-9][-a-z0-9]{0,61})?[a-z0-9])[.])*(?:[a-z][-a-z0-9]{0,61}[a-z0-9]|[a-z])[.]?)/
-      IPV4 = /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/
-      #TODO: ipv6 support
-      #IPV6 = /(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}/
-      URLREG = /^#{PROTOCOLS}((localhost)|#{DOMAIN}|#{IPV4})#{PORT}(\/.*)?$/ix
-      FILEREG = /#{FILEPREFIX}([\w-]*\/?)*/ix # match file based urls
+      FILEPREFIX = 'file'
+      PROTOCOLS = ['http', 'https', 'ftp', FILEPREFIX]
+
       CONSTANTS_DEFINED = true
     end
 
     def kurl_valid?(url)
-      !(file_prefix?(url) ? FILEREG.match(url).nil? : URLREG.match(url).nil?)
+      valid_for_prefixes(url, PROTOCOLS)
     end
 
     def file_prefix?(url)
-      !FILEPREFIX.match(url).nil?
+      valid_for_prefixes(url, [FILEPREFIX])
+    end
+
+    private
+
+    def valid_for_prefixes(url, prefixes)
+      prefixes.include?(URI.parse(url).scheme)
+    rescue URI::InvalidURIError
+      return false
     end
   end
 end

--- a/spec/helpers/katello_url_helper_spec.rb
+++ b/spec/helpers/katello_url_helper_spec.rb
@@ -18,7 +18,7 @@ module Katello
     describe "Valid https? Urls" do
       it "should validate clean http urls" do
         kurl_valid?('http://www.hugheshoney.com').must_equal(true)
-        kurl_valid?('HTtp://www.hugheshoney.com').must_equal(true)
+        kurl_valid?('HTtp://www.hugheshoney.com').must_equal(false)
         kurl_valid?('http://www.hugheshoney.com:8888').must_equal(true)
         kurl_valid?('http://www.hugheshoney.com:8888/homepage/index.html').must_equal(true)
         kurl_valid?('http://9seng.cz/katello').must_equal(true)
@@ -42,27 +42,27 @@ module Katello
       end
       it "should validate clean ftp urls" do
         kurl_valid?('ftp://65.190.152.28').must_equal(true)
-        kurl_valid?('Ftp://65.190.152.28').must_equal(true)
+        kurl_valid?('Ftp://65.190.152.28').must_equal(false)
         kurl_valid?('ftp://65.190.152.28/fedora/x86_64').must_equal(true)
         kurl_valid?('ftp://ftp.fedorahosted.org/rpms/index.html').must_equal(true)
       end
 
       it "should validate file urls" do
         kurl_valid?('file://opt/repo').must_equal(true)
-        kurl_valid?('/opt/repo').must_equal(true)
+        kurl_valid?('/opt/repo').must_equal(false)
       end
 
       it "should validate file urls" do
         kurl_valid?('file://opt/repo-is-long/').must_equal(true)
-        kurl_valid?('/opt/repo-for-me').must_equal(true)
+        kurl_valid?('/opt/repo-for-me').must_equal(false)
       end
 
       it "should validate file urls with multiple slashes" do
         file_prefix?('file://///opt/repo').must_equal(true)
         kurl_valid?('file://///opt/').must_equal(true)
-        kurl_valid?('File://///opt/').must_equal(true)
-        file_prefix?('/////opt/repo').must_equal(true)
-        kurl_valid?('/////opt/repo').must_equal(true)
+        kurl_valid?('File://///opt/').must_equal(false)
+        file_prefix?('/////opt/repo').must_equal(false)
+        kurl_valid?('/////opt/repo').must_equal(false)
       end
 
       it "should validate not fully qualified domain names" do
@@ -70,14 +70,13 @@ module Katello
         kurl_valid?('http://s-eng').must_equal(true)
         kurl_valid?('http://seng').must_equal(true)
       end
+
+      it "should validate urls with usernames and passwords" do
+        kurl_valid?('http://admin:admin@foo.com/').must_equal(true)
+      end
     end
 
     describe "Invalid Urls" do
-      it "should catch invalid ipv4 urls" do
-        kurl_valid?('https://365.190.152.28').must_equal(false)
-        kurl_valid?('http://65.190.152.28:888888').must_equal(false)
-        kurl_valid?('http://65.190.1521.28:88/homepage/index.html').must_equal(false)
-      end
       it "should catch invalid missing protocols" do
         kurl_valid?('123.190.152.28').must_equal(false)
         kurl_valid?('www.hugheshoney.com').must_equal(false)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -468,11 +468,6 @@ module Katello
           @provider.wont_be :valid?
         end
 
-        it "'https://.bogus'" do
-          @provider.repository_url = "https://.bogus"
-          @provider.wont_be :valid?
-        end
-
         it "'repo.fedorahosted.org/reposity'" do
           @provider.repository_url = "repo.fedorahosted.org/reposity"
           @provider.wont_be :valid?


### PR DESCRIPTION
This greatly simplifies our URL validation, some highlights:
- No longer validate ipv4
- No longer validate ipv6
- No longer allow uppercase url schemes
- All funky looking (but valid URI's) 
