### PR TITLE
fixes #8730 - keep track of components of composite content view versions

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -374,10 +374,11 @@ module Katello
       version = ContentViewVersion.create!(:major => major,
                                            :minor => minor,
                                            :content_view => self,
-                                           :description => description
+                                           :description => description,
+                                           :components => self.components
                                           )
-      increment!(:next_version) if minor == 0
 
+      increment!(:next_version) if minor == 0
       version
     end
 

--- a/app/models/katello/content_view_version_component.rb
+++ b/app/models/katello/content_view_version_component.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  class ContentViewVersionComponent < Katello::Model
+    belongs_to :composite_version, :class_name => "Katello::ContentViewVersion", :inverse_of => :content_view_version_components, :inverse_of =>  :content_view_version_composites
+    belongs_to :component_version, :class_name => "Katello::ContentViewVersion", :inverse_of => :content_view_version_composites, :inverse_of => :content_view_version_components
+
+    validates_lengths_from_database
+    validate :content_view_types
+
+    private
+
+    def content_view_types
+      unless composite_version.content_view.composite?
+        errors.add(:base, _("Cannot add component versions to a non-composite content view"))
+      end
+
+      if component_version.content_view.composite?
+        errors.add(:base, _("Cannot add composite versions to another composite content view"))
+      end
+
+      if composite_version.default? || component_version.default?
+        errors.add(:base, _("Cannot add default content view to composite content view"))
+      end
+    end
+  end
+end

--- a/db/migrate/20141215213720_track_version_components.rb
+++ b/db/migrate/20141215213720_track_version_components.rb
@@ -1,0 +1,17 @@
+class TrackVersionComponents < ActiveRecord::Migration
+  def change
+    create_table "katello_content_view_version_components" do |t|
+      t.integer :component_version_id, :null => false
+      t.integer :composite_version_id, :null => false
+      t.timestamps
+    end
+
+    add_index :katello_content_view_version_components, [:component_version_id, :composite_version_id],
+              :unique => true, :name => :katello_cvv_components_cid_cid_unq
+    add_foreign_key "katello_content_view_version_components", "katello_content_view_versions",
+      :name => "katello_cvv_components_component_fk", :column => "component_version_id"
+
+    add_foreign_key "katello_content_view_version_components", "katello_content_view_versions",
+      :name => "katello_cvv_components_composite_fk", :column => "composite_version_id"
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
@@ -86,6 +86,13 @@ angular.module('Bastion.content-views').config(['$stateProvider', function ($sta
         permission: 'view_content_views',
         templateUrl: 'content-views/versions/views/content-view-version-details.html'
     })
+    .state('content-views.details.version.components', {
+        collapsed: true,
+        url: '/components',
+        permission: 'view_content_views',
+        controller: 'ContentViewVersionContentController',
+        templateUrl: 'content-views/versions/views/content-view-version-components.html'
+    })
     .state('content-views.details.version.repositories', {
         collapsed: true,
         url: '/repositories',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
@@ -22,7 +22,8 @@
      *   Handles fetching content view version content and populating Nutupane based on the current
      *   ui-router state.
      */
-    function ContentViewVersionContentController($scope, translate, Nutupane, Package, Erratum, PackageGroup, PuppetModule, Repository) {
+    function ContentViewVersionContentController($scope, translate, Nutupane, Package, Erratum,
+                                                 PackageGroup, PuppetModule, Repository, ContentViewVersion) {
         var nutupane, contentTypes, currentState, params;
 
         currentState = $scope.$state.current.name.split('.').pop();
@@ -38,7 +39,8 @@
                 type: PackageGroup,
                 params: {
                     'sort_by': 'name',
-                    'sort_order': 'DESC'
+                    'sort_order': 'DESC',
+                    'content_view_version_id': $scope.$stateParams.versionId
                 }
             },
             'errata': {
@@ -46,10 +48,16 @@
             },
             'puppet-modules': {
                 type: PuppetModule
+            },
+            'components': {
+                type: ContentViewVersion,
+                params: {
+                    'composite_version_id': $scope.$stateParams.versionId
+                }
             }
         };
 
-        params = angular.extend({'content_view_version_id': $scope.$stateParams.versionId}, contentTypes[currentState].params);
+        params = contentTypes[currentState].params || {'content_view_version_id': $scope.$stateParams.versionId};
         nutupane = new Nutupane(contentTypes[currentState].type, params, 'queryPaged');
         nutupane.masterOnly = true;
 
@@ -84,6 +92,6 @@
         .controller('ContentViewVersionContentController', ContentViewVersionContentController);
 
     ContentViewVersionContentController.$inject = ['$scope', 'translate', 'Nutupane', 'Package', 'Erratum',
-                                                   'PackageGroup', 'PuppetModule', 'Repository'];
+                                                   'PackageGroup', 'PuppetModule', 'Repository', 'ContentViewVersion'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-components.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-components.html
@@ -1,0 +1,25 @@
+<div data-extend-template="layouts/details-nutupane.html">
+
+  <div data-block="header"></div>
+  <div data-block="selection-summary"></div>
+
+  <span  data-block="search"></span>
+  <span  data-block="result-count"></span>
+
+  <table data-block="table" class="table table-striped table-bordered">
+    <thead>
+      <tr bst-table-head>
+        <th bst-table-column translate>Content View Name</th>
+        <th bst-table-column translate>Version</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr bst-table-row ng-repeat="version in detailsTable.rows">
+        <td bst-table-cell>{{ version.content_view.name }}</td>
+        <td bst-table-cell>{{ version.version }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version.html
@@ -31,6 +31,12 @@
   <nav class="details-navigation">
     <ul>
 
+      <li ng-show="contentView.composite" ng-class="{active: isState('content-views.details.version.components')}">
+        <a ui-sref="content-views.details.version.components({versionId: version.id})">
+          <span translate>Components</span>
+        </a>
+      </li>
+
       <li ng-class="{active: isState('content-views.details.version.repositories')}">
         <a ui-sref="content-views.details.version.repositories({versionId: version.id})">
           <span translate>Repositories</span>

--- a/engines/bastion_katello/test/content-views/versions/content-view-version-content.controller.test.js
+++ b/engines/bastion_katello/test/content-views/versions/content-view-version-content.controller.test.js
@@ -58,7 +58,8 @@ describe('Controller: ContentViewsVersionContentController', function() {
                 Package: Package,
                 Erratum: Erratum,
                 PackageGroup: PackageGroup,
-                PuppetModule: PuppetModule
+                PuppetModule: PuppetModule,
+                ContentViewVersion: ContentViewVersion
             });
         });
     }
@@ -91,6 +92,11 @@ describe('Controller: ContentViewsVersionContentController', function() {
     it("setups up Package resource when is state is 'puppet modules'", function() {
         SetupController('content-views.details.version.puppet-modules');
         expect($scope.nutupane.resource).toBe(PuppetModule);
+    });
+
+    it("setups up ContentViewVersion resource when is state is 'components'", function() {
+        SetupController('content-views.details.version.components');
+        expect($scope.nutupane.resource).toBe(ContentViewVersion);
     });
 
     it("builds a list of repositories from the version", function() {

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -29,6 +29,7 @@ module Katello
       @beta = KTEnvironment.find(katello_environments(:beta))
       @library_dev_staging_view = ContentView.find(katello_content_views(:library_dev_staging_view))
       @library_view = ContentView.find(katello_content_views(:library_view))
+      @composite_version = ContentViewVersion.find(katello_content_view_versions(:composite_view_version_1))
     end
 
     def permissions
@@ -56,7 +57,7 @@ module Katello
     def test_index
       get :index
 
-      assert_response 404
+      assert_response :success
     end
 
     def test_index_with_content_view
@@ -77,6 +78,19 @@ module Katello
       assert_equal ['page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
       assert_equal 1, results['results'].size
       assert_equal expected_version.id, results['results'][0]['id']
+    end
+
+    def test_index_with_composite_id
+      component = @library_dev_staging_view.versions.first
+      @composite_version.components = [component]
+      @composite_version.save!
+
+      results = JSON.parse(get(:index, :composite_version_id => @composite_version.id).body)
+
+      assert_response :success
+      assert_template 'api/v2/content_view_versions/index'
+      assert_equal 1, results['results'].size
+      assert_equal component.id, results['results'][0]['id']
     end
 
     def test_index_with_content_view_by_version

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -28,6 +28,7 @@ module Katello
       @cvv.organization.kt_environments << Katello::KTEnvironment.find_by_name(:Library)
       @dev = create(:katello_environment,  :organization => @cvv.organization, :prior => @cvv.organization.library,     :name => 'dev')
       @beta = create(:katello_environment, :organization => @cvv.organization, :prior => @dev,                         :name => 'beta')
+      @composite_version = ContentViewVersion.find(katello_content_view_versions(:composite_view_version_1))
     end
 
     def test_promotable_in_sequence
@@ -76,6 +77,26 @@ module Katello
       assert cvv.repositories.archived.docker_type.count > 0
       assert_equal image_count, cvv.docker_image_count
       assert_equal tag_count, cvv.docker_tag_count
+    end
+  end
+
+  def test_components
+    @composite_version.components = [@cvv]
+    @composite_version.save!
+
+    assert_equal [@cvv], @composite_version.reload.components
+  end
+
+  def test_component_default
+    default_view = content_view_versions(:library_default_version)
+    assert_raises do
+      @composite_version.components = [default_view]
+    end
+  end
+
+  def test_component_non_composite
+    assert_raises do
+      @cvv.components = [@composite_version]
     end
   end
 end


### PR DESCRIPTION

* adds UI on the CV version details for components
* relaxes restriction on content view versions page to specify content view id
* in support of #8194