### PR TITLE
Fixes #8743 - Repo Index returns promoted repos

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -57,7 +57,10 @@ module Katello
       repositories = Repository.where(:product_id => Product.readable.where(:organization_id => @organization.id))
       repositories = repositories.where(:product_id => @product.id) if @product
 
-      if params[:content_view_id]
+      if params[:content_view_id] && params[:environment_id]
+        version = ContentViewVersion.in_environment(params[:environment_id]).where(:content_view_id => params[:content_view_id])
+        repositories = repositories.where(:content_view_version_id => version)
+      elsif params[:content_view_id]
         repositories = repositories
                          .joins(:content_view_repositories)
                          .where("#{ContentViewRepository.table_name}.content_view_id" => params[:content_view_id])

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -116,6 +116,22 @@ module Katello
       assert_template 'api/v2/repositories/index'
     end
 
+    def test_index_with_content_view_id_and_environment_id
+      repo = Repository.find(katello_repositories(:fedora_17_x86_64_dev))
+      ids = repo.content_view_version.repository_ids
+
+      @controller
+         .expects(:item_search)
+         .with(anything, anything, has_entry(:filters => [{:terms => {:id => ids}}]))
+         .returns({})
+
+      get :index, :content_view_id => repo.content_view_version.content_view_id, :environment_id => repo.environment_id,
+                 :organization_id => @organization.id
+
+      assert_response :success
+      assert_template 'api/v2/repositories/index'
+    end
+
     def test_index_with_errata_id
       ids = @errata.repositories.pluck(:id)
 


### PR DESCRIPTION
Updated repo index call to return repositories belonging to paticular env and content view combination. This code would work for non library envs previously .. Look at http://projects.theforeman.org/issues/8743 for more info.
