### PR TITLE
Fixes #8763 - Remove unnecessary ignore blocks

### DIFF
--- a/test/factories/repository_factory.rb
+++ b/test/factories/repository_factory.rb
@@ -7,10 +7,6 @@ FactoryGirl.define do
     sequence(:relative_path) { |n| "/ACME_Corporation/DEV/Repo#{n}" }
     url "http://localhost/foo"
 
-    ignore do
-      stubbed = true
-    end
-
     trait :fedora_17_el6 do
       name "Fedora 17 el6"
       label "fedora_17_el6_label"

--- a/test/factories/system_factory.rb
+++ b/test/factories/system_factory.rb
@@ -1,10 +1,5 @@
 FactoryGirl.define do
   factory :katello_system, :class => Katello::System do
-
-    ignore do
-      stubbed = true
-    end
-
     trait :alabama do
       name 'Alabama'
     end


### PR DESCRIPTION
This is to silence these warnings:

```
DEPRECATION WARNING: `#ignore` is deprecated and will be removed in 5.0. Please use `#transient` instead. (called from block (2 levels) in <top (required)> at /home/dadavis/Projects/katello/test/factories/system_factory.rb:4)
```
