### PR TITLE
fixes #8768 - fixing pulp glue tests in live mode

### DIFF
--- a/test/glue/pulp/distribution_test.rb
+++ b/test/glue/pulp/distribution_test.rb
@@ -19,11 +19,10 @@ module Katello
 
     def self.before_suite
       super
-      configure_runcible
-
       services  = ['Candlepin', 'ElasticSearch', 'Foreman']
       models    = ['Repository', 'Distribution']
       disable_glue_layers(services, models)
+      configure_runcible
 
       VCR.insert_cassette('pulp/content/distribution')
 

--- a/test/glue/pulp/erratum_test.rb
+++ b/test/glue/pulp/erratum_test.rb
@@ -21,11 +21,10 @@ module Katello
 
     def self.before_suite
       super
-      configure_runcible
-
       services  = ['Candlepin', 'ElasticSearch', 'Foreman']
       models    = ['Repository']
       disable_glue_layers(services, models)
+      configure_runcible
 
       VCR.insert_cassette('pulp/content/erratum')
 

--- a/test/glue/pulp/package_test.rb
+++ b/test/glue/pulp/package_test.rb
@@ -21,11 +21,10 @@ module Katello
 
     def self.before_suite
       super
-      configure_runcible
-
       services  = ['Candlepin', 'ElasticSearch', 'Foreman']
       models    = ['Repository', 'Package']
       disable_glue_layers(services, models)
+      configure_runcible
 
       VCR.insert_cassette('pulp/content/package')
 

--- a/test/glue/pulp/puppet_module_test.rb
+++ b/test/glue/pulp/puppet_module_test.rb
@@ -16,11 +16,10 @@ require 'support/pulp/repository_support'
 module Katello
   class GluePulpPuppetModuleTest < ActiveSupport::TestCase
     def setup
-      configure_runcible
-
       services  = ['Candlepin', 'ElasticSearch', 'Foreman']
       models    = ['Repository', 'PuppetModule']
       disable_glue_layers(services, models)
+      configure_runcible
 
       VCR.insert_cassette('glue_pulp_puppet_module')
 

--- a/test/glue/pulp/user_test.rb
+++ b/test/glue/pulp/user_test.rb
@@ -16,11 +16,10 @@ module Katello
   class GluePulpUserTest < ActiveSupport::TestCase
     def self.before_suite
       super
-      configure_runcible
-
       services  = ['Candlepin', 'ElasticSearch', 'Foreman']
       models    = ['User']
       disable_glue_layers(services, models)
+      configure_runcible
     end
 
     def setup


### PR DESCRIPTION
calling configure_runcible prior to disable_glue_layers could
result in runcible not being configured correctly
