### PR TITLE
fixes #8775 - ensure available errata are unique

### DIFF
--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -134,12 +134,13 @@ module Katello
     end
 
     def available_errata(env = nil, content_view = nil)
-      if env.nil? || content_view.nil?
-        self.applicable_errata.in_repositories(self.bound_repositories)
-      else
-        repos = Katello::Repository.in_environment(env).in_content_views([content_view])
-        self.applicable_errata.in_repositories(repos)
-      end
+      repos = if env && content_view
+                Katello::Repository.in_environment(env).in_content_views([content_view])
+              else
+                self.bound_repositories
+              end
+
+      self.applicable_errata.in_repositories(repos).uniq
     end
 
     def available_releases


### PR DESCRIPTION
The same errata may be in multiple repositories, resulting in duplicate errata:

```
system.available_errata.map(&:errata_id).count = 42
system.available_errata.map(&:errata_id).sort.uniq.count = 26
```
