### PR TITLE
fixes #8848 - fixing content host errata list

### DIFF
--- a/app/views/katello/api/v2/errata/show.json.rabl
+++ b/app/views/katello/api/v2/errata/show.json.rabl
@@ -5,7 +5,10 @@ attributes :title, :errata_id
 attributes :issued, :updated, :version, :status, :release
 attributes :severity, :description, :solution, :summary, :reboot_suggested
 attributes :_href
-attributes :cves
+
+node :cves do |e|
+  e.cves.pluck(:cve_id)
+end
 
 attributes :errata_type => :type
 


### PR DESCRIPTION
this may be a production only issue, but due to sending the AR record to be decoded to json
an error was thrown.  The solution is to send the cve name which is what was intended