### PR TITLE
Fixes #8887: returning correct CVE structure in rabl.

### DIFF
--- a/app/views/katello/api/v2/errata/show.json.rabl
+++ b/app/views/katello/api/v2/errata/show.json.rabl
@@ -6,8 +6,8 @@ attributes :issued, :updated, :version, :status, :release
 attributes :severity, :description, :solution, :summary, :reboot_suggested
 attributes :_href
 
-node :cves do |e|
-  e.cves.pluck(:cve_id)
+child :cves => :cves do
+  attributes :cve_id, :href
 end
 
 attributes :errata_type => :type

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-info.html
@@ -12,7 +12,7 @@
         <span class="info-label" translate>CVEs</span>
         <span class="info-value">
           <span ng-repeat="cve in errata.cves">
-            <a href="cve.href">{{ cve.cve_id }}</a>
+            <a href="{{ cve.href }}">{{ cve.cve_id }}</a>
             <span ng-show="!$last">,</span>
           </span>
         </span>


### PR DESCRIPTION
The UI depends on cve.id and cve.href.  Those were
removed with a878e89, this commit adds them back.

http://projects.theforeman.org/issues/8887