### PR TITLE
Fixes #8924: add last_sync_words to sync plan rabl, bz 1130300.

### DIFF
--- a/app/views/katello/api/v2/sync_plans/show.json.rabl
+++ b/app/views/katello/api/v2/sync_plans/show.json.rabl
@@ -7,6 +7,7 @@ attributes :created_at, :updated_at
 attributes :enabled
 
 child :products => :products do |_product|
+  extends 'katello/api/v2/common/syncable'
   attributes :id, :cp_id, :name, :label, :description
 
   node :repository_count do |prod|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/partials/product-table-sync-status.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/partials/product-table-sync-status.html
@@ -1,4 +1,4 @@
-<ul class="list-unstyled" ng-show="product.sync_status.finish_time">
+<ul class="list-unstyled" ng-show="product.last_sync_words">
   <p translate>
     Last synced {{ product.last_sync_words }} ago
   </p>
@@ -11,4 +11,4 @@
             </span>
   </li>
 </ul>
-<span ng-hide="product.sync_status.finish_time" translate>Never synced</span>
+<span ng-hide="product.last_sync_words" translate>Never synced</span>


### PR DESCRIPTION
The sync plan rabl representation for product was missing the
attribute last_sync_words.  This PR adds that attribute.

http://projects.theforeman.org/issues/8924
https://bugzilla.redhat.com/show_bug.cgi?id=1130300