### PR TITLE
Fixes #8621: Set sync plan on product during repository creation.

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -69,6 +69,7 @@ module Actions
               end
             end
 
+            plan_action(::Actions::Pulp::Repos::Update, repository.product) if repository.product.sync_plan
             plan_action(ElasticSearch::Reindex, repository)
           end
         end


### PR DESCRIPTION
When a repository is added to a product, if that product has a sync
plan, the sync plan needs to be setup for the new repository.