### PR TITLE
refs #8213 - split out katello package into modular sub-packages

### DIFF
--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -18,8 +18,10 @@
        <packagereq type="default">katello-all</packagereq>
        <packagereq type="default">katello-api-docs</packagereq>
        <packagereq type="default">katello-certs-tools</packagereq>
+       <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-repos</packagereq>
        <packagereq type="default">katello-repos-testing</packagereq>
+       <packagereq type="default">katello-sam</packagereq>
        <packagereq type="default">katello-utils</packagereq>
        <packagereq type="default">lucene4</packagereq>
        <packagereq type="default">lucene4-contrib</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel7.xml
+++ b/rel-eng/comps/comps-katello-server-rhel7.xml
@@ -18,8 +18,10 @@
        <packagereq type="default">katello-all</packagereq>
        <packagereq type="default">katello-api-docs</packagereq>
        <packagereq type="default">katello-certs-tools</packagereq>
+       <packagereq type="default">katello-common</packagereq>
        <packagereq type="default">katello-repos</packagereq>
        <packagereq type="default">katello-repos-testing</packagereq>
+       <packagereq type="default">katello-sam</packagereq>
        <packagereq type="default">katello-utils</packagereq>
        <packagereq type="default">lucene4</packagereq>
        <packagereq type="default">lucene4-contrib</packagereq>


### PR DESCRIPTION
Splits katello's meta-package into a -common and -sam package so we can install without Foreman's provisioning plugins which aren't needed in the SAM use case