### PR TITLE
fixes #8353 - require all neccessary pulp packages in RPM

### DIFF
--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -88,6 +88,8 @@ Requires: pulp-server
 Requires: mongodb >= 2.4
 Requires: mongodb-server >= 2.4
 Requires: cyrus-sasl-plain
+Requires: python-crane
+Requires: qpid-cpp-client-devel
 
 Requires: candlepin-selinux
 Requires: createrepo >= 0.9.9-18%{?dist}


### PR DESCRIPTION
This is required so that a Katello registered to itself may be successfully upgraded.