### PR TITLE
Fixes #7755: Use product label to make media unique.

### DIFF
--- a/app/models/katello/concerns/medium_extensions.rb
+++ b/app/models/katello/concerns/medium_extensions.rb
@@ -58,6 +58,7 @@ module Katello
           if repo.content_view && !repo.content_view.default?
             parts << repo.content_view.label
           end
+          parts << repo.product.label
           parts << repo.label
           return normalize_name(parts.compact.join('/'))
         end


### PR DESCRIPTION
Prior to, if two repositories within the same organization had the same
label (since repository labels are unique within a product) then the
subsequent repositories would fail to sync. This failure to sync resulted
in trying to create installation media with the same name which used only
the repository label. This change uses the products label as well since that
should be unique within an organization.