### PR TITLE
Fixes #8959 - Repo create cleanup

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -38,6 +38,7 @@ module Katello
       param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
       param :content_type, String, :required => true, :desc => N_("type of repo (either 'yum', 'puppet' or 'docker')")
       param :checksum_type, String, :desc => N_("checksum of the repository, currently 'sha1' & 'sha256' are supported.'")
+      param :docker_upstream_name, String, :desc => N_("name of the upstream docker repository")
     end
 
     api :GET, "/repositories", N_("List of enabled repositories")
@@ -102,6 +103,7 @@ module Katello
       repository = @product.add_repo(repo_params[:label], repo_params[:name], repo_params[:url],
                                      repo_params[:content_type], repo_params[:unprotected],
                                      gpg_key, repository_params[:checksum_type])
+      repository.docker_upstream_name = params[:docker_upstream_name] if params.key?(:docker_upstream_name)
       sync_task(::Actions::Katello::Repository::Create, repository, false, true)
       repository = Repository.find(repository.id)
       respond_for_show(:resource => repository)
@@ -127,6 +129,7 @@ module Katello
     param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
     param :checksum_type, String, :desc => N_("checksum of the repository, currently 'sha1' & 'sha256' are supported.'")
     param :url, String, :desc => N_("the feed url of the original repository ")
+    param :docker_upstream_name, String, :desc => N_("name of the upstream docker repository")
     def update
       repo_params = repository_params
       repo_params[:url] = nil if repository_params[:url].blank?

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -30,6 +30,7 @@ module Actions
                                         content_type: repository.content_type,
                                         pulp_id: repository.pulp_id,
                                         name: repository.name,
+                                        docker_upstream_name: repository.docker_upstream_name,
                                         feed: repository.url,
                                         ssl_ca_cert: repository.feed_ca,
                                         ssl_client_cert: repository.feed_cert,

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -28,6 +28,7 @@ module Actions
           param :checksum_type
           param :path
           param :with_importer
+          param :docker_upstream_name
         end
 
         def run
@@ -61,7 +62,7 @@ module Actions
             when ::Katello::Repository::PUPPET_TYPE
               importer.feed            = input[:feed]
             when ::Katello::Repository::DOCKER_TYPE
-              importer.upstream_name   = input[:name]
+              importer.upstream_name   = input[:docker_upstream_name] if input[:docker_upstream_name]
               importer.feed            = input[:feed]
             end
           end

--- a/app/lib/katello/validators/repo_docker_upstream_validator.rb
+++ b/app/lib/katello/validators/repo_docker_upstream_validator.rb
@@ -1,0 +1,24 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Validators
+    class RepoDockerUpstreamValidator < ActiveModel::Validator
+      def validate(record)
+        if record.docker? && ((record.url.blank? && record.docker_upstream_name) ||
+                             (record.url && record.docker_upstream_name.blank?))
+          record.errors[:base] << N_("Repository URL and Upstream Name cannot be empty. Both are required for syncing from the upstream.")
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -64,25 +64,28 @@ module Katello
       end
 
       def build_repository
-        ::Katello::Repository.new(:environment => product.organization.library,
-                                  :product => product,
-                                  :pulp_id => pulp_id,
-                                  :cp_label => content.label,
-                                  :content_id => content.id,
-                                  :arch => arch,
-                                  :major => major,
-                                  :minor => minor,
-                                  :relative_path => relative_path,
-                                  :name => name,
-                                  :label => label,
-                                  :url => feed_url,
-                                  :feed_ca => ca,
-                                  :feed_cert => product.certificate,
-                                  :feed_key => product.key,
-                                  :content_type => katello_content_type,
-                                  :preserve_metadata => true, #preserve repo metadata when importing from cp
-                                  :unprotected => unprotected?,
-                                  :content_view_version => product.organization.library.default_content_view_version)
+        repository = ::Katello::Repository.new(:environment => product.organization.library,
+                                               :product => product,
+                                               :pulp_id => pulp_id,
+                                               :cp_label => content.label,
+                                               :content_id => content.id,
+                                               :arch => arch,
+                                               :major => major,
+                                               :minor => minor,
+                                               :relative_path => relative_path,
+                                               :name => name,
+                                               :label => label,
+                                               :url => feed_url,
+                                               :feed_ca => ca,
+                                               :feed_cert => product.certificate,
+                                               :feed_key => product.key,
+                                               :content_type => katello_content_type,
+                                               :preserve_metadata => true, #preserve repo metadata when importing from cp
+                                               :unprotected => unprotected?,
+                                               :content_view_version => product.organization.library.default_content_view_version)
+
+        repository.docker_upstream_name = self.name if repository.docker?
+        repository
       end
 
       def check_substitutions!

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -139,7 +139,7 @@ module Katello
           Runcible::Models::PuppetImporter.new(options)
         when Repository::DOCKER_TYPE
           options = {}
-          options[:upstream_name] = self.name
+          options[:upstream_name] = self.docker_upstream_name
           options[:feed] = self.url if self.respond_to?(:url)
           Runcible::Models::DockerImporter.new(options)
         else
@@ -508,7 +508,7 @@ module Katello
 
       def pulp_update_needed?
         unless redhat?
-          allowed_changes = %w(url unprotected checksum_type)
+          allowed_changes = %w(url unprotected checksum_type docker_upstream_name)
           allowed_changes << "name" if docker?
           allowed_changes.any? { |key| previous_changes.key?(key) }
         end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -69,7 +69,8 @@ module Katello
     validates :product_id, :presence => true
     validates :pulp_id, :presence => true, :uniqueness => true, :if => proc { |r| r.name.present? }
     validates :checksum_type, :inclusion => {:in => CHECKSUM_TYPES, :allow_blank => true}
-    validates :name, :if => :docker?, :format => {
+    validates_with Validators::RepoDockerUpstreamValidator
+    validates :docker_upstream_name, :allow_nil => true, :if => :docker?, :format => {
       :with => /^([a-z0-9\-_]{4,30}\/)?[a-z0-9\-_\.]{3,30}$/,
       :message => (_("must be a valid docker name"))
     }
@@ -357,6 +358,7 @@ module Katello
                      :content_id => self.content_id,
                      :content_view_version => to_version,
                      :content_type => self.content_type,
+                     :docker_upstream_name => self.docker_upstream_name,
                      :unprotected => self.unprotected) do |clone|
 
         clone.checksum_type = self.checksum_type

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -5,6 +5,7 @@ extends 'katello/api/v2/common/org_reference'
 extends 'katello/api/v2/common/timestamps'
 
 attributes :content_type
+attributes :docker_upstream_name
 attributes :unprotected, :full_path, :checksum_type
 attributes :url,
            :relative_path

--- a/db/migrate/20150114225023_add_upstream_name_to_repository.rb
+++ b/db/migrate/20150114225023_add_upstream_name_to_repository.rb
@@ -1,0 +1,16 @@
+class AddUpstreamNameToRepository < ActiveRecord::Migration
+  def up
+    add_column :katello_repositories, :docker_upstream_name, :string
+    Katello::Repository.docker_type.each do |repo|
+      update %(
+        update #{Katello::Repository.table_name}
+              set docker_upstream_name=#{ActiveRecord::Base.sanitize(repo.name)}
+              where id=#{repo.id}
+      ).gsub(/\s+/, " ").strip
+    end
+  end
+
+  def down
+    remove_column :katello_repositories, :docker_upstream_name
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -94,13 +94,24 @@
     </div>
 
     <div class="detail">
-      <span class="info-label" translate>URL</span>
+      <span ng-show="repository.content_type !== 'docker'" class="info-label" translate>URL</span>
+      <span ng-show="repository.content_type === 'docker'" class="info-label" translate>Registry URL</span>
       <span class="info-value"
             bst-edit-text="repository.url"
             on-save="save(repository)"
             readonly="product.readonly || denied('edit_products', product)">
       </span>
     </div>
+
+    <div class="detail" ng-show="repository.content_type === 'docker'" >
+      <span class="info-label" translate>Upstream Repository Name</span>
+      <span class="info-value"
+            bst-edit-text="repository.docker_upstream_name"
+            on-save="save(repository)"
+            readonly="product.readonly || denied('edit_products', product)">
+      </span>
+    </div>
+
 
     <div class="detail" ng-show="repository.content_type == 'yum'">
       <span class="info-label" translate>Yum Metadata Checksum</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
@@ -12,79 +12,105 @@
   <div bst-alert error-messages="errorMessages" success-messages="successMessages"></div>
 
   <form name="repositoryForm" class="form-horizontal" novalidate role="form">
+    <div>
+      <h4 class="form-horizontal" translate> General Information </h4>
+      <div bst-form-group label="{{ 'Name' | translate }}">
+        <input id="name"
+               name="name"
+               ng-model="repository.name"
+               type="text"
+               tabindex="1"
+               autofocus
+               required/>
+      </div>
 
-    <div bst-form-group label="{{ 'Name' | translate }}">
-      <input id="name"
-             name="name"
-             ng-model="repository.name"
-             type="text"
-             tabindex="1"
-             autofocus
-             required/>
+      <div bst-form-group label="{{ 'Label' | translate }}">
+        <input id="label"
+               name="label"
+               ng-model="repository.label"
+               type="text"
+               tabindex="1"
+               required/>
+      </div>
+      <div bst-form-group label="{{ 'Type' | translate }}">
+        <select required
+                tabindex="3"
+                id="content_type"
+                name="content_type"
+                ng-model="repository.content_type"
+                ng-options="type.name as type.name for type in repositoryTypes"
+                autofocus>
+        </select>
+      </div>
+    </div>
+    <div ng-show="repository.content_type !== undefined">
+        <h4 translate> Sync Information </h4>
+        <div bst-form-group label="{{ 'URL' | translate }}">
+          <input id="url"
+                 name="url"
+                 ng-model="repository.url"
+                 type="text"
+                 tabindex="5"/>
+          <h6 ng-show="repository.content_type === 'docker'" translate>
+            URL of the registry you want to sync. Example: https://registry.hub.docker.com
+          </h6>
+
+        </div>
+
+        <div bst-form-group label="{{ 'Upstream Repository Name' | translate }}"  ng-show="repository.content_type === 'docker'">
+          <input id="docker_upstream_name"
+                 name="docker_upstream_name"
+                 ng-model="repository.docker_upstream_name"
+                 type="text"
+                 tabindex="1"/>
+          <h6 translate>
+            Name of the upstream repository you want to sync. Example: 'busybox' or 'fedora/ssh;.
+          </h6>
+
+        </div>
+
     </div>
 
-    <div bst-form-group label="{{ 'Label' | translate }}">
-      <input id="label"
-             name="label"
-             ng-model="repository.label"
-             type="text"
-             tabindex="1"
-             required/>
+    <div ng-show="repository.content_type === 'yum'">
+      <h4 ng-show="repository.content_type !== undefined" translate> Published Repository Information </h4>
+
+      <div bst-form-group label="{{ 'Checksum' | translate }}">
+        <select tabindex="4"
+                id="checksum_type"
+                name="checksum_type"
+                ng-model="repository.checksum_type"
+                ng-options="type.id as type.name for type in checksums">
+        </select>
+        <h6 translate>
+          For older operating systems such as Red Hat Enterprise Linux 5 or CentOS 5 it is recommended to use sha1.
+        </h6>
+      </div>
+
+      <div bst-form-group label="{{ 'Publish via HTTP' | translate }}">
+        <input id="unprotected"
+               name="unprotected"
+               ng-model="repository.unprotected"
+               type="checkbox"
+               tabindex="6"/>
+      </div>
+
+      <div bst-form-group label="{{ 'GPG Key' | translate }}">
+        <select id="gpg_key_id"
+                name="gpg_key_id"
+                ng-model="repository.gpg_key_id"
+                ng-options="gpg_key.id as gpg_key.name for gpg_key in gpgKeys"
+                tabindex="7">
+          <option value=""></option>
+        </select>
+      </div>
     </div>
 
-    <div bst-form-group label="{{ 'Type' | translate }}">
-      <select required
-              tabindex="3"
-              id="content_type"
-              name="content_type"
-              ng-model="repository.content_type"
-              ng-options="type.name as type.name for type in repositoryTypes">
-      </select>
-    </div>
-
-    <div bst-form-group label="{{ 'Checksum' | translate }}" ng-show="repository.content_type == 'yum'">
-      <select tabindex="4"
-              id="checksum_type"
-              name="checksum_type"
-              ng-model="repository.checksum_type"
-              ng-options="type.id as type.name for type in checksums">
-      </select>
-      <h6 translate>
-        For older operating systems such as Red Hat Enterprise Linux 5 or CentOS 5 it is recommended to use sha1.
-      </h6>
-    </div>
-
-    <div bst-form-group label="{{ 'URL' | translate }}">
-      <input id="url"
-             name="url"
-             ng-model="repository.url"
-             type="text"
-             tabindex="5"/>
-    </div>
-
-    <div bst-form-group label="{{ 'Publish via HTTP' | translate }}" ng-show="repository.content_type == 'yum'">
-      <input id="unprotected"
-             name="unprotected"
-             ng-model="repository.unprotected"
-             type="checkbox"
-             tabindex="6"/>
-    </div>
-
-    <div bst-form-group label="{{ 'GPG Key' | translate }}" ng-show="repository.content_type == 'yum'">
-      <select id="gpg_key_id"
-              name="gpg_key_id"
-              ng-model="repository.gpg_key_id"
-              ng-options="gpg_key.id as gpg_key.name for gpg_key in gpgKeys"
-              tabindex="7">
-        <option value=""></option>
-      </select>
-    </div>
-
-    <div bst-form-buttons
+    <div bst-form-buttons ng-show="repository.content_type !== undefined"
          on-cancel="transitionTo('products.details.repositories.index', {productId: repository.product_id})"
          on-save="save(repository)"
          working="working">
     </div>
+
 
   </form>
 </section>

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -46,29 +46,46 @@ module Katello
       refute @repo2.valid?
     end
 
-    def test_docker_repository_name_format
+    def test_docker_repository_docker_upstream_name_url
       @repo.content_type = 'docker'
-      @repo.name = 'valid'
+      @repo.docker_upstream_name = ""
+      @repo.url = "http://registry.com"
+      refute @repo.valid?
+      @repo.docker_upstream_name = "justin"
       assert @repo.valid?
-      @repo.name = 'Invalid'
+      @repo.url = ""
       refute @repo.valid?
-      @repo.name = '-_ok/valid'
+      @repo.url = "htp://boo.com"
+      #bad url
+      refute @repo.valid?
+      @repo.url = nil
+      @repo.docker_upstream_name = nil
       assert @repo.valid?
-      @repo.name = 'Invalid/valid'
-      refute @repo.valid?
-      @repo.name = 'Invalid/Invalid'
-      refute @repo.valid?
-      @repo.name = 'abcd/.-_'
+    end
+
+    def test_docker_repository_docker_upstream_name_format
+      @repo.content_type = 'docker'
+      @repo.docker_upstream_name = 'valid'
       assert @repo.valid?
-      @repo.name = 'abc/valid'
+      @repo.docker_upstream_name = 'Invalid'
       refute @repo.valid?
-      @repo.name = 'abcd/ab'
+      @repo.docker_upstream_name = '-_ok/valid'
+      assert @repo.valid?
+      @repo.docker_upstream_name = 'Invalid/valid'
       refute @repo.valid?
-      @repo.name = '/valid'
+      @repo.docker_upstream_name = 'Invalid/Invalid'
       refute @repo.valid?
-      @repo.name = 'thisisnotvalidbecauseitistoolong/valid'
+      @repo.docker_upstream_name = 'abcd/.-_'
+      assert @repo.valid?
+      @repo.docker_upstream_name = 'abc/valid'
       refute @repo.valid?
-      @repo.name = 'valid/thisisnotvalidbecauseitistoolong'
+      @repo.docker_upstream_name = 'abcd/ab'
+      refute @repo.valid?
+      @repo.docker_upstream_name = '/valid'
+      refute @repo.valid?
+      @repo.docker_upstream_name = 'thisisnotvalidbecauseitistoolong/valid'
+      refute @repo.valid?
+      @repo.docker_upstream_name = 'valid/thisisnotvalidbecauseitistoolong'
       refute @repo.valid?
     end
 
@@ -103,6 +120,7 @@ module Katello
       @repo.name = 'docker_repo'
       @repo.pulp_id = 'PULP-ID'
       @repo.content_type = Repository::DOCKER_TYPE
+      @repo.docker_upstream_name = "haha"
       assert @repo.save
       assert @repo.pulp_id.ends_with?('pulp-id')
     end


### PR DESCRIPTION
This commit does the following
1) Adds an docker_upstream_name column for repositories so as to
distinguish between the "repo name" and upstream feed repository name.
Changes in the model and actions added to accomodate this.
2) Cleans up the repo create page to only show fields relevant to the
selected content type
3) Moves content type field to the top of the create so as to make it
abundantly clear that the fields below all belong to the selected
content type.