### PR TITLE
Fixes #8960 - Handled ISE on bulk repos sync page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
@@ -49,6 +49,9 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
 
             RepositoryBulkAction.syncRepositories(params, function (task) {
                 $state.go('products.details.tasks.details', {taskId: task.id});
+            },
+            function (response) {
+                $scope.errorMessages = response.data.errors;
             });
         };
 

--- a/engines/bastion_katello/test/products/details/product-repositories.controller.test.js
+++ b/engines/bastion_katello/test/products/details/product-repositories.controller.test.js
@@ -91,11 +91,13 @@ describe('Controller: ProductRepositoriesController', function() {
     });
 
     it("provides a way to sync all of the selected repositories in the table", function() {
+        var errorFunction = jasmine.any(Function);
+
         spyOn(RepositoryBulkAction, 'syncRepositories').andCallThrough();
 
         $scope.syncSelectedRepositories();
         expect(RepositoryBulkAction.syncRepositories).toHaveBeenCalledWith({ids: expectedIds},
-            jasmine.any(Function));
+            jasmine.any(Function), errorFunction);
     });
 
 


### PR DESCRIPTION
Syncing a repo with no feed url via the bulk sync page caused an ISE.
This has now been fixed.