### PR TITLE
Fixes #8962 - CV page shows only non zero content counts in UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -112,14 +112,14 @@
               <span ng-hide="repository.url" translate>N/A</span>
             </td>
             <td bst-table-cell>
-              <div>
+              <div ng-if="repository.content_counts.docker_image && repository.content_counts.docker_image > 0">
                 <span translate>
-                  {{ repository.content_counts.docker_image || 0 }} Docker Images
+                  {{ repository.content_counts.docker_image }} Docker Images
                 </span>
               </div>
-              <div>
+              <div ng-if="repository.content_counts.docker_tag && repository.content_counts.docker_tag > 0">
                 <span translate>
-                  {{ repository.content_counts.docker_tag || 0 }} Docker Tags
+                  {{ repository.content_counts.docker_tag }} Docker Tags
                 </span>
               </div>
             </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -112,25 +112,18 @@
               <span ng-hide="repository.url" translate>N/A</span>
             </td>
             <td bst-table-cell>
-              <div>
+              <div ng-if="repository.content_counts.rpm && repository.content_counts.rpm > 0">
                 <a ng-href="/katello/content_search#/!=&search[packages][search]=&search[content_type]=packages&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_packages"
                    ng-show="repository.content_type == 'yum'"
                    translate>
-                  {{ repository.content_counts.rpm || 0 }} Packages
+                  {{ repository.content_counts.rpm }} Packages
                 </a>
               </div>
-              <div>
+              <div ng-if="repository.content_counts.erratum && repository.content_counts.erratum > 0">
                 <a ng-href="/katello/content_search#/!=&search[errata][search]=&search[content_type]=errata&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_errata"
                    ng-show="repository.content_type == 'yum'"
                    translate>
-                  {{ repository.content_counts.erratum || 0 }} Errata
-                </a>
-              </div>
-              <div>
-                <a ng-href="/katello/content_search#/!=&search[puppet_modules][search]=&search[content_type]=puppet_modules&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_puppet_modules"
-                   ng-show="repository.content_type == 'puppet'"
-                   translate>
-                  {{ repository.content_counts.puppet_module || 0 }} Puppet Modules
+                  {{ repository.content_counts.erratum }} Errata
                 </a>
               </div>
             </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -51,19 +51,21 @@
           </ul>
         </td>
         <td bst-table-cell>
-          <div translate>
-            {{ version.package_count || 0 }} Packages
+          <div translate ng-if="version.package_count && version.package_count > 0">
+            {{ version.package_count }} Packages
           </div>
-	  <span translate>{{ version.errata_counts.total || 0 }} Errata</span>
+          <div  ng-if="version.errata_counts.total && version.errata_counts.total > 0">
+	  <span translate>{{ version.errata_counts.total }} Errata</span>
           (<span errata-counts="version.errata_counts"></span>)
-          <div translate>
-            {{ version.puppet_module_count || 0 }} Puppet Modules
           </div>
-          <div translate>
-            {{ version.docker_image_count || 0 }} Docker Images
+          <div translate ng-if="version.puppet_module_count && version.puppet_module_count > 0">
+            {{ version.puppet_module_count }} Puppet Modules
           </div>
-          <div translate>
-            {{ version.docker_tag_count || 0 }} Docker Tags
+          <div translate ng-if="version.docker_image_count && version.docker_image_count > 0">
+            {{ version.docker_image_count }} Docker Images
+          </div>
+          <div translate ng-if="version.docker_tag_count && version.docker_tag_count > 0">
+            {{ version.docker_tag_count }} Docker Tags
           </div>
 
         </td>


### PR DESCRIPTION
Basically 3 pages have been updated to only rows with non zero contnet
counts. To give more context
"""
With the addition of Docker Tags/Docker Images, the typical Content view
publish page shows upto 7 items per version published and majority of
them tend to be 0. For example for a CV with 1 puppet module, the output
is going to look like
0 Packages, 0 Package Groups, 0 Errata, 1 Puppet Modules, 0 Docker
Images, 0 Docker Tags
for that row. Instead it would be better if only the non zero content
units show up on that page.
"""

This commit addresses that.