### PR TITLE
fixes #8191 - adding support for updating systems after an inc update

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -12,12 +12,14 @@
 
 module Katello
   class Api::V2::ContentViewVersionsController < Api::V2::ApiController
+    include Concerns::Api::V2::BulkSystemsExtensions
+
     before_filter :find_content_view_version, :only => [:show, :promote, :destroy]
     before_filter :find_content_view, :except => [:incremental_update]
     before_filter :find_environment, :only => [:promote, :index]
     before_filter :authorize_promotable, :only => [:promote]
     before_filter :authorize_destroy, :only => [:destroy]
-
+    before_filter :load_search_service, :only => [:incremental_update]
     before_filter :find_version_environments, :only => [:incremental_update]
 
     api :GET, "/content_view_versions", N_("List content view versions")
@@ -83,14 +85,44 @@ module Katello
       param :package_ids, Array, :desc => "Package uuids to copy into the new versions."
       param :puppet_module_ids, Array, :desc => "Puppet Modules to copy into the new versions."
     end
+    param :update_systems, Hash, :desc => N_("After generating the incremental update, apply the changes to the specified systems.  Only Errata are supported currently.") do
+      param :include, Hash, :required => true, :action_aware => true do
+        param :search, String, :required => false, :desc => N_("Search string for systems to perform an action on")
+        param :ids, Array, :required => false, :desc => N_("List of system ids to perform an action on")
+      end
+      param :exclude, Hash, :required => false, :action_aware => true do
+        param :ids, Array, :required => false, :desc => N_("List of system ids to exclude and not run an action on")
+      end
+      param :update_all_systems, :bool, :required => false, :desc => N_("Update all editable and applicable systems, not just ones using the selected Content View Versions and Environments")
+    end
     def incremental_update
+      if params[:add_content] && params[:add_content][:errata_ids].any? && params[:update_systems]
+        systems = calculate_systems_for_incremental(params[:update_systems], params[:propagate_to_composites])
+      else
+        systems = []
+      end
+
       validate_content(params[:add_content])
       task = async_task(::Actions::Katello::ContentView::IncrementalUpdates, @version_environments, params[:add_content],
-                        params[:resolve_dependencies], params[:propagate_to_composites], params[:description])
+                        params[:resolve_dependencies], params[:propagate_to_composites], systems, params[:description])
       respond_for_async :resource => task
     end
 
     private
+
+    def calculate_systems_for_incremental(bulk_params, use_composites)
+      if bulk_params[:update_all_systems]
+        version_environments  = find_version_environments_for_systems(use_composites)
+        restrict_systems = lambda do |relation|
+          errata = Erratum.where(:uuid => params[:add_content][:errata_ids])
+          relation.in_content_view_version_environments(version_environments).with_applicable_errata(errata)
+        end
+      else
+        restrict_systems = nil
+      end
+
+      find_bulk_systems(:editable, params[:update_systems], restrict_systems)
+    end
 
     def find_content_view_version
       @version = ContentViewVersion.find(params[:id])
@@ -104,6 +136,9 @@ module Katello
     end
 
     def find_version_environments
+      #Generates a data structure for incremental update:
+      # [{:content_view_version => ContentViewVersion, :environments => [KTEnvironment]}]
+
       list = params[:content_view_version_environments]
       fail _("At least one Content View Version must be specified") if list.empty?
 
@@ -125,6 +160,21 @@ module Katello
         not_found = combination[:environment_ids].map(&:to_s) - version_environment[:environments].map { |env| env.id.to_s }
         fail _("Could not find Environment with ids: %s") % not_found.join(', ') unless not_found.empty?
         @version_environments << version_environment
+      end
+    end
+
+    def find_version_environments_for_systems(include_composites)
+      if include_composites
+        version_environments_for_systems_map = {}
+        @version_environments.each do |version_environment|
+          version_environment[:content_view_version].composites.each do |composite_version|
+            version_environments_for_systems_map[composite_version.id] ||= {:content_view_version => composite_version,
+                                                                            :environments => composite_version.environments}
+          end
+        end
+        version_environments_for_systems_map.values
+      else
+        @version_environments
       end
     end
 

--- a/app/controllers/katello/concerns/api/v2/bulk_systems_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_systems_extensions.rb
@@ -1,0 +1,57 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Katello
+  module Concerns
+    module Api::V2::BulkSystemsExtensions
+      extend ActiveSupport::Concern
+
+      def find_bulk_systems(perm_method, bulk_params, restrict_to = nil)
+        #works on a structure of param_group bulk_params and transforms it into a list of systems
+        bulk_params[:included] ||= {}
+        bulk_params[:excluded] ||= {}
+        @systems = []
+
+        unless bulk_params[:included][:ids].blank?
+          @systems = System.send(perm_method).where(:uuid => bulk_params[:included][:ids])
+          @systems.where('uuid not in (?)', bulk_params[:excluded]) unless bulk_params[:excluded][:ids].blank?
+          @systems = restrict_to.call(@systems) if restrict_to
+        end
+
+        if bulk_params[:included][:search]
+          ids = find_system_ids_by_search(bulk_params[:included][:search])
+          search_systems = System.send(perm_method).where(:id => ids)
+          search_systems = search_systems.where('uuid not in (?)', bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
+          search_systems = restrict_to.call(search_systems) if restrict_to
+          @systems += search_systems
+        end
+
+        if bulk_params[:included][:ids].blank? && bulk_params[:included][:search].nil?
+          fail HttpErrors::BadRequest, _("No systems have been specified.")
+        elsif @systems.empty?
+          fail HttpErrors::Forbidden, _("Action unauthorized to be performed on selected systems.")
+        end
+        @systems
+      end
+
+      def find_system_ids_by_search(search)
+        options = {
+          :filters       => System.readable_search_filters(@organization),
+          :load_records? => false,
+          :full_result => true,
+          :fields => [:id]
+        }
+        item_search(System, {:search => search}, options)[:results].collect { |i| i.id }
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view/incremental_updates.rb
+++ b/app/lib/actions/katello/content_view/incremental_updates.rb
@@ -14,7 +14,7 @@ module Actions
   module Katello
     module ContentView
       class IncrementalUpdates < Actions::EntryAction
-        def plan(version_environments, content, dep_solve, propagate_composites, description)
+        def plan(version_environments, content, dep_solve, propagate_composites, systems, description)
           old_new_version_map = {}
           sequence do
             concurrence do
@@ -25,6 +25,10 @@ module Actions
               end
             end
             handle_composites(old_new_version_map, description, content[:puppet_module_ids]) if propagate_composites
+
+            if systems.any? && !content[:errata_ids].blank?
+              plan_action(::Actions::BulkAction, ::Actions::Katello::System::Erratum::ApplicableErrataInstall, systems, content[:errata_ids])
+            end
           end
         end
 

--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -88,6 +88,16 @@ module Katello
       where(:environment_id => organization.kt_environments.pluck(:id))
     end
 
+    def self.in_content_view_version_environments(version_environments)
+      #takes a structure of [{:content_view_version => ContentViewVersion, :environments => [KTEnvironment]}]
+      queries = version_environments.map do |version_environment|
+        version = version_environment[:content_view_version]
+        env_ids = version_environment[:environments].map(&:id)
+        "(#{table_name}.content_view_id = #{version.content_view_id} AND #{table_name}.environment_id IN (#{env_ids.join(',')}))"
+      end
+      where(queries.join(" OR "))
+    end
+
     def self.uuids_to_ids(uuids)
       systems = by_uuids(uuids)
       ids_not_found = Set.new(uuids).subtract(systems.pluck(:uuid))

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -247,7 +247,7 @@ module ::Actions::Katello::ContentView
 
     it 'plans' do
       plan_action(action, [{:content_view_version => content_view.version(library), :environments => [library]}],
-                  {:errata_ids => ["FOO"]}, true, false, "BadDescription")
+                  {:errata_ids => ["FOO"]}, true, false, [], "BadDescription")
       assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::IncrementalUpdate, content_view.version(library), [library],
                                 :content => {:errata_ids => ["FOO"]}, :resolve_dependencies => true, :description => "BadDescription")
     end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -201,7 +201,7 @@ module Katello
       errata_id = Katello::Erratum.first.uuid
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
                                             [{:content_view_version => version, :environments => [@beta]}],
-                                            {'errata_ids' => [errata_id]}, true, nil, nil).returns({})
+                                            {'errata_ids' => [errata_id]}, true, nil, [], nil).returns({})
 
       put :incremental_update, :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}],
                                :add_content => {:errata_ids => [errata_id]}, :resolve_dependencies => true

--- a/test/models/system_test.rb
+++ b/test/models/system_test.rb
@@ -120,6 +120,15 @@ module Katello
       super
     end
 
+    def test_in_content_view_version_environments
+      first_cvve = {:content_view_version => @system.content_view.version(@system.environment), :environments => [@system.environment]}
+      second_cvve = {:content_view_version => @library_view.version(@library), :environments => [@dev]} #dummy set
+      systems = System.in_content_view_version_environments([first_cvve, second_cvve])
+      assert_includes systems, @system
+      systems = System.in_content_view_version_environments([first_cvve])
+      assert_includes systems, @system
+    end
+
     def test_available_releases
       assert @system.available_releases.include?('6Server')
     end


### PR DESCRIPTION
adds an update_systems parameter to the incremental update api which uses
the same syntax as bulk systems controller


Example call:

POST /katello/api/v2/content_view_versions/incremental_update

```
{
"content_view_version_environments": [{"content_view_version_id": 17, "environment_ids": [1]}],
"add_content": {"errata_ids": ["f276483e-bc6b-42f1-bf50-7f8b6b73d508"] },
"resolve_dependencies": true,
"update_systems": {
  "update_all_systems" : true, 
  "included": {
    "search": "*"
   }
  }
}
```

