### PR TITLE
fixes #8174 - specify capsule-supported gpg key url

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -174,8 +174,7 @@ module Katello
     def yum_gpg_key_url
       # if the repo has a gpg key return a url to access it
       if (self.gpg_key && self.gpg_key.content.present?)
-        host = Facter.value(:fqdn) || SETTINGS[:fqdn]
-        gpg_key_content_api_repository_url(self, :host => host, :protocol => 'https')
+        "../..#{gpg_key_content_api_repository_url(self, :only_path => true)}"
       end
     end
 

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -164,6 +164,7 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/clean_backend_objects.rake"
 
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.1/import_errata.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.2/update_gpg_key_urls.rake"
     end
   end
 end

--- a/lib/katello/tasks/upgrades/2.2/update_gpg_key_urls.rake
+++ b/lib/katello/tasks/upgrades/2.2/update_gpg_key_urls.rake
@@ -1,0 +1,20 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '2.2' do
+      task :update_gpg_key_urls => ["environment"]  do
+        User.current = User.anonymous_api_admin
+        puts _("Importing GPG Key Urls to support Capsule Communication")
+
+        Katello::Product.find_each do |product|
+          unless product.redhat?
+            product.repositories.each do |repo|
+              if repo.yum_gpg_key_url && repo.yum_gpg_key_url != repo.content.gpgUrl
+                ForemanTasks.sync_task(::Actions::Katello::Repository::Update, repo, {})
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
if the gpg key url on content is just a path, sub-man will attempt to
append the baseurl from rhsm.conf.  This is https://hostname/pulp/repos
so by specifying a gpg key url of ../../katello/api/repositories/:id/gpg_key
subman will join the two to create a gpg key url of https://hostname/katello/api/repositories/:id/gpg_key

also including an upgrade rake task