### PR TITLE
Refs #7745: Support checking for custom header from RHSM proxied request...

### DIFF
--- a/app/services/katello/authentication/client_authentication.rb
+++ b/app/services/katello/authentication/client_authentication.rb
@@ -34,9 +34,15 @@ module Katello
         !ssl_client_cert.nil? && !ssl_client_cert.empty? && ssl_client_cert != "(null)"
       end
 
+      # HTTP_X_RHSM_SSL_CLIENT_CERT - custom client cert header typically coming from a reverse
+      #                               proxy on a Capsule passing RHSM traffic through in isolation
+      # HTTP_SSL_CLIENT_CERT - standard client cert header coming from direct interactions with the
+      #                        server
       def cert_from_request
+        request.env['HTTP_X_RHSM_SSL_CLIENT_CERT'] ||
         request.env['SSL_CLIENT_CERT'] ||
         request.env['HTTP_SSL_CLIENT_CERT'] ||
+        ENV['HTTP_X_RHSM_SSL_CLIENT_CERT'] ||
         ENV['SSL_CLIENT_CERT'] ||
         ENV['HTTP_SSL_CLIENT_CERT']
       end


### PR DESCRIPTION
...s.

When using a Capsule in isolation, the reverse proxy on the Capsule
must pass through the originating client's certificate via a custom
header; in this case, HTTP_X_RHSM_SSL_CLIENT_CERT.