### PR TITLE
fixes #9131 - publish content view was always using latest puppet module

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -224,12 +224,18 @@ module Katello
       composite? ? repositories_to_publish.pluck(&:id) : repository_ids
     end
 
+    # Returns actual puppet modules associated with all components
+    #
+    # @returns array of ElasticSearch::Item objects
+    def component_modules_to_publish
+      composite? ? components.flat_map { |version| version.puppet_modules } : nil
+    end
+
+    # Returns the content view puppet modules associated with the content view
+    #
+    # @returns array of ContentViewPuppetModule
     def puppet_modules_to_publish
-      if composite?
-        components.flat_map { |version| version.puppet_modules }
-      else
-        content_view_puppet_modules
-      end
+      composite? ? nil : content_view_puppet_modules
     end
 
     def repos_in_product(env, product)
@@ -302,7 +308,8 @@ module Katello
     end
 
     def duplicate_puppet_modules
-      counts = puppet_modules_to_publish.each_with_object(Hash.new(0)) do |puppet_module, h|
+      modules = puppet_modules_to_publish || component_modules_to_publish
+      counts = modules.each_with_object(Hash.new(0)) do |puppet_module, h|
         h[puppet_module.name] += 1
       end
       counts.select { |_k, v| v > 1 }.keys
@@ -418,11 +425,15 @@ module Katello
       # repo id to copy content.
       ids = []
       names_and_authors = []
-      puppet_modules_to_publish.each do |cvpm|
-        if cvpm.uuid
-          ids << cvpm.uuid
-        else
-          names_and_authors << { :name => cvpm.name, :author => cvpm.author }
+      if composite?
+        component_modules_to_publish.each { |puppet_module| ids << puppet_module.id }
+      else
+        puppet_modules_to_publish.each do |cvpm|
+          if cvpm.uuid
+            ids << cvpm.uuid
+          else
+            names_and_authors << { :name => cvpm.name, :author => cvpm.author }
+          end
         end
       end
 


### PR DESCRIPTION
Previously the puppet_modules_to_publish method would return a list of either
ContentViewPuppetModule objects or ElasticSearch Item objects.  Checking by uuid
or id is not sufficient so instead I split out the method into two in order to better indicate their intent