### PR TITLE
fixes #8728, #8756 - use capsule RPM for registering a content host

### DIFF
--- a/app/helpers/katello/katello_urls_helper.rb
+++ b/app/helpers/katello/katello_urls_helper.rb
@@ -17,8 +17,14 @@ module Katello
       URI(url).host unless url.nil?
     end
 
-    def subscription_manager_configuration_url
-      "#{Setting['foreman_url']}/pub/#{Katello.config.consumer_cert_rpm}".sub(/\Ahttps/, 'http')
+    def subscription_manager_configuration_url(host = nil)
+      prefix = if host && host.content_source
+                 "http://#{@host.content_source.hostname}"
+               else
+                 Setting[:foreman_url].sub(/\Ahttps/, 'http')
+               end
+
+      "#{prefix}/pub/#{Katello.config.consumer_cert_rpm}"
     end
   end
 end

--- a/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
+++ b/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
@@ -1,14 +1,10 @@
 <% if @host.params['kt_activation_keys'] %>
 # add subscription manager
 yum -t -y -e 0 install subscription-manager
-rpm -ivh <%= subscription_manager_configuration_url %>
+rpm -ivh <%= subscription_manager_configuration_url(@host) %>
 
 echo "Registering the System"
 subscription-manager register --org="<%= @host.rhsm_organization_label %>" --name="<%= @host.name %>" --activationkey="<%= @host.params['kt_activation_keys'] %>"
-
-<% if @host.content_source %>
-  subscription-manager config --rhsm.baseurl=https://<%= @host.content_source.hostname %>/pulp/repos
-<% end %>
 
 <% if @host.operatingsystem.name == "RedHat" %>
   # add the rhel rpms to install katello agent

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register.controller.js
@@ -30,16 +30,24 @@ angular.module('Bastion.content-hosts').controller('ContentHostRegisterControlle
     function ($scope, $location, Capsule, Organization, CurrentOrganization, BastionConfig) {
 
         $scope.organization = Organization.get({id: CurrentOrganization});
-        $scope.baseURL = 'http://' + $location.host();
         $scope.consumerCertRPM = BastionConfig.consumerCertRPM;
+        $scope.katelloHostname = $location.host();
+        $scope.noCapsulesFound = true;
 
         $scope.capsules = Capsule.queryUnpaged(function (data) {
-            $scope.selectedCapsule = data.results[0];
+            var defaultCapsule = _.filter(data.results, function (result) {
+                var featureNames = _.pluck(result.features, 'name');
+                return _.contains(featureNames, 'Pulp');
+            });
+
+            $scope.noCapsulesFound = _.isEmpty(data.results);
+            $scope.selectedCapsule = _.isEmpty(defaultCapsule) ? data.results[0] : defaultCapsule[0];
         });
+
 
         $scope.hostname = function (url) {
             if (url) {
-                url = url.split('https://')[1].split(':')[0];
+                url = url.split('://')[1].split(':')[0];
             }
 
             return url;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
@@ -13,29 +13,25 @@
     </div>
   </header>
 
-  <p translate>To register a content host to this server, run the following commands within a console on the client host.</p>
-
-  <p translate>Install the pre-built bootstrap RPM. This will configure the host to use this server.</p>
-
-  <pre>rpm -Uvh {{ baseURL }}/pub/{{ consumerCertRPM }}</pre>
-
-  <p translate>Use Subscription Manager to register.</p>
-
-  <pre><code>subscription-manager register --org="{{ organization.label }}" --environment="Library"</code></pre>
-
-  <p translate>Use an Activation Key to register.</p>
-
-  <pre><code>subscription-manager register --org="{{ organization.label }}" --activationkey="activationkey1"</code></pre>
-
-  <div ng-show="capsules.results.length > 0">
-    <p>
-      <h5 translate>Consuming Content From a Capsule</h5>
-      {{ "Selected Capsule:" | translate }}
-      <select ng-model="selectedCapsule"
-              ng-options="capsule.url for capsule in capsules.results">
-      </select>
-
-      <pre ng-show="selectedCapsule"><code>subscription-manager register --org="{{ organization.label }}" --baseurl="https://{{ hostname(selectedCapsule.url) }}/pulp/repos"</code></pre>
-    </p>
-  </div>
+ <p translate>To register a content host to this server, follow these steps.</p>
+  <ol>
+    <li ng-hide="noCapsulesFound">
+      <p translate>Select a Content Source:</p>
+      <p><select ng-model="selectedCapsule" ng-options="capsule.name for capsule in capsules.results"></select></p>
+    </li>
+    <li>
+      <p translate>Install the pre-built bootstrap RPM:</p>
+      <pre><code>rpm -Uvh http://{{ noCapsulesFound ? katelloHostname : hostname(selectedCapsule.url) }}/pub/{{ consumerCertRPM }}</code></pre>
+    </li>
+    <li>
+      <p translate>Run subscription-manager in a console on the client host.  You may use an Activation Key to register:</p>
+      <pre><code>subscription-manager register --org="{{ organization.label }}" --activationkey="activationkey1"</code></pre>
+      <p translate>or authenticate with a username and password:</p>
+      <pre><code>subscription-manager register --org="{{ organization.label }}" --environment="Library"</code></pre>
+    </li>
+    <li>
+      <p translate>Install katello-agent for remote actions and displaying errata information:</p>
+      <pre><code>yum -y install katello-agent</code></pre>
+    </li>
+  </ol>
 </section>

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -33,7 +33,10 @@ module BastionKatello
           host_collections
           katello_tasks
           select_organization
-        )
+        ),
+        :config => {
+          'consumerCertRPM' => Katello.config.consumer_cert_rpm
+        }
       )
     end
   end

--- a/engines/bastion_katello/test/content-hosts/content-host-register.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-host-register.controller.test.js
@@ -37,7 +37,7 @@ describe('Controller: ContentHostRegisterController', function() {
     });
 
     it('puts the current domain on the scope', function() {
-        expect($scope.baseURL).toBeDefined();
+        expect($scope.katelloHostname).toBeDefined();
     });
 
     it('should fetch a list of capsules', function(){


### PR DESCRIPTION
I think this makes the page a bit easier to use, and it now lets you get the RPM from the selected content source.  No more need for `--baseurl` as that's in the RPM.