### PR TITLE
fixes #9158 - do not find foreman host by mac

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -363,16 +363,8 @@ module Katello
     end
 
     def find_foreman_host(organization)
-      if params[:facts].present? && params[:facts]['network.hostname'].present?
-        mac_addresses =  System.interfaces(params[:facts]).
-                                map { |interface| interface[:mac].downcase if interface[:mac] }.
-                                reject { |mac| mac.nil? }
-
-        foreman_host = Host.where(:name => params[:facts]['network.hostname'],
-                                  :organization_id => organization.id,
-                                  :mac => mac_addresses).first
-      end
-      foreman_host
+      Host.where(:name => params[:facts]['network.hostname'],
+                 :organization_id => organization.id).first if params[:facts]
     end
 
     def get_content_view_environment(key, value)


### PR DESCRIPTION
MAC address is no longer a database field, but I don't think this is buying us anything.... `:name` is unique.  

I even wonder about whether searching organization.id.  There's no reason a host in Org A can't subscribe for content from Org B.
