### PR TITLE
Fixes #9167: Fix chained scopes when using scoped_search in API

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -98,7 +98,7 @@ module Katello
       scoped = scoped.of_type(params[:types]) if params[:types]
 
       respond_for_index :template => '../errata/index',
-                        :collection => scoped_search(scoped, 'issued', 'desc')
+                        :collection => scoped_search(scoped, 'issued', 'desc', Erratum)
     end
 
     api :GET, "/content_views/:content_view_id/filters/:id/available_package_groups",


### PR DESCRIPTION
Scoped search claims to support being applied to a set of scopes via
scopes.search_for. However, when multiple joins are used within the 'scopes'
the last join wins in the prior format. To combat this, we apply the
search_for first, which is itself a scope, and merge the scopes into
that result.