### PR TITLE
Fixes 9174 - replace uuidtools with securenumber

### DIFF
--- a/app/lib/katello/bulk_actions.rb
+++ b/app/lib/katello/bulk_actions.rb
@@ -74,7 +74,7 @@ module Katello
     def perform_bulk_action
       consumer_ids = self.systems.collect { |i| i.uuid }
       group = Glue::Pulp::ConsumerGroup.new
-      group.pulp_id = ::UUIDTools::UUID.random_create.to_s
+      group.pulp_id = SecureRandom.uuid
       group.consumer_ids = consumer_ids
       group.set_pulp_consumer_group
       yield(group)

--- a/app/lib/katello/util/model.rb
+++ b/app/lib/katello/util/model.rb
@@ -36,7 +36,7 @@ module Katello
       end
 
       def self.uuid
-        UUIDTools::UUID.random_create.to_s
+        SecureRandom.uuid
       end
 
       def self.controller_path_to_model_hash

--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -178,7 +178,7 @@ module Katello
 
     def perform_group_action
       group = Glue::Pulp::ConsumerGroup.new
-      group.pulp_id = ::UUIDTools::UUID.random_create.to_s
+      group.pulp_id = SecureRandom.uuid
       group.consumer_ids = consumer_ids
       group.set_pulp_consumer_group
       yield(group)

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "oauth"
   gem.add_dependency "rest-client"
 
-  gem.add_dependency "uuidtools"
   gem.add_dependency "rabl"
   gem.add_dependency "tire", "~> 0.6.2"
   gem.add_dependency "logging", ">= 1.8.0"

--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -23,7 +23,7 @@ require "deface"
 require 'jquery-ui-rails'
 require 'qpid_messaging'
 
-require "uuidtools"
+require "securerandom"
 
 # to make Foreman#in_rake? helper available if Foreman's lib is available
 lib_foreman = File.expand_path('lib/foreman', Rails.root)

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -110,7 +110,6 @@
        <packagereq type="default">ruby193-rubygem-tire</packagereq>
        <packagereq type="default">ruby193-rubygem-transaction-simple</packagereq>
        <packagereq type="default">ruby193-rubygem-ttfunk</packagereq>
-       <packagereq type="default">ruby193-rubygem-uuidtools</packagereq>
        <packagereq type="default">ruby193-rubygem-warden</packagereq>
        <packagereq type="default">ruby193-rubygem-yui-compressor</packagereq>
        <packagereq type="default">rubygem-hammer_cli_csv</packagereq>
@@ -202,7 +201,6 @@
        <packagereq type="optional">ruby193-rubygem-thin-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-transaction-simple-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-ttfunk-doc</packagereq>
-       <packagereq type="optional">ruby193-rubygem-uuidtools-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-webmock-doc</packagereq>
     </packagelist>
   </group>

--- a/rel-eng/comps/comps-katello-server-rhel7.xml
+++ b/rel-eng/comps/comps-katello-server-rhel7.xml
@@ -110,7 +110,6 @@
        <packagereq type="default">ruby193-rubygem-tire</packagereq>
        <packagereq type="default">ruby193-rubygem-transaction-simple</packagereq>
        <packagereq type="default">ruby193-rubygem-ttfunk</packagereq>
-       <packagereq type="default">ruby193-rubygem-uuidtools</packagereq>
        <packagereq type="default">ruby193-rubygem-warden</packagereq>
        <packagereq type="default">ruby193-rubygem-yui-compressor</packagereq>
        <packagereq type="default">rubygem-hammer_cli_csv</packagereq>
@@ -202,7 +201,6 @@
        <packagereq type="optional">ruby193-rubygem-thin-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-transaction-simple-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-ttfunk-doc</packagereq>
-       <packagereq type="optional">ruby193-rubygem-uuidtools-doc</packagereq>
        <packagereq type="optional">ruby193-rubygem-webmock-doc</packagereq>
     </packagelist>
   </group>

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -111,7 +111,6 @@ Requires: %{?scl_prefix}rubygem-rails
 Requires: %{?scl_prefix}rubygem-json
 Requires: %{?scl_prefix}rubygem-oauth
 Requires: %{?scl_prefix}rubygem-rest-client
-Requires: %{?scl_prefix}rubygem-uuidtools
 Requires: %{?scl_prefix}rubygem-rabl
 Requires: %{?scl_prefix}rubygem-tire => 0.6.2
 Requires: %{?scl_prefix}rubygem-tire < 0.7


### PR DESCRIPTION
Among less dependencies, it also fixes the rpm build, as the uuidtools were not specified as build dependency