### PR TITLE
Refs #8710 - created katello-debug sub-package

### DIFF
--- a/deploy/katello.spec
+++ b/deploy/katello.spec
@@ -122,6 +122,7 @@ Requires:       rubygem-hammer_cli_katello
 Requires:       rubygem-hammer_cli_import
 Requires:       rubygem-hammer_cli_gutterball
 Requires:       %{?scl_prefix}rubygem-foreman_gutterball
+Requires:       %{name}-debug
 
 %description common
 Common runtime components of %{name}
@@ -143,7 +144,6 @@ usermod -a -G katello-shared tomcat
 %ghost %attr(600, katello, katello) %{_sysconfdir}/%{name}/secret_token
 
 %{homedir}/script
-/usr/share/foreman/script/foreman-debug.d/katello-debug.sh
 %config(noreplace) %{_sysconfdir}/%{name}/service-list
 %{_mandir}/man8/katello-service.8*
 %{_sbindir}/service-wait
@@ -165,6 +165,18 @@ getent passwd %{name} >/dev/null || \
 getent group katello-shared > /dev/null || groupadd -r katello-shared
 usermod -a -G katello-shared katello
 exit 0
+
+# ------ Debug ----------------
+%package debug
+Summary: Katello Debug utilities
+Group: Applications/System
+Requires: foreman-debug
+
+%description debug
+Useful utilities for debug info collecting
+
+%files debug
+%{_datadir}/foreman/script/foreman-debug.d/katello-debug.sh
 
 # ------ SAM ------------------
 

--- a/rel-eng/comps/comps-katello-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-server-rhel6.xml
@@ -19,6 +19,7 @@
        <packagereq type="default">katello-api-docs</packagereq>
        <packagereq type="default">katello-certs-tools</packagereq>
        <packagereq type="default">katello-common</packagereq>
+       <packagereq type="default">katello-debug</packagereq>
        <packagereq type="default">katello-repos</packagereq>
        <packagereq type="default">katello-repos-testing</packagereq>
        <packagereq type="default">katello-sam</packagereq>

--- a/rel-eng/comps/comps-katello-server-rhel7.xml
+++ b/rel-eng/comps/comps-katello-server-rhel7.xml
@@ -19,6 +19,7 @@
        <packagereq type="default">katello-api-docs</packagereq>
        <packagereq type="default">katello-certs-tools</packagereq>
        <packagereq type="default">katello-common</packagereq>
+       <packagereq type="default">katello-debug</packagereq>
        <packagereq type="default">katello-repos</packagereq>
        <packagereq type="default">katello-repos-testing</packagereq>
        <packagereq type="default">katello-sam</packagereq>


### PR DESCRIPTION
With review of katello-debug plugin script, did a cleanup.

@jsherrill @ehelms can you guys give me assistance in changing composes,
building and pushing the subpackage change out?

I also want to make a change to the installer to install `katello-debug`
package on Capsules. What is the best way to do that @iNecas?

Thanks