### PR TITLE
Fixes #9209 - Default capsule now checked using Pulp feature

### DIFF
--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -48,13 +48,11 @@ module Katello
     end
 
     def self.with_environment(environment, include_default = false)
-      scope = SmartProxy.joins(:capsule_lifecycle_environments).
-          where(katello_capsule_lifecycle_environments: { lifecycle_environment_id: environment.id })
+      features = [SmartProxy::PULP_NODE_FEATURE]
+      features << SmartProxy::PULP_FEATURE if include_default
 
-      unless include_default
-        server_fqdn = Facter.value(:fqdn) || SETTINGS[:fqdn]
-        scope = scope.where("#{ SmartProxy.table_name }.name not in (?)", server_fqdn)
-      end
+      scope = SmartProxy.with_features(features).joins(:capsule_lifecycle_environments).
+          where(katello_capsule_lifecycle_environments: { lifecycle_environment_id: environment.id })
 
       scope.map { |proxy| self.new(proxy) }
     end

--- a/test/lib/capsule_content_test.rb
+++ b/test/lib/capsule_content_test.rb
@@ -31,5 +31,29 @@ module Katello
       capsule_content.lifecycle_environments.must_include(environment)
       capsule_content.lifecycle_environments(organization.id).wont_include(environment)
     end
+
+    specify "listing capsule content in environment" do
+      pulp_node_feature = Feature.create(:name => SmartProxy::PULP_NODE_FEATURE)
+      pulp_default_feature = Feature.create(:name => SmartProxy::PULP_FEATURE)
+
+      with_pulp_node = smart_proxies(:four).tap do |proxy|
+        proxy.features << pulp_node_feature
+      end
+      with_pulp = smart_proxies(:three).tap do |proxy|
+        proxy.features << pulp_default_feature
+      end
+      pulp_node_capsule_content = Katello::CapsuleContent.new(with_pulp_node)
+      pulp_node_capsule_content.add_lifecycle_environment(environment)
+
+      pulp_capsule_content = Katello::CapsuleContent.new(with_pulp)
+      pulp_capsule_content.add_lifecycle_environment(environment)
+
+      refute_includes CapsuleContent.with_environment(environment, false).map(&:capsule), with_pulp
+      refute_includes CapsuleContent.with_environment(environment).map(&:capsule), with_pulp
+      assert_includes CapsuleContent.with_environment(environment).map(&:capsule), with_pulp_node
+
+      assert_includes CapsuleContent.with_environment(environment, true).map(&:capsule), with_pulp
+      assert_includes CapsuleContent.with_environment(environment, true).map(&:capsule), with_pulp_node
+    end
   end
 end

--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -13,7 +13,7 @@
 module Support
   module CapsuleSupport
     def pulp_feature
-      @pulp_feture ||= Feature.create(name: SmartProxy::PULP_NODE_FEATURE)
+      @pulp_feature ||= Feature.create(name: SmartProxy::PULP_NODE_FEATURE)
     end
 
     def proxy_with_pulp


### PR DESCRIPTION
Previously default capsules would be checked via matching hostnames of
the satellite and the hostname given to the capsule. This caused all
sorts of issues when customers did things like renaming hosts etc.

This is now fixed by using the fact that only the default capsule  has
"Pulp" feature, as opposed to the other capsules that typically have the 'Pulp Node'
feature.