### PR TITLE
Ref #9300: destroy ktenv should no longer call disable_a

### DIFF
--- a/app/lib/actions/katello/environment/destroy.rb
+++ b/app/lib/actions/katello/environment/destroy.rb
@@ -29,7 +29,6 @@ module Actions
           skip_repo_destroy = options.fetch(:skip_repo_destroy, false)
           organization_destroy = options.fetch(:organization_destroy, false)
           sequence do
-            env.disable_auto_reindex!
             action_subject(env)
 
             concurrence do
@@ -53,7 +52,6 @@ module Actions
 
         def finalize
           environment = ::Katello::KTEnvironment.find(input['kt_environment']['id'])
-          environment.disable_auto_reindex!
           environment.destroy!
         end
       end

--- a/test/actions/katello/environment_test.rb
+++ b/test/actions/katello/environment_test.rb
@@ -68,7 +68,6 @@ module ::Actions::Katello::Environment
       content_view = stub
       cve = mock(:content_view => content_view)
       action.stubs(:action_subject).with(environment)
-      environment.expects(:disable_auto_reindex!)
       environment.expects(:content_view_environments).returns([cve])
       environment.expects(:deletable?).returns(true)
       environment.expects(:organization).returns(mock)


### PR DESCRIPTION
..uto_reindex