### PR TITLE
fixes #9402 - allow removal of cv version with archive deletion

### DIFF
--- a/app/lib/actions/katello/content_view_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_environment/destroy.rb
@@ -38,16 +38,8 @@ module Actions
               end
             end
             plan_action(Candlepin::Environment::Destroy, cp_id: cv_env.cp_id) unless skip_cp_update
-            plan_self(:id => cv_env.id)
-          end
-        end
-
-        def finalize
-          cv_env = ::Katello::ContentViewEnvironment.find_by_id(input[:id])
-          if cv_env.nil?
-            output[:response] = "Content view with ID #{input[:id]} is (probably) already deleted"
-          else
             cv_env.destroy!
+            plan_self
           end
         end
       end

--- a/app/lib/actions/katello/content_view_puppet_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/destroy.rb
@@ -18,16 +18,8 @@ module Actions
           action_subject(puppet_env)
           plan_action(Pulp::Repository::Destroy, pulp_id: puppet_env.pulp_id)
           plan_action(ElasticSearch::Repository::Destroy, pulp_id: puppet_env.pulp_id)
-          plan_self
-        end
-
-        def finalize
-          puppet_env = ::Katello::ContentViewPuppetEnvironment.
-            find(input[:content_view_puppet_environment][:id])
-
           puppet_env.destroy!
-        rescue ActiveRecord::RecordNotFound => e
-          output[:response] = e.message
+          plan_self
         end
 
         def humanized_name

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -186,7 +186,11 @@ module Katello
     end
 
     def puppet_module_count
-      PuppetModule.module_count([self.archive_puppet_environment])
+      if self.archive_puppet_environment
+        PuppetModule.module_count([self.archive_puppet_environment])
+      else
+        0
+      end
     end
 
     def package_count


### PR DESCRIPTION
For user facing object it makes sense to delete them in the finalize phase
but for these non-user facing objects it makes less sense, so remove them in the plan phase