### PR TITLE
refs #9179 - adding python-mongoengine for EL7

### DIFF
--- a/rel-eng/comps/comps-katello-pulp-server-rhel7.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-rhel7.xml
@@ -47,6 +47,7 @@
        <packagereq type="default">python-gofer</packagereq>
        <packagereq type="default">python-isodate</packagereq>
        <packagereq type="default">python-kombu</packagereq>
+       <packagereq type="default">python-mongoengine</packagereq>
        <packagereq type="default">python-nectar</packagereq>
        <packagereq type="default">python-oauth2</packagereq>
        <packagereq type="default">python-okaara</packagereq>


### PR DESCRIPTION
EPEL carries this for RHEL6 but for 7 we have to ship it