### PR TITLE
fixes #9416 - content view update - dynflow'ize it

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -80,9 +80,8 @@ module Katello
     param :name, String, :desc => N_("New name for the content view")
     param_group :content_view
     def update
-      @view.update_attributes!(view_params)
-
-      respond :resource => @view
+      sync_task(::Actions::Katello::ContentView::Update, @view, view_params)
+      respond :resource => @view.reload
     end
 
     api :POST, "/content_views/:id/publish", N_("Publish a content view")

--- a/app/lib/actions/elastic_search/reindex_on_association_change.rb
+++ b/app/lib/actions/elastic_search/reindex_on_association_change.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module ElasticSearch
+    class ReindexOnAssociationChange < ElasticSearch::Abstract
+      def plan(record)
+        plan_self(id: record.id,
+                  class_name: record.class.name)
+      end
+
+      input_format do
+        param :id
+        param :class_name
+      end
+
+      def finalize
+        model_class = input[:class_name].constantize
+        record      = model_class.find_by_id(input[:id])
+
+        if record
+          record.update_index if record.respond_to? :update_index
+          record.class.index.refresh if record.class.respond_to? :index
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view/update.rb
+++ b/app/lib/actions/katello/content_view/update.rb
@@ -1,0 +1,44 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module ContentView
+      class Update < Actions::EntryAction
+        def plan(content_view, content_view_params)
+          content_view.disable_auto_reindex!
+          content_view.disable_auto_reindex_on_association!
+          repositories = repositories_to_reindex(content_view, content_view_params)
+
+          action_subject content_view
+          content_view.update_attributes!(content_view_params)
+
+          if ::Katello.config.use_elasticsearch
+            plan_action(ElasticSearch::Reindex, content_view)
+            repositories.each { |repository| plan_action(ElasticSearch::ReindexOnAssociationChange, repository) }
+          end
+        end
+
+        private
+
+        def repositories_to_reindex(content_view, params)
+          repoids = []
+          if params["repository_ids"]
+            repoids += (content_view.repository_ids - params["repository_ids"])
+            repoids += (params["repository_ids"] - content_view.repository_ids)
+          end
+          ::Katello::Repository.where(:id => repoids)
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/ext/indexed_model.rb
+++ b/app/models/katello/ext/indexed_model.rb
@@ -59,6 +59,14 @@ module Katello
           @disable_auto_reindex = false
         end
 
+        def disable_auto_reindex_on_association!
+          @disable_auto_reindex_on_association = true
+        end
+
+        def enable_auto_reindex_on_association!
+          @disable_auto_reindex_on_association = false
+        end
+
         def refresh_index
           return if @disable_auto_reindex
           self.class.index.refresh if self.class.respond_to?(:index)
@@ -91,6 +99,7 @@ module Katello
         end
 
         def reindex_on_association_change(record)
+          return if @disable_auto_reindex_on_association
           record.update_index if record.respond_to? :update_index
           record.class.index.refresh if record.class.respond_to? :index
         end

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -207,6 +207,25 @@ module ::Actions::Katello::ContentView
     end
   end
 
+  class UpdateTest < TestBase
+    let(:action_class) { ::Actions::Katello::ContentView::Update }
+    let(:content_view) { katello_content_views(:library_dev_view) }
+    let(:repository) { katello_repositories(:rhel_6_x86_64) }
+    let(:action) { create_action action_class }
+
+    it 'plans' do
+      action.expects(:action_subject).with(content_view)
+      plan_action action, content_view, 'repository_ids' => [repository.id]
+      assert_action_planed action, ::Actions::ElasticSearch::Reindex
+      assert_action_planed action, ::Actions::ElasticSearch::ReindexOnAssociationChange
+    end
+
+    it 'raises error when validation fails' do
+      ::Actions::Katello::ContentView::Update.any_instance.expects(:action_subject).with(content_view)
+      proc { create_and_plan_action action_class, content_view, :name => '' }.must_raise(ActiveRecord::RecordInvalid)
+    end
+  end
+
   class DestroyTest < TestBase
     let(:action_class) { ::Actions::Katello::ContentView::Destroy }
 


### PR DESCRIPTION
Converted the content view update action to use dynflow.  Since
this action uses elasticsearch to update relationships, it should
be using dynflow.

This becomes more important for plugins like fusor, which will
create custom actions involving content view updating.