### PR TITLE
Fixes #7796 - Enable docker repos from the CDN

### DIFF
--- a/app/assets/javascripts/katello/providers/provider_redhat.js
+++ b/app/assets/javascripts/katello/providers/provider_redhat.js
@@ -55,10 +55,11 @@ KT.redhat_provider_page = (function($) {
         } else {
             options['repo'] = "0";
         }
-
+        options['pulp_id'] = checkbox.attr("data-pulp-id");
         options['content_id'] = checkbox.attr("data-content-id");
         options['releasever'] = checkbox.attr("data-releasever");
         options['basearch'] = checkbox.attr("data-basearch");
+        options['registry_name'] = checkbox.attr("data-registry-name");
 
         $(checkbox).hide();
         $('#spinner_'+id).removeClass('hidden').show();

--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -52,16 +52,10 @@ module Katello
     # to the inclusion of a modules.
     param :id, :identifier, :desc => N_("organization ID"), :required => true
     param :redhat_repository_url, String, :desc => N_("Red Hat CDN URL")
-    param :redhat_docker_registry_url,  String, :desc => N_("Red Hat Docker Registry URL")
     param_group :resource, ::Api::V2::TaxonomiesController
     def update
       if params.key?(:redhat_repository_url)
         @organization.redhat_provider.update_attributes!(:repository_url => params[:redhat_repository_url])
-      end
-
-      if params.key?(:redhat_docker_registry_url)
-        @organization.redhat_provider.update_attributes!(:docker_registry_url =>
-                                                          params[:redhat_docker_registry_url])
       end
       super
     end

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -68,8 +68,9 @@ module Katello
     api :PUT, "/products/:product_id/repository_sets/:id/enable", N_("Enable a repository from the set")
     param :id, :number, :required => true, :desc => N_("ID of the repository set to enable")
     param :product_id, :number, :required => true, :desc => N_("ID of the product containing the repository set")
-    param :basearch, String, :required => true, :desc => N_("Basearch to enable")
-    param :releasever, String, :required => true, :desc => N_("Releasever to enable")
+    param :basearch, String, :required => false, :desc => N_("Basearch to enable")
+    param :releasever, String, :required => false, :desc => N_("Releasever to enable")
+    param :registry_name, String, :required => false, :desc => N_("Registry name to enable in the case of a docker repository")
     def enable
       task = sync_task(::Actions::Katello::RepositorySet::EnableRepository, @product, @product_content.content, substitutions)
       respond_for_async :resource => task
@@ -78,8 +79,9 @@ module Katello
     api :PUT, "/products/:product_id/repository_sets/:id/disable", N_("Disable a repository form the set")
     param :id, :number, :required => true, :desc => N_("ID of the repository set to enable")
     param :product_id, :number, :required => true, :desc => N_("ID of the product containing the repository set")
-    param :basearch, String, :required => true, :desc => N_("Basearch to disable")
-    param :releasever, String, :required => true, :desc => N_("Releasever to disable")
+    param :basearch, String, :required => false, :desc => N_("Basearch to disable")
+    param :releasever, String, :required => false, :desc => N_("Releasever to disable")
+    param :registry_name, String, :required => false, :desc => N_("Registry name to enable in the case of a docker repository")
     def disable
       task = sync_task(::Actions::Katello::RepositorySet::DisableRepository, @product, @product_content.content, substitutions)
       respond_for_async :resource => task
@@ -103,7 +105,7 @@ module Katello
     end
 
     def substitutions
-      params.slice(:basearch, :releasever)
+      params.slice(:basearch, :releasever, :registry_name)
     end
   end
 end

--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -101,7 +101,7 @@ module Katello
     end
 
     def substitutions
-      params.slice(:basearch, :releasever)
+      params.slice(:basearch, :releasever, :registry_name)
     end
 
     def task_error(task)

--- a/app/lib/actions/katello/repository_set/disable_repository.rb
+++ b/app/lib/actions/katello/repository_set/disable_repository.rb
@@ -18,8 +18,11 @@ module Actions
           _("Disable")
         end
 
-        def plan(product, content, substitutions)
-          if repository = repository_mapper(product, content, substitutions).find_repository
+        def plan(product, content, options)
+          if repository = repository_mapper(product,
+                                            content,
+                                            options,
+                                            options[:registry_name]).find_repository
             action_subject(repository)
             plan_action(ElasticSearch::Reindex, repository.product)
             plan_action(Repository::Destroy, repository)
@@ -30,10 +33,17 @@ module Actions
 
         private
 
-        def repository_mapper(product, content, substitutions)
-          ::Katello::Candlepin::Content::RepositoryMapper.new(product,
-                                                              content,
-                                                              substitutions)
+        def repository_mapper(product, content, substitutions, registry_name)
+          if content.type == ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
+            ::Katello::Candlepin::Content::DockerRepositoryMapper.new(product,
+                                                                content,
+                                                                registry_name)
+
+          else
+            ::Katello::Candlepin::Content::RepositoryMapper.new(product,
+                                                                content,
+                                                                substitutions)
+          end
         end
       end
     end

--- a/app/lib/actions/katello/repository_set/enable_repository.rb
+++ b/app/lib/actions/katello/repository_set/enable_repository.rb
@@ -18,9 +18,9 @@ module Actions
           _("Enable")
         end
 
-        def plan(product, content, substitutions)
-          mapper = repository_mapper(product, content, substitutions)
-          mapper.check_substitutions!
+        def plan(product, content, options)
+          mapper = repository_mapper(product, content, options, options[:registry_name])
+          mapper.validate!
           if mapper.find_repository
             fail ::Katello::Errors::ConflictException, _("The repository is already enabled")
           end
@@ -32,10 +32,17 @@ module Actions
 
         private
 
-        def repository_mapper(product, content, substitutions)
-          ::Katello::Candlepin::Content::RepositoryMapper.new(product,
-                                                              content,
-                                                              substitutions)
+        def repository_mapper(product, content, substituions, registry_name)
+          if content.type == ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
+            ::Katello::Candlepin::Content::DockerRepositoryMapper.new(product,
+                                                                content,
+                                                                registry_name)
+
+          else
+            ::Katello::Candlepin::Content::RepositoryMapper.new(product,
+                                                                content,
+                                                                substituions)
+          end
         end
       end
     end

--- a/app/lib/actions/katello/repository_set/scan_cdn.rb
+++ b/app/lib/actions/katello/repository_set/scan_cdn.rb
@@ -29,21 +29,51 @@ module Actions
         end
 
         def plan(product, content_id)
-          content = product.product_content_by_id(content_id).content
+          prod_content = product.product_content_by_id(content_id).content
 
-          plan_self(product_id:  product.id, content_id: content.id)
+          plan_self(product_id:  product.id, content_id: prod_content.id)
         end
 
         def run
-          output[:results] = cdn_var_substitutor.substitute_vars(content.contentUrl).map do |(substitutions, path)|
-            prepare_result(substitutions, path)
-          end
+          output[:results] = fetch_results
         end
 
         private
 
+        def fetch_results
+          if content.type == ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
+            prepare_results_docker_content
+          else
+            cdn_var_substitutor.substitute_vars(content.contentUrl).map do |(substitutions, path)|
+              prepare_result(substitutions, path)
+            end
+          end
+        end
+
         def cdn_var_substitutor
           product.cdn_resource.substitutor
+        end
+
+        def prepare_results_docker_content
+          registries = product.cdn_resource.get_docker_registries(content.contentUrl)
+          registries.map do |registry|
+            mapper = ::Katello::Candlepin::Content::DockerRepositoryMapper.new(product,
+                                                                content,
+                                                                registry['name'])
+            mapper.registries = registries
+            mapper.registry_repo = registry
+            repo = mapper.find_repository
+
+            {
+              substitutions: {},
+              path:          mapper.feed_url,
+              repo_name:     mapper.name,
+              pulp_id:       mapper.pulp_id,
+              registry_name: registry["name"],
+              enabled:       !repo.nil?,
+              promoted:      (!repo.nil? && repo.promoted?)
+            }
+          end
         end
 
         def prepare_result(substitutions, _path)
@@ -54,7 +84,8 @@ module Actions
             repo_name:     mapper.name,
             pulp_id:       mapper.pulp_id,
             enabled:       !repo.nil?,
-            promoted:      (!repo.nil? && repo.promoted?)}
+            promoted:      (!repo.nil? && repo.promoted?)
+          }
         end
 
         def product
@@ -63,7 +94,7 @@ module Actions
 
         def content
           return @content if defined? @content
-          if product_content = @product.product_content_by_id(input[:content_id])
+          if product_content = product.product_content_by_id(input[:content_id])
             @content = product_content.content
           else
             fail "Couldn't find content '%s'" % input[:content_id]

--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -64,38 +64,33 @@ module Katello
       end
 
       def build_repository
-        repository = ::Katello::Repository.new(:environment => product.organization.library,
-                                               :product => product,
-                                               :pulp_id => pulp_id,
-                                               :cp_label => content.label,
-                                               :content_id => content.id,
-                                               :arch => arch,
-                                               :major => major,
-                                               :minor => minor,
-                                               :relative_path => relative_path,
-                                               :name => name,
-                                               :label => label,
-                                               :url => feed_url,
-                                               :feed_ca => ca,
-                                               :feed_cert => product.certificate,
-                                               :feed_key => product.key,
-                                               :content_type => katello_content_type,
-                                               :preserve_metadata => true, #preserve repo metadata when importing from cp
-                                               :unprotected => unprotected?,
-                                               :content_view_version => product.organization.library.default_content_view_version)
-
-        repository.docker_upstream_name = self.name if repository.docker?
-        repository
+        ::Katello::Repository.new(:environment => product.organization.library,
+                                 :product => product,
+                                 :pulp_id => pulp_id,
+                                 :cp_label => content.label,
+                                 :content_id => content.id,
+                                 :arch => arch,
+                                 :major => major,
+                                 :minor => minor,
+                                 :relative_path => relative_path,
+                                 :name => name,
+                                 :label => label,
+                                 :url => feed_url,
+                                 :feed_ca => ca,
+                                 :feed_cert => product.certificate,
+                                 :feed_key => product.key,
+                                 :content_type => katello_content_type,
+                                 :preserve_metadata => true, #preserve repo metadata when importing from cp
+                                 :unprotected => unprotected?,
+                                 :content_view_version => product.organization.library.default_content_view_version)
       end
 
-      def check_substitutions!
-        unless content_type == ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
-          if substitutor.valid_substitutions?(content.contentUrl, substitutions)
-            return true
-          else
-            fail _("%{substitutions} are not valid substitutions for %{content_url}") %
-                { substitutions: substitutions, content_url: content.contentUrl }
-          end
+      def validate!
+        if substitutor.valid_substitutions?(content.contentUrl, substitutions)
+          return true
+        else
+          fail _("%{substitutions} are not valid substitutions for %{content_url}") %
+              { substitutions: substitutions, content_url: content.contentUrl }
         end
       end
 
@@ -166,6 +161,88 @@ module Katello
 
       def kickstart?
         content.type.downcase == 'kickstart'
+      end
+
+      def ca
+        File.read(::Katello::Resources::CDN::CdnResource.ca_file)
+      end
+    end
+
+    class DockerRepositoryMapper
+      attr_reader :product, :content
+      attr_accessor :container_registry_name, :registries, :registry_repo
+      def initialize(product, content, container_registry_name = nil)
+        @product = product
+        @content = content
+        @container_registry_name = container_registry_name
+      end
+
+      def registry
+        validate!
+        @registries ||= product.cdn_resource.get_docker_registries(content.contentUrl)
+        @registry_repo ||= registries.detect do |reg|
+          reg['name'] == @container_registry_name
+        end
+      end
+
+      def find_repository
+        ::Katello::Repository.where(product_id: product.id,
+                                    environment_id: product.organization.library.id,
+                                    docker_upstream_name: container_registry_name).first
+      end
+
+      def build_repository
+        unless registry
+          Rails.logger.error("Docker registry with pulp_id #{container_registry_name} was not found at #{content.contentUrl}")
+          fail _("Docker repository not found")
+        end
+        ::Katello::Repository.new(:environment => product.organization.library,
+                                 :product => product,
+                                 :pulp_id => pulp_id,
+                                 :cp_label => content.label,
+                                 :content_id => content.id,
+                                 :relative_path => relative_path,
+                                 :name => name,
+                                 :docker_upstream_name => registry["name"],
+                                 :label => label,
+                                 :url => feed_url,
+                                 :feed_ca => ca,
+                                 :feed_cert => product.certificate,
+                                 :feed_key => product.key,
+                                 :content_type => ::Katello::Repository::DOCKER_TYPE,
+                                 :preserve_metadata => true, #preserve repo metadata when importing from cp
+                                 :unprotected => true,
+                                 :content_view_version => product.organization.library.default_content_view_version)
+      end
+
+      def validate!
+        fail _("Registry name cannot be blank") if @container_registry_name.blank?
+      end
+
+      def name
+        "#{content.name} - (#{registry['name']})"
+      end
+
+      def pulp_id
+        product.repo_id(content.name, nil, registry['name'])
+      end
+
+      def feed_url
+        docker_repo_uri =  URI.parse(registry["url"])
+        docker_repo_uri =  URI.parse("https://" + registry["url"]) unless docker_repo_uri.host
+        "#{docker_repo_uri.scheme}://#{docker_repo_uri.host}:#{docker_repo_uri.port}"
+      end
+
+      def label
+        ::Katello::Util::Model.labelize(name)
+      end
+
+      def katello_content_type
+        ::Katello::Repository::DOCKER_TYPE
+      end
+
+      def relative_path
+        ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(product.organization.library, content.contentUrl)
       end
 
       def ca

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -139,10 +139,6 @@ module Katello
           redhat_provider.repository_url
         end
 
-        def redhat_docker_registry_url
-          redhat_provider.docker_registry_url
-        end
-
         def being_deleted?
           ForemanTasks::Task::DynflowTask.for_action(::Actions::Katello::Organization::Destroy).
             for_resource(self).active.any?

--- a/app/models/katello/glue/candlepin/content.rb
+++ b/app/models/katello/glue/candlepin/content.rb
@@ -12,7 +12,7 @@
 
 module Katello
   module Glue::Candlepin::Content
-    CANDLEPIN_DOCKER_TYPE = "containerImage"
+    CANDLEPIN_DOCKER_TYPE = "containerimage"
 
     def self.included(base)
       base.send :include, InstanceMethods

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -271,10 +271,11 @@ module Katello
         end
       end
 
-      def repo_id(content_name, env_label = nil)
+      def repo_id(content_name, env_label = nil, docker_repo_name = nil)
         return if content_name.nil?
         return content_name if content_name.include?(self.organization.label) && content_name.include?(self.label.to_s)
-        Repository.repo_id(self.label.to_s, content_name.to_s, env_label, self.organization.label, nil, nil)
+        Repository.repo_id(self.label.to_s, content_name.to_s, env_label,
+                           self.organization.label, nil, nil, docker_repo_name)
       end
 
       def repo_url(content_url, repo_content_type = ::Katello::Repository::YUM_TYPE)

--- a/app/models/katello/provider.rb
+++ b/app/models/katello/provider.rb
@@ -24,7 +24,7 @@ module Katello
     ANONYMOUS = 'Anonymous'.encode('utf-8')
     TYPES = [REDHAT, CUSTOM, ANONYMOUS]
 
-    attr_accessible :name, :description, :organization, :provider_type, :repository_url, :docker_registry_url
+    attr_accessible :name, :description, :organization, :provider_type, :repository_url
 
     belongs_to :organization, :inverse_of => :providers, :class_name => "Organization"
     belongs_to :task_status, :inverse_of => :provider
@@ -39,11 +39,10 @@ module Katello
     validate :only_one_rhn_provider
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
     validates_with Validators::KatelloUrlFormatValidator, :if => :redhat_provider?,
-                                                          :attributes => [:repository_url, :docker_registry_url]
+                                                          :attributes => [:repository_url]
 
     before_destroy :prevent_redhat_deletion
     before_validation :sanitize_repository_url
-    before_validation :sanitize_docker_registry_url
 
     scope :redhat, where(:provider_type => REDHAT)
     scope :custom, where(:provider_type => CUSTOM)
@@ -52,7 +51,7 @@ module Katello
     def self.create_anonymous!(organization)
       create!(:name => SecureRandom.uuid, :description => nil,
               :organization => organization, :provider_type => ANONYMOUS,
-              :repository_url => nil, :docker_registry_url => nil)
+              :repository_url => nil)
     end
 
     def only_one_rhn_provider
@@ -74,7 +73,7 @@ module Katello
 
     def constraint_redhat_update
       if !new_record? && redhat_provider?
-        allowed_changes = %w(repository_url  docker_registry_url task_status_id)
+        allowed_changes = %w(repository_url task_status_id)
         not_allowed_changes = changes.keys - allowed_changes
         unless not_allowed_changes.empty?
           errors.add(:base, _("the following attributes can not be updated for the Red Hat provider: [ %s ]") % not_allowed_changes.join(", "))
@@ -165,11 +164,6 @@ module Katello
     end
 
     protected
-
-    def sanitize_docker_registry_url
-      sanitize_url(:docker_registry_url,
-                   Katello.config.redhat_docker_registry_url)
-    end
 
     def sanitize_repository_url
       sanitize_url(:repository_url, Katello.config.redhat_repository_url)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -287,8 +287,18 @@ module Katello
       end
     end
 
-    def self.repo_id(product_label, repo_label, env_label, organization_label, view_label, version)
-      [organization_label, env_label, view_label, version, product_label, repo_label].compact.join("-").gsub(/[^-\w]/, "_")
+    def self.repo_id(product_label, repo_label, env_label, organization_label,
+                     view_label, version, docker_repo_name = nil)
+      actual_repo_id = [organization_label,
+                        env_label,
+                        view_label,
+                        version,
+                        product_label,
+                        repo_label,
+                        docker_repo_name].compact.join("-").gsub(/[^-\w]/, "_")
+      # docker repo names need to be in lower case
+      actual_repo_id = actual_repo_id.downcase if docker_repo_name
+      actual_repo_id
     end
 
     def clone_id(env, content_view, version = nil)

--- a/app/views/katello/api/v2/organizations/show.json.rabl
+++ b/app/views/katello/api/v2/organizations/show.json.rabl
@@ -3,7 +3,7 @@ object @taxonomy
 extends "api/v2/taxonomies/show"
 
 attributes :task_id, :label, :system_info_keys, :distributor_info_keys, :default_info,
-  :owner_details, :redhat_repository_url, :redhat_docker_registry_url
+  :owner_details, :redhat_repository_url
 
 attributes :service_levels, :service_level if ::Katello.config.use_cp
 

--- a/app/views/katello/providers/redhat/_repos.html.haml
+++ b/app/views/katello/providers/redhat/_repos.html.haml
@@ -16,6 +16,7 @@
                                :data => { :url => toggle_repository_product_path(scan_cdn.input[:product_id]),
                                           'content-id' => scan_cdn.input[:content_id],
                                           'pulp-id' => result[:pulp_id],
+                                          'registry-name' => result[:registry_name],
                                           :releasever => result[:substitutions][:releasever],
                                           :basearch => result[:substitutions][:basearch] },
                                :disabled => result[:promoted], :checked=>(:checked if result[:enabled])}

--- a/config/katello_defaults.yml
+++ b/config/katello_defaults.yml
@@ -33,8 +33,6 @@ common:
   simple_search_tokens: [":", " and\\b", " or\\b", " not\\b"]
 
   redhat_repository_url: https://cdn.redhat.com
-  redhat_docker_registry_url: https://registry.access.redhat.com
-
   consumer_cert_rpm: 'katello-ca-consumer-latest.noarch.rpm'
 
   #setup how often you want

--- a/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
+++ b/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
@@ -1,8 +1,6 @@
 class AddDockerContainerRegistryUrlToProviders < ActiveRecord::Migration
   def up
     add_column :katello_providers, :docker_registry_url, :string
-    ::Katello::Provider.redhat.update_all(:docker_registry_url =>
-                                          Katello.config.redhat_docker_registry_url)
   end
 
   def down

--- a/db/migrate/20150224083608_remove_docker_registry_url.rb
+++ b/db/migrate/20150224083608_remove_docker_registry_url.rb
@@ -1,0 +1,9 @@
+class RemoveDockerRegistryUrl < ActiveRecord::Migration
+  def up
+    remove_column :katello_providers, :docker_registry_url
+  end
+
+  def down
+    add_column :katello_providers, :docker_registry_url, :string
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
@@ -10,16 +10,6 @@
         readonly="organization.readonly">
       </span>
     </div>
-
-    <div class="detail">
-      <span class="info-label" translate>Red Hat Docker Registry URL</span>
-      <span class="info-value"
-        bst-edit-text="organization.redhat_docker_registry_url"
-        on-save="saveCdnUrl(organization)"
-        readonly="organization.readonly">
-      </span>
-    </div>
-
   </div>
 </section>
 

--- a/test/actions/katello/docker_repository_set_test.rb
+++ b/test/actions/katello/docker_repository_set_test.rb
@@ -1,0 +1,171 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module ::Actions::Katello::RepositorySet
+  class DockerTestBase < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryGirl::Syntax::Methods
+
+    before do
+      disable_lazy_accessors
+      get_organization(:empty_organization)
+      product.stubs(:cdn_resource => cdn_resource)
+      ::Katello::Product.stubs(:find).with(product.id).returns(product)
+    end
+
+    let(:options) do
+      {:registry_name => registry_name}
+    end
+    let(:cdn_resource) do
+      ::Katello::Resources::CDN::CdnResource.new(content_url).tap do |cdn_resource|
+        cdn_resource.stubs(:get).with(File.join(content_url,
+                                                  Katello::Resources::CDN::CdnResource::
+                                                  CDN_DOCKER_CONTAINER_LISTING)).returns(registry.to_json)
+      end
+    end
+
+    let(:content_url) { '/content/dist/rhel/server/7/7Server/x86_64/containers' }
+
+    let(:action) { create_action action_class }
+    let(:product) { katello_products(:redhat) }
+
+    let(:content) do
+      ::Katello::Candlepin::Content.new(id: 'docker-content-123',
+                                        name: 'Docker Content 123',
+                                        type: 'containerimage',
+                                        label: 'content-123',
+                                        contentUrl: content_url)
+    end
+
+    let(:registry_name) do
+      "dream-registry"
+    end
+    let(:registry_feed_url) do
+      "test.com:5000"
+    end
+    let(:registry) do
+      {
+        "header" => {
+          "version" => "1.0"
+        },
+        "payload" => {
+          "registries" => [
+            { "name" => registry_name,
+              "url" => "#{registry_feed_url}/rhel"
+            }
+          ]
+        }
+      }
+    end
+
+    let(:expected_pulp_id) { "empty_organization-redhat_label-docker_content_123-#{registry_name}".downcase }
+    let(:expected_relative_path) { "Empty_Organization/library_label/product/x86_64/6Server" }
+
+    def repository_already_enabled!
+      katello_repositories(:rhel_6_x86_64).
+          update_attributes!(relative_path: "#{expected_relative_path}",
+                             pulp_id: expected_pulp_id,
+                             docker_upstream_name: registry_name)
+    end
+  end
+
+  class DockerScanCdnTest < DockerTestBase
+    include Support::Actions::RemoteAction
+
+    let(:action_class) { ::Actions::Katello::RepositorySet::ScanCdn }
+
+    before do
+      product.stubs(product_content_by_id: stub(content: content))
+      stub_remote_user
+    end
+
+    it 'plans' do
+      plan_action action, product, content.id
+      assert_run_phase action do
+        action.input[:product_id].must_equal product.id
+        action.input[:content_id].must_equal content.id
+      end
+    end
+
+    it 'runs' do
+      action = simulate_run
+      action.output.must_equal("results" =>
+                                 [{ "substitutions" => {},
+                                    "path" => "https://#{registry_feed_url}",
+                                    "repo_name" => "#{content.name} - (#{registry_name})",
+                                    "pulp_id" => expected_pulp_id,
+                                    "registry_name" => "dream-registry",
+                                    "enabled" => false,
+                                    "promoted" => false}])
+    end
+
+    it 'considers the repo being enabled when the repository object is present' do
+      repository_already_enabled!
+      action = simulate_run
+      action.output[:results].first[:enabled].must_equal true
+    end
+
+    def simulate_run
+      planned_action = plan_action action, product, content.id
+      run_action planned_action do |run_action|
+        run_action.stubs(content: content)
+      end
+    end
+  end
+
+  class EnableDockerRepositoryTest < DockerTestBase
+    let(:action_class) { ::Actions::Katello::RepositorySet::EnableRepository }
+
+    it 'plans' do
+      action.expects(:action_subject).with do |repository|
+        repository.pulp_id.must_equal expected_pulp_id
+        repository.docker_upstream_name.must_equal registry_name
+        repository.url.must_equal "https://#{registry_feed_url}"
+      end
+      plan_action action, product, content, options
+      assert_action_planed action, ::Actions::Katello::Repository::Create
+    end
+
+    it 'fails when repository already enabled' do
+      repository_already_enabled!
+      failed = lambda do
+        plan_action(action, product, content, options)
+      end
+      failed.must_raise(::Katello::Errors::ConflictException)
+    end
+  end
+
+  class DisableDockerRepositoryTest < DockerTestBase
+    let(:action_class) { ::Actions::Katello::RepositorySet::DisableRepository }
+
+    it 'plans' do
+      repository_already_enabled!
+
+      action.expects(:action_subject).with do |repository|
+        repository.pulp_id.must_equal expected_pulp_id
+        repository.docker_upstream_name.must_equal registry_name
+      end
+      plan_action action, product, content, options
+      assert_action_planed action, ::Actions::Katello::Repository::Destroy
+    end
+
+    it 'fails when repository not enabled' do
+      failed = lambda do
+        plan_action(action, product, content, options)
+      end
+      failed.must_raise(::Katello::Errors::NotFound)
+    end
+  end
+end

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -39,6 +39,7 @@ module Katello
       permissions
 
       @content = OpenStruct.new(id: 'content-123')
+
       Product.any_instance.stubs(productContent: [OpenStruct.new(content: @content)])
     end
 
@@ -76,6 +77,20 @@ module Katello
       assert_response :success
     end
 
+    def test_repository_enable_docker
+      assert_sync_task ::Actions::Katello::RepositorySet::EnableRepository do |product, content, substitutions|
+        product.must_equal @product
+        content.id.must_equal @content.id
+        substitutions.must_equal('registry_name' => 'boo')
+      end
+
+      put :enable,
+          product_id: @product.id,
+          id: @content.id,
+          registry_name: 'boo'
+      assert_response :success
+    end
+
     def test_enable_protected
       allowed_perms = [@import_permission]
       denied_perms = [@attach_permission, @unattach_permission, @delete_permission, @view_permission]
@@ -99,6 +114,20 @@ module Katello
           product_id: @product.id,
           id: @content.id,
           basearch: 'x86_64', releasever: '6Server'
+      assert_response :success
+    end
+
+    def test_repository_disable_docker
+      assert_sync_task ::Actions::Katello::RepositorySet::DisableRepository do |product, content, substitutions|
+        product.must_equal @product
+        content.id.must_equal @content.id
+        substitutions.must_equal('registry_name' => 'boo')
+      end
+
+      put :disable,
+          product_id: @product.id,
+          id: @content.id,
+          registry_name: 'boo'
       assert_response :success
     end
 

--- a/test/fixtures/models/katello_providers.yml
+++ b/test/fixtures/models/katello_providers.yml
@@ -15,8 +15,6 @@ redhat:
   description: Provider of all your red hat needs
   provider_type: 'Red Hat'
   repository_url: 'https://cds.example.com'
-  docker_registry_url: 'https://docker.example.com'
-
   organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
 
 candlepin_redhat:


### PR DESCRIPTION
This commit provides code to enable/create docker repos from a CDN
manifest.

Look at the commit message for description on what the code is intended to do ...