### PR TITLE
Fixes #9471: fix JS error on content host errata page, BZ1194396

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -1,12 +1,14 @@
 <span page-title ng-model="contentHost">{{ 'Errata for: ' | translate }} {{ contentHost.name }}</span>
 
-<p bst-alert="info" ng-hide="contentHost.katello_agent_installed" bst-feature-flag="remote_actions">
-  <span translate>
-    The katello-agent package is required to manage errata on this Host.
-    Please install the katello-agent package to manage errata on
-    {{ contentHost.name }}.
-  </span>
-</p>
+<div bst-feature-flag="remote_actions">
+  <p bst-alert="info" ng-hide="contentHost.katello_agent_installed">
+    <span translate>
+      The katello-agent package is required to manage errata on this Host.
+      Please install the katello-agent package to manage errata on
+      {{ contentHost.name }}.
+    </span>
+  </p>
+</div>
 
 <div data-extend-template="layouts/details-nutupane.html">
   <div data-block="header" bst-feature-flag="remote_actions">


### PR DESCRIPTION
bst-feature-flag and bst-alert were both asking for transclusion on
the same element so moving bst-feature-flag to containing element to
avoid JS error.

http://projects.theforeman.org/issues/9471
https://bugzilla.redhat.com/show_bug.cgi?id=1194396