### PR TITLE
Fixes #9522: no row-select on tables without bulk actions, BZ 1173765.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views-table-collapsed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views-table-collapsed.html
@@ -1,7 +1,7 @@
 <table class="table table-striped" ng-class="{'table-mask': table.working}">
 
   <thead>
-    <tr bst-table-head row-select>
+    <tr bst-table-head>
       <th bst-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
@@ -9,7 +9,6 @@
   <tbody>
     <tr bst-table-row
         ng-repeat="contentView in table.rows"
-        row-select="contentView"
         active-row="stateIncludes('content-views.details', {contentViewId: contentView.id})">
       <td bst-table-cell>
         <a ui-sref="content-views.details.versions({contentViewId: contentView.id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views-table-full.html
@@ -10,7 +10,7 @@
        ng-show="table.rows.length > 0">
 
   <thead>
-    <tr bst-table-head row-select>
+    <tr bst-table-head>
       <th bst-table-column><span translate>Name</span></th>
       <th bst-table-column><span translate>Composite View?</span></th>
       <th bst-table-column><span translate>Last Published</span></th>
@@ -20,7 +20,7 @@
   </thead>
 
   <tbody>
-    <tr bst-table-row ng-repeat="contentView in table.rows" row-select="contentView">
+    <tr bst-table-row ng-repeat="contentView in table.rows">
       <td bst-table-cell>
         <a ui-sref="content-views.details.versions({contentViewId: contentView.id})">
           {{ contentView.name }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections-table-collapsed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections-table-collapsed.html
@@ -1,6 +1,6 @@
 <table bst-table="table" class="table table-striped table-full" ng-class="{'table-mask': table.working}">
   <thead>
-    <tr bst-table-head row-select>
+    <tr bst-table-head>
       <th bst-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
@@ -8,7 +8,6 @@
   <tbody>
     <tr bst-table-row
         ng-repeat="hostCollection in table.rows"
-        row-select="hostCollection"
         active-row="stateIncludes('host-collections.details', {hostCollectionId: hostCollection.id})">
       <td bst-table-cell>
         <a ui-sref="host-collections.details.info({hostCollectionId: hostCollection.id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections-table-full.html
@@ -7,7 +7,7 @@
        ng-class="{'table-mask': table.working}"
        ng-show="table.rows.length > 0">
   <thead>
-    <tr bst-table-head row-select>
+    <tr bst-table-head>
       <th bst-table-column="name" sortable><span translate>Name</span></th>
       <th bst-table-column="content-hosts"><span translate>Content Hosts</span></th>
       <th bst-table-column="limit"><span translate>Limit</span></th>
@@ -15,7 +15,7 @@
   </thead>
 
   <tbody>
-    <tr bst-table-row ng-repeat="hostCollection in table.rows" row-select="hostCollection">
+    <tr bst-table-row ng-repeat="hostCollection in table.rows">
       <td bst-table-cell>
         <a ui-sref="host-collections.details.info({hostCollectionId: hostCollection.id})">
           {{ hostCollection.name }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans-table-collapsed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans-table-collapsed.html
@@ -1,6 +1,6 @@
 <table class="table table-striped" ng-class="{'table-mask': syncPlanTable.working}">
   <thead>
-    <tr bst-table-head row-select>
+    <tr bst-table-head>
       <th bst-table-column sortable><span translate>Name</span></th>
     </tr>
   </thead>
@@ -10,7 +10,6 @@
   <tbody>
     <tr bst-table-row
         ng-repeat="syncPlan in syncPlanTable.rows"
-        row-select="syncPlan"
         active-row="stateIncludes('sync-plans.details', {syncPlanId: syncPlan.id})">
       <td bst-table-cell>
         <a ui-sref="sync-plans.details.info({syncPlanId: syncPlan.id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans-table-full.html
@@ -7,7 +7,7 @@
        ng-class="{'table-mask': syncPlanTable.working}" 
        ng-show="syncPlanTable.rows.length > 0">
   <thead>
-    <tr bst-table-head row-select>
+    <tr bst-table-head>
       <th bst-table-column="name" sortable><span translate>Name</span></th>
       <th bst-table-column="description"><span translate>Description</span></th>
       <th bst-table-column="syncDate"><span translate>Original Sync Date</span></th>
@@ -20,7 +20,7 @@
   <div data-extend-template="layouts/select-all-results.html"></div>
 
   <tbody>
-    <tr bst-table-row ng-repeat="syncPlan in syncPlanTable.rows" row-select="syncPlan">
+    <tr bst-table-row ng-repeat="syncPlan in syncPlanTable.rows">
       <td bst-table-cell>
         <a ui-sref="sync-plans.details.info({syncPlanId: syncPlan.id})">
           {{ syncPlan.name }}


### PR DESCRIPTION
We were displaying row-select checkboxes on a few tables that did not
have any bulk actions and thus the checkboxes were confusing.  This
commit removes the checkboxes on these tables.

http://projects.theforeman.org/issues/9522
https://bugzilla.redhat.com/show_bug.cgi?id=1173765