### PR TITLE
fixes #9525 - add array equality assertion methods

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -60,6 +60,10 @@ module Katello
       self.joins(:system_errata).where("#{SystemErratum.table_name}.system_id" => systems)
     end
 
+    def <=>(other)
+      return self.errata_id <=> other.errata_id
+    end
+
     def systems_available
       self.systems_applicable.joins("INNER JOIN #{Katello::RepositoryErratum.table_name} on \
         #{Katello::RepositoryErratum.table_name}.erratum_id = #{self.id}").joins(:system_repositories).

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -171,6 +171,14 @@ class ActiveSupport::TestCase
       record.stubs(:reload).returns(record)
     end
   end
+
+  def assert_equal_arrays(array1, array2)
+    assert_equal array1.sort, array2.sort
+  end
+
+  def refute_equal_arrays(array1, array2)
+    refute_equal array1.sort, array2.sort
+  end
 end
 
 def disable_lazy_accessors

--- a/test/models/system_test.rb
+++ b/test/models/system_test.rb
@@ -158,7 +158,7 @@ module Katello
     end
 
     def test_available_and_applicable_errta
-      assert_equal @errata_system.applicable_errata, @errata_system.installable_errata
+      assert_equal_arrays @errata_system.applicable_errata, @errata_system.installable_errata
     end
 
     def test_installable_errata
@@ -168,8 +168,8 @@ module Katello
       @errata_system.bound_repositories = [@view_repo]
       @errata_system.save!
 
-      assert_equal lib_applicable, @errata_system.applicable_errata
-      refute_equal lib_applicable, @errata_system.installable_errata
+      assert_equal_arrays lib_applicable, @errata_system.applicable_errata
+      refute_equal_arrays lib_applicable, @errata_system.installable_errata
       assert_include @errata_system.installable_errata, Erratum.find(katello_errata(:security))
     end
 


### PR DESCRIPTION
Fixes the random case that occurred in http://ci.theforeman.org/job/test_katello_core/11499/database=postgresql,ruby=1.9.3/testReport/junit/%28root%29/Katello__SystemTest/test_available_and_applicable_errta/