### PR TITLE
Fixes #9528: fix JS error on content host errata table, BZ 1195760.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -28,6 +28,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
     function ($scope, translate, ContentHostErratum, Nutupane, Organization, Environment) {
         var errataNutupane = new Nutupane(ContentHostErratum, {'id': $scope.$stateParams.contentHostId, searchTerm: $scope.$stateParams.search}, 'get');
 
+        errataNutupane.masterOnly = true;
         $scope.detailsTable = errataNutupane.table;
         $scope.detailsTable.errataFilterTerm = "";
         $scope.detailsTable.errataCompare = function (item) {


### PR DESCRIPTION
The boolean 'masterOnly' wasn't being set on the errata nutupane
table when it should have been.  This PR sets the value.

http://projects.theforeman.org/issues/9528
https://bugzilla.redhat.com/show_bug.cgi?id=1195760