### PR TITLE
Fixes #9534: fix N+1 queries on content view index.

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -57,7 +57,9 @@ module Katello
       options[:filters] << {:term => {:composite => false}} if params[:noncomposite]
       options[:filters] << {:term => {:name => params[:name]}} if params[:name]
 
-      respond(:collection => item_search(ContentView, params, options))
+      content_view_includes = [:activation_keys, :components, :content_view_puppet_modules, :content_view_versions,
+                               :environments, :organization, :repositories]
+      respond(:collection => item_search(ContentView.includes(content_view_includes), params, options))
     end
 
     api :POST, "/organizations/:organization_id/content_views", N_("Create a content view")

--- a/app/views/katello/api/v2/content_views/_content_view.json.rabl
+++ b/app/views/katello/api/v2/content_views/_content_view.json.rabl
@@ -23,7 +23,7 @@ child :environments => :environments do
 end
 
 child :repositories => :repositories do
-  extends 'katello/api/v2/repositories/show'
+  attributes :id, :name, :label, :content_type
 end
 
 child :puppet_modules => :puppet_modules do


### PR DESCRIPTION
The content views were slow to load in the composite list/add
pages because of several N+1 queries.  This commit fixes the N+1s
on content view index.

http://projects.theforeman.org/issues/9534
https://bugzilla.redhat.com/show_bug.cgi?id=1120765