### PR TITLE
Fixes #9554: Fix broken package display on content search.

### DIFF
--- a/app/lib/katello/content_search/search_utils.rb
+++ b/app/lib/katello/content_search/search_utils.rb
@@ -17,7 +17,7 @@ module Katello
     delegate :page_size, :to => :current_user
 
     def self.search_envs(mode)
-      if mode != :all
+      if mode != 'all'
         KTEnvironment.readable.where(:id => self.env_ids)
       else
         KTEnvironment.readable


### PR DESCRIPTION
When the content search mode was moved to a string, this place that it
was checked got overlooked and broke the package search.