### PR TITLE
Fixes #9564: limit components rabl to fix N+1 queries, BZ 1177609.

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -57,8 +57,8 @@ module Katello
       options[:filters] << {:term => {:composite => false}} if params[:noncomposite]
       options[:filters] << {:term => {:name => params[:name]}} if params[:name]
 
-      content_view_includes = [:activation_keys, :components, :content_view_puppet_modules, :content_view_versions,
-                               :environments, :organization, :repositories]
+      content_view_includes = [:activation_keys, :content_view_puppet_modules, :content_view_versions,
+                               :environments, :organization, :repositories, components: [:content_view, :environments]]
       respond(:collection => item_search(ContentView.includes(content_view_includes), params, options))
     end
 

--- a/app/views/katello/api/v2/content_views/_content_view.json.rabl
+++ b/app/views/katello/api/v2/content_views/_content_view.json.rabl
@@ -49,7 +49,15 @@ node :permissions do |cv|
 end
 
 child :components => :components do
-  extends 'katello/api/v2/content_view_versions/show'
+  attributes :id, :name, :label, :content_view_id, :version
+
+  child :environments => :environments do
+    attributes :id, :name, :label
+  end
+
+  child :content_view => :content_view do
+    attributes :id, :name, :label, :description, :next_version
+  end
 end
 
 child :activation_keys => :activation_keys do


### PR DESCRIPTION
There were several N+1 queries because we were including all of the
content view version rabl for components.  This commit reduces the fields
we include in the rabl and thus removes N+1 queries, speeding up the page.

http://projects.theforeman.org/issues/9564
https://bugzilla.redhat.com/show_bug.cgi?id=1177609