### PR TITLE
Fixes #9345: fix content view promotion in IE, BZ1168457.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
@@ -22,7 +22,7 @@
        mode="singleSelect"
        selection-required="false"
        path-attribute="environments"
-       disabled="denied('promote_or_remove_content_views', contentView)"
+       ng-hide="denied('promote_or_remove_content_views', contentView)"
        ng-show="working">
   </div>
 


### PR DESCRIPTION
Content view promotion was broken in IE because we were using
the "disabled" attribute on a div which is not valid HTML and
was resulting in the path selector checkboxes being disabled.
This commit changes the disabled attribute to an ng-hide.

http://projects.theforeman.org/issues/9345
https://bugzilla.redhat.com/show_bug.cgi?id=1168457