### PR TITLE
fixes #9462,#9557,#9556 - various inherited hostgroup issues

### DIFF
--- a/app/assets/javascripts/katello/hosts/activation_key_edit.js
+++ b/app/assets/javascripts/katello/hosts/activation_key_edit.js
@@ -58,11 +58,19 @@ function ktHideParams() {
 }
 
 function getSelectedEnvId() {
-  return $("#hostgroup_lifecycle_environment_id").val();
+    var dataId = $("#hostgroup_lifecycle_environment_id > option:selected").data("id");
+    if (dataId === undefined) {
+        dataId = $("#hostgroup_lifecycle_environment_id").val();
+    }
+    return dataId;
 }
 
 function getSelectedContentViewId() {
-  return $("#hostgroup_content_view_id").val();
+    var dataId = $("#hostgroup_content_view_id > option:selected").data("id");
+    if (dataId === undefined) {
+        dataId = $("#hostgroup_content_view_id").val();
+    }
+    return dataId;
 }
 
 function ktSetParam(name, value) {

--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -83,7 +83,8 @@ KT.hosts.getContentViewSelect = function() {
 };
 
 KT.hosts.getSelectedContentView = function() {
-    return KT.hosts.getContentViewSelect().val();
+    var select = KT.hosts.getContentViewSelect();
+    return select.val() || select.find("option:selected").data("id");
 };
 
 KT.hosts.getSelectedEnvironment = function () {
@@ -91,6 +92,10 @@ KT.hosts.getSelectedEnvironment = function () {
     if(envId === undefined || envId.length === 0) {
         envId = $("#host_lifecycle_environment_id").val()
     }
+    if(envId === undefined || envId.length === 0) {
+        envId = $("#hostgroup_lifecycle_environment_id > option:selected").data("id");
+    }
+
     if(envId && envId.length === 0) {
         envId = undefined;
     }
@@ -108,6 +113,7 @@ KT.hosts.onKatelloHostEditLoad = function(){
             });
         });
     });
+    KT.hosts.toggle_installation_medium();
 };
 
 
@@ -116,14 +122,14 @@ KT.hosts.toggle_installation_medium = function() {
 
 
     if ($('#hostgroup_parent_id').length > 0) {
-      lifecycle_environment_id = $('#hostgroup_lifecycle_environment_id').val();
-      content_view_id = $('#hostgroup_content_view_id').val();
+      lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
+      content_view_id = KT.hosts.getSelectedContentView();
       content_source_id = $('#hostgroup_content_source_id').val();
       architecture_id = $('#hostgroup_architecture_id').val();
       operatingsystem_id = $('#hostgroup_operatingsystem_id').val();
     } else {
-      lifecycle_environment_id = $('#host_lifecycle_environment_id').val();
-      content_view_id = $('#host_content_view_id').val();
+      lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
+      content_view_id = KT.hosts.getSelectedContentView();
       content_source_id = $('#host_content_source_id').val();
       architecture_id = $('#host_architecture_id').val();
       operatingsystem_id = $('#host_operatingsystem_id').val();

--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -19,7 +19,7 @@ module Katello
     def blank_or_inherit_with_id(f, attr)
       return true unless f.object.respond_to?(:parent_id) && f.object.parent_id
       inherited_value  = f.object.send(attr).try(:id) || ''
-      %(<option data-id="#{inherited_value}">#{blank_or_inherit_f(f, attr)}</option>)
+      %(<option data-id="#{inherited_value}" value="">#{blank_or_inherit_f(f, attr)}</option>)
     end
 
     def envs_by_kt_org
@@ -70,7 +70,7 @@ module Katello
         views = [host.content_view]
       end
       view_options = views.map do |view|
-        selected = host.content_view == view ? 'selected' : ''
+        selected = host[:content_view_id] == view.id ? 'selected' : ''
         %(<option #{selected} value="#{view.id}">#{h(view.name)}</option>)
       end
       view_options = view_options.join

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -29,18 +29,18 @@ module Katello
       end
 
       def content_view
-        return super unless ancestry.present?
+        return super if ancestry.nil? || self.content_view_id.present?
         Katello::ContentView.find_by_id(inherited_content_view_id)
       end
 
       def lifecycle_environment
-        return super unless ancestry.present?
+        return super if ancestry.nil? || self.lifecycle_environment_id.present?
         Katello::KTEnvironment.find_by_id(inherited_lifecycle_environment_id)
       end
 
       # instead of calling nested_attribute_for(:content_source_id) in Foreman, define the methods explictedly
       def content_source
-        return super unless ancestry.present?
+        return super if ancestry.nil? || self.content_source_id.present?
         SmartProxy.find_by_id(inherited_content_source_id)
       end
 

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -55,6 +55,22 @@ module Katello
       assert_equal @view, @root.content_view
     end
 
+    def test_inherited_content_view_with_ancestry_nill
+      @child.content_view = @view
+      @child.save!
+
+      assert_equal @view, @child.content_view
+      assert_equal nil, @root.content_view
+    end
+
+    def test_inherited_lifecycle_environment_with_ancestry_nil
+      @child.lifecycle_environment = @library
+      @child.save!
+
+      assert_equal @library, @child.lifecycle_environment
+      assert_equal nil, @root.lifecycle_environment
+    end
+
     def test_content_and_puppet_match?
       @root.content_view = @view
       @root.lifecycle_environment = @library


### PR DESCRIPTION
this commit fixes:
* Error "unable to load activation keys" on initial host group load
* Error "host group not found" when trying to update/save a host group with a parent
* Install Media Url not using inherited cv and lifecycle env