### PR TITLE
fixes #9577 - fixing host single and bulk delete

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -18,9 +18,14 @@ module Katello
       included do
         def destroy
           sync_task(::Actions::Katello::System::HostDestroy, @host)
-          process_success(:object => @host)
+          process_success(:success_redirect => hosts_path)
         rescue StandardError => ex
           process_error(:object => @host, :error_msg => ex.message)
+        end
+
+        def submit_multiple_destroy
+          task = async_task(::Actions::BulkAction, ::Actions::Katello::System::HostDestroy, @hosts)
+          redirect_to(foreman_tasks_task_path(task.id))
         end
 
         def puppet_environment_for_content_view

--- a/app/lib/actions/katello/system/host_destroy.rb
+++ b/app/lib/actions/katello/system/host_destroy.rb
@@ -20,14 +20,19 @@ module Actions
             if host.content_host
               plan_action(Katello::System::Destroy, host.content_host)
             end
-            unless host.reload.destroy
-              fail host.errors.full_messages.join('; ')
-            end
+            plan_self(:host_id => host.id)
           end
         end
 
         def humanized_name
           _("Destroy Host")
+        end
+
+        def finalize
+          host = Host.find(input[:host_id])
+          unless host.reload.destroy
+            fail host.errors.full_messages.join('; ')
+          end
         end
       end
     end

--- a/test/actions/katello/system_test.rb
+++ b/test/actions/katello/system_test.rb
@@ -106,8 +106,7 @@ module ::Actions::Katello::System
       host = mock
       content_host = mock
       host.expects(:content_host).at_least(1).returns(content_host)
-      host.expects(:reload).returns(host)
-      host.expects(:destroy).returns(true)
+      host.expects(:id).at_least(1).returns(1)
 
       action.stubs(:action_subject).with(host)
 


### PR DESCRIPTION
* single host delete was broken due to content host AR destroy being moved to finalize in dynflow
* multi host delete was never actually implemented in dynflow