### PR TITLE
Fixes #9580: fix N+1 queries on activation key list, BZ 1196742.

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -309,7 +309,9 @@ module Katello
         :filters       => filters,
         :load_records? => true
       }
-      item_search(ActivationKey, params, options)
+
+      activation_key_includes = [:content_view, :environment, :host_collections, :organization]
+      item_search(ActivationKey.includes(activation_key_includes), params, options)
     end
 
     def activation_key_params

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -115,16 +115,16 @@ module Katello
       cp_pools = self.get_key_pools
       if cp_pools
         pools = cp_pools.collect { |cp_pool| Pool.find_pool(cp_pool['id'], cp_pool) }
+        product_ids = pools.map(&:product_id)
+        marketing_products = MarketingProduct.includes(:engineering_products, :marketing_engineering_products).
+            where(:cp_id => product_ids)
+        products = Product.where(:cp_id => product_ids).where('type != ?', "Katello::MarketingProduct")
 
-        pools.each do |pool|
-          Product.where(:cp_id => pool.product_id).each do |product|
-            if product.is_a? Katello::MarketingProduct
-              all_products += product.engineering_products
-            else
-              all_products << product
-            end
-          end
+        marketing_products.each do |product|
+          all_products += product.engineering_products
         end
+
+        all_products += products
       end
 
       all_products

--- a/app/views/katello/api/v2/activation_keys/show.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/show.json.rabl
@@ -4,7 +4,12 @@ attributes :id, :name, :description, :unlimited_content_hosts, :auto_attach
 
 extends 'katello/api/v2/common/org_reference'
 
-attributes :content_view, :content_view_id
+attributes :content_view_id
+
+child :content_view => :content_view do
+  attributes :id, :name
+end
+
 child :environment => :environment do
   attributes :name, :id
 end


### PR DESCRIPTION
The activation key list page was loading slowly because of N+1
queries, this commit eager loads the relevant associations and
thus speeds up the page.

http://projects.theforeman.org/issues/9580
https://bugzilla.redhat.com/show_bug.cgi?id=1196742