### PR TITLE
Fixes #9582: display content tab after content view is loaded BZ1196720.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -27,7 +27,6 @@
 angular.module('Bastion.content-views').controller('ContentViewDetailsController',
     ['$scope', 'ContentView', 'ContentViewVersion', 'AggregateTask', 'translate',
     function ($scope, ContentView, ContentViewVersion, AggregateTask, translate) {
-
         $scope.successMessages = [];
         $scope.errorMessages = [];
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -63,7 +63,7 @@
   </div>
 
   <nav>
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs" ng-show="contentView.$resolved">
       <li ng-class="{active: stateIncludes('content-views.details.version') || stateIncludes('content-views.details.versions')}">
         <a ui-sref="content-views.details.versions" translate>
           Versions


### PR DESCRIPTION
We were displaying the yum content tab before we knew whether ot not
the content view was a composite.  In extreme cases the tab was around
long enough for the user to click on it.  This commit does not show the
tab until the content view has loaded and we can show the correct menu.

http://projects.theforeman.org/issues/9582
https://bugzilla.redhat.com/show_bug.cgi?id=1196720