### PR TITLE
fixes #9585 - speed up enabling redhat repos

### DIFF
--- a/app/lib/katello/util/cdn_var_substitutor.rb
+++ b/app/lib/katello/util/cdn_var_substitutor.rb
@@ -107,7 +107,7 @@ module Katello
         if substituable?(real_path)
           return false
         else
-          is_valid = valid_path?(real_path, 'repodata/') || valid_path?(real_path, 'PULP_MANIFEST')
+          is_valid = valid_path?(real_path, 'repodata/repomd.xml') || valid_path?(real_path, 'PULP_MANIFEST')
           unless is_valid
             @resource.log :error, "No valid metadata files found for #{real_path}"
           end


### PR DESCRIPTION
this fix makes 2 changes:
1.  fetch /repodata/repomd.xml instead of just /repodata/.  The repodata index takes ~10 seconds to render
2.  delay metadata generation into a 2nd task.  This way if long running syncs are running the create will still be short