### PR TITLE
Fixes #9583: improve repository deletion responses BZ 1166365.

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -140,8 +140,7 @@ module Katello
     api :DELETE, "/repositories/:id", N_("Destroy a custom repository")
     param :id, :identifier, :required => true
     def destroy
-      trigger(::Actions::Katello::Repository::Destroy, @repository)
-
+      sync_task(::Actions::Katello::Repository::Destroy, @repository)
       respond_for_destroy
     end
 

--- a/app/lib/katello/api/v2/rendering.rb
+++ b/app/lib/katello/api/v2/rendering.rb
@@ -32,6 +32,11 @@ module Katello
           try_specific_resource_template(options[:template] || params[:action], "async", options)
         end
 
+        def respond_for_bulk_async(options = {})
+          options[:status] ||= 202
+          try_specific_resource_template(options[:template] || params[:action], "bulk_async", options)
+        end
+
         def respond_with_template(action, resource_name, options = {}, &_block)
           yield if block_given?
           status = options[:status] || 200

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -255,11 +255,19 @@ module Katello
       end
 
       def package_group_count
-        self.pulp_repo_facts[:content_unit_counts][:package_group] || 0
+        content_unit_counts = 0
+        if self.pulp_repo_facts
+          content_unit_counts = self.pulp_repo_facts[:content_unit_counts][:package_group]
+        end
+        content_unit_counts
       end
 
       def puppet_module_count
-        self.pulp_repo_facts[:content_unit_counts][:puppet_module] || 0
+        content_unit_counts = 0
+        if self.pulp_repo_facts
+          content_unit_counts = self.pulp_repo_facts[:content_unit_counts][:puppet_module]
+        end
+        content_unit_counts
       end
 
       # remove errata and groups from this repo

--- a/app/views/katello/api/v2/common/bulk_async.json.rabl
+++ b/app/views/katello/api/v2/common/bulk_async.json.rabl
@@ -1,0 +1,7 @@
+object @resource
+
+attributes :errors
+
+node :task do
+  partial('katello/api/v2/tasks/show', :object => @resource.task)
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
@@ -39,9 +39,9 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
         $scope.successMessages = [];
         $scope.errorMessages = [];
 
-
         $scope.checksums = [{name: translate('Default'), id: null}, {id: 'sha256', name: 'sha256'}, {id: 'sha1', name: 'sha1'}];
         $scope.repositoriesTable = repositoriesNutupane.table;
+        $scope.repositoriesTable.removeRow = repositoriesNutupane.removeRow;
         repositoriesNutupane.query();
 
         $scope.syncSelectedRepositories = function () {
@@ -56,21 +56,23 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
         };
 
         $scope.removeSelectedRepositories = function () {
-            var params = getParams(), removalPromise;
+            var params = getParams(), removalPromise, removeSuccess;
+
+            removeSuccess = function (response) {
+                if (response.errors && response.errors.length > 0) {
+                    $scope.warningMessages = response.errors;
+                    $scope.warningTaskId = response.task.id;
+                } else {
+                    $state.go('products.details.tasks.details', {taskId: response.task.id});
+                }
+            };
 
             $scope.removingRepositories = true;
-            removalPromise = RepositoryBulkAction.removeRepositories(params, success, error).$promise;
+            removalPromise = RepositoryBulkAction.removeRepositories(params, removeSuccess, error).$promise;
 
             removalPromise["finally"](function () {
                 repositoriesNutupane.refresh();
                 $scope.removingRepositories = false;
-            });
-        };
-
-        $scope.removeRepository = function (repository) {
-            repositoriesNutupane.removeRow(repository.id);
-            repository.$delete(function () {
-                $scope.transitionTo('products.details.repositories.index', {productId: $scope.$stateParams.productId});
             });
         };
 
@@ -98,13 +100,8 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
             };
         }
 
-        function success(response) {
-            $scope.successMessages = response.displayMessages.success;
-            $scope.errorMessages = response.displayMessages.error;
-        }
-
         function error(response) {
-            $scope.successMessages = response.data.errors;
+            $scope.errorMessages = response.data.errors;
         }
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
@@ -2,6 +2,15 @@
 
 <section class="details details-full">
   <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
+  <div bst-alert="danger" ng-show="warningMessages">
+    <strong translate>There were errors while removing the following Repositories:</strong>
+    <ol>
+      <li data-ng-repeat="message in warningMessages">
+        {{ message }}
+      </li>
+    </ol>
+    <a ui-sref="products.details.tasks.details({taskId: warningTaskId})" translate>Click here to see the task for the successful removals.</a>
+  </div>
   <h4 translate>Repositories</h4>
 
   <input type="text"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
@@ -141,6 +141,22 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
             return $scope.getRepoNonDeletableReason(repo, product) === null;
         };
 
+        $scope.removeRepository = function (repository) {
+            var success, error, repositoryName = repository.name;
+
+            success = function () {
+                $scope.transitionTo('products.details.repositories.index', {productId: $scope.$stateParams.productId});
+                $scope.$parent.successMessages = [translate('Repository "%s" successfully deleted').replace('%s', repositoryName)];
+            };
+
+            error = function error(response) {
+                $scope.errorMessages = response.data.errors;
+            };
+
+            $scope.repositoriesTable.removeRow(repository.id);
+            repository.$delete(success, error);
+        };
+
         $scope.checksumTypeDisplay = function (checksum) {
             if (checksum === null) {
                 checksum = translate('Default');

--- a/engines/bastion_katello/test/products/details/product-repositories.controller.test.js
+++ b/engines/bastion_katello/test/products/details/product-repositories.controller.test.js
@@ -72,16 +72,6 @@ describe('Controller: ProductRepositoriesController', function() {
         expect($scope.repositoriesTable).toBe(expectedTable);
     });
 
-    it('should provide a way to remove a repository', function() {
-        var repository = new Repository();
-        repository.id = 1;
-        spyOn($scope, 'transitionTo');
-
-        $scope.removeRepository(repository);
-
-        expect($scope.transitionTo).toHaveBeenCalled();
-    });
-
     it("provides a way to remove all of the selected repositories in the table", function() {
         spyOn(RepositoryBulkAction, 'removeRepositories').andCallThrough();
 

--- a/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
@@ -12,7 +12,7 @@
  **/
 
 describe('Controller: RepositoryDetailsInfoController', function() {
-    var $scope, $state, translate, Repository;
+    var $scope, $state, translate, repository;
 
     beforeEach(module(
         'Bastion.repositories',
@@ -25,6 +25,8 @@ describe('Controller: RepositoryDetailsInfoController', function() {
             GPGKey = $injector.get('MockResource').$new(),
             Repository = $injector.get('MockResource').$new();
 
+        repository = new Repository();
+
         $scope = $injector.get('$rootScope').$new();
         $state = $injector.get('$state');
         $scope.$stateParams = {
@@ -33,8 +35,9 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         };
 
         $scope.repositoriesTable = {
-            replaceRow: function (row) {}
-        }
+            replaceRow: function (row) {},
+            removeRow: function () {}
+        };
 
         translate = function(message) {
             return message;
@@ -177,5 +180,17 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         repository.product_type = "custom";
         expect($scope.getRepoNonDeletableReason(repository, product)).toBe(null);
         expect($scope.canRemove(repository, product)).toBe(true);
+    });
+
+    it('should provide a way to remove a repository', function() {
+        repository.id = 1;
+
+        spyOn($scope.repositoriesTable, 'removeRow');
+        spyOn($scope, 'transitionTo');
+
+        $scope.removeRepository(repository);
+
+        expect($scope.repositoriesTable.removeRow).toHaveBeenCalledWith(1);
+        expect($scope.transitionTo).toHaveBeenCalledWith('products.details.repositories.index', {productId: 1});
     });
 });

--- a/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
@@ -47,6 +47,10 @@ module Katello
     end
 
     def test_destroy_repositories
+      assert_async_task(::Actions::BulkAction) do |action_class|
+        action_class.must_equal ::Actions::Katello::Repository::Destroy
+      end
+
       put :destroy_repositories, :ids => @repositories.collect(&:id), :organization_id => @organization.id
 
       assert_response :success

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -415,6 +415,10 @@ module Katello
     end
 
     def test_destroy
+      assert_sync_task(::Actions::Katello::Repository::Destroy) do |repo|
+        repo.id == @repository.id
+      end
+
       delete :destroy, :id => @repository.id
 
       assert_response :success


### PR DESCRIPTION
This commit fixes a few issues around repository removal.

When deleting a single repository we were spawning an async task
but not showing the task.  With this commit removing a repository
was changed to be a synchronous task.

When deleting multiple repositories we were creating several async
tasks but not returning any task IDs.  This commit instead creates
a parent task and returns that task to the user.

Also fixed is a ISE caused by referencing [] on nil pulp repo facts.

http://projects.theforeman.org/issues/9583
https://bugzilla.redhat.com/show_bug.cgi?id=1166365