### PR TITLE
Fixes #9608 add repository/puppet module to CV components BZ 1197836.

### DIFF
--- a/app/views/katello/api/v2/content_views/_content_view.json.rabl
+++ b/app/views/katello/api/v2/content_views/_content_view.json.rabl
@@ -55,7 +55,7 @@ node :permissions do |cv|
 end
 
 child :components => :components do
-  attributes :id, :name, :label, :content_view_id, :version
+  attributes :id, :name, :label, :content_view_id, :version, :puppet_module_count
 
   child :environments => :environments do
     attributes :id, :name, :label
@@ -63,6 +63,10 @@ child :components => :components do
 
   child :content_view => :content_view do
     attributes :id, :name, :label, :description, :next_version
+  end
+
+  child :repositories => :repositories do
+    attributes :id, :name, :label, :description
   end
 end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-content-views-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-content-views-list.html
@@ -67,7 +67,7 @@
           </div>
           <div>
             <a ui-sref="content-views.details.puppet-modules.list({contentViewId: contentViewVersion.content_view.id})" translate>
-              {{ contentViewVersion.puppet_modules.length || 0 }} Puppet Modules
+              {{ contentViewVersion.puppet_module_count || 0 }} Puppet Modules
             </a>
           </div>
         </td>


### PR DESCRIPTION
We removed the inclusion of the entire repsoitories rabl in 0603abc in order
to speed up the page but repository and puppet module counts are being used
in the UI and thus need to be included in the rabl.

http://projects.theforeman.org/issues/9608
https://bugzilla.redhat.com/show_bug.cgi?id=1197836