### PR TITLE
refs #8175 - require qpid-dispatch-router

### DIFF
--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -90,6 +90,7 @@ Requires: mongodb-server >= 2.4
 Requires: cyrus-sasl-plain
 Requires: python-crane
 Requires: qpid-cpp-client-devel
+Requires: qpid-dispatch-router
 
 Requires: katello-selinux
 Requires: candlepin-selinux


### PR DESCRIPTION
This is required for the self-registered case, so all deps are downloaded prior to running the installer, which will shut down/restart various services.
