### PR TITLE
Refs #9518, #9310 - Create containers in API using katello repos

### DIFF
--- a/app/models/katello/concerns/container_extensions.rb
+++ b/app/models/katello/concerns/container_extensions.rb
@@ -25,9 +25,9 @@ module Katello
 
       def repository_pull_url_with_katello
         repo_url = repository_pull_url_without_katello
-
-        if self.katello? && self.capsule && Repository.where(:pulp_id => repository_name).count > 0
-          "#{URI(self.capsule.url).hostname}:5000/#{repo_url}"
+        if Repository.where(:pulp_id => repository_name).count > 0
+          image_capsule = self.capsule  || CapsuleContent.default_capsule.capsule
+          "#{URI(image_capsule.url).hostname}:5000/#{repo_url}"
         else
           repo_url
         end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -342,6 +342,10 @@ module Katello
       end
     end
 
+    def container_repository_name
+      pulp_id if docker?
+    end
+
     # TODO: break up method
     # rubocop:disable MethodLength
     def build_clone(options)

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -6,7 +6,7 @@ extends 'katello/api/v2/common/timestamps'
 
 attributes :content_type
 attributes :docker_upstream_name
-attributes :unprotected, :full_path, :checksum_type
+attributes :unprotected, :full_path, :checksum_type, :container_repository_name
 attributes :url,
            :relative_path
 attributes :major, :minor

--- a/test/factories/container_factory.rb
+++ b/test/factories/container_factory.rb
@@ -4,6 +4,5 @@ FactoryGirl.define do
     association :compute_resource, :factory => :docker_stuff
     sequence(:repository_name) { |n| "katello_repo#{n}" }
     sequence(:tag) { |n| "katello_tag#{n}" }
-    katello true
   end
 end

--- a/test/models/concerns/container_extensions_test.rb
+++ b/test/models/concerns/container_extensions_test.rb
@@ -29,5 +29,19 @@ module Katello
       url = @container.repository_pull_url
       assert_equal "#{hostname}:5000/#{@container.repository_name}:#{@container.tag}", url
     end
+
+    def test_container_repo_url_no_capsule
+      counter = OpenStruct.new(:count => 1)
+      hostname = "www.redhat-registry.com"
+      default_capsule = mock
+      CapsuleContent.expects(:default_capsule).returns(default_capsule)
+      capsule = mock
+      capsule.expects(:url => "http://" + hostname + ":8000")
+      default_capsule.expects(:capsule).returns(capsule)
+      @container.stubs(:capsule).returns
+      Repository.expects(:where).with(:pulp_id => @container.repository_name).returns(counter)
+      url = @container.repository_pull_url
+      assert_equal "#{hostname}:5000/#{@container.repository_name}:#{@container.tag}", url
+    end
   end
 end


### PR DESCRIPTION
Also includes a couple of changes to show the container image name for a docker repository. Users can use this value in the hammer docker container create command.
