### PR TITLE
Fixes #9610 - Docker Content now hidden for composite cv

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -104,7 +104,8 @@
         </a>
       </li>
 
-      <li ng-class="{active: stateIncludes('content-views.details.repositories.docker')}">
+      <li ng-class="{active: stateIncludes('content-views.details.repositories.docker')}"
+          ng-hide="contentView.composite">
         <a ui-sref="content-views.details.repositories.docker.list" translate>
           Docker Content
         </a>


### PR DESCRIPTION
Composite CV page wrongly showed the Docker Content tab
even though the content for the composite should themselves
come from the individual content views.
This commit addresses that issue by hiding Docker Content tab
if a cv is composite