### PR TITLE
fixes #9647 - speed up puppet class import

### DIFF
--- a/app/lib/katello/foreman.rb
+++ b/app/lib/katello/foreman.rb
@@ -32,9 +32,8 @@ module Katello
           foreman_environment.save!
         end
 
-        host = Facter.value(:fqdn) || SETTINGS[:fqdn]
-        if (foreman_smart_proxy = SmartProxy.find_by_name(host))
-          PuppetClassImporter.new(:url => foreman_smart_proxy.url).update_environment(foreman_environment)
+        if (foreman_smart_proxy = SmartProxy.default_capsule)
+          PuppetClassImporter.new(:url => foreman_smart_proxy.url, :env => foreman_environment.name).update_environment
         end
       end
     end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -50,6 +50,10 @@ module Katello
                               :inverse_of => :content_source
 
         scope :with_content, with_features(PULP_FEATURE, PULP_NODE_FEATURE)
+
+        def self.default_capsule
+          with_features(PULP_FEATURE).first
+        end
       end
 
       def default_capsule?

--- a/app/services/katello/puppet_class_importer_extensions.rb
+++ b/app/services/katello/puppet_class_importer_extensions.rb
@@ -17,18 +17,18 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
-        def update_environment(environment)
+        def update_environment
           change_types = %w(new obsolete updated)
           changed  = self.changes
 
           change_types.each do |kind|
-            changed[kind].slice!(environment.name) unless changed[kind].empty?
+            changed[kind].slice!(@environment) unless changed[kind].empty?
           end
 
           #prevent the puppet environment from being deleted, by removing special '_destroy_' String
-          if changed['obsolete'][environment.name]
-            changed['obsolete'][environment.name] =
-              changed['obsolete'][environment.name].select { |klass| klass != '_destroy_' }
+          if changed['obsolete'][@environment]
+            changed['obsolete'][@environment] =
+              changed['obsolete'][@environment].select { |klass| klass != '_destroy_' }
           end
 
           # PuppetClassImporter expects [kind][env] to be in json format


### PR DESCRIPTION
this only imports puppet classes from the relevant puppet env on publish/promote
speeding up publish and promote a good deal when you have a large number of environments
also change the logic for looking up default capsule in this operation