### PR TITLE
Fixes #9658: correct CH count when applying errata, BZ1198815.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -64,7 +64,9 @@ angular.module('Bastion.errata').controller('ErrataContentHostsController',
         };
 
         $scope.goToNextStep = function () {
+            $scope.$parent.numberOfContentHostsToUpdate = nutupane.table.allResultsSelectCount();
             $scope.$parent.selectedContentHosts = nutupane.getAllSelectedResults();
+
             if ($scope.errata) {
                 $scope.transitionTo('errata.details.apply', {errataId: $scope.errata.id});
             } else {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -22,10 +22,10 @@
 
   <section ng-hide="updates">
     <p translate ng-show="errata">
-      Apply {{ errata.errata_id }} to {{ selectedContentHosts.included.ids.length }} Content Host(s)?
+      Apply {{ errata.errata_id }} to {{ numberOfContentHostsToUpdate }} Content Host(s)?
     </p>
     <p translate ng-hide="errata">
-      Apply {{ errataIds.length }} Errata to {{ selectedContentHosts.included.ids.length }} Content Host(s)?
+      Apply {{ errataIds.length }} Errata to {{ numberOfContentHostsToUpdate }} Content Host(s)?
     </p>
   </section>
 

--- a/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
@@ -28,7 +28,8 @@ describe('Controller: ErrataContentHostsController', function() {
         Nutupane = function() {
             this.table = {
                 params: {},
-                showColumns: function () {}
+                showColumns: function () {},
+                allResultsSelectCount: function () {}
             };
             this.enableSelectAllResults = function () {};
             this.getAllSelectedResults = function () {


### PR DESCRIPTION
We were displaying the wrong number of content hosts on the apply page when
you selected all content hosts.  This commit fixes the displayed count.

http://projects.theforeman.org/issues/9658
https://bugzilla.redhat.com/show_bug.cgi?id=1198815