### PR TITLE
fixes #9182 - add newpackage type + icons

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-errata.html
@@ -38,6 +38,10 @@
             <i class="fa fa-plus-square inline-icon" title="{{ 'Enhancement' | translate }}"></i>
           </span>
 
+          <span ng-show="errata.type == 'newpackage'">
+            <i class="fa fa-th-large inline-icon" title="{{ 'New Package' | translate }}"></i>
+          </span>
+
         {{ errata.type }}
         <span ng-show="errata.severity">- {{ errata.severity }}</span>
       </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
@@ -49,6 +49,10 @@
               <i class="fa fa-plus-square inline-icon" title="{{ 'Enhancement' | translate }}"></i>
             </span>
 
+            <span ng-show="errata.type == 'newpackage'">
+              <i class="fa fa-th-large inline-icon" title="{{ 'New Package' | translate }}"></i>
+            </span>
+
           {{ errata.type | errataType}}
           <span ng-show="errata.severity">- {{ errata.severity | errataSeverity}}</span>
         </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-type.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-type.filter.js
@@ -37,6 +37,9 @@ angular.module('Bastion.errata').filter('errataType', ['translate', function (tr
         case 'security':
             errataType = translate('Security Advisory');
             break;
+        case 'newpackage':
+            errataType = translate('New Package Advisory');
+            break;
         default:
             errataType = type;
         }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-table-full.html
@@ -33,6 +33,10 @@
             <i class="fa fa-plus-square inline-icon" title="{{ 'Enhancement' | translate }}"></i>
           </span>
 
+          <span ng-show="errata.type == 'newpackage'">
+            <i class="fa fa-th-large inline-icon" title="{{ 'New Package' | translate }}"></i>
+          </span>
+
         {{ errata.type | errataType}}
         <span ng-show="errata.severity">- {{ errata.severity | errataSeverity}}</span>
       </td>

--- a/engines/bastion_katello/test/errata/errata-type.filter.test.js
+++ b/engines/bastion_katello/test/errata/errata-type.filter.test.js
@@ -35,6 +35,10 @@ describe('Filter:errataType', function() {
         expect(filter('security')).toBe('Security Advisory');
     });
 
+    it("returns 'New Package Advisory' if newpackage.", function() {
+        expect(filter('newpackage')).toBe('New Package Advisory');
+    });
+
     it("returns provided type if not found.", function() {
         expect(filter('blah')).toBe('blah');
     });


### PR DESCRIPTION
Fedora and EPEL both have an erratum type commonly used called 'newpackage'. I don't think it needs to really be displayed elsewhere, but considering most people sync EPEL, and maybe some sync Fedora, it's nice to have the icon and formatted name for it.

This is the icon I picked - it kind of looks like a package to me (well, more than anything else available). http://fortawesome.github.io/Font-Awesome/icon/th-large/


![errata](https://cloud.githubusercontent.com/assets/429763/6512733/5eb76dca-c376-11e4-8774-59ecaa3f43c1.png)
