### PR TITLE
fixes #9462,#9557,#9556 - various inherited hostgroup issues

### DIFF
--- a/app/assets/javascripts/katello/hosts/activation_key_edit.js
+++ b/app/assets/javascripts/katello/hosts/activation_key_edit.js
@@ -58,11 +58,19 @@ function ktHideParams() {
 }
 
 function getSelectedEnvId() {
-  return $("#hostgroup_lifecycle_environment_id").val();
+    var dataId = $("#hostgroup_lifecycle_environment_id > option:selected").data("id");
+    if (dataId === undefined) {
+        dataId = $("#hostgroup_lifecycle_environment_id").val();
+    }
+    return dataId;
 }
 
 function getSelectedContentViewId() {
-  return $("#hostgroup_content_view_id").val();
+    var dataId = $("#hostgroup_content_view_id > option:selected").data("id");
+    if (dataId === undefined) {
+        dataId = $("#hostgroup_content_view_id").val();
+    }
+    return dataId;
 }
 
 function ktSetParam(name, value) {

--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -83,7 +83,8 @@ KT.hosts.getContentViewSelect = function() {
 };
 
 KT.hosts.getSelectedContentView = function() {
-    return KT.hosts.getContentViewSelect().val();
+    var select = KT.hosts.getContentViewSelect();
+    return select.val() || select.find("option:selected").data("id");
 };
 
 KT.hosts.getSelectedEnvironment = function () {
@@ -91,6 +92,10 @@ KT.hosts.getSelectedEnvironment = function () {
     if(envId === undefined || envId.length === 0) {
         envId = $("#host_lifecycle_environment_id").val()
     }
+    if(envId === undefined || envId.length === 0) {
+        envId = $("#hostgroup_lifecycle_environment_id > option:selected").data("id");
+    }
+
     if(envId && envId.length === 0) {
         envId = undefined;
     }
@@ -108,6 +113,7 @@ KT.hosts.onKatelloHostEditLoad = function(){
             });
         });
     });
+    KT.hosts.toggle_installation_medium();
 };
 
 
@@ -116,14 +122,14 @@ KT.hosts.toggle_installation_medium = function() {
 
 
     if ($('#hostgroup_parent_id').length > 0) {
-      lifecycle_environment_id = $('#hostgroup_lifecycle_environment_id').val();
-      content_view_id = $('#hostgroup_content_view_id').val();
+      lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
+      content_view_id = KT.hosts.getSelectedContentView();
       content_source_id = $('#hostgroup_content_source_id').val();
       architecture_id = $('#hostgroup_architecture_id').val();
       operatingsystem_id = $('#hostgroup_operatingsystem_id').val();
     } else {
-      lifecycle_environment_id = $('#host_lifecycle_environment_id').val();
-      content_view_id = $('#host_content_view_id').val();
+      lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
+      content_view_id = KT.hosts.getSelectedContentView();
       content_source_id = $('#host_content_source_id').val();
       architecture_id = $('#host_architecture_id').val();
       operatingsystem_id = $('#host_operatingsystem_id').val();

--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -123,7 +123,7 @@ module Katello
       ids = params[:product_ids]
       @products  = Product.where(:id => ids).editable
       @sync_plan.product_ids = (@sync_plan.product_ids + @products.collect { |p| p.id }).uniq
-      @sync_plan.save!
+      sync_task(::Actions::Katello::SyncPlan::UpdateProducts, @sync_plan)
       respond_for_show
     end
 
@@ -134,7 +134,7 @@ module Katello
       ids = params[:product_ids]
       @products  = Product.where(:id => ids).editable
       @sync_plan.product_ids = (@sync_plan.product_ids - @products.collect { |p| p.id }).uniq
-      @sync_plan.save!
+      sync_task(::Actions::Katello::SyncPlan::UpdateProducts, @sync_plan)
       respond_for_show
     end
 

--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -19,7 +19,7 @@ module Katello
     def blank_or_inherit_with_id(f, attr)
       return true unless f.object.respond_to?(:parent_id) && f.object.parent_id
       inherited_value  = f.object.send(attr).try(:id) || ''
-      %(<option data-id="#{inherited_value}">#{blank_or_inherit_f(f, attr)}</option>)
+      %(<option data-id="#{inherited_value}" value="">#{blank_or_inherit_f(f, attr)}</option>)
     end
 
     def envs_by_kt_org
@@ -70,7 +70,7 @@ module Katello
         views = [host.content_view]
       end
       view_options = views.map do |view|
-        selected = host.content_view == view ? 'selected' : ''
+        selected = host[:content_view_id] == view.id ? 'selected' : ''
         %(<option #{selected} value="#{view.id}">#{h(view.name)}</option>)
       end
       view_options = view_options.join

--- a/app/lib/actions/katello/sync_plan/update_products.rb
+++ b/app/lib/actions/katello/sync_plan/update_products.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Katello
+    module SyncPlan
+      class UpdateProducts < Actions::EntryAction
+        def plan(sync_plan)
+          action_subject(sync_plan)
+          sync_plan.save!
+          sync_plan.products.each do |product|
+            plan_action(::Actions::Katello::Product::Update, product, :sync_plan_id => sync_plan.id)
+          end
+        end
+
+        def humanized_name
+          _("Update Sync Plan Products")
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -29,18 +29,18 @@ module Katello
       end
 
       def content_view
-        return super unless ancestry.present?
+        return super if ancestry.nil? || self.content_view_id.present?
         Katello::ContentView.find_by_id(inherited_content_view_id)
       end
 
       def lifecycle_environment
-        return super unless ancestry.present?
+        return super if ancestry.nil? || self.lifecycle_environment_id.present?
         Katello::KTEnvironment.find_by_id(inherited_lifecycle_environment_id)
       end
 
       # instead of calling nested_attribute_for(:content_source_id) in Foreman, define the methods explictedly
       def content_source
-        return super unless ancestry.present?
+        return super if ancestry.nil? || self.content_source_id.present?
         SmartProxy.find_by_id(inherited_content_source_id)
       end
 

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -37,19 +37,10 @@ module Katello
     validate :validate_sync_date
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
-    before_save :reassign_sync_plan_to_products
-
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true
     scoped_search :on => :interval, :complete_value => true
     scoped_search :on => :enabled, :complete_value => true
-
-    def reassign_sync_plan_to_products
-      # triggers orchestration in products
-      self.products.each do |product|
-        ::ForemanTasks.sync_task(::Actions::Katello::Product::Update, product, :sync_plan_id => self.id)
-      end
-    end
 
     def validate_sync_date
       errors.add :base, _("Start Date and Time can't be blank") if self.sync_date.nil?

--- a/test/actions/katello/sync_plan_test.rb
+++ b/test/actions/katello/sync_plan_test.rb
@@ -1,0 +1,39 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'katello_test_helper'
+
+module ::Actions::Katello::SyncPlan
+  class TestBase < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::RemoteAction
+    include Support::Actions::Fixtures
+    include FactoryGirl::Syntax::Methods
+
+    let(:action) { create_action action_class }
+    let(:sync_plan) { Katello::SyncPlan.find(katello_sync_plans(:sync_plan_hourly)) }
+    let(:product) { Katello::Product.find(katello_products(:redhat)) }
+  end
+
+  class CreateTest < TestBase
+    let(:action_class) { ::Actions::Katello::SyncPlan::UpdateProducts }
+
+    it 'plans' do
+      sync_plan.expects(:save!)
+      action.expects(:action_subject)
+      sync_plan.products << product
+
+      plan_action action, sync_plan
+      assert_action_planed_with(action, ::Actions::Katello::Product::Update, product, :sync_plan_id => sync_plan.id)
+    end
+  end
+end

--- a/test/controllers/api/v2/sync_plans_controller_test.rb
+++ b/test/controllers/api/v2/sync_plans_controller_test.rb
@@ -25,7 +25,7 @@ module Katello
 
     def models
       @organization = get_organization
-      @sync_plan = katello_sync_plans(:sync_plan_hourly)
+      @sync_plan = Katello::SyncPlan.find(katello_sync_plans(:sync_plan_hourly))
       @products = katello_products(:fedora, :redhat, :empty_product)
     end
 
@@ -152,12 +152,7 @@ module Katello
     end
 
     def test_add_products
-      @products.each do |product|
-        ::ForemanTasks.expects(:sync_task).
-          with(::Actions::Katello::Product::Update,
-               product,
-               :sync_plan_id => @sync_plan.id)
-      end
+      ::ForemanTasks.expects(:sync_task).with(::Actions::Katello::SyncPlan::UpdateProducts, @sync_plan)
 
       put :add_products, :id => @sync_plan.id, :organization_id => @organization.id,
           :product_ids => @products.collect { |p| p.id }

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -55,6 +55,22 @@ module Katello
       assert_equal @view, @root.content_view
     end
 
+    def test_inherited_content_view_with_ancestry_nill
+      @child.content_view = @view
+      @child.save!
+
+      assert_equal @view, @child.content_view
+      assert_equal nil, @root.content_view
+    end
+
+    def test_inherited_lifecycle_environment_with_ancestry_nil
+      @child.lifecycle_environment = @library
+      @child.save!
+
+      assert_equal @library, @child.lifecycle_environment
+      assert_equal nil, @root.lifecycle_environment
+    end
+
     def test_content_and_puppet_match?
       @root.content_view = @view
       @root.lifecycle_environment = @library


### PR DESCRIPTION
this commit fixes:
* Error "unable to load activation keys" on initial host group load
* Error "host group not found" when trying to update/save a host group with a parent
* Install Media Url not using inherited cv and lifecycle env