### PR TITLE
Fixes #9688 - Uses cdn url scheme for docker repo feeds

### DIFF
--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -228,8 +228,9 @@ module Katello
       end
 
       def feed_url
+        cdn_uri = URI.parse(product.provider.repository_url)
         docker_repo_uri =  URI.parse(registry["url"])
-        docker_repo_uri =  URI.parse("https://" + registry["url"]) unless docker_repo_uri.host
+        docker_repo_uri =  URI.parse("#{cdn_uri.scheme}://#{registry['url']}") unless docker_repo_uri.host
         "#{docker_repo_uri.scheme}://#{docker_repo_uri.host}:#{docker_repo_uri.port}"
       end
 


### PR DESCRIPTION
Basically we need some code that says if cdn uses http, then make the
upstram feed url also http else use https. We are assuming the cdn's
protocol scheme and redhats registrys proto schemes are identical.