### PR TITLE
Fixes #9697: use appropriate styling for AK CH table, BZ 1199584.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -1,12 +1,16 @@
 <span page-title ng-model="activationKey">{{ 'Content Hosts for Activation Key:' | translate }} {{ activationKey.name }}</span>
 
-<div class="details details-full">
+<div class="nutupane">
 
   <h3 translate>
     Attached to Content Hosts
   </h3>
 
-  <table class="table table-striped" bst-table="table" ng-class="{'table-mask': table.working}">
+  <div ng-show="!table.working && contentHosts.length === 0">
+    <td colspan="6" translate>This activation key is not associated with any content hosts.</td>
+  </div>
+
+  <table class="table table-bordered table-striped" bst-table="table" ng-show="contentHosts.length > 0" ng-class="{'table-mask': table.working}">
     <thead>
       <tr bst-table-head>
         <th bst-table-column="name" sortable><span translate>Name</span></th>
@@ -21,10 +25,6 @@
     </thead>
 
     <tbody>
-      <tr ng-show="!table.working && contentHosts.length === 0">
-        <td colspan="6" translate>This activation key is not associated with any content hosts.</td>
-      </tr>
-
       <tr bst-table-row ng-repeat="contentHost in contentHosts"
           ng-controller="ContentHostStatusController">
         <td bst-table-cell>


### PR DESCRIPTION
We were using incorrect styling for the Activation Key Content Host
association table and thus causing long hostnames to overlap the
column next to them.  This commit fixes the styling so there is no
overlap.

http://projects.theforeman.org/issues/9697
https://bugzilla.redhat.com/show_bug.cgi?id=1199584