### PR TITLE
Fixes #9698: use correct styling for association tables, BZ 1199626.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -1,12 +1,16 @@
 <span page-title ng-model="activationKey">{{ 'Content Hosts for Activation Key:' | translate }} {{ activationKey.name }}</span>
 
-<div class="details details-full">
+<div class="nutupane">
 
   <h3 translate>
     Attached to Content Hosts
   </h3>
 
-  <table class="table table-striped" bst-table="table" ng-class="{'table-mask': table.working}">
+  <div bst-alert="info" ng-show="!table.working && contentHosts.length === 0">
+    <span translate>This activation key is not associated with any content hosts.</span>
+  </div>
+
+  <table class="table table-bordered table-striped" bst-table="table" ng-show="contentHosts.length > 0" ng-class="{'table-mask': table.working}">
     <thead>
       <tr bst-table-head>
         <th bst-table-column="name" sortable><span translate>Name</span></th>
@@ -21,10 +25,6 @@
     </thead>
 
     <tbody>
-      <tr ng-show="!table.working && contentHosts.length === 0">
-        <td colspan="6" translate>This activation key is not associated with any content hosts.</td>
-      </tr>
-
       <tr bst-table-row ng-repeat="contentHost in contentHosts"
           ng-controller="ContentHostStatusController">
         <td bst-table-cell>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-activation-keys.html
@@ -1,12 +1,16 @@
 <span page-title ng-model="subscription">{{ 'Activation Keys for Subscription:' | translate }} {{ subscription.product_name }}</span>
 
-<div class="details details-full">
+<div class="nutupane">
 
   <h3 translate>
     Included in Activation Keys
   </h3>
 
-  <table class="table table-striped" bst-table="table" ng-class="{'table-mask': working}">
+  <div bst-alert="info" ng-show="!working && activationKeys.length === 0">
+    <span translate>This subscription is not associated with any activation keys.</span>
+  </div>
+
+  <table class="table table-bordered table-striped" bst-table="table" ng-show="activationKeys.length > 0" ng-class="{'table-mask': working}">
     <thead>
       <tr bst-table-head>
         <th bst-table-column="name" sortable><span translate>Name</span></th>
@@ -18,10 +22,6 @@
     </thead>
 
     <tbody>
-      <tr ng-show="!working && activationKeys.length === 0">
-        <td colspan="5" translate>This subscription is not associated with any activation keys.</td>
-      </tr>
-
       <tr ng-show="working">
         <td colspan="5" translate>
           <div class="loading-mask fa-3x" ng-show="working">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-content-hosts.html
@@ -1,12 +1,16 @@
 <span page-title ng-model="subscription">{{ 'Content Hosts for Subscription:' | translate }} {{ subscription.name }}</span>
 
-<div class="details details-full">
+<div class="nutupane">
 
   <h3 translate>
     Attached to Content Hosts
   </h3>
 
-  <table class="table table-striped" bst-table="table" ng-class="{'table-mask': working}">
+  <div bst-alert="info" ng-show="!working && contentHosts.length === 0">
+    <span translate>This subscription is not attached to any content hosts.</span>
+  </div>
+
+  <table class="table table-bordered table-striped" bst-table="table" ng-show="contentHosts.length > 0" ng-class="{'table-mask': working}">
     <thead>
       <tr bst-table-head>
         <th bst-table-column="name" sortable><span translate>Name</span></th>
@@ -24,10 +28,6 @@
     </thead>
 
     <tbody>
-      <tr ng-show="!working && contentHosts.length === 0">
-        <td colspan="9" translate>This subscription is not attached to any content hosts.</td>
-      </tr>
-
       <tr ng-show="working">
         <td colspan="9" translate>
           <div class="loading-mask fa-3x" ng-show="working">


### PR DESCRIPTION
We were using incorrect styling for the Activation Key Content Host
association table and the Subscription association tables and thus
causing long names to overlap the column next to them. This commit
fixes the styling so there is no overlap.

http://projects.theforeman.org/issues/9698
https://bugzilla.redhat.com/show_bug.cgi?id=1199626