### PR TITLE
Refs #8710 - katello-debug script is no longer a symlink

### DIFF
--- a/deploy/katello.spec
+++ b/deploy/katello.spec
@@ -89,11 +89,12 @@ install -p -m0644 etc/service-list %{buildroot}%{_sysconfdir}/%{name}/
 #create symlinks for important scripts
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_sbindir}
-mkdir -p %{buildroot}/usr/share/foreman/script/foreman-debug.d/
-ln -sv %{homedir}/script/katello-debug.sh %{buildroot}/usr/share/foreman/script/foreman-debug.d/katello-debug.sh
 ln -sv %{homedir}/script/katello-remove %{buildroot}%{_bindir}/katello-remove
 ln -sv %{homedir}/script/katello-service %{buildroot}%{_bindir}/katello-service
 ln -sv %{homedir}/script/service-wait %{buildroot}%{_sbindir}/service-wait
+
+#foreman-debug must not be a symlink
+install -Dp -m0755 script/katello-debug.sh %{buildroot}/usr/share/foreman/script/foreman-debug.d/katello-debug.sh
 
 chmod +x %{buildroot}%{homedir}/script/*
 

--- a/deploy/script/katello-debug.sh
+++ b/deploy/script/katello-debug.sh
@@ -20,55 +20,55 @@ add_cmd "find /root/ssl-build -ls | sort -k 11" "katello_ssl_build_dir"
 add_cmd "find /etc/pki -ls | sort -k 11" "katello_pki_dir"
 
 # Katello
-add_files "/etc/pulp/server/plugins.d/*"
-add_files "/etc/foreman/plugins/katello.yaml"
+add_files /etc/pulp/server/plugins.d/*
+add_files /etc/foreman/plugins/katello.yaml
 
 # Splice
-add_files "/var/log/splice/*"
-add_files "/etc/splice/*"
-add_files "/etc/httpd/conf.d/splice.conf"
+add_files /var/log/splice/*
+add_files /etc/splice/*
+add_files /etc/httpd/conf.d/splice.conf
 
 # Candlepin
-add_files "/var/log/candlepin/*"
-add_files "/var/log/tomcat6/*"
-add_files "/var/log/tomcat/*"
-add_files "/etc/candlepin/candlepin.conf"
-add_files "/etc/tomcat6/server.xml"
-add_files "/etc/tomcat/server.xml"
+add_files /var/log/candlepin/*
+add_files /var/log/tomcat6/*
+add_files /var/log/tomcat/*
+add_files /etc/candlepin/candlepin.conf
+add_files /etc/tomcat6/server.xml
+add_files /etc/tomcat/server.xml
 
 # Elastic Search
-add_files "/var/log/elasticsearch/*"
-add_files "/etc/elasticsearch/*"
+add_files /var/log/elasticsearch/*
+add_files /etc/elasticsearch/*
 
 # Pulp
-add_files "/etc/pulp/*.conf"
-add_files "/etc/httpd/conf.d/pulp.conf"
-add_files "/etc/pulp/server/plugins.conf.d/nodes/distributor/*"
+add_files /etc/pulp/*.conf
+add_files /etc/httpd/conf.d/pulp.conf
+add_files /etc/pulp/server/plugins.conf.d/nodes/distributor/*
 
 # MongoDB (*)
 if [ $NOGENERIC -eq 0 ]; then
-  add_files "/var/log/mongodb/*"
-  add_files "/var/lib/mongodb/mongodb.log*"
+  add_files /var/log/mongodb/*
+  add_files /var/lib/mongodb/mongodb.log*
 fi
 
 # Qpidd (*)
 if [ $NOGENERIC -eq 0 ]; then
-  add_files "/etc/qpid/*"
-  add_files "/etc/qpidd.conf"
+  add_files /etc/qpid/*
+  add_files /etc/qpidd.conf
 fi
 
 # Gofer
-add_files "/etc/gofer"
-add_files "/var/log/gofer"
+add_files /etc/gofer
+add_files /var/log/gofer
 
 # FreeIPA (*)
 if [ $NOGENERIC -eq 0 ]; then
-  add_files "/var/log/ipa*-install.log"
-  add_files "/var/log/ipaupgrade.log"
-  add_files "/var/log/dirsrv/slapd-*/logs/access"
-  add_files "/var/log/dirsrv/slapd-*/logs/errors"
-  add_files "/etc/dirsrv/slapd-*/dse.ldif"
-  add_files "/etc/dirsrv/slapd-*/schema/99user.ldif"
+  add_files /var/log/ipa*-install.log
+  add_files /var/log/ipaupgrade.log
+  add_files /var/log/dirsrv/slapd-*/logs/access
+  add_files /var/log/dirsrv/slapd-*/logs/errors
+  add_files /etc/dirsrv/slapd-*/dse.ldif
+  add_files /etc/dirsrv/slapd-*/schema/99user.ldif
 fi
 
 # Legend:


### PR DESCRIPTION
Additional fix for https://github.com/Katello/katello/pull/4970

Scratch: http://koji.katello.org/koji/taskinfo?taskID=232535

This must not be symlink into katello.rpm because on capsules katello.rpm is
not even installed.