### PR TITLE
Fixes #9697: hide confirmation after bulk action or cancel, BZ 1199584.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action.controller.js
@@ -30,6 +30,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionContro
     function ($scope, $q, $location, translate, ContentHostBulkAction, CurrentOrganization) {
         $scope.successMessages = [];
         $scope.errorMessages = [];
+        $scope.showConfirm = false;
 
         $scope.unregisterContentHosts = {
             confirm: false,
@@ -46,6 +47,14 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionContro
             $scope.state.working = working;
             $scope.state.successMessages = success;
             $scope.state.errorMessages = errors;
+        };
+
+        $scope.showConfirmDialog = function () {
+            $scope.showConfirm = true;
+        };
+
+        $scope.hideConfirmDialog = function () {
+            $scope.showConfirm = false;
         };
 
         $scope.actionParams = {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-environment.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-environment.html
@@ -4,12 +4,12 @@
   <section>
     <h4 translate>Assign Environment and Content View</h4>
 
-    <div bst-alert="info" ng-show="confirm">
+    <div bst-alert="info" ng-show="showConfirm">
       <p translate>
         Are you sure you want to assign the {{ table.numSelected }} content host(s) selected to {{ selected.contentView.name }} in {{ selected.environment.name }}?
       </p>
-      <button class="btn btn-default" ng-click="confirm = false" translate>No</button>
-      <button class="btn btn-default" ng-click="confirm = false; performAction()" translate>Yes</button>
+      <button class="btn btn-default" ng-click="hideConfirmDialog();" translate>No</button>
+      <button class="btn btn-default" ng-click="hideConfirmDialog(); performAction()" translate>Yes</button>
     </div>
 
     <div path-selector="environments"
@@ -42,7 +42,7 @@
       <button class="btn btn-default fr"
               translate
               ng-hide="denied('edit_content_hosts', contentHost)"
-              ng-click="confirm = true"
+              ng-click="showConfirmDialog();"
               ng-disabled="disableAssignButton(confirm)">
         Assign
       </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
@@ -2,12 +2,12 @@
 
 <section>
 
-  <div bst-alert="info" ng-show="confirm">
+  <div bst-alert="info" ng-show="showConfirm">
     <p translate>
       Are you sure you want to apply the {{ detailsTable.numSelected }} selected errata to the content hosts chosen?
     </p>
-    <button class="btn btn-default" ng-click="confirm = false; detailsTable.working = false" translate>No</button>
-    <button class="btn btn-default" ng-click="confirm = false; installErrata()" translate>Yes</button>
+    <button class="btn btn-default" ng-click="hideConfirmDialog(); detailsTable.working = false" translate>No</button>
+    <button class="btn btn-default" ng-click="hideConfirmDialog(); installErrata()" translate>Yes</button>
   </div>
 
   <div bst-alert="warning" ng-show="outOfDate && table.numSelected > 0">
@@ -34,7 +34,7 @@
 
       <button class="btn btn-primary"
               ng-disabled="table.numSelected === 0 || detailsTable.working || detailsTable.numSelected === 0"
-              ng-click="confirm = true">
+              ng-click="showConfirmDialog()">
         <i class="fa fa-plus"></i>
         {{ "Install Selected" | translate }}
       </button>

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action.controller.test.js
@@ -67,5 +67,18 @@ describe('Controller: ContentHostsBulkActionController', function() {
         );
     });
 
+    it("defaults showConfirm to false", function () {
+        expect($scope.showConfirm).toBe(false);
+    });
 
+    it("provides a way to show a confirmation dialog", function () {
+        $scope.showConfirmDialog();
+        expect($scope.showConfirm).toBe(true);
+    });
+
+    it("provides a way to hide a confirmation dialog", function () {
+        $scope.showConfirmDialog();
+        $scope.hideConfirmDialog();
+        expect($scope.showConfirm).toBe(false);
+    });
 });


### PR DESCRIPTION
The bulk action environment and errata actions were not hiding the
confirmation dialog after performing the action or cancelling.  This
commit fixes the issue.

http://projects.theforeman.org/issues/9697
https://bugzilla.redhat.com/show_bug.cgi?id=1199584