### PR TITLE
Fixes #9741 - Fixed a puppet module count error in a CVV

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -186,7 +186,8 @@ module Katello
     end
 
     def puppet_module_count
-      PuppetModule.module_count([self.archive_puppet_environment])
+      env = self.archive_puppet_environment
+      env.nil? ? 0 : PuppetModule.module_count([env])
     end
 
     def package_count


### PR DESCRIPTION
A nil reference error was being raised when one requested the puppet
module count in a content view version if there were contnet view puppet
environments associated to it. This commit fixes that by checking for
the nil case.