### PR TITLE
Fixes #9737: fix CH filter for incremental update, BZ 1200441. 

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -71,7 +71,7 @@ module Katello
         errata_ids = params.fetch(:errata_ids, [])
         errata_ids << params[:erratum_id] if params[:erratum_id]
         systems = systems_by_errata(errata_ids, params[:erratum_restrict_installable],
-            params[:erratum_restrict_non_installable]).readable
+            params[:erratum_restrict_non_installable])
       else
         systems = System.readable
       end
@@ -418,11 +418,11 @@ module Katello
       end
 
       if installable
-        System.with_installable_errata(errata)
+        System.readable.with_installable_errata(errata)
       elsif non_installable
-        System.with_non_installable_errata(errata)
+        System.readable.with_non_installable_errata(errata)
       else
-        System.with_applicable_errata(errata)
+        System.readable.with_applicable_errata(errata)
       end
     end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -52,8 +52,8 @@ angular.module('Bastion.errata').controller('ErrataContentHostsController',
             $scope.environments = response.results;
         });
 
-        $scope.toggleAvailable = function () {
-            nutupane.table.params['erratum_restrict_available'] = $scope.errata.showAvailable;
+        $scope.toggleInstallable = function () {
+            nutupane.table.params['erratum_restrict_installable'] = $scope.errata.showInstallable;
             nutupane.refresh();
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -21,8 +21,8 @@
       <div>
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="errata.showAvailable" ng-change="toggleAvailable()"/>
-            <span translate>Only show content hosts where {{ errata.title }} is currently available in the host's Lifecycle Environment.</span>
+            <input type="checkbox" ng-model="errata.showInstallable" ng-change="toggleInstallable()"/>
+            <span translate>Only show content hosts where {{ errata.title }} is currently installable in the host's Lifecycle Environment.</span>
           </label>
         </div>
       </div>

--- a/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
@@ -81,11 +81,11 @@ describe('Controller: ErrataContentHostsController', function() {
 
     it("allows the filtering of installable errata only", function () {
         $scope.errata = {
-            showAvailable: true
+            showInstallable: true
         };
         
-        $scope.toggleAvailable();
-        expect($scope.detailsTable.params['erratum_restrict_available']).toBe(true)
+        $scope.toggleInstallable();
+        expect($scope.detailsTable.params['erratum_restrict_installable']).toBe(true)
     });
 
     it("provides a way to filter on environment", function () {


### PR DESCRIPTION
There were a couple of issues with the Content Host filtering on
the incremental update content host selection page.  Firstly, the
incorrect parameter was being sent and secondly we were returning
all readable systems regardless of the filter.  This commit fixes
both issues.

http://projects.theforeman.org/issues/9729
https://bugzilla.redhat.com/show_bug.cgi?id=1200441