### PR TITLE
fixes #9750 - always reindex errata packages

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -96,9 +96,8 @@ module Katello
           update_bugzillas(json['references'].select { |r| r['type'] == 'bugzilla' })
           update_cves(json['references'].select { |r| r['type'] == 'cve' })
         end
-
-        update_packages(json['pkglist']) unless json['pkglist'].blank?
       end
+      update_packages(json['pkglist']) unless json['pkglist'].blank?
     end
 
     def self.list_filenames_by_clauses(clauses)

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -99,6 +99,22 @@ module Katello
 
       assert_equal errata.reload.packages.count, pkg_count + 1
     end
+
+    def test_update_from_json_new_packages
+      pkg = {:name => 'foo', :version => 3, :arch => 'x86_64', :epoch => 0, :release => '.el3', :filename => 'blahblah.rpm'}.with_indifferent_access
+      pkg2 = {:name => 'bar', :version => 3, :arch => 'x86_64', :epoch => 0, :release => '.el3', :filename => 'foo.rpm'}.with_indifferent_access
+      errata = katello_errata(:security)
+      pkg_count = errata.packages.count
+
+      json = errata.attributes.merge('pkglist' => [{'packages' => [pkg]}])
+      errata.update_from_json(json)
+      assert_equal errata.reload.packages.count, pkg_count + 1
+
+      json = errata.attributes.merge('pkglist' => [{'packages' => [pkg, pkg2]}])
+      errata.update_from_json(json)
+
+      assert_equal errata.reload.packages.count, pkg_count + 2
+    end
   end
 
   class ErratumAvailableTest < ErratumTestBase


### PR DESCRIPTION
even if "updated" has not been updated.
Otherwise syncing el6 and then el7 would result in errata that
are shared between the two only showing el6 packages