### PR TITLE
fixes #9786 - fixing searching and adding pagination to hosts errata

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -85,7 +85,10 @@ module Katello
       }
     end
 
-    def scoped_search(query, default_sort_by, default_sort_order, resource = resource_class)
+    def scoped_search(query, default_sort_by, default_sort_order, options = {})
+      resource = options.fetch(:resource_class, resource_class)
+      includes = options.fetch(:includes, [])
+
       total = query.count
       query = resource.search_for(*search_options).where("#{resource.table_name}.id" => query)
       sub_total = query.count
@@ -93,6 +96,7 @@ module Katello
       sort_attr = "#{query.table_name}.#{sort_attr}" unless sort_attr.to_s.include?('.')
 
       query = query.order("#{sort_attr} #{params[:sort_order] || default_sort_order}")
+      query = query.includes(includes) if includes.length > 0
 
       if params[:full_result]
         params[:per_page] = total

--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -98,7 +98,7 @@ module Katello
       scoped = scoped.of_type(params[:types]) if params[:types]
 
       respond_for_index :template => '../errata/index',
-                        :collection => scoped_search(scoped, 'issued', 'desc', Erratum)
+                        :collection => scoped_search(scoped, 'issued', 'desc', :resource_class => Erratum)
     end
 
     api :GET, "/content_views/:content_view_id/filters/:id/available_package_groups",

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -61,7 +61,7 @@ module Katello
     param :library, [true, false], :desc => N_("set true if you want to see only library environments")
     param :name, String, :desc => N_("filter only environments containing this name")
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, KTEnvironment))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, :resource_class => KTEnvironment))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/system_errata_controller.rb
+++ b/app/controllers/katello/api/v2/system_errata_controller.rb
@@ -12,12 +12,35 @@
 
 module Katello
   class Api::V2::SystemErrataController < Api::V2::ApiController
+    include Katello::Concerns::FilteredAutoCompleteSearch
+
     before_filter :find_system
     before_filter :find_errata_ids, :only => :apply
+    before_filter :find_environment, :only => :index
+    before_filter :find_content_view, :only => :index
 
     resource_description do
       api_version 'v2'
       api_base_url "/katello/api"
+    end
+
+    def resource_class
+      Erratum
+    end
+
+    api :GET, "/systems/:system_id/errata", N_("List errata available for the content host"), :deprecated => true
+    param :id, String, :desc => N_("UUID of the content host"), :required => true
+    param :content_view_id, :number, :desc => N_("Calculate Applicable Errata based on a particular Content View"), :required => false
+    param :environment_id, :number, :desc => N_("Calculate Applicable Errata based on a particular Environment"), :required => false
+    param_group :search, Api::V2::ApiController
+    def index
+      if  (params[:content_view_id] && params[:environment_id].nil?) || (params[:environment_id] && params[:content_view_id].nil?)
+        fail _("Either both parameters 'content_view_id' and 'environment_id' should be specified or neither should be specified")
+      end
+
+      collection = scoped_search(index_relation, 'updated_at', 'desc', :resource_class => Erratum, :includes => [:cves])
+      @installable_errata_ids = @system.installable_errata.pluck("#{Katello::Erratum.table_name}.id")
+      respond_for_index :collection => collection
     end
 
     api :PUT, "/systems/:system_id/errata/apply", N_("Schedule errata for installation"), :deprecated => true
@@ -36,7 +59,21 @@ module Katello
       respond_for_show :resource => errata
     end
 
+    protected
+
+    def index_relation
+      @system.installable_errata(@environment, @content_view)
+    end
+
     private
+
+    def find_content_view
+      ContentView.readable.find(params[:content_view_id]) if params[:content_view_id]
+    end
+
+    def find_environment
+      KTEnvironment.readable.find(params[:environment_id]) if params[:environment_id]
+    end
 
     def find_system
       @system = System.first(:conditions => { :uuid => params[:system_id] })

--- a/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
@@ -103,7 +103,8 @@ module Katello
         N_("Fetch applicable errata for a system."), :deprecated => true
     param_group :bulk_params
     def applicable_errata
-      respond_for_index(:collection => scoped_search(Katello::Erratum.installable_for_systems(@systems), 'updated', 'desc', Erratum))
+      respond_for_index(:collection => scoped_search(Katello::Erratum.installable_for_systems(@systems), 'updated', 'desc',
+                                                     :resource_class => Erratum))
     end
 
     api :PUT, "/systems/bulk/install_content", N_("Install content on one or more systems"), :deprecated => true

--- a/app/controllers/katello/concerns/filtered_auto_complete_search.rb
+++ b/app/controllers/katello/concerns/filtered_auto_complete_search.rb
@@ -18,7 +18,7 @@ module Katello
       def auto_complete_search
         begin
           options = resource_class.respond_to?(:completer_scope_options) ? resource_class.completer_scope_options : {}
-          items = self.index_relation.complete_for(params[:search], options)
+          items = resource_class.where(:id => self.index_relation).complete_for(params[:search], options)
           items = items.map do |item|
             category = (['and', 'or', 'not', 'has'].include?(item.to_s.sub(/^.*\s+/, ''))) ? _('Operators') : ''
             part = item.to_s.sub(/^.*\b(and|or)\b/i) { |match| match.sub(/^.*\s+/, '') }

--- a/app/views/katello/api/v2/system_errata/index.json.rabl
+++ b/app/views/katello/api/v2/system_errata/index.json.rabl
@@ -2,6 +2,6 @@ object false
 
 extends "katello/api/v2/common/metadata"
 
-child @collection[:records] => :results do
+child @collection[:results] => :results do
   extends("katello/api/v2/systems/erratum")
 end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -205,7 +205,6 @@ Katello::Engine.routes.draw do
             post :host_collections, :action => :add_host_collections
             delete :host_collections, :action => :remove_host_collections
             get :packages, :action => :package_profile
-            get :errata
             get :pools
             get :releases
             put :refresh_subscriptions
@@ -285,9 +284,10 @@ Katello::Engine.routes.draw do
               put :upgrade_all
             end
           end
-          api_resources :errata, :only => [:show], :controller => :system_errata do
+          api_resources :errata, :only => [:show, :index], :controller => :system_errata do
             collection do
               put :apply
+              get :auto_complete_search
             end
           end
         end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-erratum.factory.js
@@ -31,6 +31,7 @@ angular.module('Bastion.content-hosts').factory('ContentHostErratum',
                 });
                 return data;
             }},
+            autocomplete: {method: 'GET', isArray: true, params: {action: 'auto_complete_search'}},
             apply: {method: 'PUT', params: {action: 'apply'}}
         });
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -26,7 +26,16 @@
 angular.module('Bastion.content-hosts').controller('ContentHostErrataController',
     ['$scope', 'translate', 'ContentHostErratum', 'Nutupane', 'Organization', 'Environment',
     function ($scope, translate, ContentHostErratum, Nutupane, Organization, Environment) {
-        var errataNutupane = new Nutupane(ContentHostErratum, {'id': $scope.$stateParams.contentHostId, searchTerm: $scope.$stateParams.search}, 'get');
+        var errataNutupane, params = {
+            'id':  $scope.$stateParams.contentHostId,
+            'sort_by':          'updated',
+            'sort_order':       'DESC',
+            'paged':            true,
+            'errata_restrict_applicable': true
+        };
+
+
+        errataNutupane = new Nutupane(ContentHostErratum, params, 'get');
 
         errataNutupane.masterOnly = true;
         $scope.detailsTable = errataNutupane.table;

--- a/test/controllers/api/v2/system_errata_controller_test.rb
+++ b/test/controllers/api/v2/system_errata_controller_test.rb
@@ -30,7 +30,23 @@ module Katello
       @request.env['HTTP_ACCEPT'] = 'application/json'
 
       @system = katello_systems(:simple_server)
+      @errata_system = katello_systems(:errata_server)
       permissions
+    end
+
+    def test_index
+      get :index, :system_id => @errata_system.uuid
+
+      assert_response :success
+      assert_template 'api/v2/system_errata/index'
+    end
+
+    def test_index_other_env
+      get :index, :system_id => @errata_system.uuid, :content_view_id => @errata_system.organization.default_content_view.id,
+          :environment_id => @errata_system.organization.library.id
+
+      assert_response :success
+      assert_template 'api/v2/system_errata/index'
     end
 
     def test_apply

--- a/test/controllers/api/v2/systems_controller_test.rb
+++ b/test/controllers/api/v2/systems_controller_test.rb
@@ -196,13 +196,6 @@ module Katello
       end
     end
 
-    def test_errata
-      get :errata, :id => @errata_system.uuid
-
-      assert_response :success
-      assert_template 'api/v2/systems/errata'
-    end
-
     def test_update
       input = {
         :id => @system.id,
@@ -216,14 +209,6 @@ module Katello
       end
       post :update, input
       assert_response :success
-    end
-
-    def test_errata_other_env
-      get :errata, :id => @errata_system.uuid, :content_view_id => @errata_system.organization.default_content_view.id,
-          :environment_id => @errata_system.organization.library.id
-
-      assert_response :success
-      assert_template 'api/v2/systems/errata'
     end
   end
 end


### PR DESCRIPTION
This makes a number of changes around content host errata:
* Moves the errata list api call to the system_errata_controller
* Adds autocomplete
* Refactors scoped_search() to allow includes to be passed in (since it ignores them)
* changes UI to use pagination