### PR TITLE
Fixes #9608: correct repository count, BZ 1197836.

### DIFF
--- a/app/views/katello/api/v2/content_views/_content_view.json.rabl
+++ b/app/views/katello/api/v2/content_views/_content_view.json.rabl
@@ -65,7 +65,7 @@ child :components => :components do
     attributes :id, :name, :label, :description, :next_version
   end
 
-  child :repositories => :repositories do
+  child :archived_repos => :repositories do
     attributes :id, :name, :label, :description
   end
 end


### PR DESCRIPTION
The respository counts were wrong on the content view
composite list page.  This commit fixes the counts.

http://projects.theforeman.org/issues/9608
https://bugzilla.redhat.com/show_bug.cgi?id=1197836