### PR TITLE
fixes #9798 - don't plan CVPE deletion if this is the default version, BZ1076568

### DIFF
--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -24,7 +24,7 @@ module Actions
                 repo_options[:planned_destroy] = true
                 plan_action(Repository::Destroy, repo, repo_options)
               end
-              plan_action(ContentViewPuppetEnvironment::Destroy, version.archive_puppet_environment)
+              plan_action(ContentViewPuppetEnvironment::Destroy, version.archive_puppet_environment) unless version.default?
             end
           end
 


### PR DESCRIPTION
@daviddavis said in a gist:
> It looks like default content view versions don't have content_view_puppet_environments, so we need to skip them here. Not sure if this is the best solution. Was also thinking as an alternative maybe we could create a new action to destroy default content views.