### PR TITLE
fixes #9799 - changing structure of incremental update around composites

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -57,7 +57,6 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 };
 
                 params['content_view_version_environments'] = [];
-                params['propagate_to_composites'] = true;
                 params['resolve_dependencies'] = true;
 
                 //get a list of unique content view verion ids with their environments
@@ -71,13 +70,10 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                             }
                         });
                     }
-                    else {
-
-                        if (cvIdEnvIds[versionId] === undefined) {
-                            cvIdEnvIds[versionId] = [];
-                        }
-                        cvIdEnvIds[versionId] = _.uniq(cvIdEnvIds[versionId].concat(_.pluck(update.environments, 'id')));
+                    if (cvIdEnvIds[versionId] === undefined) {
+                        cvIdEnvIds[versionId] = [];
                     }
+                    cvIdEnvIds[versionId] = _.uniq(cvIdEnvIds[versionId].concat(_.pluck(update.environments, 'id')));
                 });
 
                 angular.forEach(cvIdEnvIds, function (envIds, cvId) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -50,8 +50,10 @@
         <tr ng-repeat="update in updates">
           <td>
             <div>
-              <i class="fa fa-chevron-down" ng-show="update.componentsVisible && update.components" ng-click="toggleComponents(update)"></i>
-              <i class="fa fa-chevron-right" ng-hide="update.componentsVisible && update.components" ng-click="toggleComponents(update)"></i>
+              <span ng-show="update.components.length > 0">
+                <i class="fa fa-chevron-down" ng-show="update.componentsVisible && update.components" ng-click="toggleComponents(update)"></i>
+                <i class="fa fa-chevron-right" ng-hide="update.componentsVisible && update.components" ng-click="toggleComponents(update)"></i>
+              </span>
               <a ng-href="/content_views/{{ update.content_view_version.content_view.id }}/versions/{{update.content_view_version.id}}">{{ update.content_view_version.content_view.name }}</a> <span ng-show="{{update.components}}">*</span>
             </div>
             <div ng-show="update.componentsVisible">

--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -144,7 +144,6 @@ describe('Controller: ApplyErrataController', function() {
                         'content_view_version_id': 1,
                         'environment_ids': [2]
                     }],
-                    'propagate_to_composites': true,
                     'resolve_dependencies': true
                 };
 
@@ -197,8 +196,10 @@ describe('Controller: ApplyErrataController', function() {
                     'content_view_version_environments': [{
                         'content_view_version_id': 5,
                         'environment_ids': []
+                    },{
+                        'content_view_version_id': 1,
+                        'environment_ids': [2]
                     }],
-                    'propagate_to_composites': true,
                     'resolve_dependencies': true
                 };
 
@@ -236,8 +237,10 @@ describe('Controller: ApplyErrataController', function() {
                     'content_view_version_environments': [{
                         'content_view_version_id': 5,
                         'environment_ids': [99]
+                    },{
+                        'content_view_version_id': 1,
+                        'environment_ids': [2]
                     }],
-                    'propagate_to_composites': true,
                     'resolve_dependencies': true
                 };
 

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -193,8 +193,8 @@ module Katello
       version = @library_dev_staging_view.versions.first
       errata_id = Katello::Erratum.first.uuid
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
-                                            [{:content_view_version => version, :environments => [@beta]}],
-                                            {'errata_ids' => [errata_id]}, true, nil, [], nil).returns({})
+                                            [{:content_view_version => version, :environments => [@beta]}], [],
+                                            {'errata_ids' => [errata_id]}, true, [], nil).returns({})
 
       put :incremental_update, :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}],
                                :add_content => {:errata_ids => [errata_id]}, :resolve_dependencies => true


### PR DESCRIPTION
Now when performing an incremental update, you simply pass the composites
in the "content_view_version_environments" structure as a parameter.
This gives the user control over exactly which composites are updated.
If a user passes a composite without a componenet specified an error is thrown