### PR TITLE
Fixes #9839: show no rows message if table isn't working BZ 1203851.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys-table-full.html
@@ -1,9 +1,3 @@
-<p bst-alert="info" ng-show="table.rows.length === 0">
-  <span translate>
-    You currently don't have any Activation Keys, you can add Activation Keys using the button on the right.
-  </span>
-</p>
-
 <table class="table table-striped" ng-class="{'table-mask': table.working}" ng-show="table.rows.length > 0">
   <thead>
     <tr bst-table-head>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
@@ -13,4 +13,7 @@
     </button>
   </div>
 
+  <span data-block="no-rows-message" translate>
+    You currently don't have any Activation Keys, you can add Activation Keys using the button on the right.
+  </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -45,7 +45,7 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <p bst-alert="info" ng-show="addSubscriptionsTable.rows.length === 0">
+      <p bst-alert="info" ng-show="addSubscriptionsTable.rows.length === 0 && !addSubscriptionsTable.working">
         <span translate>
           You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu.
         </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -44,7 +44,7 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <p bst-alert="info" ng-show="subscriptionsTable.rows.length === 0">
+      <p bst-alert="info" ng-show="subscriptionsTable.rows.length === 0 && !subscriptionsTable.working">
         <span translate>
           You currently don't have any Subscriptions associated with this Content Host, you can add Subscriptions after selecting the 'Add' tab.
         </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-full.html
@@ -1,4 +1,4 @@
-<p bst-alert="info" ng-show="contentHostTable.rows.length === 0">
+<p bst-alert="info" ng-show="contentHostTable.rows.length === 0 && !contentHostTable.working">
   <span translate>
     You currently don't have any Content Hosts, you can register Content Hosts using the button on the right.
   </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
@@ -25,7 +25,7 @@
   </div>
 
   <div data-block="table">
-    <p bst-alert="info" ng-show="detailsTable.rows.length === 0">
+    <p bst-alert="info" ng-show="detailsTable.rows.length === 0 && !detailsTable.working">
       <span translate>
         You currently don't have any Filters included in this Content View, you can add a new Filter by using the button on the right.
       </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
@@ -22,7 +22,7 @@
   </div>
 
   <div data-block="table">
-    <p bst-alert="info" ng-show="detailsTable.rows.length === 0">
+    <p bst-alert="info" ng-show="detailsTable.rows.length === 0 && !detailsTable.working">
       <span translate>
         You currently don't have any Puppet Modules included in this Content View, you can add Puppet Modules using the button on the right.
       </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views-table-full.html
@@ -1,4 +1,4 @@
-<p bst-alert="info" ng-show="table.rows.length === 0">
+<p bst-alert="info" ng-show="table.rows.length === 0 && !table.working">
   <span translate>
     You currently don't have any Content Views, you can create Content View using the button on the right.
   </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys-table-full.html
@@ -1,6 +1,3 @@
-<p bst-alert="info" ng-show="table.rows.length === 0">
-  <span translate>You currently don't have any Gpg keys, you can add Gpg keys using the button on the right.</span>
-</p>
 <table bst-table="table"
        class="table table-striped"
        ng-class="{'table-mask': table.working}"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
@@ -13,4 +13,8 @@
     </button>
   </div>
 
+  <span data-block="no-rows-message" translate>
+    You currently don't have any Gpg keys, you can add Gpg keys using the button on the right.
+  </span>
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-content-hosts.html
@@ -46,7 +46,7 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <p bst-alert="info" ng-show="addContentHostsTable.rows.length === 0">
+      <p bst-alert="info" ng-show="addContentHostsTable.rows.length === 0 && !addContentHostsTable.working">
         <span translate>
           You currently don't have any Content Hosts, you can create new Content Hosts by selecting Contents Host from main menu and then clicking the button on the right.
         </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-content-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-content-hosts-list.html
@@ -45,7 +45,7 @@
         {{ "Loading..." | translate }}
       </div>
 
-      <p bst-alert="info" ng-show="contentHostsTable.rows.length === 0">
+      <p bst-alert="info" ng-show="contentHostsTable.rows.length === 0 && !contentHostsTable.working">
         <span translate>
           You currently don't have any Content Hosts in this Host Group, you can add Content Hosts after selecting the 'Add' tab.
         </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections-table-full.html
@@ -1,9 +1,4 @@
-<p bst-alert="info" ng-show="table.rows.length === 0">
-  <span translate>
-    You currently don't have any Host Collections, you can add Host Collections using the button on the right.
-  </span>
-</p>
-<table class="table table-striped" 
+<table class="table table-striped"
        ng-class="{'table-mask': table.working}"
        ng-show="table.rows.length > 0">
   <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
@@ -15,4 +15,7 @@
     </button>
   </div>
 
+  <span data-block="no-rows-message" translate>
+    You currently don't have any Host Collections, you can add Host Collections using the button on the right.
+  </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
@@ -145,7 +145,7 @@
   </table>
 </section>
 
-<p bst-alert="info" ng-show="repositoriesTable.rows.length === 0">
+<p bst-alert="info" ng-show="repositoriesTable.rows.length === 0 && !repositoriesTable.working">
   <span translate>
     You currently don't have any Repositories included in this Product, you can add Repositories using the button on the right.
   </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products-table-full.html
@@ -1,9 +1,3 @@
-<p bst-alert="info" ng-show="productTable.rows.length === 0">
-  <span translate>
-    You currently don't have any Products<span bst-feature-flag="custom_products">, you can add Products using the button on the right</span>.
-  </span>
-</p>
-
 <table class="table table-striped" ng-class="{'table-mask': productTable.working}" ng-show="productTable.rows.length > 0">
   <thead>
     <tr bst-table-head row-select>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -38,4 +38,8 @@
     </button>
   </div>
 
+  <span data-block="no-rows-message" translate>
+    You currently don't have any Products<span bst-feature-flag="custom_products">, you can add Products using the button on the right</span>.
+  </span>
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions-table-full.html
@@ -1,8 +1,3 @@
-<p bst-alert="info" ng-show="table.rows.length === 0">
-  <span translate>
-    You currently don't have any Subscriptions, you can add Subscriptions by importing a manifest using the button on the right labeled 'Manage Manifest'.
-  </span>
-</p>
 <table class="table table-striped" ng-class="{'table-mask': table.working}" ng-show="table.rows.length > 0">
   <thead>
     <tr bst-table-head>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
@@ -13,4 +13,7 @@
     </button>
   </div>
 
+  <span data-block="no-rows-message" translate>
+    You currently don't have any Subscriptions, you can add Subscriptions by importing a manifest using the button on the right labeled 'Manage Manifest'.
+  </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans-table-full.html
@@ -1,4 +1,4 @@
-<p bst-alert="info" ng-show="syncPlanTable.rows.length === 0">
+<p bst-alert="info" ng-show="syncPlanTable.rows.length === 0 && !syncPlanTable.working">
   <span translate>
     You currently don't have any Sync Plan, you can add Sync Plans using the button on the right.
   </span>


### PR DESCRIPTION
Only show the message about not having any items on a nutupane table
if the table isn't currently working.

http://projects.theforeman.org/issues/9839
https://bugzilla.redhat.com/show_bug.cgi?id=1203851

Requires Katello/bastion#55