### PR TITLE
Backport #8552 - Don't initialize cp task if no qpid config

### DIFF
--- a/test/actions/candlepin/listen_on_events_test.rb
+++ b/test/actions/candlepin/listen_on_events_test.rb
@@ -22,6 +22,23 @@ class Actions::Candlepin::ListenOnCandlepinEventsTest < ActiveSupport::TestCase
       create_and_plan_action action_class
     end
 
+    it 'initializes when configuration present' do
+      ::Actions::Candlepin::CandlepinListeningService.stubs(:new).at_least_once
+      action_class.stubs(:connect_listening_service)
+
+      Katello.config[:qpid] = {:url => 'url', :subscriptions_queue_address => 'addr'}
+      ::Actions::Candlepin::ListenOnCandlepinEvents.any_instance.stubs(:configured?).returns(true)
+      run_action planned_action
+    end
+
+    it 'does not intialize when configuration missing' do
+      ::Actions::Candlepin::CandlepinListeningService.stubs(:new).never
+      action_class.stubs(:connect_listening_service)
+
+      ::Actions::Candlepin::ListenOnCandlepinEvents.any_instance.stubs(:configured?).returns(false)
+      run_action planned_action
+    end
+
     it 'reindexes and acknowledges messages' do
       Actions::Candlepin::ListenOnCandlepinEvents.any_instance.stubs(:suspend)
       Actions::Candlepin::CandlepinListeningService.any_instance.stubs(:create_connection)


### PR DESCRIPTION
method_missing exception was produced when starting the candlepin
listening service without qpid configs set in the katello.yml or
katello_defaults.yml. This checks that configs are present before
starting candlepin listending service.