### PR TITLE
Fixes #9872: Properly destroy systems that are of type Hypervisor.

### DIFF
--- a/app/lib/actions/katello/system/destroy.rb
+++ b/app/lib/actions/katello/system/destroy.rb
@@ -26,11 +26,11 @@ module Actions
             plan_action(Pulp::Consumer::Destroy, uuid: system.uuid) unless skip_pulp
           end
 
-          plan_self
+          plan_self(:system_id => system.id)
         end
 
         def finalize
-          system = ::Katello::System.find(input[:system][:id])
+          system = ::Katello::System.find(input[:system_id])
           system.destroy!
         end
 


### PR DESCRIPTION
The Foreman Tasks input object attempts to build a hash based on the
class name being passed in as the action subject. Since the Hypervisor
class inherits from system, and calls the system destroy the action
generated input[:hypervisor] even though the finalize expected a hash
with input[:system]. This prevented hyprvisor deletion from the database
and leads to 410 gone in Candlepin.