### PR TITLE
Fixes #9838 - additional pkgs for .30 qpid

### DIFF
--- a/rel-eng/comps/comps-katello-client-rhel6.xml
+++ b/rel-eng/comps/comps-katello-client-rhel6.xml
@@ -26,7 +26,9 @@
        <packagereq type="default">python-pulp-rpm-common</packagereq>
        <packagereq type="default">python-qpid</packagereq>
        <packagereq type="default">python-qpid-common</packagereq>
+       <packagereq type="default">python-saslwrapper</packagereq>
        <packagereq type="default">qpid-proton-c</packagereq>
+       <packagereq type="default">saslwrapper</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/rel-eng/comps/comps-katello-client-rhel7.xml
+++ b/rel-eng/comps/comps-katello-client-rhel7.xml
@@ -26,7 +26,9 @@
        <packagereq type="default">python-pulp-rpm-common</packagereq>
        <packagereq type="default">python-qpid</packagereq>
        <packagereq type="default">python-qpid-common</packagereq>
+       <packagereq type="default">python-saslwrapper</packagereq>
        <packagereq type="default">qpid-proton-c</packagereq>
+       <packagereq type="default">saslwrapper</packagereq>
     </packagelist>
   </group>
 </comps>

--- a/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-rhel6.xml
@@ -67,11 +67,12 @@
        <packagereq type="default">python-requests</packagereq>
        <packagereq type="default">python-rhsm</packagereq>
        <packagereq type="default">python-semantic-version</packagereq>
+       <packagereq type="default">python-saslwrapper</packagereq>
        <packagereq type="default">python-webpy</packagereq>
        <packagereq type="default">qpid-cpp-client</packagereq>
        <packagereq type="default">qpid-cpp-client-devel</packagereq>
        <packagereq type="default">qpid-cpp-server</packagereq>
-       <packagereq type="default">qpid-cpp-server-store</packagereq>
+       <packagereq type="default">qpid-cpp-server-linearstore</packagereq>
        <packagereq type="default">qpid-proton-c</packagereq>
        <packagereq type="default">python-qpid-proton</packagereq>
        <packagereq type="default">qpid-dispatch-router</packagereq>
@@ -79,6 +80,7 @@
        <packagereq type="default">libqpid-dispatch</packagereq>
        <packagereq type="default">qpid-qmf</packagereq>
        <packagereq type="default">qpid-tools</packagereq>
+       <packagereq type="default">saslwrapper</packagereq>
     </packagelist>
   </group>
   <group>

--- a/rel-eng/comps/comps-katello-pulp-server-rhel7.xml
+++ b/rel-eng/comps/comps-katello-pulp-server-rhel7.xml
@@ -68,11 +68,12 @@
        <packagereq type="default">python-requests</packagereq>
        <packagereq type="default">python-rhsm</packagereq>
        <packagereq type="default">python-semantic-version</packagereq>
+       <packagereq type="default">python-saslwrapper</packagereq>
        <packagereq type="default">python-webpy</packagereq>
        <packagereq type="default">qpid-cpp-client</packagereq>
        <packagereq type="default">qpid-cpp-client-devel</packagereq>
        <packagereq type="default">qpid-cpp-server</packagereq>
-       <packagereq type="default">qpid-cpp-server-store</packagereq>
+       <packagereq type="default">qpid-cpp-server-linearstore</packagereq>
        <packagereq type="default">qpid-proton-c</packagereq>
        <packagereq type="default">python-qpid-proton</packagereq>
        <packagereq type="default">qpid-dispatch-router</packagereq>
@@ -80,6 +81,7 @@
        <packagereq type="default">libqpid-dispatch</packagereq>
        <packagereq type="default">qpid-qmf</packagereq>
        <packagereq type="default">qpid-tools</packagereq>
+       <packagereq type="default">saslwrapper</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
* saslwrapper
* python-saslwrapper
* qpid-cpp-server-linearstore instead of qpid-cpp-server-store
(cherry picked from commit 299aec364fc1b8cb9dcb50872f9acf83c20c4688)