### PR TITLE
Fixes #9891 - Upstream Repo name now updatable

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -257,7 +257,7 @@ module Katello
     end
 
     def repository_params
-      keys = [:url, :gpg_key_id, :unprotected, :name, :checksum_type]
+      keys = [:url, :gpg_key_id, :unprotected, :name, :checksum_type, :docker_upstream_name]
       keys += [:label, :content_type] if params[:action] == "create"
       params.require(:repository).permit(*keys)
     end


### PR DESCRIPTION
In the Repo details page the upstream repo name was not getting updated
prior to this commit. This commit fixes it