### PR TITLE
Fixes #9913: ensure unique count on errata CH counts, BZ1206329.

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -67,7 +67,7 @@ module Katello
     def systems_available
       self.systems_applicable.joins("INNER JOIN #{Katello::RepositoryErratum.table_name} on \
         #{Katello::RepositoryErratum.table_name}.erratum_id = #{self.id}").joins(:system_repositories).
-        where("#{Katello::SystemRepository.table_name}.repository_id = #{Katello::RepositoryErratum.table_name}.repository_id")
+        where("#{Katello::SystemRepository.table_name}.repository_id = #{Katello::RepositoryErratum.table_name}.repository_id").uniq
     end
 
     def systems_unavailable


### PR DESCRIPTION
The content host counts for errata were showing duplicates for
installable errata.  This commit ensures the installable count
is unique.

http://projects.theforeman.org/issues/9913
https://bugzilla.redhat.com/show_bug.cgi?id=1206329