### PR TITLE
fixes #9923 - replaced Author column with Description in cv versions

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -26,7 +26,7 @@
         <th bst-table-column><span translate>Status</span></th>
         <th bst-table-column><span translate>Environments</span></th>
         <th bst-table-column><span translate>Content</span></th>
-        <th bst-table-column><span translate>Author</span></th>
+        <th bst-table-column><span translate>Description</span></th>
         <th class="col-sm-2" bst-table-column><span translate>Actions</span></th>
       </tr>
     </thead>
@@ -75,7 +75,11 @@
           </div>
 
         </td>
-        <td bst-table-cell>{{ version.user }}</td>
+        <td bst-table-cell>
+          <div class="description">
+            {{ version.description }}
+          </div>
+        </td>
         <td class="col-sm-2">
           <button class="btn btn-default"
                   ui-sref="content-views.details.promotion({contentViewId: contentView.id, versionId: version.id})"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-details.html
@@ -7,7 +7,7 @@
 
   <div class="detail">
     <span class="info-label" translate>Description</span>
-    <span class="info-value">{{ version.description }}</span>
+    <span class="info-value" bst-edit-textarea="version.description" readonly="true"></span>
   </div>
 
 </div>

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.less
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.less
@@ -4,6 +4,7 @@
   @import "tasks";
   @import "environments";
   @import "errata";
+  @import "content-views";
 
   .center-paragraph {
     text-align: center;

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/content-views.less
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/content-views.less
@@ -1,0 +1,6 @@
+
+.description {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
The Author column never showed a value (there is no .user in the json). The description seems to me to be a more valuable bit of information. User can be determined from Tasks tab