### PR TITLE
Fixes #9933: use correct param for search BZ1205855.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.module.js
@@ -265,7 +265,7 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
         template: '<div ui-view></div>'
     })
     .state('content-hosts.details.errata.index', {
-        url: '/errata?search',
+        url: '/errata?getSearch',
         permission: 'view_content_hosts',
         collapsed: true,
         templateUrl: 'content-hosts/content/views/content-host-errata.html'

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -27,10 +27,11 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
     ['$scope', 'translate', 'ContentHostErratum', 'Nutupane', 'Organization', 'Environment',
     function ($scope, translate, ContentHostErratum, Nutupane, Organization, Environment) {
         var errataNutupane, params = {
-            'id':  $scope.$stateParams.contentHostId,
-            'sort_by':          'updated',
-            'sort_order':       'DESC',
-            'paged':            true,
+            'id': $scope.$stateParams.contentHostId,
+            'sort_by': 'updated',
+            'sort_order': 'DESC',
+            'paged': true,
+            searchTerm: $scope.$stateParams.getSearch,
             'errata_restrict_applicable': true
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -181,7 +181,7 @@
       <div class="detail">
         <span class="info-label" translate>Security</span>
         <span class="info-value">
-          <a ui-sref="content-hosts.details.errata.index({search: 'type:security'})">
+          <a ui-sref="content-hosts.details.errata.index({getSearch: 'type=security'})">
             <i class="fa fa-warning inline-icon"
                ng-class="{black: contentHost.errata_counts.security === 0, red: contentHost.errata_counts.security > 0}"
                title="{{ 'Security' | translate }}"></i>
@@ -193,7 +193,7 @@
       <div class="detail">
         <span class="info-label" translate>Bug Fix</span>
         <span class="info-value">
-          <a ui-sref="content-hosts.details.errata.index({search: 'type:bugfix'})">
+          <a ui-sref="content-hosts.details.errata.index({getSearch: 'type=bugfix'})">
             <i class="fa fa-bug inline-icon"
                ng-class="{black: contentHost.errata_counts.bugfix === 0, yellow: contentHost.errata_counts.bugfix > 0}"
                title="{{ 'Bug Fix' | translate }}"></i>
@@ -205,7 +205,7 @@
       <div class="detail">
         <span class="info-label" translate>Enhancement</span>
         <span class="info-value">
-          <a ui-sref="content-hosts.details.errata.index({search: 'type:enhancement'})">
+          <a ui-sref="content-hosts.details.errata.index({getSearch: 'type=enhancement'})">
             <i class="fa fa-plus-square inline-icon"
                ng-class="{black: contentHost.errata_counts.enhancement === 0, yellow: contentHost.errata_counts.enhancement > 0}"
                title="{{ 'Enhancement' | translate }}"></i>


### PR DESCRIPTION
The links to the content host errata page from the
content host details page were using the incorrect
search link.  This commit fixes the incorrect link.

http://projects.theforeman.org/issues/9933
https://bugzilla.redhat.com/show_bug.cgi?id=1205855