### PR TITLE
Fixes #9934: do not refresh errata on initial load BZ 1206704.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
@@ -106,7 +106,9 @@ angular.module('Bastion.errata').controller('ErrataController',
                 nutupane.setParams(params);
             }
 
-            nutupane.refresh();
+            if (!nutupane.table.initialLoad) {
+                nutupane.refresh();
+            }
         });
 
         $scope.goToNextStep = function () {


### PR DESCRIPTION
We were loading the errata nutupane twice which was causing an
issue where infinite scroll was not fetching enough results to
scroll on certain resolutions.  This commit only reloads the
nutupane if it's not the initial load.

http://projects.theforeman.org/issues/9934
https://bugzilla.redhat.com/show_bug.cgi?id=1206704