### PR TITLE
Fixes #5684: cancel repository discovery is now dynflowed

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -92,8 +92,8 @@ module Katello
     param :label, String, :desc => N_("Organization label")
     param :url, String, :desc => N_("base url to perform repo discovery on")
     def cancel_repo_discover
-      # TODO: implement task canceling
-      render :json => { message: "not implemented" }
+      task = @organization.cancel_repo_discovery
+      respond_for_async :resource => task
     end
 
     api :GET, "/organizations/:label/download_debug_certificate", N_("Download a debug certificate")

--- a/app/lib/katello/repo_discovery.rb
+++ b/app/lib/katello/repo_discovery.rb
@@ -12,23 +12,28 @@
 
 module Katello
   class RepoDiscovery
-    attr_reader :found
+    attr_reader :found, :crawled, :to_follow
 
-    def initialize(url, options = {})
+    def initialize(url, proxy = {}, crawled = [], found = [], to_follow = [])
       #add a / on the end, as directories require it or else
       #  They will get double slahes on them
-      url += '/' unless url.ends_with?('/')
-      @uri = URI(url)
-      @found = []
-      @crawled = []
-      @options = options
+      @uri = uri(url)
+      @found = found
+      @crawled = crawled
+      @to_follow = to_follow
+      @proxy = proxy
     end
 
-    def run(found_lambda, continue_lambda)
+    def uri(url)
+      url += '/' unless url.ends_with?('/')
+      URI(url)
+    end
+
+    def run(resume_point)
       if @uri.scheme == 'file'
-        file_crawl(found_lambda, continue_lambda)
+        file_crawl(uri(resume_point))
       elsif %w(http https).include?(@uri.scheme)
-        http_crawl(found_lambda, continue_lambda)
+        http_crawl(uri(resume_point))
       else
         fail _("Unsupported URL protocol %s.")  % @uri.scheme
       end
@@ -36,40 +41,34 @@ module Katello
 
     private
 
-    def http_crawl(found_lambda, continue_lambda)
-      Anemone.crawl(@uri, @options) do |anemone|
+    def http_crawl(resume_point)
+      Anemone.crawl(resume_point, @proxy) do |anemone|
         anemone.focus_crawl do |page|
-          return false unless continue_lambda.call
           @crawled << page.url.path
 
-          to_follow = []
           page.links.each do |link|
             if link.path.ends_with?('/repodata/')
               @found << page.url.to_s
-              found_lambda.call(page.url.to_s)
             else
-              to_follow << link if should_follow?(link.path)
+              @to_follow << link.to_s if should_follow?(link.path)
             end
           end
           page.discard_doc! #saves memory, doc not needed
-          to_follow
+          []
         end
       end
-      @found
     end
 
-    def file_crawl(found_lambda, continue_lambda)
-      directories = Dir.glob("#{@uri.path}**/")
-      directories.each do |dir|
-        return false unless continue_lambda.call
-
-        if dir.ends_with?('/repodata/')
-          found_path = Pathname(dir).parent.to_s
-          @found << "file://#{found_path}"
-          found_lambda.call("file://#{found_path}")
-        end
+    def file_crawl(resume_point)
+      if resume_point.path.ends_with?('/repodata/')
+        found_path = Pathname(resume_point.path).parent.to_s
+        @found << "file://#{found_path}"
       end
-      @found
+      if resume_point.path == @uri.path
+        Dir.glob("#{@uri.path}**/").each { |path| @to_follow << path }
+        @to_follow.shift
+      end
+      @crawled << resume_point.path
     end
 
     def should_follow?(path)

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -1,18 +1,21 @@
 <span page-title>{{ 'Repository Discovery' | translate }}</span>
 
 <div class="row">
-  <form ng-submit="discover()" role="form" class="col-sm-6">
+  <form ng-submit="discover()" name="discoveryForm" class="col-sm-6">
     <div class="input-group">
 
-      <input type="url"
+      <input type="text"
+             ng-pattern="/^(file:\/\/|http:\/\/|https:\/\/).+/"
              class="form-control input-lg"
              placeholder="{{ 'URL to discover' | translate }}"
              ng-model="discovery.url"
-             ng-disabled="discovery.pending"/>
+             ng-disabled="discovery.pending"
+             name="discoveryUrl"
+             required/>
 
       <span class="input-group-btn input-group-lg">
         <button ng-show="!discovery.pending && permitted('edit_products')"
-               ng-disabled="!discovery.url"
+               ng-disabled="discoveryForm.discoveryUrl.$invalid"
                translate
                type="submit"
                class="btn btn-primary btn-lg">

--- a/test/lib/repo_discovery_test.rb
+++ b/test/lib/repo_discovery_test.rb
@@ -16,16 +16,16 @@ module Katello
   class FileRepoDiscoveryTest < ActiveSupport::TestCase
     def test_run
       base_url = "file://#{Katello::Engine.root}/test/fixtures/"
-
-      rd = RepoDiscovery.new(base_url)
+      crawled = []
       found = []
-      add_proc = lambda { |url| found << url }
-      continue_proc = lambda { true }
+      to_follow = [base_url]
+      rd = RepoDiscovery.new(base_url, crawled, found, to_follow)
 
-      found_final = rd.run(add_proc, continue_proc)
-      assert_equal found, found_final  #validate that final list equals incremental list
-      assert_equal 1, found.size
-      assert_equal found.first, base_url + 'test_repos/zoo'
+      rd.run(to_follow.shift)
+      assert_equal 1, rd.crawled.size
+      refute_empty rd.to_follow
+      assert_empty rd.found
+      assert_equal rd.crawled.first, "#{Katello::Engine.root}/test/fixtures/"
     end
   end
 end


### PR DESCRIPTION
Repository discovery can now be cancelled