### PR TITLE
Fixes #9992: fix no rows message on errata CH page BZ 1208216.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -46,15 +46,14 @@
     </form>
   </div>
 
-  <div data-block="table">
-    <p bst-alert="warning" data-i18n
-       ng-show="detailsTable.rows.length > 0 && stateIncludes('errata.details.content-hosts.unavailable')">
-      The Content View or Lifecycle Environment needs to be updated in order to make errata available to these hosts.
-    </p>
+  <span data-block="no-rows-message" translate>
+    No Content Hosts match this Erratum.
+  </span>
 
-    <span data-block="no-rows-message" translate>
-      No Content Hosts match this Erratum.
-    </span>
+  <div data-block="table">
+    <p bst-alert="warning" ng-show="detailsTable.rows.length > 0 && stateIncludes('errata.details.content-hosts.unavailable')">
+      <span translate>The Content View or Lifecycle Environment needs to be updated in order to make errata available to these hosts.</span>
+    </p>
 
     <table class="table table-striped table-bordered"
            ng-class="{'table-mask': detailsTable.working}"


### PR DESCRIPTION
The no rows message on the Errata Content Host page was displaying
regardless of whether or not there were rows in the table because
it was placed inside the table data-block.  This commit moves the
no rows message data-block outside of the table data-block such
that the message will only be displayed under the correct
circumstances.

http://projects.theforeman.org/issues/9992
https://bugzilla.redhat.com/show_bug.cgi?id=1208216