### PR TITLE
Fixes #10011: fix long URI error when applying errata BZ 1208678.

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -52,6 +52,7 @@ module Katello
     end
 
     api :GET, "/systems", N_("List content hosts"), :deprecated => true
+    api :POST, "/systems/post_index", N_("List content hosts when you have a query string parameter that will cause a 414."), :deprecated => true
     api :GET, "/organizations/:organization_id/systems", N_("List content hosts in an organization"), :deprecated => true
     api :GET, "/environments/:environment_id/systems", N_("List content hosts in environment"), :deprecated => true
     api :GET, "/host_collections/:host_collection_id/systems", N_("List content hosts in a host collection"), :deprecated => true

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -266,6 +266,7 @@ Katello::Engine.routes.draw do
             get :events
           end
           collection do
+            match '/post_index' => 'systems#index', :via => :post
             match '/bulk/add_host_collections' => 'systems_bulk_actions#bulk_add_host_collections', :via => :put
             match '/bulk/remove_host_collections' => 'systems_bulk_actions#bulk_remove_host_collections', :via => :put
             match '/bulk/install_content' => 'systems_bulk_actions#install_content', :via => :put

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host.factory.js
@@ -25,6 +25,7 @@ angular.module('Bastion.content-hosts').factory('ContentHost',
 
         return BastionResource('/katello/api/v2/systems/:id/:action/:action2', {id: '@uuid'}, {
             get: {method: 'GET', params: {fields: 'full'}},
+            getPost: {method: 'POST', params: {fields: 'full', action: 'post_index'}},
             update: {method: 'PUT'},
             releaseVersions: {method: 'GET', params: {action: 'releases'}},
             subscriptions: {method: 'GET', params: {action: 'subscriptions'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -41,7 +41,7 @@ angular.module('Bastion.errata').controller('ErrataContentHostsController',
             params['errata_ids[]'] = _.pluck($scope.table.getSelected(), 'id');
         }
 
-        nutupane = new Nutupane(ContentHost, params);
+        nutupane = new Nutupane(ContentHost, params, 'getPost');
         nutupane.table.closeItem = function () {};
         nutupane.enableSelectAllResults();
 


### PR DESCRIPTION
Regrettably use POST instead of GET when obtaining a list of
content hosts for an errata in order to avoid long URI issue.

http://projects.theforeman.org/issues/10011
https://bugzilla.redhat.com/show_bug.cgi?id=1208678