### PR TITLE
fixes #10127 - remove dynflow stacktrace when unregistering, BZ 1208100

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -216,6 +216,7 @@ module Katello
     #api :DELETE, "/consumers/:id", N_("Unregister a consumer")
     #param :id, String, :desc => N_("UUID of the consumer"), :required => true
     def consumer_destroy
+      User.current = User.anonymous_admin
       sync_task(::Actions::Katello::System::Destroy, @system)
       render :text => _("Deleted consumer '%s'") % params[:id], :status => 204
     end


### PR DESCRIPTION
Fixing a DynFlow stacktrace that is thrown when a content-host attempts
to unregister. DynFlow would throw an ActiveRecord Validation error
stating 'Resource cannot be blank'. The resource is it referring to is a
user/owner of the DynFlow task that is being planned. Since the
content-host was registered with an activation key it is userless, and
dynflow doesn't like that.