### PR TITLE
Fixes #10132: Allow viewer role to view content dashboard.

### DIFF
--- a/app/models/katello/concerns/user_extensions.rb
+++ b/app/models/katello/concerns/user_extensions.rb
@@ -192,7 +192,7 @@ module Katello
         end
 
         def allowed_organizations
-          (admin? || anonymous_admin) ? Organization.all : self.organizations
+          admin? ? Organization.all : self.organizations
         end
 
         private


### PR DESCRIPTION
This was previously changed form hidden to anonymous_admin, however,
when we switch to using the hidden administrators for backend operations
we only needed to check whether the user as an admin since the hidden
users are all admins.