### PR TITLE
Fixes #8544: Carry subscription-manager for EL5 in our client repos.

### DIFF
--- a/rel-eng/comps/comps-katello-client-rhel5.xml
+++ b/rel-eng/comps/comps-katello-client-rhel5.xml
@@ -25,9 +25,11 @@
        <packagereq type="default">python-pulp-rpm-common</packagereq>
        <packagereq type="default">python-qpid</packagereq>
        <packagereq type="default">python-qpid-common</packagereq>
+       <packagereq type="default">python-rhsm</packagereq>
        <packagereq type="default">python-saslwrapper</packagereq>
        <packagereq type="default">qpid-proton-c</packagereq>
        <packagereq type="default">saslwrapper</packagereq>
+       <packagereq type="default">subscription-manager</packagereq>
     </packagelist>
   </group>
 </comps>


### PR DESCRIPTION
Updates to subscription-manager that are not backwards compatible
to EL5 have been pushed into the public repositories. Thus, we can
just carry subscription-manager and python-rhsm from a known
working state in our client repositories.