### PR TITLE
Fixes #10152 - reduce num queries in sys#index

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -98,7 +98,8 @@ module Katello
 
       options = {
         :filters       => filters,
-        :load_records? => true
+        :load_records? => true,
+        :includes => [:content_view, :activation_keys, :environment]
       }
       respond_for_index(:collection => item_search(System, params, options))
     end

--- a/app/views/katello/api/v2/systems/base.json.rabl
+++ b/app/views/katello/api/v2/systems/base.json.rabl
@@ -1,0 +1,31 @@
+object @resource
+
+@resource ||= @object
+
+node(:id) { |resource| resource.uuid }
+attributes :id => :katello_id
+attributes :uuid, :name, :description
+attributes :location
+attributes :content_view, :content_view_id
+attributes :distribution
+attributes :katello_agent_installed? => :katello_agent_installed
+attributes :registered_by
+
+child :environment => :environment do
+  extends 'katello/api/v2/environments/show'
+end
+
+child :activation_keys => :activation_keys do
+  attributes :id, :name, :description
+end
+
+# Candlepin attributes
+attributes :entitlementStatus
+attributes :autoheal
+attributes :release, :ipv4_address
+attributes :checkin_time, :created
+attributes :installedProducts
+
+node :errata_counts do |system|
+  partial('katello/api/v2/errata/counts', :object => Katello::RelationPresenter.new(system.installable_errata))
+end

--- a/app/views/katello/api/v2/systems/index.json.rabl
+++ b/app/views/katello/api/v2/systems/index.json.rabl
@@ -1,3 +1,7 @@
 object false
 
-extends "katello/api/v2/common/index"
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends "katello/api/v2/systems/base"
+end

--- a/app/views/katello/api/v2/systems/show.json.rabl
+++ b/app/views/katello/api/v2/systems/show.json.rabl
@@ -2,27 +2,12 @@ object @resource
 
 @resource ||= @object
 
-node(:id) { |resource| resource.uuid }
-attributes :id => :katello_id
-attributes :uuid, :name, :description
-attributes :location
-attributes :content_view, :content_view_id
-attributes :distribution
-attributes :katello_agent_installed? => :katello_agent_installed
-attributes :registered_by
-
-glue :environment do
-  attributes :organization_id
-end
+extends "katello/api/v2/systems/base"
 
 child :products => :products do |_product|
   attributes :id, :name
 end
 attributes :content_overrides
-
-node :errata_counts do |system|
-  partial('katello/api/v2/errata/counts', :object => Katello::RelationPresenter.new(system.installable_errata))
-end
 
 child :foreman_host => :host do
   attributes :id, :name
@@ -50,21 +35,6 @@ end
 child :custom_info => :customInfo do
   attributes :id, :keyname, :value
 end
-
-child :environment => :environment do
-  extends 'katello/api/v2/environments/show'
-end
-
-child :activation_keys => :activation_keys do
-  attributes :id, :name, :description
-end
-
-# Candlepin attributes
-attributes :entitlementStatus
-attributes :autoheal
-attributes :release, :ipv4_address
-attributes :checkin_time, :created
-attributes :installedProducts
 
 attributes :serviceLevel => :service_level
 


### PR DESCRIPTION
Fixes #10152 - reduce num querys in sys#index …
* system's rabl  index renders without the use of the show template
* include :content_view, :activation_keys in elastic query for N+1 issue