### PR TITLE
Fixes #10249 - treat canceled tasks as errors

### DIFF
--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -104,11 +104,13 @@ module Katello
 
     class PulpError < StandardError
       def self.from_task(task)
-        if task[:state] == 'error'
+        if %w(error canceled).include?(task[:state])
           message = if task[:exception]
                       Array(task[:exception]).join('; ')
                     elsif task[:error]
                       "#{task[:error][:code]}: #{task[:error][:description]}"
+                    elsif task[:state] == 'canceled'
+                      _("Task canceled")
                     else
                       _("Pulp task error")
                     end


### PR DESCRIPTION
This gives the indication that the task was not finished properly and should
be resumed. Without this patch, we always treated it as success, which is not
correct behavior.