### PR TITLE
Fixes #10257: Connect capsule and its content host at the DB level.

### DIFF
--- a/app/lib/actions/katello/system/create.rb
+++ b/app/lib/actions/katello/system/create.rb
@@ -43,6 +43,8 @@ module Actions
           system.save!
           action_subject system
 
+          connect_to_smart_proxy(system)
+
           cp_create = plan_action(Candlepin::Consumer::Create, consumer_create_input)
           return if cp_create.error
 
@@ -62,6 +64,16 @@ module Actions
           system.disable_auto_reindex!
           system.uuid = input[:uuid]
           system.save!
+        end
+
+        def connect_to_smart_proxy(system)
+          smart_proxy = SmartProxy.where(:name => system.name).first
+
+          if smart_proxy
+            smart_proxy.content_host = system
+            smart_proxy.organizations << system.organization unless smart_proxy.organizations.include?(system.organization)
+            smart_proxy.save!
+          end
         end
       end
     end

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -41,7 +41,7 @@ module Katello
     delegate :uuid, :to => :consumer, :prefix => true
 
     def consumer
-      @consumer ||= System.where(name: @capsule.name).first
+      @consumer ||= @capsule.content_host
       unless @consumer
         fail Errors::CapsuleContentMissingConsumer, _("Could not find Content Host with exact name '%s', verify the Capsule is registered with that name.")  %
             @capsule.name

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -23,6 +23,7 @@ module Katello
         before_create :associate_organizations
         before_create :associate_default_location
         before_create :associate_lifecycle_environments
+        before_create :associate_content_host
         attr_accessible :lifecycle_environment_ids
 
         alias_method_chain :refresh, :dynflow
@@ -48,6 +49,11 @@ module Katello
                               :inverse_of => :content_source
         has_many :hostgroups, :class_name => "::Hostgroup",     :foreign_key => :content_source_id,
                               :inverse_of => :content_source
+
+        belongs_to :content_host,
+                   :class_name => "Katello::System",
+                   :inverse_of => :capsule,
+                   :foreign_key => :content_host_id
 
         scope :with_content, with_features(PULP_FEATURE, PULP_NODE_FEATURE)
 
@@ -86,6 +92,11 @@ module Katello
 
       def associate_lifecycle_environments
         self.lifecycle_environments = Katello::KTEnvironment.all if self.default_capsule?
+      end
+
+      def associate_content_host
+        content_host = Katello::System.where(:name => self.name).order("created_at DESC").first
+        self.content_host = content_host if content_host
       end
     end
   end

--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -63,6 +63,12 @@ module Katello
 
     belongs_to :content_view, :inverse_of => :systems
 
+    has_one :capsule,
+            :class_name => "::SmartProxy",
+            :inverse_of => :content_host,
+            :foreign_key => :content_host_id,
+            :dependent => :nullify
+
     validates_lengths_from_database
     before_validation :set_default_content_view, :unless => :persisted?
     validates :environment, :presence => true

--- a/db/migrate/20150423134004_add_content_host_id_to_smart_proxy.rb
+++ b/db/migrate/20150423134004_add_content_host_id_to_smart_proxy.rb
@@ -1,0 +1,19 @@
+class AddContentHostIdToSmartProxy < ActiveRecord::Migration
+  class SmartProxy < ActiveRecord::Base
+  end
+
+  class Katello::System < ActiveRecord::Base
+  end
+
+  def change
+    add_column :smart_proxies, :content_host_id, :integer
+    add_foreign_key :smart_proxies, :katello_systems, :column => "content_host_id"
+
+    SmartProxy.all.each do |proxy|
+      content_host = ::Katello::System.where(:name => proxy.name).order("created_at DESC").first
+
+      proxy.content_host_id = content_host.id
+      proxy.save!
+    end
+  end
+end

--- a/lib/katello/tasks/clean_backend_objects.rake
+++ b/lib/katello/tasks/clean_backend_objects.rake
@@ -17,10 +17,7 @@ namespace :katello do
           ::Katello::Resources::Candlepin::Consumer.destroy(system.uuid) unless cp_fail
           system.del_pulp_consumer unless (pulp_fail || system.is_a?(Katello::Hypervisor))
           Katello::System.index.remove system
-          system.system_activation_keys.destroy_all
-          system.system_host_collections.destroy_all
-          system.system_errata.destroy_all
-          system.delete
+          system.destroy!
         end
       end
     end

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -32,6 +32,7 @@ module ::Actions::Katello::CapsuleContent
       @capsule_system = create(:katello_system,
                                :capsule,
                                name: proxy_with_pulp.name,
+                               capsule: proxy_with_pulp,
                                environment: environment)
     end
   end

--- a/test/support/actions/remote_action.rb
+++ b/test/support/actions/remote_action.rb
@@ -12,8 +12,12 @@
 module Support
   module Actions
     module RemoteAction
-      def stub_remote_user
+      def stub_remote_user(admin = false)
         usr = mock('user', remote_id: 'user', login: 'user')
+        usr.stubs(:admin?).returns(admin)
+        usr.stubs(:location_and_child_ids).returns([])
+        usr.stubs(:organization_and_child_ids).returns([])
+
         User.stubs(:current).returns usr
       end
 


### PR DESCRIPTION
Currently there is no direct connection between a capsule and the
content host that represents it other than look ups by hostname during
certain operations. If the Capsule has been re-registered, then there
are situations where multiple content host records with the same hostname
can exist. This in turn can lead to a number of issues including the inability
to create repositories and sync content properly. This change adds a
system_id attribute to the smart proxy model. When a content host is created
a check is performed for any smart proxies with that hostname and the
two are associated (or re-associated if the smart proxy already had a
content host attached). This will also link an existing content host
to a smart proxy when the proxy is created.