### PR TITLE
Fixes #10258: hide "published at" section if puppet or ssl BZ 1131940.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
@@ -21,18 +21,21 @@
  * @requires translate
  * @requires Repository
  * @requires GPGKey
+ * @requires CurrentOrganization
  *
  * @description
  *   Provides the functionality for the repository details pane.
  */
 angular.module('Bastion.repositories').controller('RepositoryDetailsInfoController',
-    ['$scope', '$state', '$q', 'translate', 'Repository', 'GPGKey', function ($scope, $state, $q, translate, Repository, GPGKey) {
+    ['$scope', '$state', '$q', 'translate', 'Repository', 'GPGKey', 'CurrentOrganization',
+    function ($scope, $state, $q, translate, Repository, GPGKey, CurrentOrganization) {
         var updateRepositoriesTable;
 
         $scope.successMessages = [];
         $scope.errorMessages = [];
         $scope.uploadSuccessMessages = [];
         $scope.uploadErrorMessages = [];
+        $scope.organization = CurrentOrganization;
 
         $scope.progress = {uploading: false};
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -138,13 +138,19 @@
             on-save="save(repository)"
             readonly="product.readonly || denied('edit_products', product)">
       </span>
-
     </div>
 
-    <div class="detail">
+    <div class="detail" ng-hide="repository.content_type === 'puppet'">
       <span class="info-label" translate>Published At</span>
       <span class="info-value">
         <a ng-href="{{ repository.full_path }}">{{ repository.full_path }}</a>
+
+        <p bst-alert='info' ng-hide="repository.unprotected">
+          <span translate>
+            In order to browse this repository you must <a ng-href="/organizations/{{ organization }}/edit">download the certificate</a>
+            or ask your admin for a certificate.
+          </span>
+        </p>
       </span>
     </div>
 


### PR DESCRIPTION
We currently don't support publishing puppet repositories via http or
browsing ssl repositories so we should hide the link.

http://projects.theforeman.org/issues/10258
https://bugzilla.redhat.com/show_bug.cgi?id=1131940