### PR TITLE
Fixes #10309: prevent ISE on CH bulk actions errata BZ1216195.

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -86,7 +86,7 @@ module Katello
     end
 
     def scoped_search(query, default_sort_by, default_sort_order, options = {})
-      resource = options.fetch(:resource_class, resource_class)
+      resource = options[:resource_class] || resource_class
       includes = options.fetch(:includes, [])
 
       total = query.count


### PR DESCRIPTION
We were calling the resource class method in cases where it was
not appropriate because fetch() calls the default before checking
if the value exists.  This commit sets the default after attempting
the fetch first.

http://projects.theforeman.org/issues/10309
https://bugzilla.redhat.com/show_bug.cgi?id=1216195