### PR TITLE
fixes #10331 - fix assocation from lifecycle environment to hosts

### DIFF
--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -46,7 +46,7 @@ module Katello
     has_many :content_view_histories, :class_name => "Katello::ContentViewHistory", :dependent => :destroy,
                                       :inverse_of => :environment, :foreign_key => :katello_environment_id
 
-    has_many :hosts,      :class_name => "::Host::Managed", :foreign_key => :content_view_id,
+    has_many :hosts,      :class_name => "::Host::Managed", :foreign_key => :lifecycle_environment_id,
                               :inverse_of => :lifecycle_environment, :dependent => :restrict
     has_many :hostgroups, :class_name => "::Hostgroup",     :foreign_key => :lifecycle_environment_id,
                           :inverse_of => :lifecycle_environment, :dependent => :restrict


### PR DESCRIPTION
User was getting strange errors trying to delete a lifecycle environment that had no hosts... this is why