### PR TITLE
Fixes #10383: change errata issued/updated columns to date, BZ1215756.

### DIFF
--- a/db/migrate/20150505180030_change_errata_timestamps_to_dates.rb
+++ b/db/migrate/20150505180030_change_errata_timestamps_to_dates.rb
@@ -1,0 +1,15 @@
+class ChangeErrataTimestampsToDates < ActiveRecord::Migration
+  def up
+    change_column(:katello_errata, :issued, :date)
+    change_column(:katello_errata, :updated, :date)
+    add_index(:katello_errata, :issued)
+    add_index(:katello_errata, :updated)
+  end
+
+  def down
+    change_column(:katello_errata, :issued, :timestamp)
+    change_column(:katello_errata, :updated, :timestamp)
+    remove_index(:katello_errata, :issued)
+    remove_index(:katello_errata, :updated)
+  end
+end


### PR DESCRIPTION
Use date types instead of timestamps for errata issued and updated
dates so as to avoid unnecessary timezone math.

http://projects.theforeman.org/issues/10383
https://bugzilla.redhat.com/show_bug.cgi?id=1215756