### PR TITLE
fixes #10422 - send hash to capsule sync plan as expected

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -51,7 +51,7 @@ module Katello
     param :environment_id, Integer, :desc => 'Id of the environment to limit the synchronization on'
     def sync
       find_environment if params[:environment_id]
-      task = async_task(::Actions::Katello::CapsuleContent::Sync, capsule_content, @environment)
+      task = async_task(::Actions::Katello::CapsuleContent::Sync, capsule_content, :environment => @environment)
       respond_for_async :resource => task
     end
 

--- a/test/controllers/api/v2/capsule_content_controller_test.rb
+++ b/test/controllers/api/v2/capsule_content_controller_test.rb
@@ -72,9 +72,9 @@ module Katello
     end
 
     def test_sync
-      assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule_content, caps_environment|
+      assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule_content, options|
         capsule_content.capsule.id.must_equal proxy_with_pulp.id
-        caps_environment.id.must_equal environment.id
+        options[:environment].id.must_equal environment.id
       end
 
       post :sync, :id => proxy_with_pulp.id, :environment_id => environment.id


### PR DESCRIPTION
This is the minimum to get capsule sync working again.  The action plan was changed to expect a hash.
