### PR TITLE
Fixes #10388 - Remove license from javascript files

### DIFF
--- a/app/assets/javascripts/katello/common/env_select.js
+++ b/app/assets/javascripts/katello/common/env_select.js
@@ -1,15 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
 var env_select =   {
     /* Click callback should be a function:
      *

--- a/app/assets/javascripts/katello/common/experimental/katello-globals.module.js
+++ b/app/assets/javascripts/katello/common/experimental/katello-globals.module.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc module
  * @name  Katello.globals
  *

--- a/app/assets/javascripts/katello/common/index.js
+++ b/app/assets/javascripts/katello/common/index.js
@@ -1,15 +1,3 @@
-/* Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "katello/common/katello.global"
 //= require "katello/common/katello.common.js"
 //= require "katello/common/katello"

--- a/app/assets/javascripts/katello/common/jquery.jeditable.custominputs.js
+++ b/app/assets/javascripts/katello/common/jquery.jeditable.custominputs.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 $(document).ready(function() {
 
     // override textfield

--- a/app/assets/javascripts/katello/common/katello.common.js
+++ b/app/assets/javascripts/katello/common/katello.common.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 //requires jQuery
 KT.common = (function() {
     var root_url;

--- a/app/assets/javascripts/katello/common/katello.global.js
+++ b/app/assets/javascripts/katello/common/katello.global.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //Katello global object namespace that all others should be attached to
 var KT = {};
 

--- a/app/assets/javascripts/katello/common/katello.js
+++ b/app/assets/javascripts/katello/common/katello.js
@@ -1,17 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-
 /*
  * Katello Global JavaScript File
  * Author: @jrist

--- a/app/assets/javascripts/katello/common/katello_object.js
+++ b/app/assets/javascripts/katello/common/katello_object.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 KT.object = KT.object || {};
 
 // The KT Object label will handle the interaction where a user enters a

--- a/app/assets/javascripts/katello/common/menu.js
+++ b/app/assets/javascripts/katello/common/menu.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 /*
  * Katello JavaScript Menu File
  * Author: jrist

--- a/app/assets/javascripts/katello/common/notices.js
+++ b/app/assets/javascripts/katello/common/notices.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 var notices = (function() {
     return {
         setup_notices: function(pollingTimeOut) {

--- a/app/assets/javascripts/katello/common/search.js
+++ b/app/assets/javascripts/katello/common/search.js
@@ -1,17 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-
 KT.favorite = function(form, input) {
     var success =  function(data) {
             form.find(".qdropdown").html(data);

--- a/app/assets/javascripts/katello/common/vendor.js
+++ b/app/assets/javascripts/katello/common/vendor.js
@@ -1,15 +1,3 @@
-/* Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "bastion/underscore/underscore"
 //= require "jquery.ui.dialog"
 //= require "jquery.ui.sortable"

--- a/app/assets/javascripts/katello/containers/container.js
+++ b/app/assets/javascripts/katello/containers/container.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 var KT = KT ? KT : {};
 
 KT.container = (function(){

--- a/app/assets/javascripts/katello/content_search/content_search.js
+++ b/app/assets/javascripts/katello/content_search/content_search.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 /*jshint multistr: true */
 
 $(document).ready(function() {

--- a/app/assets/javascripts/katello/content_search/index.js
+++ b/app/assets/javascripts/katello/content_search/index.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "katello/chosen.jquery"
 //= require "katello/jquery.hoverIntent"
 //= require "katello/common/env_select_scroll"

--- a/app/assets/javascripts/katello/dashboard/dashboard.js
+++ b/app/assets/javascripts/katello/dashboard/dashboard.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 KT.dashboard = (function(){
     var plot = function() {
         if (KT.subscription_data) {

--- a/app/assets/javascripts/katello/dashboard/index.js
+++ b/app/assets/javascripts/katello/dashboard/index.js
@@ -1,14 +1,1 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "katello/dashboard/dashboard"

--- a/app/assets/javascripts/katello/html5/index.js
+++ b/app/assets/javascripts/katello/html5/index.js
@@ -1,14 +1,2 @@
-/* Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "katello/html5/html5"
 //= require "katello/html5/excanvas"

--- a/app/assets/javascripts/katello/notices/index.js
+++ b/app/assets/javascripts/katello/notices/index.js
@@ -1,14 +1,1 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "katello/notices/notices_list"

--- a/app/assets/javascripts/katello/notices/notices_list.js
+++ b/app/assets/javascripts/katello/notices/notices_list.js
@@ -1,15 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
 KT.notices_list = (function() {
     var deleteAll = function(e) {
         $('#notification_list').empty();

--- a/app/assets/javascripts/katello/organizations/download_certificate.js
+++ b/app/assets/javascripts/katello/organizations/download_certificate.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 $(document).ready(function() {
     $('#download_debug_cert_key').live('click', function(e) {
         e.preventDefault();

--- a/app/assets/javascripts/katello/providers/provider_redhat.js
+++ b/app/assets/javascripts/katello/providers/provider_redhat.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 $(document).ready(function() {
     var spinner = '<i class="icon-spinner inline-icon icon-spin"></i>';
 

--- a/app/assets/javascripts/katello/providers/redhat/index.js
+++ b/app/assets/javascripts/katello/providers/redhat/index.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "katello/jquery.treeTable"
 //= require "katello/widgets/jquery.jeditable.helpers"
 //= require "katello/widgets/tabs"

--- a/app/assets/javascripts/katello/sync_management/index.js
+++ b/app/assets/javascripts/katello/sync_management/index.js
@@ -1,15 +1,2 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //= require "katello/jquery.treeTable"
 //= require "katello/sync_management/sync_management"

--- a/app/assets/javascripts/katello/sync_management/sync_management.js
+++ b/app/assets/javascripts/katello/sync_management/sync_management.js
@@ -1,17 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-
 $(document).ready(function() {
   // Setup initial state
 

--- a/app/assets/javascripts/katello/widgets/auto_complete.js
+++ b/app/assets/javascripts/katello/widgets/auto_complete.js
@@ -1,15 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
 KT.auto_complete_box = function(params) {
 
     var settings = {

--- a/app/assets/javascripts/katello/widgets/comparison_grid.js
+++ b/app/assets/javascripts/katello/widgets/comparison_grid.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 var KT = (KT === undefined) ? {} : KT;
 
 KT.comparison_grid = function(){

--- a/app/assets/javascripts/katello/widgets/env_content_view_selector.js
+++ b/app/assets/javascripts/katello/widgets/env_content_view_selector.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 KT.env_content_view_selector = (function() {
     var env_div,
         content_view_div,

--- a/app/assets/javascripts/katello/widgets/filtertable/filtertable.js
+++ b/app/assets/javascripts/katello/widgets/filtertable/filtertable.js
@@ -1,15 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
 var filtertable = (function() {
     return {
         initialize : function() {

--- a/app/assets/javascripts/katello/widgets/jquery.jeditable.helpers.js
+++ b/app/assets/javascripts/katello/widgets/jquery.jeditable.helpers.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * Helper functions that may be included and used from pages using
  * inline editing via jeditable.
  */

--- a/app/assets/javascripts/katello/widgets/one_panel.js
+++ b/app/assets/javascripts/katello/widgets/one_panel.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 var one_panel = {
   selectedItems: {},
   setup: function () {

--- a/app/assets/javascripts/katello/widgets/path_selector.js
+++ b/app/assets/javascripts/katello/widgets/path_selector.js
@@ -1,18 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-
-/**
  * @param div_id   -  id of div to house env_selector
  * @param name    -  the name of this env selector ( in case there is more than one)
  * @param environments - array of environment paths

--- a/app/assets/javascripts/katello/widgets/subpanel_new.js
+++ b/app/assets/javascripts/katello/widgets/subpanel_new.js
@@ -1,15 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
 $(document).ready(function(){
   var form_id = $('#new_subpanel'),
       form_submit_id = form_id.find('.subpanel_create'),

--- a/app/assets/javascripts/katello/widgets/tabs.js
+++ b/app/assets/javascripts/katello/widgets/tabs.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 /*
  * Katello JavaScript Menu File
  * Author: jrist

--- a/app/assets/stylesheets/katello/_katello_mixins.scss
+++ b/app/assets/stylesheets/katello/_katello_mixins.scss
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 //katello specific mixins
 
 @mixin column-count($c) {

--- a/app/assets/stylesheets/katello/_overrides.scss
+++ b/app/assets/stylesheets/katello/_overrides.scss
@@ -1,15 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
 $primary_color: rgb(0, 112, 143);
 $static_width: 1152px;
 $fa-font-path: "../bastion/font-awesome";

--- a/deploy/katello.spec
+++ b/deploy/katello.spec
@@ -1,16 +1,3 @@
-# vim: sw=4:ts=4:et
-#
-# Copyright 2014 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 %if "%{?scl}" == "ruby193"
     %global scl_prefix %{scl}-
     %global scl_ruby /usr/bin/ruby193-ruby

--- a/deploy/script/service-wait
+++ b/deploy/script/service-wait
@@ -1,16 +1,3 @@
-#!/bin/bash
-#
-# Copyright 2014 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-#
 # Wrapper around /sbin/service command.
 #
 # Some services do not start or stop properly and return non-zero values

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-key.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-key.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
-
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc factory
  * @name  Bastion.activation-keys.factory:ActivationKey
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeysController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2013-2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.activation-keys
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activationKeyConsumed.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activationKeyConsumed.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.activation-keys.filter:activationKeyConsumedFilter
  */

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-add-host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-add-host-collections.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.systems.controller:ActivationKeyAddHostCollectionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-add-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-add-subscriptions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeyAddSubscriptionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeyAssociationsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details-info.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeyDetailsInfoController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeyDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-host-collections.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.systems.controller:ActivationKeyHostCollectionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-product-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-product-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeyProductDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-products.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeyProductsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:ActivationKeySubscriptionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/new-activation-key.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/new-activation-key.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.activation-keys.controller:NewActivationKeyController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 BASTION_MODULES.push(
     'Bastion.activation-keys',
     'Bastion.content-views',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
@@ -1,15 +1,3 @@
-/* Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 //= require "bastion_katello/host-collections/host-collections.module.js"
 //= require_tree "./host-collections"
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsule.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsule.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.capsules.factory:Capsule
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsules.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsules.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.capsules
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-environment.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-environment.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostsBulkActionEnvironmentController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-errata.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostsBulkActionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostsBulkActionHostCollectionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-packages.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostsBulkActionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostsBulkActionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostsBulkActionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-erratum.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-hosts.factory:ContentHostErratum
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-events.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-events.controller.js
@@ -1,17 +1,3 @@
-
-/**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 /**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostEventsController

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-package.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-package.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-hosts.factory:ContentHostPackage
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostRegisterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-status.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-status.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostStatusController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-hosts.factory:ContentHost
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-hosts.service:ContentHostsHelper
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.content-hosts
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostErrataController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostPackagesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-host-collections.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostAddHostCollectionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostAddSubscriptionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-base-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-base-subscriptions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostBaseSubscriptionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-host-collections.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostHostCollectionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-product-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-product-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostProductDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-products.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostProductsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-hosts.controller:ContentHostSubscriptionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-view.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-view.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-views.factory:ContentView
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.module.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.content-views
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc object
  * @name Bastion.content-views.config
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-deletion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-deletion.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewDeletionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewVersionDeletionActivationKeys
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-confirm.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-confirm.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewVersionDeletionConfirm
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-content-hosts.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewVersionDeletionContentHosts
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-environments.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-environments.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewVersionDeletionEnvironments
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewVersionDeletion
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewAvailableDockerRepositoriesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-puppet-modules.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-puppet-modules.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:AvailablePuppetModulesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewAvailableRepositoriesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-composite-available-content-views.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-composite-available-content-views.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewCompositeAvailableContentViewsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-composite-content-views-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-composite-content-views-list.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewCompositeContentViewsListController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details-history.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details-history.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewHistoryController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewDockerRepositoriesListController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewPromotionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewPublishController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewRepositoriesListController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories.service.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.service:ContentViewRepositoriesService
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewVersionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:AvailableErrataFilterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-package-group-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-package-group-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:AvailablePackageGroupFilterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/date-type-errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/date-type-errata-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:DateTypeErrataFilterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/edit-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/edit-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:FilterEditController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter-list.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ErrataFilterListController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ErrataFilterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-content-type.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-content-type.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.content-views.filter:FilterContentType
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:FilterDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-helper.service.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-views.service:FilterHelper
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-repositories.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:FilterRepositoriesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-type.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-type.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.content-views.filter:FilterType
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-views.factory:Filter
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filters.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filters.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:FiltersController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/new-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/new-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:NewFilterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:PackageFilterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-group-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-group-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:PackageGroupFilterController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-group-list-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-group-list-filter.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:PackageFilterListController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/rule.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/rule.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-views.filters.factory:Filter
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-names.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-names.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewPuppetModulesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewPuppetModulesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-views.factory:ContentViewPuppetModule
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-modules.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-modules.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:ContentViewPuppetModulesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.content-views.controller:NewContentViewController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.controller.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.content-views.factory:ContentViewVersion
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-versions.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-versions.module.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.content-views.versions
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/custom-info/custom-info.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/custom-info/custom-info.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.custom-info.factory:CustomInfo
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/custom-info/custom-info.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/custom-info/custom-info.module.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.custom-info
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-images/docker-image.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-images/docker-image.factory.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-images/docker-images.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-images/docker-images.module.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tags-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tags-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.docker-tags.controller:DockerTagsDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2015 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.docker-tags.controller:DockerTagsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2015 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.docker-tags.factory:DockerTag
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2015 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.docker-tags
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.routes.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2015 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc object
  * @name Bastion.docker-tags.config
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environment.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environment.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.environments.factory:Environment
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.environments.controller:EnvironmentsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.module.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.environments
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.routes.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc object
  * @name Bastion.environments.config
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/new-environment.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/new-environment.controller.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2015 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.errata.controller:ApplyErrataController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.errata.controller:ErrataContentHostsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-details-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-details-repositories.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.errata.controller:ErrataDetailsRepositoriesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.errata.controller:ErrataDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-counts.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-counts.directive.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc directive
  * @name bastion.errata:errataCounts
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-severity.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-severity.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.errata.filter:errataSeverity
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-type.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-type.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.errata.filter:errataType
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.errata.controller:ErrataController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.errata
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc object
  * @name Bastion.errata.config
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.errata.factory:Erratum
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details-info.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.gpgKeys.controller:GPGKeyDetailsInfoController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.gpg-keys.controller:GPGKeyDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-key.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-key.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Katello.gpg-keys.factory:GPGKey
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-keys.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-keys.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.gpg-keys.controller:GPGKeysController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-keys.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-keys.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.gpg-keys
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/new/new-gpg-key.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/new/new-gpg-key.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.gpg-keys.controller:NewGPGKeyController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-content-hosts.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.host-collections.controller:HostCollectionAddContentHostsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-content-hosts.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.host-collections.controller:HostCollectionContentHostsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.host-collections.controller:HostCollectionDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
-
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc factory
  * @name  Bastion.host-collections.factory:HostCollection
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.host-collections.controller:HostCollectionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.host-collections
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/new/host-collection-form.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/new/host-collection-form.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.host-collections.controller:HostCollectionFormController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/new/new-host-collection.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/new/new-host-collection.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.host-collections.controller:NewHostCollectionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/check-current-organization.run.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/check-current-organization.run.js
@@ -1,17 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-
 (function () {
 
     /**

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization-selector.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization-selector.controller.js
@@ -1,17 +1,3 @@
-/**
-* Copyright 2015 Red Hat, Inc.
-*
-* This software is licensed to you under the GNU General Public
-* License as published by the Free Software Foundation; either version
-* 2 of the License (GPLv2) or (at your option) any later version.
-* There is NO WARRANTY for this software, express or implied,
-* including the implied warranties of MERCHANTABILITY,
-* NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-* have received a copy of GPLv2 along with this software; if not, see
-* http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-**/
-
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.organizations.factory:Organization
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.organizations
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.routes.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
 
     /**

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-group.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-group.factory.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-groups.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-groups.module.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.providers.factory:Package
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.packages
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action-sync-plan.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductsBulkActionSyncPlanController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action-sync.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action-sync.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductsBulkActionSyncController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductsBulkActionController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details-info.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductDetailsInfoController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductRepositoriesController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-form.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-form.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:DiscoveryFormController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:DisocveryController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/new-product.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/new-product.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:NewProductController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/product-form.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/product-form.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductFormController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.products.factory:Product
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.products.controller:ProductsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.products
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-module.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-module.factory.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-modules.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-modules.module.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 (function () {
     'use strict';
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.repositories.controller:RepositoryDetailsInfoController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-content.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.repositories.controller:RepositoryManageContentController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.repositories.controller:NewRepositoryController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repositories.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repositories.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.repositories
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repository.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repository.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.repositories.factory:Repository
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-associations-activation-keys.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-associations-activation-keys.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:SubscriptionAssociationsActivationKeysController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-associations-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-associations-content-hosts.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:SubscriptionAssociationsContentHostsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:SubscriptionDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-product-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-product-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:SubscriptionProductDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-products.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:SubscriptionProductsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:ManifestDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-history.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-history.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:ManifestHistoryController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:ManifestImportController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:ManifestController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscription-type.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscription-type.directive.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc directive
  * @name Bastion.subscriptions:subscriptionType
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptionAttachAmountFilter.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptionAttachAmountFilter.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.subscriptions.filter:subscriptionAttachAmountFilter.filter.js
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptionConsumed.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptionConsumed.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.subscriptions.filter:subscriptionConsumedFilter
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions-helper.service.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc service
  * @name  Bastion.subscriptions.service:SubscriptionsHelper
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
-/**
  * @ngdoc object
  * @name  Bastion.subscriptions.controller:SubscriptionsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2013-2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.subscriptions.factory:Subscription
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2013-2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.subscriptions
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-add-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-add-products.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.sync-plans.controller:SyncPlanAddProductsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.syncPlans.controller:SyncPlanDetailsInfoController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.sync-plan.controller:SyncPlanDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-products.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.sync-plans.controller:SyncPlanProductsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.sync-plans.controller:NewSyncPlanController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan.factory.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc factory
  * @name  Bastion.sync-plans.factory:SyncPlan
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014  Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.syncPlans.controller:SyncPlansController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.sync-plans
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/aggregate-task.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/aggregate-task.factory.js
@@ -1,17 +1,4 @@
 /**
-* Copyright 2014 Red Hat, Inc.
-*
-* This software is licensed to you under the GNU General Public
-* License as published by the Free Software Foundation; either version
-* 2 of the License (GPLv2) or (at your option) any later version.
-* There is NO WARRANTY for this software, express or implied,
-* including the implied warranties of MERCHANTABILITY,
-* NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-* have received a copy of GPLv2 along with this software; if not, see
-* http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-**/
-
-/**
 * @ngdoc service
 * @name  Bastion.tasks.factory:AggregateTask
 *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-details.controller.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc object
  * @name  Bastion.tasks.controller:TaskDetailsController
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-compile.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-compile.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.tasks.filter:taskInputCompile
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-part.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-part.directive.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc directive
  * @name  Bastion.tasks.directive:taskInputPart
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-reduce.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-reduce.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.tasks.filter:taskInputReduce
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-short.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-input-short.filter.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc filter
  * @name  Bastion.tasks.filter:taskInputCompile
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task.factory.js
@@ -1,17 +1,4 @@
  /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc service
  * @name  Bastion.tasks.factory:Task
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-nutupane.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-nutupane.factory.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc factory
  * @name  Bastion.tasks.factory:TaskNutupane
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-table.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-table.directive.js
@@ -1,17 +1,4 @@
 /**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
-/**
  * @ngdoc directive
  * @name  Bastion.tasks.directive:tasksTable
  *

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
@@ -1,17 +1,4 @@
 /**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
-/**
  * @ngdoc module
  * @name  Bastion.tasks
  *

--- a/engines/bastion_katello/test/activation-keys/activation-key.factory.test.js
+++ b/engines/bastion_katello/test/activation-keys/activation-key.factory.test.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: ActivationKey', function() {
 
     beforeEach(module('Bastion.activation-keys', 'Bastion.test-mocks'));

--- a/engines/bastion_katello/test/activation-keys/activation-keys.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/activation-keys.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 describe('Controller: ActivationKeysController', function() {
     var $scope,
         ActivationKey,

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-add-host-collections.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-add-host-collections.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 describe('Controller: ActivationKeyAddHostCollectionsController', function() {
     var $scope,
         ActivationKey,

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-add-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-add-subscriptions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 describe('Controller: ActivationKeyAddSubscriptionsController', function() {
     var $scope,
         ActivationKey,

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ActivationKeyAssociationsController', function() {
     var $scope,
         ActivationKey,

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-product-details.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-product-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ActivationKeyProductDetailsController', function () {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-products.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-products.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ActivationKeyProductDetailsController', function () {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/activation-keys/new/new-activation-key.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/new/new-activation-key.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-*/
-
 describe('Controller: NewActivationKeyController', function() {
     var $scope,
         $httpBackend,

--- a/engines/bastion_katello/test/capsules/capsule.factory.test.js
+++ b/engines/bastion_katello/test/capsules/capsule.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Capsule', function() {
     var $httpBackend,
         capsules,

--- a/engines/bastion_katello/test/content-hosts/bulk-action.factory.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk-action.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: ContentHostBulkAction', function() {
     var $httpBackend,
         ContentHostBulkAction,

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-environment.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-environment.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsBulkActionEnvironmentController', function() {
     var $scope, BulkAction, selectedContentHosts, CurrentOrganization, ContentView, paths, Organization;
 

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-errata.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsBulkActionErrataController', function() {
     var $scope, $q, translate, ContentHostBulkAction, HostCollection, selectedErrata,
          selectedContentHosts, CurrentOrganization, Nutupane;

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-host-collections.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsBulkActionHostCollectionsController', function() {
     var $scope, $q, translate, ContentHostBulkAction, HostCollection, Organization,
         Task, CurrentOrganization, Nutupane, $location, hostCollectionIds;

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-packages.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsBulkActionPackagesController', function() {
     var $scope, $q, translate, ContentHostBulkAction, HostCollection, Organization,
         Task, CurrentOrganization, selected;

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsBulkActionSubscriptionsController', function() {
     var $scope, $_q_, translate, ContentHostBulkAction, HostCollection, Organization, Task, CurrentOrganization;
 

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsBulkActionController', function() {
     var $scope, $q, selected, translate, ContentHostBulkAction, HostCollection, Organization, Task, CurrentOrganization;
 

--- a/engines/bastion_katello/test/content-hosts/content-host-erratum.factory.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-host-erratum.factory.test.js
@@ -1,16 +1,3 @@
-/**
-* Copyright 2014 Red Hat, Inc.
-*
-* This software is licensed to you under the GNU General Public
-* License as published by the Free Software Foundation; either version
-* 2 of the License (GPLv2) or (at your option) any later version.
-* There is NO WARRANTY for this software, express or implied,
-* including the implied warranties of MERCHANTABILITY,
-* NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-* have received a copy of GPLv2 along with this software; if not, see
-* http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-**/
-
 describe('Factory: ContentHostErratum', function($provide) {
     var $httpBackend,
         task,

--- a/engines/bastion_katello/test/content-hosts/content-host-package.factory.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-host-package.factory.test.js
@@ -1,16 +1,3 @@
-/**
-* Copyright 2014 Red Hat, Inc.
-*
-* This software is licensed to you under the GNU General Public
-* License as published by the Free Software Foundation; either version
-* 2 of the License (GPLv2) or (at your option) any later version.
-* There is NO WARRANTY for this software, express or implied,
-* including the implied warranties of MERCHANTABILITY,
-* NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-* have received a copy of GPLv2 along with this software; if not, see
-* http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-**/
-
 describe('Factory: ContentHostPackage', function() {
     var $httpBackend,
         task,

--- a/engines/bastion_katello/test/content-hosts/content-host-register.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-host-register.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostRegisterController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-hosts/content-host.factory.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-host.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: ContentHost', function() {
     var ContentHost,
         releaseVersions,

--- a/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsController', function() {
     var ContentHostsHelper;
 

--- a/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostsController', function() {
     var $scope, translate, ContentHost, Nutupane;
 

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostErrataController', function() {
     var $scope, Nutupane, ContentHostErratum, Environment, Organization,
         mockContentHost, mockTask, mockErratum, ContentHost, mockContentView, nutupaneMock;

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostPackagesController', function() {
     var $scope, Nutupane, ContentHostPackage, mockContentHost, mockTask, translate, ContentHost;
 

--- a/engines/bastion_katello/test/content-hosts/details/content-host-add-host-collections.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-add-host-collections.controller.test.js
@@ -1,16 +1,3 @@
-1/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostAddHostCollectionsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-add-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-add-subscriptions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostAddSubscriptionsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-base-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-base-subscriptions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostBaseSubscriptionsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostDetailsInfoController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostDetailsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-host-collections.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-host-collections.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostHostCollectionsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-product-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-product-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostProductDetailsController', function () {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-products.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-products.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostProductDetailsController', function () {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-hosts/details/content-host-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-subscriptions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentHostSubscriptionsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-views/content-view.factory.test.js
+++ b/engines/bastion_katello/test/content-views/content-view.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: ContentView', function() {
     var $httpBackend,
         ContentView,

--- a/engines/bastion_katello/test/content-views/content-views.controller.test.js
+++ b/engines/bastion_katello/test/content-views/content-views.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewsController', function() {
     var $scope,
         ContentView,

--- a/engines/bastion_katello/test/content-views/details/content-view-available-docker-repositories.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-available-docker-repositories.controller.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewAvailableDockerRepositoriesController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-available-repositories.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-available-repositories.controller.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewAvailableRepositoriesController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-composite-available-content-views.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-composite-available-content-views.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewCompositeAvailableContentViewsController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-composite-content-views-list.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-composite-content-views-list.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewCompositeContentViewsListController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-details-history.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-details-history.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewHistoryController', function() {
     var $scope, history, Nutupane;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-details.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewDetailsController', function() {
     var $scope,
         ContentView,

--- a/engines/bastion_katello/test/content-views/details/content-view-docker-repositories-list.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-docker-repositories-list.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewDockerRepositoriesListController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-publish.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-publish.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewPublishController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-repositories-list.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-repositories-list.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewRepositoriesListController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-repositories.service.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-repositories.service.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Service: ContentViewRepositoriesService', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/details/content-view-versions.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-versions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewVersionsController', function() {
     var $scope
 

--- a/engines/bastion_katello/test/content-views/details/deletion/content-view-deletion.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/deletion/content-view-deletion.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewDeletionController', function() {
     var $scope,
         versions,

--- a/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-activation-keys.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-activation-keys.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewVersionDeletionActivationKeysController', function() {
     var $scope, Organization, CurrentOrganization;
 

--- a/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-confirm.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-confirm.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewVersionDeletionConfirmController', function() {
     var $scope, environments, version, ContentView;
 

--- a/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-content-hosts.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewVersionDeletionContentHostsController', function() {
     var $scope, Organization, CurrentOrganization;
 

--- a/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-environments.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion-environments.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewVersionDeletionEnvironmentsController', function() {
     var $scope, environments, version;
 

--- a/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/deletion/content-view-version-deletion.controller.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
 describe('ContentViewVersionDeletionController', function() {
     var $scope, ContentViewVersion, ContentView, $state;
 

--- a/engines/bastion_katello/test/content-views/details/filters/available-errata-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/available-errata-filter.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: AvailableErrataFilterController', function() {
     var $scope, Rule;
 

--- a/engines/bastion_katello/test/content-views/details/filters/available-package-group-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/available-package-group-filter.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: AvailablePackageGroupFilterController', function() {
     var $scope, Rule;
 

--- a/engines/bastion_katello/test/content-views/details/filters/date-type-errata-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/date-type-errata-filter.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: DateTypeErrataFilterController', function() {
     var $scope, Rule;
 

--- a/engines/bastion_katello/test/content-views/details/filters/errata-filter-list.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/errata-filter-list.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ErrataFilterListController', function() {
     var $scope,
         Rule;

--- a/engines/bastion_katello/test/content-views/details/filters/errata-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/errata-filter.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ErrataFilterController', function() {
     var $scope, Filter;
 

--- a/engines/bastion_katello/test/content-views/details/filters/filter-content-type.filter.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter-content-type.filter.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 describe('Filter: filterContentType', function() {
     var filterContentTypeFilter;
 

--- a/engines/bastion_katello/test/content-views/details/filters/filter-details.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: FilterDetailsController', function() {
     var $scope, Filter;
 

--- a/engines/bastion_katello/test/content-views/details/filters/filter-helper.service.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter-helper.service.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 describe('Service: FilterHelper', function() {
     var FilterHelper;
 

--- a/engines/bastion_katello/test/content-views/details/filters/filter-repositories.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter-repositories.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: FilterRepositoriesController', function() {
     var $scope, $controller, dependencies, Filter, filter;
 

--- a/engines/bastion_katello/test/content-views/details/filters/filter-type.filter.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter-type.filter.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
-
 describe('Filter: filterType', function() {
     var filterTypeFilter;
 

--- a/engines/bastion_katello/test/content-views/details/filters/filter.factory.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Filter', function() {
     var $httpBackend,
         filters;

--- a/engines/bastion_katello/test/content-views/details/filters/filters.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filters.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: FiltersController', function() {
     var $scope,
         Filter;

--- a/engines/bastion_katello/test/content-views/details/filters/new-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/new-filter.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewFilterController', function() {
     var $scope,
         Filter,

--- a/engines/bastion_katello/test/content-views/details/filters/package-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/package-filter.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: PackageFilterController', function() {
     var $scope, Rule, Package;
 

--- a/engines/bastion_katello/test/content-views/details/filters/package-group-list-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/package-group-list-filter.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: PackageGroupFilterListController', function() {
     var $scope,
         Rule;

--- a/engines/bastion_katello/test/content-views/details/filters/rule.factory.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/rule.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Rule', function() {
     var $httpBackend,
         rules;

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-names.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-names.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewPuppetModuleNamesController', function() {
     var $scope, $controller, dependencies, ContentView;
 

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewPuppetModuleVersionsController', function() {
     var $scope, $controller, dependencies, ContentView, ContentViewPuppetModule, puppetModule;
 

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module.factory.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: ContentViewPuppetModule', function() {
     var $httpBackend,
         ContentViewPuppetModule,

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-modules.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-modules.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewPuppetModulesController', function() {
     var $scope, Nutupane, ContentViewPuppetModule, puppetModule;
 

--- a/engines/bastion_katello/test/content-views/new/content-view-new.controller.test.js
+++ b/engines/bastion_katello/test/content-views/new/content-view-new.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewContentViewController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/content-views/versions/content-view-version-content.controller.test.js
+++ b/engines/bastion_katello/test/content-views/versions/content-view-version-content.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewsVersionContentController', function() {
     var $scope,
         Package,

--- a/engines/bastion_katello/test/content-views/versions/content-view-version-details.controller.test.js
+++ b/engines/bastion_katello/test/content-views/versions/content-view-version-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ContentViewVersionController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/content-views/versions/content-view-version.factory.test.js
+++ b/engines/bastion_katello/test/content-views/versions/content-view-version.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: ContentViewVersion', function () {
     var $httpBackend,
         contentViewVersion;

--- a/engines/bastion_katello/test/custom-info/custom-info.factory.test.js
+++ b/engines/bastion_katello/test/custom-info/custom-info.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: CustomInfo', function() {
     var $httpBackend;
 

--- a/engines/bastion_katello/test/docker-images/docker-image.factory.test.js
+++ b/engines/bastion_katello/test/docker-images/docker-image.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: DockerImage', function () {
     var $httpBackend,
         dockerImages;

--- a/engines/bastion_katello/test/docker-tags/docker-tag.factory.test.js
+++ b/engines/bastion_katello/test/docker-tags/docker-tag.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2015 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: DockerTag', function () {
     var $httpBackend,
         dockerTags;

--- a/engines/bastion_katello/test/docker-tags/docker-tags.controller.test.js
+++ b/engines/bastion_katello/test/docker-tags/docker-tags.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2015 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: DockerTagsController', function() {
     var $scope,
         DockerTag,

--- a/engines/bastion_katello/test/environments/content.service.test.js
+++ b/engines/bastion_katello/test/environments/content.service.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either environment
- * 2 of the License (GPLv2) or (at your option) any later environment.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Service: ContentService', function() {
     var ContentService, Package;
 

--- a/engines/bastion_katello/test/environments/details/environment-content.controller.test.js
+++ b/engines/bastion_katello/test/environments/details/environment-content.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either environment
- * 2 of the License (GPLv2) or (at your option) any later environment.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: EnvironmentContentController', function() {
     var $scope,
         Repository,

--- a/engines/bastion_katello/test/environments/details/environment.controller.test.js
+++ b/engines/bastion_katello/test/environments/details/environment.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either environment
- * 2 of the License (GPLv2) or (at your option) any later environment.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: EnvrionmentController', function () {
     var $scope;
 

--- a/engines/bastion_katello/test/environments/environment.factory.test.js
+++ b/engines/bastion_katello/test/environments/environment.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Environment', function() {
     var environments;
 

--- a/engines/bastion_katello/test/environments/environments.controller.test.js
+++ b/engines/bastion_katello/test/environments/environments.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: EnvironmentsController', function () {
     var $scope, paths;
 

--- a/engines/bastion_katello/test/environments/new-environment.controller.test.js
+++ b/engines/bastion_katello/test/environments/new-environment.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewEnvironmentController', function() {
     var $scope,
         FormUtils,

--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -1,16 +1,3 @@
-/**
-* Copyright 2014 Red Hat, Inc.
-*
-* This software is licensed to you under the GNU General Public
-* License as published by the Free Software Foundation; either version
-* 2 of the License (GPLv2) or (at your option) any later version.
-* There is NO WARRANTY for this software, express or implied,
-* including the implied warranties of MERCHANTABILITY,
-* NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-* have received a copy of GPLv2 along with this software; if not, see
-* http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-**/
-
 describe('Controller: ApplyErrataController', function() {
     var $controller, dependencies, $scope, translate, ContentHostBulkAction, ContentViewVersion,
         CurrentOrganization;

--- a/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/errata-content-hosts.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ErrataContentHostsController', function() {
     var $scope, translate, Nutupane, ContentHost, ContentHostBulkAction,
         CurrentOrganization;

--- a/engines/bastion_katello/test/errata/details/errata-details.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/errata-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ErrataDetailsController', function() {
     var $scope, Erratum;
 

--- a/engines/bastion_katello/test/errata/errata-counts.directive.test.js
+++ b/engines/bastion_katello/test/errata/errata-counts.directive.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
 describe('Directive: errataCounts', function() {
     var $scope, $compile, element;
 

--- a/engines/bastion_katello/test/errata/errata-severity.filter.test.js
+++ b/engines/bastion_katello/test/errata/errata-severity.filter.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
 describe('Filter:errataSeverity', function() {
     var filter;
 

--- a/engines/bastion_katello/test/errata/errata-type.filter.test.js
+++ b/engines/bastion_katello/test/errata/errata-type.filter.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
 describe('Filter:errataType', function() {
     var filter;
 

--- a/engines/bastion_katello/test/errata/errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/errata.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ErrataController', function() {
     var $scope,
         $location,

--- a/engines/bastion_katello/test/errata/erratum.factory.test.js
+++ b/engines/bastion_katello/test/errata/erratum.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Erratum', function() {
     var Erratum, erratum;
 

--- a/engines/bastion_katello/test/gpg-keys/details/gpg-details-info.controller.test.js
+++ b/engines/bastion_katello/test/gpg-keys/details/gpg-details-info.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: GPGKeyDetailsInfoController', function() {
     var $scope, translate;
 

--- a/engines/bastion_katello/test/gpg-keys/details/gpg-details.controller.test.js
+++ b/engines/bastion_katello/test/gpg-keys/details/gpg-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: GPGKeyDetailsController', function() {
     var $scope, translate;
 

--- a/engines/bastion_katello/test/gpg-keys/gpg-keys.factory.test.js
+++ b/engines/bastion_katello/test/gpg-keys/gpg-keys.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: GPGKey', function() {
     var $httpBackend,
         gpgKeys;

--- a/engines/bastion_katello/test/gpg-keys/new/new-gpg-key-controller.test.js
+++ b/engines/bastion_katello/test/gpg-keys/new/new-gpg-key-controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewGPGKeyController', function() {
     var $scope, translate;
 

--- a/engines/bastion_katello/test/host-collections/details/host-collection-add-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/details/host-collection-add-content-hosts.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: HostCollectionAddContentHostsController', function() {
     var $scope,
         HostCollection,

--- a/engines/bastion_katello/test/host-collections/details/host-collection-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/details/host-collection-content-hosts.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: HostCollectionContentHostsController', function() {
     var $scope,
         HostCollection,

--- a/engines/bastion_katello/test/host-collections/details/host-collection-details.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/details/host-collection-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: HostCollectionDetailsController', function() {
     var $scope, translate, HostCollection, newHostCollection;
 

--- a/engines/bastion_katello/test/host-collections/host-collection.factory.test.js
+++ b/engines/bastion_katello/test/host-collections/host-collection.factory.test.js
@@ -1,16 +1,3 @@
-/**
- Copyright 2014 Red Hat, Inc.
-
- This software is licensed to you under the GNU General Public
- License as published by the Free Software Foundation; either version
- 2 of the License (GPLv2) or (at your option) any later version.
- There is NO WARRANTY for this software, express or implied,
- including the implied warranties of MERCHANTABILITY,
- NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- have received a copy of GPLv2 along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: HostCollection', function() {
     var HostCollection, $httpBackend, hostCollections;
 

--- a/engines/bastion_katello/test/host-collections/host-collections.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/host-collections.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: HostCollectionsController', function() {
     var $scope,
         HostCollection,

--- a/engines/bastion_katello/test/host-collections/new/host-collection-form.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/new/host-collection-form.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: HostCollectionFormController', function() {
     var $scope,
         $httpBackend;

--- a/engines/bastion_katello/test/host-collections/new/new-host-collection.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/new/new-host-collection.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewHostCollectionController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/organizations/organization-selector.controller.test.js
+++ b/engines/bastion_katello/test/organizations/organization-selector.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either environment
- * 2 of the License (GPLv2) or (at your option) any later environment.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: OrganizationSelectorController', function() {
     var $scope,
         $rootScope,

--- a/engines/bastion_katello/test/organizations/organization.factory.test.js
+++ b/engines/bastion_katello/test/organizations/organization.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Organization', function() {
     var $httpBackend,
         task,

--- a/engines/bastion_katello/test/package-groups/package-group.factory.test.js
+++ b/engines/bastion_katello/test/package-groups/package-group.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: PackageGroup', function () {
     var $httpBackend,
         packageGroups;

--- a/engines/bastion_katello/test/products/bulk/products-bulk-action-sync-plan.controller.test.js
+++ b/engines/bastion_katello/test/products/bulk/products-bulk-action-sync-plan.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductsBulkActionSyncPlanController', function() {
     var $scope, $q, ProductBulkAction, SyncPlan, Nutupane, selected;
 

--- a/engines/bastion_katello/test/products/bulk/products-bulk-action-sync.controller.test.js
+++ b/engines/bastion_katello/test/products/bulk/products-bulk-action-sync.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductsBulkActionSyncController', function() {
     var $scope, $q, translate, ProductBulkAction, selected;
 

--- a/engines/bastion_katello/test/products/bulk/products-bulk-action.controller.test.js
+++ b/engines/bastion_katello/test/products/bulk/products-bulk-action.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductsBulkActionController', function() {
     var $scope, $q, translate, ProductBulkAction, CurrentOrganization, selected;
 

--- a/engines/bastion_katello/test/products/details/product-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/product-details-info.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductDetailsInfoController', function() {
     var $scope, translate, MenuExpander;
 

--- a/engines/bastion_katello/test/products/details/product-details.controller.test.js
+++ b/engines/bastion_katello/test/products/details/product-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductDetailsController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/products/details/product-repositories.controller.test.js
+++ b/engines/bastion_katello/test/products/details/product-repositories.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductRepositoriesController', function() {
     var $scope, $q, expectedTable, expectedIds, Repository, RepositoryBulkAction, Nutupane;
 

--- a/engines/bastion_katello/test/products/discovery/discovery-form.controller.test.js
+++ b/engines/bastion_katello/test/products/discovery/discovery-form.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: DiscoveryFormController', function() {
     var $scope,
         Product,

--- a/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
+++ b/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: DiscoveryController', function() {
     var $scope, Organization, mockTask, mockOrg, CurrentOrganization;
 

--- a/engines/bastion_katello/test/products/new/new-product.controller.test.js
+++ b/engines/bastion_katello/test/products/new/new-product.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewProductController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/products/new/product-form.controller.test.js
+++ b/engines/bastion_katello/test/products/new/product-form.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductFormController', function() {
     var $scope,
         FormUtils,

--- a/engines/bastion_katello/test/products/product.factory.test.js
+++ b/engines/bastion_katello/test/products/product.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Product', function() {
     var $httpBackend,
         products;

--- a/engines/bastion_katello/test/products/products.controller.test.js
+++ b/engines/bastion_katello/test/products/products.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ProductsController', function() {
     var $scope,
         Nutupane;

--- a/engines/bastion_katello/test/puppet-modules/puppet-modules.factory.test.js
+++ b/engines/bastion_katello/test/puppet-modules/puppet-modules.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: PuppetModules', function () {
     var $httpBackend,
         puppetModules;

--- a/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: RepositoryDetailsInfoController', function() {
     var $scope, $state, translate, repository;
 

--- a/engines/bastion_katello/test/repositories/details/repository-details-manage-content.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-manage-content.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: RepositoryManageContentController', function() {
     var $scope, translate, Repository, Nutupane, PuppetModule, Package, DockerImage;
 

--- a/engines/bastion_katello/test/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/repositories/new/new-repository.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewRepositoryController', function() {
     var $scope,
         FormUtils,

--- a/engines/bastion_katello/test/repositories/repository.factory.test.js
+++ b/engines/bastion_katello/test/repositories/repository.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Repository', function() {
     var $httpBackend,
         repositories;

--- a/engines/bastion_katello/test/subscriptions/details/subscription-associations-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/details/subscription-associations-content-hosts.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SubscriptionAssociationsContentHostsController', function() {
     var $scope,
         Subscription,

--- a/engines/bastion_katello/test/subscriptions/details/subscription-details.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/details/subscription-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SubscriptionDetailsController', function() {
     var $scope, translate;
 

--- a/engines/bastion_katello/test/subscriptions/details/subscription-product-details.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/details/subscription-product-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SubscriptionProductDetailsController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/subscriptions/details/subscription-products.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/details/subscription-products.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SubscriptionProductsController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/subscriptions/manifest/manifest-details.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/manifest/manifest-details.controller.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ManifestDetailsController', function() {
     var $scope, organization, $q;
 

--- a/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ManifestImportController', function() {
     var $scope, organization, history, $q, Task, Organization, Subscription;
 

--- a/engines/bastion_katello/test/subscriptions/manifest/manifest.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/manifest/manifest.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: ManifestController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/subscriptions/subscription-type.directive.test.js
+++ b/engines/bastion_katello/test/subscriptions/subscription-type.directive.test.js
@@ -1,15 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- */
 describe('Directive: subscriptionType', function() {
     var $scope, $compile, element;
 

--- a/engines/bastion_katello/test/subscriptions/subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/subscriptions.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SubscriptionsController', function() {
     var $scope,
         Nutupane,

--- a/engines/bastion_katello/test/subscriptions/subscriptions.factory.test.js
+++ b/engines/bastion_katello/test/subscriptions/subscriptions.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Subscription', function() {
     var $httpBackend,
         Subscription,

--- a/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: NewSyncPlanController', function() {
     var $scope, translate, SyncPlan;
 

--- a/engines/bastion_katello/test/sync-plans/sync-plan-add-products.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plan-add-products.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SyncPlanAddProductsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/sync-plans/sync-plan-details-info.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plan-details-info.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SyncPlanDetailsInfoController', function() {
     var $scope, translate, MenuExpander;
 

--- a/engines/bastion_katello/test/sync-plans/sync-plan-details.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plan-details.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SyncPlanDetailsController', function() {
     var $scope;
 

--- a/engines/bastion_katello/test/sync-plans/sync-plan-products.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plan-products.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SyncPlanProductsController', function() {
     var $scope,
         $controller,

--- a/engines/bastion_katello/test/sync-plans/sync-plan.factory.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plan.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: SyncPlan', function() {
     var $httpBackend,
         SyncPlan,

--- a/engines/bastion_katello/test/sync-plans/sync-plans.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plans.controller.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Controller: SyncPlansController', function() {
     var $scope,
         translate,

--- a/engines/bastion_katello/test/tasks/task.factory.test.js
+++ b/engines/bastion_katello/test/tasks/task.factory.test.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 describe('Factory: Task', function() {
     var $httpBackend,
         tasks;

--- a/engines/bastion_katello/test/test-mocks.module.js
+++ b/engines/bastion_katello/test/test-mocks.module.js
@@ -1,16 +1,3 @@
-/**
- * Copyright 2014 Red Hat, Inc.
- *
- * This software is licensed to you under the GNU General Public
- * License as published by the Free Software Foundation; either version
- * 2 of the License (GPLv2) or (at your option) any later version.
- * There is NO WARRANTY for this software, express or implied,
- * including the implied warranties of MERCHANTABILITY,
- * NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
- * have received a copy of GPLv2 along with this software; if not, see
- * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- **/
-
 angular.module('Bastion.test-mocks', ['ui.router']);
 
 angular.module('Bastion.test-mocks').config(['$provide', function ($provide) {

--- a/script/pulp_integration_tests
+++ b/script/pulp_integration_tests
@@ -1,14 +1,3 @@
-# Copyright 2014 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 #!/bin/bash
 
 ruby test/integration/pulp/test_runner.rb $@


### PR DESCRIPTION
This finishes the license removal. Be sure to view each commit separately as viewing the commits together won't be possible via Github.