### PR TITLE
fixes #10489 - adding two timeouts for content tasks

### DIFF
--- a/app/lib/actions/pulp/consumer/abstract_content_action.rb
+++ b/app/lib/actions/pulp/consumer/abstract_content_action.rb
@@ -13,6 +13,21 @@ module Actions
           end
         end
 
+        def process_timeout
+          accept_timeout = Setting['content_action_accept_timeout']
+          finish_timeout = Setting['content_action_finish_timeout']
+          pulp_state = output[:pulp_tasks][0][:state]
+
+          if pulp_state == 'waiting'
+            fail _("Host did not respond within %s seconds. Is katello-agent installed and goferd running on the Host?") % accept_timeout
+          elsif output[:client_accepted].nil?
+            output[:client_accepted] = Time.now.to_s
+            schedule_timeout(finish_timeout)
+          elsif pulp_state == 'running'
+            fail _("Host did not finish content action in %s seconds") % finish_timeout
+          end
+        end
+
         def find_errors(tasks)
           messages = []
           tasks.each do |pulp_task|

--- a/app/lib/actions/pulp/consumer/content_install.rb
+++ b/app/lib/actions/pulp/consumer/content_install.rb
@@ -12,10 +12,12 @@ module Actions
         end
 
         def invoke_external_task
-          pulp_extensions.consumer.install_content(input[:consumer_uuid],
+          task = pulp_extensions.consumer.install_content(input[:consumer_uuid],
                                                    input[:type],
                                                    input[:args],
                                                     "importkeys" => true)
+          schedule_timeout(Setting['content_action_accept_timeout'])
+          task
         end
 
         def presenter

--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -9,7 +9,9 @@ class Setting::Katello < Setting
         self.set('katello_default_user_data', N_("Default user data for new Operating Systems"), 'Katello Kickstart Default User Data'),
         self.set('katello_default_PXELinux', N_("Default PXElinux template for new Operating Systems"), 'Kickstart default PXELinux'),
         self.set('katello_default_iPXE', N_("Default iPXE template for new Operating Systems"), 'Kickstart default iPXE'),
-        self.set('katello_default_ptable', N_("Default partitioning table for new Operating Systems"), 'Kickstart default')
+        self.set('katello_default_ptable', N_("Default partitioning table for new Operating Systems"), 'Kickstart default'),
+        self.set('content_action_accept_timeout', N_("Time in seconds to wait for a Host to pickup a remote action"), 20),
+        self.set('content_action_finish_timeout', N_("Time in seconds to wait for a Host to finish a remote action"), 3600)
       ].each { |s| self.create! s.update(:category => "Setting::Katello") }
     end
     true


### PR DESCRIPTION
The first will fail the task if the client does not pick up the task
this likely means that either the client is not running, goferd is not running,
or goferd is having some sort of communication issue. (Default 20 seconds)

The second will fail if the client has picked up the task but has not completed it
after some time.  This could happen if the link is really really slow, or the client dies
in the middle of a content action.  (Default to 60 minutes)