### PR TITLE
fixes #10495 - create custom products with metadata_expire set to 1

### DIFF
--- a/app/lib/actions/candlepin/product/content_create.rb
+++ b/app/lib/actions/candlepin/product/content_create.rb
@@ -27,6 +27,7 @@ module Actions
                      contentUrl: input[:content_url],
                      type: input[:type],
                      label: input[:label],
+                     metadataExpire: 1,
                      vendor: ::Katello::Provider::CUSTOM)
         end
       end

--- a/app/lib/actions/candlepin/product/content_update.rb
+++ b/app/lib/actions/candlepin/product/content_update.rb
@@ -31,6 +31,7 @@ module Actions
                      gpgUrl: input[:gpg_key_url],
                      type: input[:type],
                      label: input[:label],
+                     metadataExpire: 1,
                      vendor: ::Katello::Provider::CUSTOM)
         end
       end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -172,6 +172,7 @@ module Katello
 
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.1/import_errata.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.2/update_gpg_key_urls.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.2/update_metadata_expire.rake"
     end
   end
 end

--- a/lib/katello/tasks/upgrades/2.2/update_metadata_expire.rake
+++ b/lib/katello/tasks/upgrades/2.2/update_metadata_expire.rake
@@ -1,0 +1,18 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '2.2' do
+      task :update_metadata_expire => ["environment"]  do
+        User.current = User.anonymous_api_admin
+        puts _("Updating Expire Metadata for Custom Content")
+
+        Katello::Product.find_each do |product|
+          unless product.redhat?
+            product.repositories.each do |repo|
+              ForemanTasks.sync_task(::Actions::Katello::Repository::Update, repo, {})
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
also provide upgrade rake task
Red Hat products will have it set to 1 via candlepin