### PR TITLE
fixes #10523 - use admin user for facts updating

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -250,9 +250,9 @@ module Katello
                      :releaseVer, :serviceLevel, :lastCheckin, :autoheal
                     ]
       attrs[:installedProducts] = [] if attrs.key?(:installedProducts) && attrs[:installedProducts].nil?
-
-      sync_task(::Actions::Katello::System::Update, @system, attrs.slice(*slice_attrs))
-
+      User.as_anonymous_admin do
+        sync_task(::Actions::Katello::System::Update, @system, attrs.slice(*slice_attrs))
+      end
       render :json => {:content => _("Facts successfully updated.")}, :status => 200
     end
 


### PR DESCRIPTION
as foreman-tasks cannot handle a fake CpConsumerUser due to locking