### PR TITLE
Fixes #10525: remove unnecessary reference to tipsy, BZ 1222135.

### DIFF
--- a/app/assets/javascripts/katello/dashboard/dashboard.js
+++ b/app/assets/javascripts/katello/dashboard/dashboard.js
@@ -83,7 +83,6 @@ KT.dashboard = (function(){
 
         if (id === 'errata') {
             $(document).trigger('close.tipsy');
-            KT.tipsy.custom.disable_details_tooltip($('.errata-info'));
         }
 
         $.ajax({
@@ -118,6 +117,8 @@ KT.dashboard = (function(){
             btn.parents(".errata_item").siblings().hide();
             btn.removeClass("expanded").addClass("collapsed");
         });
+
+        $('.errata_item .col_1 .fa').tooltip({container: 'body'});
     },
     register_sync_progress = function() {
         $(".progressbar").each(function(){
@@ -191,5 +192,4 @@ $(window).load(function() {
     $(".loading").each(function(){
        KT.dashboard.widgetReload($(this));
     });
-    KT.tipsy.custom.tooltip($('.tipsy-icon.errata-info'));
 });

--- a/app/helpers/katello/dashboard_helper.rb
+++ b/app/helpers/katello/dashboard_helper.rb
@@ -110,11 +110,11 @@ module Katello
     def errata_type_class(errata)
       case errata.errata_type
       when Erratum::SECURITY
-        return "icon-warning-sign"
+        return "fa fa-warning"
       when Erratum::ENHANCEMENT
-        return "icon-plus-sign-alt"
+        return "fa fa-plus-square"
       when Erratum::BUGZILLA
-        return "icon-bug"
+        return "fa fa-bug"
       end
     end
 

--- a/app/views/katello/dashboard/_errata.haml
+++ b/app/views/katello/dashboard/_errata.haml
@@ -15,7 +15,7 @@
             .errata
               %div.errata_item
                 .col_1
-                  %div{:class => 'tipsify ' + errata_type_class(erratum),
-                       'original-title' => errata_human_type(erratum.errata_type)}
+                  %div{:class => errata_type_class(erratum),
+                       :title => errata_human_type(erratum.errata_type)}
                 %a{:href=>"/errata/#{erratum.uuid}/info", :class=>"col_2"}
                   #{erratum.errata_id} (#{content_hosts.length} #{_('Content Hosts')})


### PR DESCRIPTION
Tipsy was removed and this reference was not removed.  This commit
replaces the lingering reference with a BS3 tooltip and also fixes
the icons for the errata dashboard display.

http://projects.theforeman.org/issues/10525
https://bugzilla.redhat.com/show_bug.cgi?id=1222135