### PR TITLE
Fixes #10540: correct product link on errata repo page BZ 1222660.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-repositories.html
@@ -62,7 +62,7 @@
             </a>
           </td>
           <td bst-table-cell>
-            <a ng-href="/products/{{ repository.product.id }}">
+            <a ui-sref="products.details.repositories.index({productId: repository.product.id})">
               {{ repository.product.name }}
             </a>
           </td>


### PR DESCRIPTION
The link to products from the errata repositories page was incorrect,
this commit fixes the link.

http://projects.theforeman.org/issues/10540
https://bugzilla.redhat.com/show_bug.cgi?id=1222660