### PR TITLE
Fixes #10575: add available content to AK products index BZ 1223743.

### DIFF
--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -26,6 +26,7 @@ module Katello
     param :name, String, :desc => N_("Filter products by name")
     param :enabled, :bool, :desc => N_("Filter products by enabled or disabled")
     param :custom, :bool, :desc => N_("Filter products by custom")
+    param :include_available_content, :bool, :desc => N_("Whether to include available content attribute in results")
     param_group :search, Api::V2::ApiController
     def index
       options = {

--- a/app/views/katello/api/v2/products/base.json.rabl
+++ b/app/views/katello/api/v2/products/base.json.rabl
@@ -12,6 +12,8 @@ attributes :sync_summary
 attributes :gpg_key_id
 attributes :redhat? => :redhat
 
+attributes :available_content => :available_content, :if => params[:include_available_content]
+
 child :sync_plan do
   extends 'katello/api/v2/sync_plans/show'
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-products.controller.js
@@ -33,7 +33,8 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyProductsContr
             ActivationKey.products({id: $scope.activationKey.id,
                                     'organization_id': CurrentOrganization,
                                     enabled: true,
-                                    'full_result': true
+                                    'full_result': true,
+                                    'include_available_content': true
                                    }, function (response) {
                 $scope.products = response.results;
                 $scope.displayArea.isAvailableContent = $scope.isAnyAvailableContent($scope.products);


### PR DESCRIPTION
We removed available_content from the product index with e179a60 and
the activation key product pages require it.  This commit allows a
parameter to be passed to include the available_content attribute
in the response so that this page can be correctly rendered.

http://projects.theforeman.org/issues/10575
https://bugzilla.redhat.com/show_bug.cgi?id=1223743