### PR TITLE
Fixes #10590 : The product help message should not reference a reposi…

### DIFF
--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -88,7 +88,7 @@ module Katello
       respond_for_async :resource => task
     end
 
-    api :POST, "/products/:id/sync", "Sync a repository"
+    api :POST, "/products/:id/sync", N_("Sync all repositories for a product")
     param :id, :identifier, :required => true, :desc => "product ID"
     def sync
       task = async_task(::Actions::BulkAction,


### PR DESCRIPTION
…tory

In addition to changing the help text, it is now localized like the other help commands