### PR TITLE
fixes #10281 - do not display inaccessible red hat repos for enable

### DIFF
--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -21,14 +21,8 @@ module Katello
           render :partial => 'katello/providers/redhat/errors', :locals => { :error_message => task_error(task), :task => task}
         else
           repos = task.output[:results]
-
-          repos = repos.select do |repo|
-            if repo[:path].include?('kickstart')
-              repo[:substitutions][:releasever].include?('Server') ? repo[:enabled] : true
-            else
-              true
-            end
-          end
+          repos = exclude_rolling_kickstart_repos(repos)
+          repos = available_synced_repos(repos)
 
           render :partial => 'katello/providers/redhat/repos', :locals => {:scan_cdn => task, :repos => repos}
         end
@@ -94,6 +88,40 @@ module Katello
 
     def task_error(task)
       task.failed_steps.first.action(task.execution_plan).steps.map { |s| s.try(:error).try(:message) }.reject(&:blank?).join(', ')
+    end
+
+    def exclude_rolling_kickstart_repos(repos)
+      repos.select do |repo|
+        if repo[:path].include?('kickstart')
+          repo[:substitutions][:releasever].include?('Server') ? repo[:enabled] : true
+        else
+          true
+        end
+      end
+    end
+
+    def available_synced_repos(repos)
+      @product.repositories.each do |product_repo|
+        found = repos.detect do |repo|
+          product_repo.pulp_id == repo[:pulp_id]
+        end
+        unless found
+          repos << {
+            :repo_name => product_repo.name,
+            :path => product_repo.url,
+            :pulp_id => product_repo.pulp_id,
+            :content_id => product_repo.content_id,
+            :substitutions => {
+              :basearch => product_repo.arch,
+              :releasever => product_repo.minor
+            },
+            :enabled => true,
+            :promoted => product_repo.promoted?,
+            :registry_name => product_repo.docker_upstream_name
+          }
+        end
+      end
+      repos
     end
   end
 end

--- a/app/lib/actions/katello/repository_set/scan_cdn.rb
+++ b/app/lib/actions/katello/repository_set/scan_cdn.rb
@@ -32,14 +32,17 @@ module Actions
           if content.type == ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
             prepare_results_docker_content
           else
-            cdn_var_substitutor.substitute_vars(content.contentUrl).map do |(substitutions, path)|
+            substitutor = cdn_var_substitutor
+            return [] unless substitutor
+            substitutor.substitute_vars(content.contentUrl).map do |(substitutions, path)|
               prepare_result(substitutions, path)
             end
           end
         end
 
         def cdn_var_substitutor
-          product.cdn_resource.substitutor
+          return unless (cdn_resource = product.cdn_resource)
+          cdn_resource.substitutor
         end
 
         def prepare_results_docker_content

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -205,7 +205,8 @@ module Katello
     end
 
     def cdn_resource
-      certs = { :ssl_client_cert => OpenSSL::X509::Certificate.new(certificate),
+      return unless (product_certificate = certificate)
+      certs = { :ssl_client_cert => OpenSSL::X509::Certificate.new(product_certificate),
                 :ssl_client_key => OpenSSL::PKey::RSA.new(key) }
       ::Katello::Resources::CDN::CdnResource.new(provider.repository_url, certs)
     end

--- a/app/views/katello/providers/redhat/_repo_sets.haml
+++ b/app/views/katello/providers/redhat/_repo_sets.haml
@@ -6,26 +6,29 @@
       - orphaned = orphaned_product_ids.include?(product.id)
       - if product_map[product.id]
         - contents = product_map[product.id].sort{|p1, p2| p1.content.name <=> p2.content.name}
-        %tr.product{:id=>"#{tab_id}_prod_#{product.id}", :class=>cycle(nil, 'alt')}
-          %td
-            = "#{product.name} " +  (orphaned ? _('(Orphaned)') : '')
+        - has_content = !orphaned || product.repositories.length > 0
+        - if has_content
+          %tr.product{:id=>"#{tab_id}_prod_#{product.id}", :class=>cycle(nil, 'alt')}
+            %td
+              = "#{product.name} " +  (orphaned ? _('(Orphaned)') : '')
 
-        %tr{:class=>"child-of-#{tab_id}_prod_#{product.id} #{current_cycle()}"}
-          %td
-            %table.content_table
-              %thead
-                %th
-                  = _('Repository Set')
-              %tbody
-                - for product_content in contents
-                  %tr.collapsed.repo_set{:id=>"repo_set_#{product_content.content.id}"}
-                    %td
-                      %span.expander_area{:data=>{:url => available_repositories_product_path(product.id),
-                                                   'content-id'=> product_content.content.id,
-                                                   :orphaned => orphaned.to_s}}
-                        =image_tag( "katello/icons/spinner.gif", :class=>"hidden fl repo_set_spinner",
-                            :id=>"spinner_set_#{product_content.content.id}", :style=>"margin-left:-18px;")
-                        %span.expander
-                        #{product_content.content.name}
+          %tr{:class=>"child-of-#{tab_id}_prod_#{product.id} #{current_cycle()}"}
+            %td
+              %table.content_table
+                %thead
+                  %th
+                    = _('Repository Set')
+                %tbody
+                  - for product_content in contents
+                    - if !orphaned || product.repositories.detect {|repo| repo.cp_label == product_content.content.label}
+                      %tr.collapsed.repo_set{:id=>"repo_set_#{product_content.content.id}"}
+                        %td
+                          %span.expander_area{:data=>{:url => available_repositories_product_path(product.id),
+                                                       'content-id'=> product_content.content.id,
+                                                       :orphaned => orphaned.to_s}}
+                            =image_tag( "katello/icons/spinner.gif", :class=>"hidden fl repo_set_spinner",
+                                :id=>"spinner_set_#{product_content.content.id}", :style=>"margin-left:-18px;")
+                            %span.expander
+                            #{product_content.content.name}
 
-                      %table{:style=>'display:none;'}
+                          %table{:style=>'display:none;'}

--- a/app/views/katello/providers/redhat/_repos.html.haml
+++ b/app/views/katello/providers/redhat/_repos.html.haml
@@ -1,24 +1,30 @@
 %table.repo_table{:style=>'display: none;'}
-  %thead
-    %th.skinny_column
-      = _('Enabled?')
-    %th
-      = _('Repository')
-  %tbody
-    - repos.each do |result|
-      %tr.repo{:id=>"repo_#{result[:pulp_id]}"}
+  - if repos.empty?
+    %tbody
+      %tr
         %td
-          %label
-            =image_tag( "katello/icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{result[:pulp_id]}", :style=>"margin-right:1px;")
-            %input.repo_enable{:id=>"input_repo_#{result[:pulp_id]}",
-                               :type=>:checkbox,
-                               :value=>result[:pulp_id],
-                               :data => { :url => toggle_repository_product_path(scan_cdn.input[:product_id]),
-                                          'content-id' => scan_cdn.input[:content_id],
-                                          'pulp-id' => result[:pulp_id],
-                                          'registry-name' => result[:registry_name],
-                                          :releasever => result[:substitutions][:releasever],
-                                          :basearch => result[:substitutions][:basearch] },
-                               :disabled => result[:promoted], :checked=>(:checked if result[:enabled])}
-        %td
-          #{result[:repo_name]}
+          = _("No repositories accessible. Check that Red Hat Subscriptions have been imported.")
+  - else
+    %thead
+      %th.skinny_column
+        = _('Enabled?')
+      %th
+        = _('Repository')
+    %tbody
+      - repos.each do |result|
+        %tr.repo{:id=>"repo_#{result[:pulp_id]}"}
+          %td
+            %label
+              =image_tag( "katello/icons/spinner.gif", :class=>"hidden fl", :id=>"spinner_#{result[:pulp_id]}", :style=>"margin-right:1px;")
+              %input.repo_enable{:id=>"input_repo_#{result[:pulp_id]}",
+                                 :type=>:checkbox,
+                                 :value=>result[:pulp_id],
+                                 :data => { :url => toggle_repository_product_path(scan_cdn.input[:product_id]),
+                                            'content-id' => scan_cdn.input[:content_id],
+                                            'pulp-id' => result[:pulp_id],
+                                            'registry-name' => result[:registry_name],
+                                            :releasever => result[:substitutions][:releasever],
+                                            :basearch => result[:substitutions][:basearch] },
+                                 :disabled => result[:promoted], :checked=>(:checked if result[:enabled])}
+          %td
+            #{result[:repo_name]}


### PR DESCRIPTION
Orphaned repos that have been enabled and sync'ed are the only ones shown.

When a subscription is removed (via expiration or manifest refresh), the cdn is no longer available for the repos that came from that sub. This means that new listings are not available when expanding in the Red Hat Repositories page. Previously synced repos should remain visible on the page. This PR fixes the UI page for this case.