### PR TITLE
Fixes #10617: don't use scroll on unpaged tables BZ 1223968.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
@@ -26,6 +26,8 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableDockerRe
         },
         'queryUnpaged');
 
+        nutupane.load();
+
         nutupane.searchTransform = function () {
             return "NOT ( content_view_ids:" + $scope.$stateParams.contentViewId + " )";
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
@@ -28,6 +28,8 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableReposito
         },
         'queryUnpaged');
 
+        nutupane.load();
+
         nutupane.searchTransform = function () {
             return "NOT ( content_view_ids:" + $scope.$stateParams.contentViewId + " )";
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
@@ -25,6 +25,9 @@ angular.module('Bastion.content-views').controller('ContentViewDockerRepositorie
 
         },
         'queryUnpaged');
+
+        nutupane.load();
+
         $scope.repositoriesTable = nutupane.table;
 
         $scope.removeRepositories = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
@@ -26,6 +26,9 @@ angular.module('Bastion.content-views').controller('ContentViewRepositoriesListC
             'content_type': 'yum'
         },
         'queryUnpaged');
+
+        nutupane.load();
+
         $scope.repositoriesTable = nutupane.table;
 
         $scope.removeRepositories = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -78,58 +78,54 @@
       {{ "Loading..." | translate }}
     </div>
 
-    <div bst-infinite-scroll="repositoriesTable.nextPage()" data="repositoriesTable.rows">
+    <table ng-show="repositoriesTable.rows.length > 0"  class="table table-bordered table-striped">
+      <thead>
+        <tr bst-table-head row-select>
+          <th bst-table-column translate>Name</th>
+          <th bst-table-column translate>Product</th>
+          <th bst-table-column translate>Last Sync</th>
+          <th bst-table-column translate>Sync State</th>
+          <th bst-table-column translate>Content</th>
+        </tr>
+      </thead>
 
-      <table ng-show="repositoriesTable.rows.length > 0"  class="table table-bordered table-striped">
-        <thead>
-          <tr bst-table-head row-select>
-            <th bst-table-column translate>Name</th>
-            <th bst-table-column translate>Product</th>
-            <th bst-table-column translate>Last Sync</th>
-            <th bst-table-column translate>Sync State</th>
-            <th bst-table-column translate>Content</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <tr bst-table-row
-              row-select="repository"
-              ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
-            <td bst-table-cell>
-              <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
-                {{ repository.name }}
-              </a>
-            </td>
-            <td bst-table-cell>{{ repository.product.name }}</td>
-            <td bst-table-cell>
-              <span ng-show="repository.url">
-                {{ repository.last_sync.ended_at | date:"short" }}
+      <tbody>
+        <tr bst-table-row
+            row-select="repository"
+            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
+          <td bst-table-cell>
+            <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
+              {{ repository.name }}
+            </a>
+          </td>
+          <td bst-table-cell>{{ repository.product.name }}</td>
+          <td bst-table-cell>
+            <span ng-show="repository.url">
+              {{ repository.last_sync.ended_at | date:"short" }}
+            </span>
+            <span ng-hide="repository.url" translate>N/A</span>
+          </td>
+          <td bst-table-cell>
+            <span ng-show="repository.url">
+              <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
+            </span>
+            <span ng-hide="repository.url" translate>N/A</span>
+          </td>
+          <td bst-table-cell>
+            <div ng-if="repository.content_counts.docker_image && repository.content_counts.docker_image > 0">
+              <span translate>
+                {{ repository.content_counts.docker_image }} Docker Images
               </span>
-              <span ng-hide="repository.url" translate>N/A</span>
-            </td>
-            <td bst-table-cell>
-              <span ng-show="repository.url">
-                <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
+            </div>
+            <div ng-if="repository.content_counts.docker_tag && repository.content_counts.docker_tag > 0">
+              <span translate>
+                {{ repository.content_counts.docker_tag }} Docker Tags
               </span>
-              <span ng-hide="repository.url" translate>N/A</span>
-            </td>
-            <td bst-table-cell>
-              <div ng-if="repository.content_counts.docker_image && repository.content_counts.docker_image > 0">
-                <span translate>
-                  {{ repository.content_counts.docker_image }} Docker Images
-                </span>
-              </div>
-              <div ng-if="repository.content_counts.docker_tag && repository.content_counts.docker_tag > 0">
-                <span translate>
-                  {{ repository.content_counts.docker_tag }} Docker Tags
-                </span>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-    </div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -78,62 +78,58 @@
       {{ "Loading..." | translate }}
     </div>
 
-    <div bst-infinite-scroll="repositoriesTable.nextPage()" data="repositoriesTable.rows">
+    <table ng-show="repositoriesTable.rows.length > 0"  class="table table-bordered table-striped">
+      <thead>
+        <tr bst-table-head row-select>
+          <th bst-table-column translate>Name</th>
+          <th bst-table-column translate>Product</th>
+          <th bst-table-column translate>Last Sync</th>
+          <th bst-table-column translate>Sync State</th>
+          <th bst-table-column translate>Content</th>
+        </tr>
+      </thead>
 
-      <table ng-show="repositoriesTable.rows.length > 0"  class="table table-bordered table-striped">
-        <thead>
-          <tr bst-table-head row-select>
-            <th bst-table-column translate>Name</th>
-            <th bst-table-column translate>Product</th>
-            <th bst-table-column translate>Last Sync</th>
-            <th bst-table-column translate>Sync State</th>
-            <th bst-table-column translate>Content</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <tr bst-table-row
-              row-select="repository"
-              ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
-            <td bst-table-cell>
-              <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
-                {{ repository.name }}
+      <tbody>
+        <tr bst-table-row
+            row-select="repository"
+            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
+          <td bst-table-cell>
+            <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
+              {{ repository.name }}
+            </a>
+          </td>
+          <td bst-table-cell>{{ repository.product.name }}</td>
+          <td bst-table-cell>
+            <span ng-show="repository.url">
+              {{ repository.last_sync.ended_at | date:"short" }}
+            </span>
+            <span ng-hide="repository.url" translate>N/A</span>
+          </td>
+          <td bst-table-cell>
+            <span ng-show="repository.url">
+              <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
+            </span>
+            <span ng-hide="repository.url" translate>N/A</span>
+          </td>
+          <td bst-table-cell>
+            <div ng-if="repository.content_counts.rpm && repository.content_counts.rpm > 0">
+              <a ng-href="/katello/content_search#/!=&search[packages][search]=&search[content_type]=packages&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_packages"
+                 ng-show="repository.content_type == 'yum'"
+                 translate>
+                {{ repository.content_counts.rpm }} Packages
               </a>
-            </td>
-            <td bst-table-cell>{{ repository.product.name }}</td>
-            <td bst-table-cell>
-              <span ng-show="repository.url">
-                {{ repository.last_sync.ended_at | date:"short" }}
-              </span>
-              <span ng-hide="repository.url" translate>N/A</span>
-            </td>
-            <td bst-table-cell>
-              <span ng-show="repository.url">
-                <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
-              </span>
-              <span ng-hide="repository.url" translate>N/A</span>
-            </td>
-            <td bst-table-cell>
-              <div ng-if="repository.content_counts.rpm && repository.content_counts.rpm > 0">
-                <a ng-href="/katello/content_search#/!=&search[packages][search]=&search[content_type]=packages&search[subgrid][repo_id]={{ repository.id }}&search[subgrid][type]=repo_packages"
-                   ng-show="repository.content_type == 'yum'"
-                   translate>
-                  {{ repository.content_counts.rpm }} Packages
-                </a>
-              </div>
-              <div ng-if="repository.content_counts.erratum && repository.content_counts.erratum > 0">
-                <a ui-sref="errata.index({repositoryId: repository.id})"
-                   ng-show="repository.content_type == 'yum'"
-                   translate>
-                  {{ repository.content_counts.erratum }} Errata
-                </a>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-    </div>
+            </div>
+            <div ng-if="repository.content_counts.erratum && repository.content_counts.erratum > 0">
+              <a ui-sref="errata.index({repositoryId: repository.id})"
+                 ng-show="repository.content_type == 'yum'"
+                 translate>
+                {{ repository.content_counts.erratum }} Errata
+              </a>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 
 </div>

--- a/engines/bastion_katello/test/content-views/details/content-view-available-docker-repositories.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-available-docker-repositories.controller.test.js
@@ -14,7 +14,7 @@ describe('Controller: ContentViewAvailableDockerRepositoriesController', functio
             this.getAllSelectedResults = function () {
                 return {included: {ids: [1, 2]}};
             };
-
+            this.load = function () {};
             this.table = {};
         };
 

--- a/engines/bastion_katello/test/content-views/details/content-view-available-repositories.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-available-repositories.controller.test.js
@@ -15,6 +15,7 @@ describe('Controller: ContentViewAvailableRepositoriesController', function() {
                 return {included: {ids: [1, 2]}};
             };
 
+            this.load = function () {};
             this.table = {};
         };
 

--- a/engines/bastion_katello/test/content-views/details/content-view-composite-available-content-views.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-composite-available-content-views.controller.test.js
@@ -20,6 +20,7 @@ describe('Controller: ContentViewCompositeAvailableContentViewsController', func
                 };
             };
 
+            this.load = function () {};
             this.table = {};
             this.setParams = function () {};
             this.refresh = function () {};

--- a/engines/bastion_katello/test/content-views/details/content-view-docker-repositories-list.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-docker-repositories-list.controller.test.js
@@ -15,6 +15,7 @@ describe('Controller: ContentViewDockerRepositoriesListController', function() {
                 return {included: {ids: [1, 2]}};
             };
 
+            this.load = function () {};
             this.table = {};
         };
 

--- a/engines/bastion_katello/test/content-views/details/content-view-repositories-list.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-repositories-list.controller.test.js
@@ -14,7 +14,7 @@ describe('Controller: ContentViewRepositoriesListController', function() {
             this.getAllSelectedResults = function () {
                 return {included: {ids: [1, 2]}};
             };
-
+            this.load = function () {};
             this.table = {};
         };
 


### PR DESCRIPTION
We were using infinite scroll on unpaged tables which resulted in
the rows being loaded twice.  This commit removes the extra load
by removing the infinite scroll directive on the table and calling
nutupane.load() directly.

http://projects.theforeman.org/issues/10617
https://bugzilla.redhat.com/show_bug.cgi?id=1223968