### PR TITLE
Fixes #10620 - Repos no longer protected by default

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -89,9 +89,9 @@ module Katello
       end
       repo_params[:label] = labelize_params(repo_params)
       repo_params[:url] = nil if repo_params[:url].blank?
-
+      unprotected =  repo_params.key?(:unprotected) ? repo_params[:unprotected] : true
       repository = @product.add_repo(repo_params[:label], repo_params[:name], repo_params[:url],
-                                     repo_params[:content_type], repo_params[:unprotected],
+                                     repo_params[:content_type], unprotected,
                                      gpg_key, repository_params[:checksum_type])
       repository.docker_upstream_name = repo_params[:docker_upstream_name] if repo_params[:docker_upstream_name]
       sync_task(::Actions::Katello::Repository::Create, repository, false, true)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -61,6 +61,7 @@ module Katello
       :with => /^([a-z0-9\-_]{4,30}\/)?[a-z0-9\-_\.]{3,30}$/,
       :message => (_("must be a valid docker name"))
     }
+
     #validates :content_id, :presence => true #add back after fixing add_repo orchestration
     validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
@@ -75,6 +76,7 @@ module Katello
       :message => (_("must be one of the following: %s") % TYPES.join(', '))
     }
     validate :ensure_valid_docker_attributes, :if => :docker?
+    validate :ensure_docker_repo_unprotected, :if => :docker?
 
     # TODO: remove this default scope
     # rubocop:disable Rails/DefaultScope
@@ -513,6 +515,13 @@ module Katello
         field = url.blank? ? :url : :docker_upstream_name
         errors.add(field, N_("cannot be blank. Either provide all or no sync information."))
         errors.add(:base, N_("Repository URL or Upstream Name is empty. Both are required for syncing from the upstream."))
+      end
+    end
+
+    def ensure_docker_repo_unprotected
+      unless unprotected
+        errors.add(:base, N_("Docker Repositories are not protected at this time. " \
+                             "They need to be published via http to be available to containers."))
       end
     end
   end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -220,6 +220,7 @@ redis:
   product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
+  unprotected:           <%= true %>
 
 busybox:
   name:                 busybox
@@ -232,6 +233,7 @@ busybox:
   product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_default_version) %>
+  unprotected:           <%= true %>
 
 busybox_view1:
   name:                 busybox
@@ -245,6 +247,7 @@ busybox_view1:
   product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_view_version_1) %>
+  unprotected:           <%= true %>
 
 busybox_view2:
   name:                 busybox
@@ -258,6 +261,7 @@ busybox_view2:
   product_id:           <%= ActiveRecord::Fixtures.identify(:puppet_product) %>
   gpg_key_id:           <%= ActiveRecord::Fixtures.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::Fixtures.identify(:library_view_version_2) %>
+  unprotected:           <%= true %>
 
 rhel_6_x86_64_composite_view_version_1:
   name:                 RHEL 6 x86_64

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -35,6 +35,7 @@ module Katello
     end
 
     def test_docker_repository_docker_upstream_name_url
+      @repo.unprotected = true
       @repo.content_type = 'docker'
       @repo.docker_upstream_name = ""
       @repo.url = "http://registry.com"
@@ -52,6 +53,7 @@ module Katello
     end
 
     def test_docker_repository_docker_upstream_name_format
+      @repo.unprotected = true
       @repo.content_type = 'docker'
       @repo.docker_upstream_name = 'valid'
       assert @repo.valid?
@@ -109,8 +111,20 @@ module Katello
       @repo.pulp_id = 'PULP-ID'
       @repo.content_type = Repository::DOCKER_TYPE
       @repo.docker_upstream_name = "haha"
+      @repo.unprotected = true
       assert @repo.save
       assert @repo.pulp_id.ends_with?('pulp-id')
+    end
+
+    def test_docker_repo_unprotected
+      @repo.name = 'docker_repo'
+      @repo.pulp_id = 'PULP-ID'
+      @repo.content_type = Repository::DOCKER_TYPE
+      @repo.docker_upstream_name = "haha"
+      @repo.unprotected = true
+      assert @repo.save
+      @repo.unprotected = false
+      refute @repo.save
     end
 
     def test_yum_type_pulp_id


### PR DESCRIPTION
Repositories created via UI are not protected by default, however this
is not the case for CLI. Repos created by the cli tend to have the
protection on by default. This does not work well for docker, so trying
to be consistent here.
Also updated code to always set protected to false for docker type. This
is because docker type does not have any protection at this time.