### PR TITLE
fixes #10459,#10435 - do not create a puppet env for cvs with no modules

### DIFF
--- a/app/lib/actions/katello/content_view/node_metadata_generate.rb
+++ b/app/lib/actions/katello/content_view/node_metadata_generate.rb
@@ -20,7 +20,7 @@ module Actions
 
             cv_puppet_env = ::Katello::ContentViewPuppetEnvironment.in_environment(environment).
                 in_content_view(content_view).first
-            plan_action(Katello::Repository::NodeMetadataGenerate, cv_puppet_env)
+            plan_action(Katello::Repository::NodeMetadataGenerate, cv_puppet_env) if cv_puppet_env && cv_puppet_env.puppet_environment
           end
           plan_self(:environment_name => environment.name)
         end

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -22,7 +22,8 @@ module Actions
                 end
               end
 
-              plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => environment)
+              plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => environment,
+                          :puppet_modules_present => version.puppet_module_count > 0)
 
               repos_to_delete(version, environment).each do |repo|
                 plan_action(Repository::Destroy, repo, :planned_destroy => true)

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -25,7 +25,8 @@ module Actions
 
               sequence do
                 plan_action(ContentViewPuppetEnvironment::CreateForVersion, version)
-                plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => library)
+                plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => library,
+                            :puppet_modules_present => content_view.puppet_modules.any?)
               end
 
               repos_to_delete(content_view).each do |repo|

--- a/app/lib/actions/katello/content_view_puppet_environment/clone.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/clone.rb
@@ -5,46 +5,63 @@ module Actions
         attr_accessor :new_puppet_environment
 
         def plan(from_version, options)
-          environment = options[:environment]
-          new_version = options[:new_version]
+          environment = options.fetch(:environment, nil)
+          new_version = options.fetch(:new_version, nil)
+          puppet_modules_present = options.fetch(:puppet_modules_present, true)
           source = from_version.content_view_puppet_environments.archived.first
 
+          #don't create a cvpe if no puppet modules are present, but reuse it if it is present
           if environment
-            clone = find_or_build_puppet_env(from_version, environment)
+            clone = find_or_build_puppet_env(from_version, environment, puppet_modules_present)
+            return if clone.new_record? && !puppet_modules_present #CVPE is not needed
           else
             clone = find_or_build_puppet_archive(new_version)
           end
 
           sequence do
-            if clone.new_record?
-              plan_action(ContentViewPuppetEnvironment::Create, clone, true)
+            if clone.puppet_environment.nil? && !puppet_modules_present
+              plan_action(ContentViewPuppetEnvironment::Destroy, clone)
             else
-              clone.content_view_version = from_version
-              clone.save!
-              plan_action(ContentViewPuppetEnvironment::Clear, clone)
-            end
+              clone = setup_puppet_environment_clone(from_version, clone)
 
-            self.new_puppet_environment = clone
-            plan_action(Pulp::Repository::CopyPuppetModule,
-                        source_pulp_id: source.pulp_id,
-                        target_pulp_id: clone.pulp_id,
-                        criteria: nil)
+              self.new_puppet_environment = clone
+              plan_action(Pulp::Repository::CopyPuppetModule,
+                          source_pulp_id: source.pulp_id,
+                          target_pulp_id: clone.pulp_id,
+                          criteria: nil)
 
-            concurrence do
-              plan_action(Katello::Repository::MetadataGenerate, clone) if environment
-              plan_action(ElasticSearch::ContentViewPuppetEnvironment::IndexContent, id: clone.id)
+              concurrence do
+                plan_action(Katello::Repository::MetadataGenerate, clone) if environment
+                plan_action(ElasticSearch::ContentViewPuppetEnvironment::IndexContent, id: clone.id)
+              end
             end
           end
         end
 
         private
 
-        # The environment clone clone of the repository is the one
+        def setup_puppet_environment_clone(from_version, clone)
+          if clone.new_record?
+            plan_action(ContentViewPuppetEnvironment::Create, clone, true)
+          else
+            clone.content_view_version = from_version
+            clone.save!
+            plan_action(ContentViewPuppetEnvironment::Clear, clone)
+          end
+          clone
+        end
+
+        # The environment clone of the repository is the one
         # visible for the systems in the environment
-        def find_or_build_puppet_env(version, environment)
+        def find_or_build_puppet_env(version, environment, puppet_modules_present)
           puppet_env = ::Katello::ContentViewPuppetEnvironment.in_content_view(version.content_view).
               in_environment(environment).scoped(:readonly => false).first
           puppet_env = version.content_view.build_puppet_env(:environment => environment) unless puppet_env
+
+          if puppet_env.puppet_environment.nil? && puppet_modules_present
+            puppet_env.puppet_environment = ::Katello::Foreman.build_puppet_environment(version.content_view.organization,
+                                                                                       environment, version.content_view)
+          end
           puppet_env
         end
 

--- a/app/lib/katello/foreman.rb
+++ b/app/lib/katello/foreman.rb
@@ -1,14 +1,14 @@
 module Katello
   class Foreman
-    def self.create_puppet_environment(org, env, content_view)
+    def self.build_puppet_environment(org, env, content_view)
       unless content_view.default?
-        Environment.find_or_create_by_katello_id(org, env, content_view)
+        Environment.find_or_build_by_katello_id(org, env, content_view)
       end
     end
 
     def self.update_puppet_environment(content_view, environment)
-      unless content_view.default?
-        content_view_puppet_env = content_view.version(environment).puppet_env(environment)
+      content_view_puppet_env = content_view.version(environment).puppet_env(environment)
+      if !content_view.default? && content_view_puppet_env
         foreman_environment = content_view_puppet_env.puppet_environment
 
         # Associate the puppet environment with the locations that are currently

--- a/app/models/katello/concerns/environment_extensions.rb
+++ b/app/models/katello/concerns/environment_extensions.rb
@@ -30,15 +30,15 @@ module Katello
           Environment.where(:katello_id => katello_id).first
         end
 
-        def create_by_katello_id(org, env, content_view)
+        def build_by_katello_id(org, env, content_view)
           env_name = Environment.construct_name(org, env, content_view)
           katello_id = Environment.construct_katello_id(org, env, content_view)
-          Environment.create!(:name => env_name, :organizations => [org], :katello_id => katello_id)
+          Environment.new(:name => env_name, :organizations => [org], :katello_id => katello_id)
         end
 
-        def find_or_create_by_katello_id(org, env, content_view)
+        def find_or_build_by_katello_id(org, env, content_view)
           Environment.find_by_katello_id(org, env, content_view) ||
-              Environment.create_by_katello_id(org, env, content_view)
+              Environment.build_by_katello_id(org, env, content_view)
         end
 
         def construct_katello_id(org, env, content_view)

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -412,16 +412,11 @@ module Katello
       pulp_id = ContentViewPuppetEnvironment.generate_pulp_id(organization.label, to_env.try(:label),
                                                               self.label, version.try(:version))
 
-      env = ContentViewPuppetEnvironment.new(:environment => to_env,
-                                             :content_view_version => to_version,
-                                             :name => self.name,
-                                             :pulp_id => pulp_id
-                                            )
-      if to_env
-        env.puppet_environment = Katello::Foreman.create_puppet_environment(content_view.organization,
-                                                                            to_env, content_view)
-      end
-      env
+      ContentViewPuppetEnvironment.new(:environment => to_env,
+                                       :content_view_version => to_version,
+                                       :name => self.name,
+                                       :pulp_id => pulp_id
+                                      )
     end
 
     def create_puppet_env(options)

--- a/app/models/katello/content_view_puppet_environment.rb
+++ b/app/models/katello/content_view_puppet_environment.rb
@@ -18,7 +18,7 @@ module Katello
     validates_lengths_from_database
     validates :pulp_id, :presence => true, :uniqueness => true
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
-    validates :puppet_environment_id, :presence => true, :if => :environment
+    validates :puppet_environment, :presence => true, :if => :environment
 
     scope :non_archived, where('environment_id is not NULL')
     scope :archived, where('environment_id is NULL')

--- a/test/models/concerns/environment_extensions_test.rb
+++ b/test/models/concerns/environment_extensions_test.rb
@@ -24,21 +24,23 @@ module Katello
       assert_equal name, ["KT", @org.label, @env.label, @content_view.label, @content_view.id].join('_')
     end
 
-    def test_create_by_katello_id
-      refute_nil Environment.create_by_katello_id(@org, @env, @content_view)
+    def test_build_by_katello_id
+      env = Environment.build_by_katello_id(@org, @env, @content_view)
+      refute_nil env
+      env.save!
     end
 
     def test_find_by_katello_id
       assert_nil Environment.find_by_katello_id(@org, @env, @content_view)
 
-      Environment.create_by_katello_id(@org, @env, @content_view)
-
+      env = Environment.build_by_katello_id(@org, @env, @content_view)
+      env.save!
       refute_nil Environment.find_by_katello_id(@org, @env, @content_view)
     end
 
     def test_find_or_create_by_katello_id
       assert_nil Environment.find_by_katello_id(@org, @env, @content_view)
-      refute_nil Environment.find_or_create_by_katello_id(@org, @env, @content_view)
+      refute_nil Environment.find_or_build_by_katello_id(@org, @env, @content_view)
     end
   end
 end


### PR DESCRIPTION
during publishing and promotion.  If you are promoting to an environment where there were no puppet modules before (and thus no puppet environment), but now there are, one will be created.  If you are promoting to an environment where there were puppet modules before, but now there are not, the existing environment is NOT deleted, but is cleared out as it is today.

Also handles:
  * If a puppet environment has been deleted, and there are no modules
         delete the content view puppet environment
  * If a puppet environment has been deleted and there are modules, recreate it