### PR TITLE
Fixes #10631: hide errata confirm if no errata IDs BZ 1223963.

### DIFF
--- a/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
@@ -181,6 +181,7 @@ module Katello
     private
 
     def find_errata
+      params[:errata_ids] ||= []
       @errata = Katello::Erratum.where(:uuid => params[:errata_ids])
       not_found = params[:errata_ids] - @errata.pluck(:uuid)
       fail _("Could not find all specified errata ids: %s") % not_found.join(', ') unless not_found.empty?

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -58,7 +58,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 params['content_view_version_environments'] = [];
                 params['resolve_dependencies'] = true;
 
-                //get a list of unique content view verion ids with their environments
+                //get a list of unique content view version ids with their environments
                 angular.forEach($scope.updates, function (update) {
                     var versionId = update['content_view_version'].id;
 
@@ -119,7 +119,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 }
             }
 
-            if ($scope.selectedContentHosts) {
+            if ($scope.selectedContentHosts && $scope.errataIds) {
                 $scope.selectedContentHosts['errata_ids'] = $scope.errataIds;
                 $scope.selectedContentHosts['organization_id'] = CurrentOrganization;
                 ContentHostBulkAction.availableIncrementalUpdates($scope.selectedContentHosts, function (updates) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -17,7 +17,11 @@
   <p class="alert alert-warning" translate>You must select at least one Content Host in order to apply Errata.</p>
 </section>
 
-<section class="details details-full" ng-show="selectedContentHosts">
+<section class="col-md-4" ng-hide="errataIds">
+  <p class="alert alert-warning" translate>You must select at least one Errata to apply.</p>
+</section>
+
+<section class="details details-full" ng-show="selectedContentHosts && errataIds">
   <h3 ng-show="errata" translate>Apply {{ errata.errata_id }}</h3>
 
   <section ng-hide="updates">


### PR DESCRIPTION
There was at least one case where errata IDs were not provided
to the available incremental update call.  This commit prevents
the display of that page if there are no errata IDs provided.
In addition, fix the available_incremental_updates API to return
an empty list if the param errata_ids is not provided.

http://projects.theforeman.org/issues/10631
https://bugzilla.redhat.com/show_bug.cgi?id=1223963