### PR TITLE
Fix breakage in scoped_search from previous cherry pick.

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -98,7 +98,7 @@ module Katello
       scoped = scoped.of_type(params[:types]) if params[:types]
 
       respond_for_index :template => '../errata/index',
-                        :collection => scoped_search(scoped, 'issued', 'desc', Erratum)
+                        :collection => scoped_search(scoped, 'issued', 'desc', :resource_class => Erratum)
     end
 
     api :GET, "/content_views/:content_view_id/filters/:id/available_package_groups",

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -61,7 +61,7 @@ module Katello
     param :library, [true, false], :desc => N_("set true if you want to see only library environments")
     param :name, String, :desc => N_("filter only environments containing this name")
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, KTEnvironment))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, :resource_class => KTEnvironment))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
@@ -103,7 +103,7 @@ module Katello
         N_("Fetch applicable errata for a system."), :deprecated => true
     param_group :bulk_params
     def applicable_errata
-      respond_for_index(:collection => scoped_search(Katello::Erratum.installable_for_systems(@systems), 'updated', 'desc', Erratum))
+      respond_for_index(:collection => scoped_search(Katello::Erratum.installable_for_systems(@systems), 'updated', 'desc', :resource_class => Erratum))
     end
 
     api :PUT, "/systems/bulk/install_content", N_("Install content on one or more systems"), :deprecated => true


### PR DESCRIPTION
A previous cherry-pick introduced passing the resource class to
scoped search via  named parameter but updates to other classes were
missed.