### PR TITLE
fixes #10655 - fix organization delete

### DIFF
--- a/app/lib/actions/candlepin/product/delete_subscriptions.rb
+++ b/app/lib/actions/candlepin/product/delete_subscriptions.rb
@@ -1,14 +1,14 @@
 module Actions
   module Candlepin
     module Product
-      class DeleteSubscriptions < Candlepin::AbstractAsyncTask
+      class DeleteSubscriptions < Candlepin::Abstract
         input_format do
           param :organization_label
           param :cp_id
         end
 
-        def invoke_external_task
-          output[:response] = ::Katello::Resources::Candlepin::Product.delete_subscriptions(input[:organization_label], input[:cp_id])
+        def run
+          ::Katello::Resources::Candlepin::Product.delete_subscriptions(input[:organization_label], input[:cp_id])
         end
       end
     end

--- a/app/lib/actions/candlepin/product/delete_unused.rb
+++ b/app/lib/actions/candlepin/product/delete_unused.rb
@@ -1,0 +1,13 @@
+module Actions
+  module Candlepin
+    module Product
+      class DeleteUnused < Candlepin::Abstract
+        def plan(organization)
+          organization.products.each do |product|
+            plan_action(Candlepin::Product::Destroy, cp_id: product.cp_id) unless product.used_by_another_org?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -7,7 +7,7 @@ module Actions
 
           sequence do
             concurrence do
-              version.archived_repos.each do |repo|
+              version.repositories.each do |repo|
                 repo_options = options.clone
                 repo_options[:planned_destroy] = true
                 plan_action(Repository::Destroy, repo, repo_options)

--- a/app/lib/actions/katello/organization/destroy.rb
+++ b/app/lib/actions/katello/organization/destroy.rb
@@ -19,6 +19,7 @@ module Actions
             destroy_contents(organization)
             plan_self
             plan_action(Candlepin::Owner::Destroy, label:  organization.label) if ::Katello.config.use_cp
+            plan_action(Candlepin::Product::DeleteUnused, organization)
             plan_action(Katello::Organization::IndexSubscriptions, organization) if ::Katello.config.use_cp
           end
         end

--- a/app/lib/actions/katello/product/destroy.rb
+++ b/app/lib/actions/katello/product/destroy.rb
@@ -10,7 +10,6 @@ module Actions
             fail _("Cannot delete a Red Hat Products or Products with Repositories published in a Content View")
           end
 
-          no_other_assignment = ::Katello::Product.where(["cp_id = ? AND id != ?", product.cp_id, product.id]).count == 0
           action_subject(product)
 
           sequence do
@@ -22,15 +21,15 @@ module Actions
                   plan_action(Katello::Repository::Destroy, repo, repo_options)
                 end
               end
-            end
-            concurrence do
-              plan_action(Candlepin::Product::DeletePools,
-                            cp_id: product.cp_id, organization_label: product.organization.label)
-              plan_action(Candlepin::Product::DeleteSubscriptions,
-                            cp_id: product.cp_id, organization_label: product.organization.label)
+              concurrence do
+                plan_action(Candlepin::Product::DeletePools,
+                              cp_id: product.cp_id, organization_label: product.organization.label)
+                plan_action(Candlepin::Product::DeleteSubscriptions,
+                              cp_id: product.cp_id, organization_label: product.organization.label)
+              end
             end
 
-            if no_other_assignment
+            if !product.used_by_another_org? && !organization_destroy
               if product.is_a? ::Katello::MarketingProduct
                 concurrence do
                   product.productContent.each do |pc|
@@ -44,13 +43,13 @@ module Actions
               plan_action(Candlepin::Product::Destroy, cp_id: product.cp_id)
             end
 
-            plan_self
+            plan_self(:product_id => product.id)
             plan_action(ElasticSearch::Provider::ReindexSubscriptions, product.provider) unless organization_destroy
           end
         end
 
         def finalize
-          product = ::Katello::Product.find(input[:product][:id])
+          product = ::Katello::Product.find(input[:product_id])
           product.destroy!
         end
 

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -149,6 +149,10 @@ module Katello
       provider.anonymous_provider?
     end
 
+    def used_by_another_org?
+      self.class.where(["cp_id = ? AND id != ?", cp_id, id]).count > 0
+    end
+
     def gpg_key_name=(name)
       if name.blank?
         self.gpg_key = nil

--- a/test/actions/candlepin/product_test.rb
+++ b/test/actions/candlepin/product_test.rb
@@ -63,9 +63,49 @@ class Actions::Candlepin::Product::DestroyTest < ActiveSupport::TestCase
     end
 
     it 'runs' do
-      action_class.any_instance.expects(:done?).returns(true)
       ::Katello::Resources::Candlepin::Product.expects(:delete_subscriptions).with(label, cp_id)
       run_action planned_action
+    end
+  end
+
+  describe "Delete Unused" do
+    before(:all) { stub_remote_user }
+    let(:action_class) { ::Actions::Candlepin::Product::DeleteUnused }
+    let(:org) { get_organization }
+    let(:destroy_action) { ::Actions::Candlepin::Product::Destroy  }
+
+    context('without duplicate') do
+      let(:planned_action) do
+        create_and_plan_action(action_class, org)
+      end
+
+      it 'plans deletion of all products' do
+        org.products.each do |product|
+          assert_action_planed_with(planned_action, destroy_action, cp_id: product.cp_id)
+        end
+      end
+    end
+
+    context('with duplicate') do
+      let(:other_org) { taxonomies(:organization1) }
+      let(:redhat_product) { katello_products(:redhat) }
+
+      let(:other_product) do
+        create(:katello_product,
+               :cp_id => redhat_product.cp_id,
+               :organization => other_org,
+               :name => redhat_product.name,
+               :label => 'dont_label_me',
+               :provider => other_org.redhat_provider)
+      end
+
+      let(:planned_action) do
+        create_and_plan_action(action_class, other_org)
+      end
+
+      it 'does not plan deletion of duplicated product' do
+        refute_action_planed(planned_action, destroy_action)
+      end
     end
   end
 

--- a/test/actions/katello/foreman_test.rb
+++ b/test/actions/katello/foreman_test.rb
@@ -24,8 +24,8 @@ class Actions::Katello::Foreman::ContentUpdateTest < ActiveSupport::TestCase
     assert_finalize_phase(action)
     action.input.must_equal("environment_id" => environment.id,
                             "content_view_id" => content_view.id,
-                            "remote_user" => "user",
-                            "remote_cp_user" => "user")
+                            "remote_user" => User.current.login,
+                            "remote_cp_user" => User.current.remote_id)
   end
 
   it 'updates the foreman content' do

--- a/test/fixtures/models/katello_providers.yml
+++ b/test/fixtures/models/katello_providers.yml
@@ -28,3 +28,10 @@ puppet_labs:
   description:    Fie, fie, you counterfeit. You puppet, you!
   provider_type:  Custom
   organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
+redhat2:
+  name: Red Hat Provider2
+  description: Provider of all your red hat needs
+  provider_type: 'Red Hat'
+  repository_url: 'https://cds.example.com'
+  organization_id: <%= ActiveRecord::Fixtures.identify(:organization1) %>

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -82,5 +82,21 @@ module Katello
       assert_equal 2, products.length
       products.each { |prod| assert prod.syncable_content? }
     end
+
+    def test_not_used_by_other_org
+      refute @redhat_product.used_by_another_org?
+    end
+
+    def test_used_by_other_orgs
+      other_org = taxonomies(:organization1)
+      create(:katello_product,
+             :cp_id => @redhat_product.cp_id,
+             :organization => other_org,
+             :name => @redhat_product.name,
+             :label => 'dont_label_me',
+             :provider => other_org.redhat_provider)
+
+      assert @redhat_product.used_by_another_org?
+    end
   end
 end

--- a/test/support/actions/remote_action.rb
+++ b/test/support/actions/remote_action.rb
@@ -2,12 +2,13 @@ module Support
   module Actions
     module RemoteAction
       def stub_remote_user(admin = false)
-        usr = mock('user', remote_id: 'user', login: 'user')
-        usr.stubs(:admin?).returns(admin)
-        usr.stubs(:location_and_child_ids).returns([])
-        usr.stubs(:organization_and_child_ids).returns([])
-
-        User.stubs(:current).returns usr
+        if admin
+          User.current = users(:admin)
+          User.current.remote_id = 'admin'
+        else
+          User.current = users(:one)
+          User.current.remote_id = 'one'
+        end
       end
 
       # runcible_expects(action, :extensions, :consumer, :create).with('uuid')


### PR DESCRIPTION
* product destroy action could not handle marketing products
* due to multiple subscriptions containing the same products, product
    destroy across products would cause the same subscription to be planned to delete
    multiple times, causing 404 or 400
* Subscription delete is not a async task, yet we were attempting to treat it as such
    This caused an error when trying to fetch the status of the non-existent task

This changes causes product and subscription destroy in candlepin to not actually happen when
they were happening.  Instead we let candlepin clean up the organizations subscriptions and
we wait until after the org is deleted to clean up any products not used by other organizations