### PR TITLE
Fixes #10551 - Allow users to search content view versions by version and repository

### DIFF
--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -95,6 +95,7 @@ Katello::Engine.routes.draw do
             post :promote
           end
           collection do
+            get :auto_complete_search
             post :incremental_update
           end
         end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
@@ -14,6 +14,7 @@ angular.module('Bastion.content-views.versions').factory('ContentViewVersion',
         return BastionResource('/katello/api/v2/content_view_versions/:id/:action',
             {id: '@id'},
             {
+                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 update: {method: 'PUT'},
                 incrementalUpdate: {method: 'POST', params: {action: 'incremental_update'}},
                 promote: {method: 'POST', params: {action: 'promote'}}

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -52,7 +52,6 @@ module Katello
       expected_version = ContentViewVersion.find(katello_content_view_versions(:library_view_version_2))
 
       results = JSON.parse(get(:index, :content_view_id => @library_view.id, :environment_id => @library.id).body)
-
       assert_response :success
       assert_template 'api/v2/content_view_versions/index'
 


### PR DESCRIPTION
Because version is stored in a major and minor column I had to write a custom function to search by version. All the operators that scoped search provides in auto complete are accounted for. Ran into issues using scoped search gem to search cvv by environment, Seems to be an problem with a has-many-through relationship.