### PR TITLE
Fixes #10681:  show correct installable count BZ 1226997.

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -65,7 +65,9 @@ module Katello
     def self.installable_for_systems(systems = nil)
       query = Katello::Erratum.joins(:system_errata).joins(:repository_errata).joins("INNER JOIN #{Katello::SystemRepository.table_name} on \
         #{Katello::SystemRepository.table_name}.system_id = #{Katello::SystemErratum.table_name}.system_id").
-          where("#{Katello::SystemRepository.table_name}.repository_id = #{Katello::RepositoryErratum.table_name}.repository_id")
+        joins("INNER JOIN #{Katello::RepositoryErratum.table_name} AS system_repo_errata ON \
+          system_repo_errata.erratum_id = #{Katello::Erratum.table_name}.id").
+        where("#{Katello::SystemRepository.table_name}.repository_id = system_repo_errata.repository_id")
       query.where("#{Katello::SystemRepository.table_name}.system_id" => [systems.map(&:id)]) if systems
       query
     end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
@@ -71,12 +71,12 @@ angular.module('Bastion.errata').controller('ErrataController',
         $scope.showApplicable = true;
         $scope.showInstallable = false;
 
-        $scope.toggleApplicable = function () {
-            nutupane.table.params['errata_restrict_applicable'] = $scope.showApplicable;
-            nutupane.refresh();
-        };
+        $scope.toggleFilters = function () {
+            if ($scope.showInstallable === true) {
+                $scope.showApplicable = true;
+            }
 
-        $scope.toggleInstallable = function () {
+            nutupane.table.params['errata_restrict_applicable'] = $scope.showApplicable;
             nutupane.table.params['errata_restrict_installable'] = $scope.showInstallable;
             nutupane.refresh();
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -34,12 +34,13 @@
 
     <div class="col-sm-3">
       <label class="checkbox-inline" title="{{ 'Only show Errata that is Applicable to one or more Content Hosts' | translate }}">
-        <input type="checkbox" ng-model="showApplicable" ng-change="toggleApplicable()"/>
+        <input type="checkbox" ng-model="showApplicable" ng-disabled="showInstallable" ng-change="toggleFilters()"/>
         <span translate>Applicable</span>
+        <i class="fa fa-question-circle" ng-show="showInstallable" title="{{ 'Errata is automatically Applicable if it is Installable' | translate }}"></i>
       </label>
 
       <label class="checkbox-inline" title="{{ 'Only show Errata that is Installable on one or more Content Hosts' | translate }}">
-        <input type="checkbox" ng-model="showInstallable" ng-change="toggleInstallable()"/>
+        <input type="checkbox" ng-model="showInstallable" ng-change="toggleFilters()"/>
         <span translate>Installable</span>
       </label>
     </div>

--- a/engines/bastion_katello/test/errata/errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/errata.controller.test.js
@@ -70,16 +70,20 @@ describe('Controller: ErrataController', function() {
         expect($scope.repositories[0]['id']).toBe('all');
     });
 
-    it("allows the filtering of applicable errata only", function () {
-        $scope.showApplicable = true;
-        $scope.toggleApplicable();
-        expect($scope.table.params['errata_restrict_applicable']).toBe(true)
+    it("allows the filtering of errata", function () {
+        $scope.showApplicable = false;
+        $scope.showInstallable = false;
+        $scope.toggleFilters();
+        expect($scope.table.params['errata_restrict_applicable']).toBe(false)
+        expect($scope.table.params['errata_restrict_installable']).toBe(false)
     });
 
-    it("allows the filtering of installable errata only", function () {
-        $scope.showInstallable = false;
-        $scope.toggleInstallable();
-        expect($scope.table.params['errata_restrict_installable']).toBe(false)
+    it("ensures showApplicable is true if showInstallable is true", function () {
+        $scope.showApplicable = false;
+        $scope.showInstallable = true;
+        $scope.toggleFilters();
+        expect($scope.table.params['errata_restrict_applicable']).toBe(true)
+        expect($scope.table.params['errata_restrict_installable']).toBe(true)
     });
 
     it('should set the repository_id param on Nutupane when a repository is chosen', function () {

--- a/test/fixtures/models/katello_system_errata.yml
+++ b/test/fixtures/models/katello_system_errata.yml
@@ -5,3 +5,11 @@ errata_server_security:
 errata_server_bugfix:
   erratum_id: <%= ActiveRecord::Fixtures.identify(:bugfix) %>
   system_id: <%= ActiveRecord::Fixtures.identify(:errata_server) %>
+
+errata_server_dev_security:
+  erratum_id: <%= ActiveRecord::Fixtures.identify(:security) %>
+  system_id: <%= ActiveRecord::Fixtures.identify(:errata_server_dev) %>
+
+errata_server_dev_bugfix:
+  erratum_id: <%= ActiveRecord::Fixtures.identify(:bugfix) %>
+  system_id: <%= ActiveRecord::Fixtures.identify(:errata_server_dev) %>

--- a/test/fixtures/models/katello_systems.yml
+++ b/test/fixtures/models/katello_systems.yml
@@ -30,3 +30,10 @@ errata_server:
   uuid:         010E99C0-3276-11E2-81C1-0800200Czzzzz
   environment_id: <%= ActiveRecord::Fixtures.identify(:library) %>
   content_view_id: <%= ActiveRecord::Fixtures.identify(:acme_default) %>
+
+errata_server_dev:
+  name:         Errata Dev Server
+  description:  Errata server in the dev environment
+  uuid:         010E99C0-3276-11E2-81C1-0800200Czzzz1
+  environment_id: <%= ActiveRecord::Fixtures.identify(:dev) %>
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:acme_default) %>

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -8,6 +8,7 @@ module Katello
       @bugfix = katello_errata(:bugfix)
       @enhancement = katello_errata(:enhancement)
       @errata_server = katello_systems(:errata_server)
+      @errata_server_dev = katello_systems(:errata_server_dev)
       @simple_server = katello_systems(:simple_server)
     end
   end
@@ -122,6 +123,21 @@ module Katello
 
     def test_installable_for_systems
       errata = Erratum.installable_for_systems([@errata_server, @simple_server])
+      assert_includes errata, @security
+      refute_includes errata, @bugfix
+      refute_includes errata, @enhancement
+    end
+
+    def test_installable_for_systems_dev_environment
+      errata = Erratum.installable_for_systems([@errata_server_dev, @simple_server])
+      assert_includes errata, @security
+      refute_includes errata, @bugfix
+      refute_includes errata, @enhancement
+    end
+
+    def test_installable_for_systems_dev_environment_with_repos
+      #Tests issue #10681
+      errata = Erratum.installable_for_systems([@errata_server_dev, @simple_server]).in_repositories(@repo)
       assert_includes errata, @security
       refute_includes errata, @bugfix
       refute_includes errata, @enhancement


### PR DESCRIPTION
The installable count was incorrect when a repository was
provided becuase the query was incorrect.  This commit
fixes the query for systems when a repository is provided.
In addition, this commit prevents only installable from
being selected (as installable is a subset of applicable)
and shows a tooltip in that case.

http://projects.theforeman.org/issues/10681
https://bugzilla.redhat.com/show_bug.cgi?id=1226997