### PR TITLE
refs #10655 - fixing a couple more issues with org delete

### DIFF
--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -26,10 +26,12 @@ module Actions
           check_version_deletion(versions, cv_envs)
 
           sequence do
-            concurrence do
-              all_cv_envs.each do |cv_env|
-                if cv_env.systems.any? || cv_env.activation_keys.any?
-                  plan_action(ContentViewEnvironment::ReassignObjects, cv_env, options)
+            unless organization_destroy
+              concurrence do
+                all_cv_envs.each do |cv_env|
+                  if cv_env.systems.any? || cv_env.activation_keys.any?
+                    plan_action(ContentViewEnvironment::ReassignObjects, cv_env, options)
+                  end
                 end
               end
             end

--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -12,7 +12,9 @@ module Actions
                 repo_options[:planned_destroy] = true
                 plan_action(Repository::Destroy, repo, repo_options)
               end
-              plan_action(ContentViewPuppetEnvironment::Destroy, version.archive_puppet_environment) unless version.default?
+              version.content_view_puppet_environments.each do |cvpe|
+                plan_action(ContentViewPuppetEnvironment::Destroy, cvpe) unless version.default?
+              end
             end
           end
 

--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -14,7 +14,7 @@ module Actions
           action_subject(repository)
           plan_action(ContentViewPuppetModule::Destroy, repository) if repository.puppet?
           plan_action(Pulp::Repository::Destroy, pulp_id: repository.pulp_id)
-          plan_action(Product::ContentDestroy, repository) unless skip_environment_update
+          plan_action(Product::ContentDestroy, repository)
           plan_action(ElasticSearch::Repository::Destroy, pulp_id: repository.pulp_id)
 
           view_env = repository.content_view.content_view_environment(repository.environment)


### PR DESCRIPTION
* Deleting the environment caused a content view version deletion, which attempted
  to reassign all activation keys and systems
* repo deletion was not deleting the candlepin content for custom repos.  Thus when trying to later
  create the same repo within the same product within the same named org, it would fail as the content already
  exists