### PR TITLE
Fixes #10705: fix errata CH installable filter BZ 1228292.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -25,7 +25,7 @@ angular.module('Bastion.errata').controller('ErrataContentHostsController',
         };
 
         if (!params['erratum_id']) {
-            params['errata_ids[]'] = _.pluck($scope.table.getSelected(), 'id');
+            params['errata_ids'] = _.pluck($scope.table.getSelected(), 'id');
         }
 
         nutupane = new Nutupane(ContentHost, params, 'getPost');

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -22,7 +22,7 @@
         <div class="checkbox">
           <label>
             <input type="checkbox" ng-model="errata.showInstallable" ng-change="toggleInstallable()"/>
-            <span translate>Only show content hosts where {{ errata.title }} is currently installable in the host's Lifecycle Environment.</span>
+            <span translate>Only show content hosts where the errata is currently installable in the host's Lifecycle Environment.</span>
           </label>
         </div>
       </div>


### PR DESCRIPTION
The filtering for content hosts where the errata is installable
was broken after changing the method to POST in 9b27077.  This
commit fixes the referenced param so that the filter will work.

http://projects.theforeman.org/issues/10705
https://bugzilla.redhat.com/show_bug.cgi?id=1228292