### PR TITLE
Fixes #10640: only show one repo per CVV BZ 1223699.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
@@ -28,7 +28,8 @@
                 type: Repository,
                 params: {
                     'content_type': "yum",
-                    'content_view_version_id': $scope.$stateParams.versionId
+                    'content_view_version_id': $scope.$stateParams.versionId,
+                    library: true
                 }
             },
             'packages': {

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -142,6 +142,20 @@ module Katello
       assert_template 'api/v2/repositories/index'
     end
 
+    def test_index_with_content_view_version_id_and_library
+      ids = @view.versions.first.repositories.pluck(:library_instance_id).reject(&:blank?)
+
+      @controller
+          .expects(:item_search)
+          .with(anything, anything, has_entry(:filters => [{:terms => {:id => ids}}]))
+          .returns({})
+
+      get :index, :content_view_version_id => @view.versions.first.id, :organization_id => @organization.id, :library => true
+
+      assert_response :success
+      assert_template 'api/v2/repositories/index'
+    end
+
     def test_index_with_library
       ids = @organization.default_content_view.versions.first.repositories.pluck(:id)
 


### PR DESCRIPTION
We were showing multiple repositories per CV based on
the number of environments.  This commit fixes the display
to only show the library version of the repository.

http://projects.theforeman.org/issues/10640
https://bugzilla.redhat.com/show_bug.cgi?id=1223699