### PR TITLE
fixes #10718 - correctly show repos

### DIFF
--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -22,7 +22,7 @@ module Katello
         else
           repos = task.output[:results]
           repos = exclude_rolling_kickstart_repos(repos)
-          repos = available_synced_repos(repos)
+          repos = available_synced_repos(repos) if params[:orphaned]
 
           render :partial => 'katello/providers/redhat/repos', :locals => {:scan_cdn => task, :repos => repos}
         end


### PR DESCRIPTION
This fixes the repos showing up on wrong tabs of the UI (eg. kickstart showing up in rpm)