### PR TITLE
Fixes #10774: fix content host errata results BZ 1228316.

### DIFF
--- a/app/controllers/katello/api/v2/system_errata_controller.rb
+++ b/app/controllers/katello/api/v2/system_errata_controller.rb
@@ -56,11 +56,11 @@ module Katello
     private
 
     def find_content_view
-      ContentView.readable.find(params[:content_view_id]) if params[:content_view_id]
+      @content_view = ContentView.readable.find(params[:content_view_id]) if params[:content_view_id]
     end
 
     def find_environment
-      KTEnvironment.readable.find(params[:environment_id]) if params[:environment_id]
+      @environment = KTEnvironment.readable.find(params[:environment_id]) if params[:environment_id]
     end
 
     def find_system


### PR DESCRIPTION
The values for @content_view and @environment were never set and thus
always nil resulting in the errata always being installable errata
instead of applicable errata, if applicable.

http://projects.theforeman.org/issues/10774
https://bugzilla.redhat.com/show_bug.cgi?id=1228316