### PR TITLE
Fixes #10775: only show one message for CVV page BZ 1230408.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -1,6 +1,7 @@
 <span page-title ng-model="contentView">{{ 'Versions for Content View:' | translate }} {{ contentView.name }}</span>
 
 <div data-extend-template="layouts/details-nutupane.html">
+  <div data-block="messages"></div>
 
   <span data-block="no-rows-message" translate>
     This Content View does not have any versions, create your first Content View Version by using the "Publish New Version" button on the right.


### PR DESCRIPTION
The CVV page was duplicating messages that were already
included in the CV page.  This commit removes the duplicated
messages in the CVV page.

http://projects.theforeman.org/issues/10775
https://bugzilla.redhat.com/show_bug.cgi?id=1230408