### PR TITLE
Refs #10767 - task summary widgets to content dashboard

### DIFF
--- a/app/assets/stylesheets/katello/dashboard.scss
+++ b/app/assets/stylesheets/katello/dashboard.scss
@@ -568,3 +568,8 @@ $col_width: (($static_width) * 0.5);
   }
 }
 
+.task_summary{
+  height: 130px;
+  overflow: auto;
+}
+

--- a/app/lib/katello/dashboard/error_warning_tasks_widget.rb
+++ b/app/lib/katello/dashboard/error_warning_tasks_widget.rb
@@ -1,0 +1,14 @@
+module Katello
+  class Dashboard::ErrorWarningTasksWidget < Dashboard::Widget
+    def accessible?
+      User.current.admin? ||
+       (current_organization &&
+        User.current.allowed_organizations.include?(current_organization) &&
+        HostCollection.readable?)
+    end
+
+    def title
+      _("Tasks in Warning/Error")
+    end
+  end
+end

--- a/app/lib/katello/dashboard/layout.rb
+++ b/app/lib/katello/dashboard/layout.rb
@@ -9,6 +9,8 @@ module Katello
         sync
         host_collections
         errata
+        tasks_summary
+        error_warning_tasks
       )
 
       attr_accessor :widgets, :columns, :organization, :current_user

--- a/app/lib/katello/dashboard/tasks_summary_widget.rb
+++ b/app/lib/katello/dashboard/tasks_summary_widget.rb
@@ -1,0 +1,13 @@
+module Katello
+  class Dashboard::TasksSummaryWidget < Dashboard::Widget
+    def accessible?
+      User.current.admin? ||
+       (current_organization &&
+        current_organization.subscriptions_readable?)
+    end
+
+    def title
+      _("Tasks Summary")
+    end
+  end
+end

--- a/app/views/katello/dashboard/_error_warning_tasks.haml
+++ b/app/views/katello/dashboard/_error_warning_tasks.haml
@@ -1,0 +1,4 @@
+.task_summary.widget
+  = render :partial => 'overrides/foreman/about/latest_tasks_in_error_warning_table'
+.clearfloat
+.clear

--- a/app/views/katello/dashboard/_tasks_summary.html.haml
+++ b/app/views/katello/dashboard/_tasks_summary.html.haml
@@ -1,0 +1,4 @@
+#task_summary.widget
+  = render :partial => 'overrides/foreman/about/task_status_table'
+.clearfloat
+.clear


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman-tasks/pull/109
* add widget that show task count by state/status
* adds list of the latest tasks in warning and error