### PR TITLE
Fixes #10798: fix overlap of CVV repository selector BZ 1228390.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-package-groups.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-package-groups.html
@@ -3,10 +3,14 @@
   <div data-block="header"></div>
   <div data-block="selection-summary"></div>
 
-  <span class="input-group-addon" data-block="search-filter">
-    <select ng-model="repository" ng-options="repository.name for (id, repository) in repositories">
-    </select>
-  </span>
+    <div data-block="filters">
+      <div class="row">
+        <div class="form-group col-sm-4">
+          <select class="form-control" ng-model="repository" ng-options="repository.name for (id, repository) in repositories">
+          </select>
+        </div>
+      </div>
+    </div>
 
   <table data-block="table" class="table table-striped table-bordered">
     <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-packages.html
@@ -3,10 +3,14 @@
   <div data-block="header"></div>
   <div data-block="selection-summary"></div>
 
-  <span class="input-group-addon" data-block="search-filter">
-    <select ng-model="repository" ng-options="repository.name for (id, repository) in repositories">
-    </select>
-  </span>
+  <div data-block="filters">
+    <div class="row">
+      <div class="form-group col-sm-4">
+        <select class="form-control" ng-model="repository" ng-options="repository.name for (id, repository) in repositories">
+        </select>
+      </div>
+    </div>
+  </div>
 
   <table data-block="table" class="table table-striped table-bordered">
     <thead>


### PR DESCRIPTION
Move the repository selector for content view version packages and
package groups to the filters section so that it is above the search
field and thus does not overlap.

http://projects.theforeman.org/issues/10798
https://bugzilla.redhat.com/show_bug.cgi?id=1228390