### PR TITLE
Fixes #10822 - Don't clean up env content during CV remove

### DIFF
--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -54,7 +54,9 @@ module Actions
               ::Katello::ContentViewHistory.create!(:content_view_version => version,
                                                     :user => ::User.current.login,
                                                     :status => ::Katello::ContentViewHistory::IN_PROGRESS, :task => self.task)
-              plan_action(ContentViewVersion::Destroy, version, :skip_environment_check => true)
+              plan_action(ContentViewVersion::Destroy, version,
+                          :skip_environment_check => true,
+                          :skip_destroy_env_content => true)
             end
 
             plan_self(content_view_id: content_view.id,

--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -4,15 +4,18 @@ module Actions
       class Destroy < Actions::Base
         def plan(version, options = {})
           version.check_ready_to_destroy! unless options[:skip_environment_check]
+          destroy_env_content = !options.fetch(:skip_destroy_env_content, false)
+          repos = destroy_env_content ? version.repositories : version.archived_repos
+          puppet_envs = destroy_env_content ? version.content_view_puppet_environments : [version.archive_puppet_environment]
 
           sequence do
             concurrence do
-              version.repositories.each do |repo|
+              repos.each do |repo|
                 repo_options = options.clone
                 repo_options[:planned_destroy] = true
                 plan_action(Repository::Destroy, repo, repo_options)
               end
-              version.content_view_puppet_environments.each do |cvpe|
+              puppet_envs.each do |cvpe|
                 plan_action(ContentViewPuppetEnvironment::Destroy, cvpe) unless version.default?
               end
             end

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -200,7 +200,7 @@ module ::Actions::Katello::ContentView
 
       plan_action(action, content_view, options)
       assert_action_planed_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cv_env, :skip_elastic => false, :skip_repo_destroy => false, :organization_destroy => false)
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version, :skip_environment_check => true)
+      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version, :skip_environment_check => true, :skip_destroy_env_content => true)
     end
   end
 


### PR DESCRIPTION
The problem with ContentView::Remove was that both CVE delete and CVV delete were trying to delete the same sets of repos. Recently, CVV::Destroy was changed to delete env repos since it's used by org destroy. However, ContentView::Remove removes all CVEs before removing the CVV so we were getting a 404 from pulp. This adds an option CV::Remove can use to skip deleting a CVV's env content.