### PR TITLE
Fixes #10824 - Refactoring errata index to show available errata to content view filter usin…

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -150,7 +150,7 @@ module Katello
 
       def filter_by_content_view_filter(filter, options)
         ids = filter.send("#{singular_resource_name}_rules").map(&:uuid)
-        repo_ids = filter.applicable_repos.readable.map(&:pulp_id)
+        repo_ids = filter.applicable_repos.readable.pluck("#{Repository.table_name}.pulp_id")
 
         filter_by_ids(ids, options)
         filter_by_repo_ids(repo_ids, options)

--- a/app/controllers/katello/concerns/api/v2/repository_db_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_db_content_controller.rb
@@ -35,15 +35,22 @@ module Katello
         respond_for_index(:collection => collection)
       end
 
+      param :available_for, :string, :desc => N_("Show errata that can be added to content view filter")
+      param :filterId, :integer, :desc => N_("Content View Filter id")
       def index_relation
         collection = resource_class.scoped
         collection = filter_by_repos(Repository.readable, collection)
         collection = filter_by_repos([@repo], collection) if @repo && !@repo.puppet?
-        collection = filter_by_content_view_filter(@filter, collection) if @filter
         collection = filter_by_content_view_version(@version, collection) if @version
         collection = filter_by_environment(@environment, collection) if @environment
         collection = filter_by_repos(Repository.readable.in_organization(@organization), collection) if @organization
         collection = filter_by_ids(params[:ids], collection) if params[:ids]
+        @filter = ContentViewFilter.find(params[:filterId]) if params[:filterId]
+        if params[:available_for] == "content_view_filter" && self.respond_to?(:available_for_content_view_filter)
+          collection = self.available_for_content_view_filter(@filter, collection) if @filter
+        else
+          collection = filter_by_content_view_filter(@filter, collection) if @filter
+        end
         collection = self.custom_index_relation(collection) if self.respond_to?(:custom_index_relation)
         collection
       end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -65,8 +65,10 @@ Katello::Engine.routes.draw do
           end
           api_resources :content_view_puppet_modules
           api_resources :filters, :controller => :content_view_filters do
+            collection do
+              get :auto_complete_search
+            end
             member do
-              get :available_errata
               get :available_package_groups
             end
             api_resources :errata, :only => [:index]
@@ -85,7 +87,6 @@ Katello::Engine.routes.draw do
             get :auto_complete_search
           end
           member do
-            get :available_errata
             get :available_package_groups
           end
         end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -132,7 +132,7 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
         };
 
         $scope.$watch('detailsTable.rows', function () {
-            if ($scope.detailsTable.rows.length > 0) {
+            if ($scope.detailsTable && $scope.detailsTable.rows.length > 0) {
                 processTasks($scope.detailsTable.rows);
             }
         });

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
@@ -13,8 +13,8 @@
  *   functionality to create filter rules based off selected errata.
  */
 angular.module('Bastion.content-views').controller('AvailableErrataFilterController',
-    ['$scope', 'translate', 'Nutupane', 'Filter', 'Rule',
-    function ($scope, translate, Nutupane, Filter, Rule) {
+    ['$scope', 'translate', 'Nutupane', 'Erratum', 'Rule',
+    function ($scope, translate, Nutupane, Erratum, Rule) {
 
         var nutupane, filterByDate;
 
@@ -35,13 +35,15 @@ angular.module('Bastion.content-views').controller('AvailableErrataFilterControl
             return rules.$save(params, success, failure);
         }
 
-        $scope.nutupane = nutupane = new Nutupane(Filter, {
+        $scope.nutupane = nutupane = new Nutupane(Erratum, {
                 filterId: $scope.$stateParams.filterId,
                 'sort_order': 'DESC',
-                'sort_by': 'issued'
+                'sort_by': 'issued',
+                'available_for': 'content_view_filter'
             },
-            'availableErrata'
+            'queryUnpaged'
         );
+        nutupane.masterOnly = true;
         nutupane.enableSelectAllResults();
 
         filterByDate = function (date, type) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter-list.controller.js
@@ -13,8 +13,8 @@
  *   to remove errata from the filter.
  */
 angular.module('Bastion.content-views').controller('ErrataFilterListController',
-    ['$scope', 'translate', 'Nutupane', 'Filter', 'Rule',
-    function ($scope, translate, Nutupane, Filter, Rule) {
+    ['$scope', 'translate', 'Nutupane', 'Erratum', 'Rule',
+    function ($scope, translate, Nutupane, Erratum, Rule) {
         var nutupane;
 
         function findRules(errataIds) {
@@ -47,12 +47,12 @@ angular.module('Bastion.content-views').controller('ErrataFilterListController',
             $scope.$parent.errorMessages = [response.data.displayMessage];
         }
 
-        $scope.nutupane = nutupane = new Nutupane(Filter, {
+        $scope.nutupane = nutupane = new Nutupane(Erratum, {
                 filterId: $scope.$stateParams.filterId,
                 'sort_order': 'DESC',
                 'sort_by': 'issued'
             },
-            'errata'
+            'queryUnpaged'
         );
 
         $scope.detailsTable = nutupane.table;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter.factory.js
@@ -17,7 +17,7 @@ angular.module('Bastion.content-views').factory('Filter',
                 update: {method: 'PUT'},
                 availableErrata: {
                     method: 'GET',
-                    params: {action: 'available_errata'}
+                    params: {action: 'errata', 'available_for': 'content_view_filter'}
                 },
                 errata: {
                     method: 'GET',

--- a/engines/bastion_katello/test/content-views/details/filters/filter.factory.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter.factory.test.js
@@ -74,10 +74,10 @@ describe('Factory: Filter', function() {
     });
 
     it('provides a way to get installable errata for a filter', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_view_filters/1/available_errata?content_view_id=1')
+        $httpBackend.expectGET('/katello/api/v2/content_view_filters/1/errata?available_for=content_view_filter')
                     .respond({});
 
-        Filter.availableErrata({'filterId': '1', 'content_view_id': 1}, function (errata) {
+        Filter.availableErrata({'filterId': 1}, function (errata) {
             expect(errata).toBeDefined();
         });
     });

--- a/lib/katello/permissions/content_view_permissions.rb
+++ b/lib/katello/permissions/content_view_permissions.rb
@@ -5,8 +5,7 @@ Foreman::Plugin.find(:katello).security_block :content_views do
              {
                'katello/api/v2/content_views' => [:index, :show, :history, :available_puppet_modules,
                                                   :available_puppet_module_names],
-               'katello/api/v2/content_view_filters' => [:index, :show, :available_errata,
-                                                         :available_package_groups],
+               'katello/api/v2/content_view_filters' => [:index, :show, :available_package_groups],
                'katello/api/v2/content_view_filter_rules' => [:index, :show],
                'katello/api/v2/content_view_puppet_modules' => [:index, :show],
                'katello/api/v2/content_view_versions' => [:index, :show],

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -150,24 +150,6 @@ module Katello
       end
     end
 
-    def test_available_errata
-      @filter = katello_content_view_filters(:populated_erratum_filter)
-      get :available_errata, :content_view_id => @filter.content_view_id, :id => @filter.id
-
-      assert_response :success
-      assert_template 'katello/api/v2/content_view_filters/../errata/index'
-    end
-
-    def test_available_errata_protected
-      @filter = katello_content_view_filters(:populated_erratum_filter)
-      allowed_perms = [@view_permission]
-      denied_perms = [@create_permission, @update_permission, @destroy_permission]
-
-      assert_protected_action(:available_errata, allowed_perms, denied_perms) do
-        get :available_errata, :content_view_id => @filter.content_view_id, :id => @filter.id
-      end
-    end
-
     def test_available_package_groups
       @filter = katello_content_view_filters(:populated_package_group_filter)
       get :available_package_groups, :content_view_id => @filter.content_view_id, :id => @filter.id


### PR DESCRIPTION
…g a url parameter.

This is part of the conversion to scoped search for the filter_rules. By using a url parameter, the available errata is shown using the index of errata. This allows scoped search queries and autocomplete while searching the errata available to a content view filter