### PR TITLE
Fixes #10830 - Humanized state description for Pulp and Candlepin async actions

### DIFF
--- a/app/lib/actions/candlepin/abstract_async_task.rb
+++ b/app/lib/actions/candlepin/abstract_async_task.rb
@@ -10,6 +10,21 @@ module Actions
         end
       end
 
+      def humanized_state
+        case state
+        when :running
+          if self.external_task.nil?
+            _("initiating Candlepin task")
+          else
+            _("checking Candlepin task status")
+          end
+        when :suspended
+          _("waiting for Candlepin to finish the task")
+        else
+          super
+        end
+      end
+
       def done?
         ! ::Katello::Resources::Candlepin::Job.not_finished?(external_task)
       end

--- a/app/lib/actions/pulp/abstract_async_task.rb
+++ b/app/lib/actions/pulp/abstract_async_task.rb
@@ -46,6 +46,25 @@ module Actions
         end
       end
 
+      def humanized_state
+        case state
+        when :running
+          if self.external_task.nil?
+            _("initiating Pulp task")
+          else
+            _("checking Pulp task status")
+          end
+        when :suspended
+          if external_task && external_task.all? { |task| task[:start_time].nil? }
+            _("waiting for Pulp to start the task")
+          else
+            _("waiting for Pulp to finish the task")
+          end
+        else
+          super
+        end
+      end
+
       def done?
         external_task.all? { |task| task[:finish_time] || FINISHED_STATES.include?(task[:state]) }
       end


### PR DESCRIPTION
To be displayed in task details and Dynflow console. Requires 
https://github.com/theforeman/foreman-tasks/pull/111 and 
https://github.com/Dynflow/dynflow/pull/153