### PR TITLE
Fixes #8694 - Remove elastic search instances from content view puppet environment

### DIFF
--- a/app/lib/actions/katello/content_view_puppet_environment/create.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/create.rb
@@ -4,7 +4,6 @@ module Actions
       class Create < Actions::EntryAction
         # rubocop:disable MethodLength
         def plan(puppet_environment, clone = false)
-          puppet_environment.disable_auto_reindex!
           puppet_environment.save!
           action_subject(puppet_environment)
           plan_self
@@ -23,7 +22,6 @@ module Actions
             # publish/promote process
             unless clone
               plan_action(Katello::Repository::MetadataGenerate, puppet_environment) if puppet_environment.environment
-              plan_action(ElasticSearch::Reindex, puppet_environment)
             end
           end
         end

--- a/app/lib/actions/katello/content_view_puppet_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/destroy.rb
@@ -5,7 +5,6 @@ module Actions
         def plan(puppet_env)
           action_subject(puppet_env)
           plan_action(Pulp::Repository::Destroy, pulp_id: puppet_env.pulp_id)
-          plan_action(ElasticSearch::Repository::Destroy, pulp_id: puppet_env.pulp_id)
           plan_self
         end
 

--- a/app/models/katello/glue/elastic_search/content_view_puppet_environment.rb
+++ b/app/models/katello/glue/elastic_search/content_view_puppet_environment.rb
@@ -2,29 +2,7 @@ module Katello
   module Glue::ElasticSearch::ContentViewPuppetEnvironment
     # TODO: break this up into modules
     # rubocop:disable MethodLength
-    def self.included(base)
-      base.send :include, Ext::IndexedModel
-
-      base.class_eval do
-        index_options :extended_json => :extended_index_attrs,
-                      :json => {:except => [:pulp_repo_facts, :feed_cert]}
-
-        mapping do
-          indexes :name, :type => 'string', :analyzer => :kt_name_analyzer
-          indexes :name_sort, :type => 'string', :index => :not_analyzed
-          indexes :labels, :type => 'string', :index => :not_analyzed
-        end
-      end
-
-      def extended_index_attrs
-        {
-          :environment => self.environment.try(:name),
-          :archive => self.archive?,
-          :environment_id => self.environment.try(:id),
-          :name_sort => self.name
-        }
-      end
-
+    def self.included(_base)
       def index_puppet_modules
         Tire.index Katello::PuppetModule.index do
           create :settings => Katello::PuppetModule.index_settings, :mappings => Katello::PuppetModule.index_mapping

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -65,8 +65,6 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
                                 target_pulp_id: dev_puppet_env.pulp_id,
                                 criteria: nil
       assert_action_planed_with action, ::Actions::Katello::Repository::MetadataGenerate, dev_puppet_env
-      assert_action_planed_with action, ::Actions::ElasticSearch::ContentViewPuppetEnvironment::IndexContent,
-                                id: dev_puppet_env.id
       refute_nil dev_puppet_env.reload.puppet_environment
     end
 
@@ -79,7 +77,6 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
       refute_action_planed action, ::Actions::Katello::ContentViewPuppetEnvironment::Clear
       assert_action_planed action, ::Actions::Pulp::Repository::CopyPuppetModule
       assert_action_planed action, ::Actions::Katello::Repository::MetadataGenerate
-      assert_action_planed action, ::Actions::ElasticSearch::ContentViewPuppetEnvironment::IndexContent
     end
 
     it 'plans with uneeded existing cv puppet environment' do
@@ -90,7 +87,6 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
       assert_action_planed action, ::Actions::Katello::ContentViewPuppetEnvironment::Destroy
       refute_action_planed action, ::Actions::Pulp::Repository::CopyPuppetModule
       refute_action_planed action, ::Actions::Katello::Repository::MetadataGenerate
-      refute_action_planed action, ::Actions::ElasticSearch::ContentViewPuppetEnvironment::IndexContent
     end
 
     it 'does not plan things when cvep does not already exist and no puppet modules' do
@@ -100,7 +96,6 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
       refute_action_planed action, ::Actions::Katello::ContentViewPuppetEnvironment::Create
       refute_action_planed action, ::Actions::Pulp::Repository::CopyPuppetModule
       refute_action_planed action, ::Actions::Katello::Repository::MetadataGenerate
-      refute_action_planed action, ::Actions::ElasticSearch::ContentViewPuppetEnvironment::IndexContent
     end
   end
 


### PR DESCRIPTION
Since there is nowhere in the UI that we search for content view puppet environment, I removed elastic search from cvpe as part of the process of converting everything over to scoped search and removing elastic search.