### PR TITLE
Fixes #10904: fix errata CH selection, BZ 1233901.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -54,7 +54,7 @@ angular.module('Bastion.errata').controller('ErrataContentHostsController',
             $scope.$parent.numberOfContentHostsToUpdate = nutupane.table.allResultsSelectCount();
             $scope.$parent.selectedContentHosts = nutupane.getAllSelectedResults();
 
-            if ($scope.errata) {
+            if ($scope.errata && $scope.errata.id) {
                 $scope.transitionTo('errata.details.apply', {errataId: $scope.errata.id});
             } else {
                 $scope.transitionTo('errata.apply.confirm');


### PR DESCRIPTION
There were cases when we were attempting to transition to the
errata details screen incorrectly during errata apply. This commit
ensures that we do not transition to the errata details page
without an errata id.

http://projects.theforeman.org/issues/10904
https://bugzilla.redhat.com/show_bug.cgi?id=1233901