### PR TITLE
Refs #10962 - limit foreman tasks in rpm specs to < 0.7.0

### DIFF
--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -99,6 +99,7 @@ Requires: %{?scl_prefix}rubygem-tire < 0.7
 Requires: %{?scl_prefix}rubygem-hooks
 Requires: %{?scl_prefix}rubygem-foreman_docker >= 0.2.0
 Requires: %{?scl_prefix}rubygem-foreman-tasks >= 0.6.0
+Requires: %{?scl_prefix}rubygem-foreman-tasks < 0.7.0
 Requires: %{?scl_prefix}rubygem-justified
 Requires: %{?scl_prefix}rubygem-gettext_i18n_rails
 Requires: %{?scl_prefix}rubygem-i18n_data >= 0.2.6
@@ -123,6 +124,7 @@ BuildRequires: %{?scl_prefix}rubygem-tire < 0.7
 BuildRequires: %{?scl_prefix}rubygem-hooks
 BuildRequires: %{?scl_prefix}rubygem-foreman_docker >= 0.2.0
 BuildRequires: %{?scl_prefix}rubygem-foreman-tasks >= 0.6.0
+BuildRequires: %{?scl_prefix}rubygem-foreman-tasks < 0.7.0
 BuildRequires: %{?scl_prefix}rubygem-justified
 BuildRequires: %{?scl_prefix}rubygem-gettext_i18n_rails
 BuildRequires: %{?scl_prefix}rubygem-i18n_data >= 0.2.6


### PR DESCRIPTION
While preparing the new release of foreman tasks with Dynflow, I've hit an
issue when testing new release with old Katello, as the requirements in the
gemspec don't match the spec.

Another PR will follow updating the Katello to work with new foreman-tasks/dynflow
version, that is being prepared.