### PR TITLE
Refs #10962 - update to the Dynflow 0.8.1

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rabl"
   gem.add_dependency "tire", "~> 0.6.2"
   gem.add_dependency "hooks"
-  gem.add_dependency "foreman-tasks", "~> 0.6.0"
+  gem.add_dependency "foreman-tasks", "~> 0.7.1"
   gem.add_dependency "foreman_docker", ">= 0.2.0"
   gem.add_dependency "justified"
   gem.add_dependency "strong_parameters", "~> 0.2.1" # remove after we upgrade to Rails 4

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -35,7 +35,7 @@ module Katello
 
     initializer "katello.initialize_cp_listener", after: "foreman_tasks.initialize_dynflow" do
       unless ForemanTasks.dynflow.config.remote? || File.basename($PROGRAM_NAME) == 'rake' || Rails.env.test?
-        ForemanTasks.async_task(::Actions::Candlepin::ListenOnCandlepinEvents)
+        ::Actions::Candlepin::ListenOnCandlepinEvents.ensure_running
       end
     end
 

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -98,8 +98,8 @@ Requires: %{?scl_prefix}rubygem-tire => 0.6.2
 Requires: %{?scl_prefix}rubygem-tire < 0.7
 Requires: %{?scl_prefix}rubygem-hooks
 Requires: %{?scl_prefix}rubygem-foreman_docker >= 0.2.0
-Requires: %{?scl_prefix}rubygem-foreman-tasks >= 0.6.0
-Requires: %{?scl_prefix}rubygem-foreman-tasks < 0.7.0
+Requires: %{?scl_prefix}rubygem-foreman-tasks >= 0.7.1
+Requires: %{?scl_prefix}rubygem-foreman-tasks < 0.8.0
 Requires: %{?scl_prefix}rubygem-justified
 Requires: %{?scl_prefix}rubygem-gettext_i18n_rails
 Requires: %{?scl_prefix}rubygem-i18n_data >= 0.2.6
@@ -123,8 +123,8 @@ BuildRequires: %{?scl_prefix}rubygem-tire => 0.6.2
 BuildRequires: %{?scl_prefix}rubygem-tire < 0.7
 BuildRequires: %{?scl_prefix}rubygem-hooks
 BuildRequires: %{?scl_prefix}rubygem-foreman_docker >= 0.2.0
-BuildRequires: %{?scl_prefix}rubygem-foreman-tasks >= 0.6.0
-BuildRequires: %{?scl_prefix}rubygem-foreman-tasks < 0.7.0
+BuildRequires: %{?scl_prefix}rubygem-foreman-tasks >= 0.7.1
+BuildRequires: %{?scl_prefix}rubygem-foreman-tasks < 0.8.0
 BuildRequires: %{?scl_prefix}rubygem-justified
 BuildRequires: %{?scl_prefix}rubygem-gettext_i18n_rails
 BuildRequires: %{?scl_prefix}rubygem-i18n_data >= 0.2.6

--- a/test/fixtures/vcr_cassettes/elasticsearch/package.yml
+++ b/test/fixtures/vcr_cassettes/elasticsearch/package.yml
@@ -2,7 +2,7 @@
 http_interactions: 
 - request: 
     method: delete
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -29,7 +29,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:57 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: UTF-8
       string: "{\"settings\":{\"index\":{\"analysis\":{\"filter\":{\"ngram_filter\":{\"type\":\"edgeNGram\",\"side\":\"front\",\"min_gram\":1,\"max_gram\":30}},\"analyzer\":{\"kt_name_analyzer\":{\"type\":\"custom\",\"tokenizer\":\"keyword\"},\"autcomplete_name_analyzer\":{\"type\":\"custom\",\"tokenizer\":\"keyword\",\"filter\":[\"standard\",\"lowercase\",\"ngram_filter\"]}}}}},\"mappings\":{\"package\":{\"properties\":{\"id\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"name\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"name_autocomplete\":{\"type\":\"string\",\"analyzer\":\"autcomplete_name_analyzer\"},\"nvrea_autocomplete\":{\"type\":\"string\",\"analyzer\":\"autcomplete_name_analyzer\"},\"nvrea\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"nvrea_sort\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"nvra\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"filename\":{\"type\":\"string\",\"analyzer\":\"kt_name_analyzer\"},\"nvra_sort\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"repoids\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"sortable_version\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"sortable_release\":{\"type\":\"string\",\"index\":\"not_analyzed\"}}}}}"
@@ -58,25 +58,25 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:57 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_bulk
+    uri: http://localhost:9200/katello_package/_bulk
     body: 
       encoding: UTF-8
       string: |
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-1"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-1"}}
         {"name":"abc123-1","id":"abc123-1","_id":"abc123-1","_type":"package","version":"1.0.0","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-2"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-2"}}
         {"name":"abc123-2","id":"abc123-2","_id":"abc123-2","_type":"package","version":"1.0.0","epoch":"1","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-3"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-3"}}
         {"name":"abc123-3","id":"abc123-3","_id":"abc123-3","_type":"package","version":"1.0.0","epoch":"0","release":"0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-4"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-4"}}
         {"name":"abc123-4","id":"abc123-4","_id":"abc123-4","_type":"package","version":"1.0.0a","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0.$a","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-5"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-5"}}
         {"name":"abc123-5","id":"abc123-5","_id":"abc123-5","_type":"package","version":"1.0.0","epoch":"0","release":"1el5","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.$el.01-5"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-6"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-6"}}
         {"name":"abc123-6","id":"abc123-6","_id":"abc123-6","_type":"package","version":"1.0.1","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-1","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-7"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-7"}}
         {"name":"abc123-7","id":"abc123-7","_id":"abc123-7","_type":"package","version":"1.0.0","epoch":"0","release":"0.9","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0.01-9"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-8"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-8"}}
         {"name":"abc123-8","id":"abc123-8","_id":"abc123-8","_type":"package","version":"0.9.10","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-0.01-9.02-10","sortable_release":"01-1.01-0"}
 
     headers: 
@@ -99,12 +99,12 @@ http_interactions:
       - "837"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":46,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":1,\"ok\":true}}]}"
+      string: "{\"took\":46,\"items\":[{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":1,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":1,\"ok\":true}}]}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_refresh
+    uri: http://localhost:9200/katello_package/_refresh
     body: 
       encoding: ASCII-8BIT
       string: ""
@@ -133,7 +133,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -160,7 +160,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -245,12 +245,12 @@ http_interactions:
       - "1163"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":4,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
+      string: "{\"took\":4,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -277,7 +277,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -362,30 +362,30 @@ http_interactions:
       - "269"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":1,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":1,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_bulk
+    uri: http://localhost:9200/katello_package/_bulk
     body: 
       encoding: UTF-8
       string: |
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-1"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-1"}}
         {"name":"abc123-1","id":"abc123-1","_id":"abc123-1","_type":"package","version":"1.0.0","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-2"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-2"}}
         {"name":"abc123-2","id":"abc123-2","_id":"abc123-2","_type":"package","version":"1.0.0","epoch":"1","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-3"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-3"}}
         {"name":"abc123-3","id":"abc123-3","_id":"abc123-3","_type":"package","version":"1.0.0","epoch":"0","release":"0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-4"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-4"}}
         {"name":"abc123-4","id":"abc123-4","_id":"abc123-4","_type":"package","version":"1.0.0a","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0.$a","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-5"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-5"}}
         {"name":"abc123-5","id":"abc123-5","_id":"abc123-5","_type":"package","version":"1.0.0","epoch":"0","release":"1el5","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.$el.01-5"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-6"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-6"}}
         {"name":"abc123-6","id":"abc123-6","_id":"abc123-6","_type":"package","version":"1.0.1","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-1","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-7"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-7"}}
         {"name":"abc123-7","id":"abc123-7","_id":"abc123-7","_type":"package","version":"1.0.0","epoch":"0","release":"0.9","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0.01-9"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-8"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-8"}}
         {"name":"abc123-8","id":"abc123-8","_id":"abc123-8","_type":"package","version":"0.9.10","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-0.01-9.02-10","sortable_release":"01-1.01-0"}
 
     headers: 
@@ -408,12 +408,12 @@ http_interactions:
       - "836"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":2,\"ok\":true}}]}"
+      string: "{\"took\":1,\"items\":[{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":2,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":2,\"ok\":true}}]}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_refresh
+    uri: http://localhost:9200/katello_package/_refresh
     body: 
       encoding: ASCII-8BIT
       string: ""
@@ -442,7 +442,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -469,7 +469,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -538,12 +538,12 @@ http_interactions:
       - "418"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":0,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}}]}}"
+      string: "{\"took\":0,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -570,7 +570,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -639,12 +639,12 @@ http_interactions:
       - "1163"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":7,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -671,7 +671,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -756,12 +756,12 @@ http_interactions:
       - "418"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":2,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -788,7 +788,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -873,30 +873,30 @@ http_interactions:
       - "865"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":5,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":5,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_bulk
+    uri: http://localhost:9200/katello_package/_bulk
     body: 
       encoding: UTF-8
       string: |
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-1"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-1"}}
         {"name":"abc123-1","id":"abc123-1","_id":"abc123-1","_type":"package","version":"1.0.0","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-2"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-2"}}
         {"name":"abc123-2","id":"abc123-2","_id":"abc123-2","_type":"package","version":"1.0.0","epoch":"1","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-3"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-3"}}
         {"name":"abc123-3","id":"abc123-3","_id":"abc123-3","_type":"package","version":"1.0.0","epoch":"0","release":"0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-4"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-4"}}
         {"name":"abc123-4","id":"abc123-4","_id":"abc123-4","_type":"package","version":"1.0.0a","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0.$a","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-5"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-5"}}
         {"name":"abc123-5","id":"abc123-5","_id":"abc123-5","_type":"package","version":"1.0.0","epoch":"0","release":"1el5","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.$el.01-5"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-6"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-6"}}
         {"name":"abc123-6","id":"abc123-6","_id":"abc123-6","_type":"package","version":"1.0.1","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-1","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-7"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-7"}}
         {"name":"abc123-7","id":"abc123-7","_id":"abc123-7","_type":"package","version":"1.0.0","epoch":"0","release":"0.9","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0.01-9"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-8"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-8"}}
         {"name":"abc123-8","id":"abc123-8","_id":"abc123-8","_type":"package","version":"0.9.10","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-0.01-9.02-10","sortable_release":"01-1.01-0"}
 
     headers: 
@@ -919,12 +919,12 @@ http_interactions:
       - "836"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":3,\"ok\":true}}]}"
+      string: "{\"took\":1,\"items\":[{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":3,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":3,\"ok\":true}}]}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_refresh
+    uri: http://localhost:9200/katello_package/_refresh
     body: 
       encoding: ASCII-8BIT
       string: ""
@@ -953,7 +953,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -980,7 +980,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -1034,30 +1034,30 @@ http_interactions:
       - "1312"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":8,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":8,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_bulk
+    uri: http://localhost:9200/katello_package/_bulk
     body: 
       encoding: UTF-8
       string: |
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-1"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-1"}}
         {"name":"abc123-1","id":"abc123-1","_id":"abc123-1","_type":"package","version":"1.0.0","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-2"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-2"}}
         {"name":"abc123-2","id":"abc123-2","_id":"abc123-2","_type":"package","version":"1.0.0","epoch":"1","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-3"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-3"}}
         {"name":"abc123-3","id":"abc123-3","_id":"abc123-3","_type":"package","version":"1.0.0","epoch":"0","release":"0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-4"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-4"}}
         {"name":"abc123-4","id":"abc123-4","_id":"abc123-4","_type":"package","version":"1.0.0a","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0.$a","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-5"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-5"}}
         {"name":"abc123-5","id":"abc123-5","_id":"abc123-5","_type":"package","version":"1.0.0","epoch":"0","release":"1el5","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-1.$el.01-5"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-6"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-6"}}
         {"name":"abc123-6","id":"abc123-6","_id":"abc123-6","_type":"package","version":"1.0.1","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-1","sortable_release":"01-1.01-0"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-7"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-7"}}
         {"name":"abc123-7","id":"abc123-7","_id":"abc123-7","_type":"package","version":"1.0.0","epoch":"0","release":"0.9","repoids":["abcrepo"],"sortable_version":"01-1.01-0.01-0","sortable_release":"01-0.01-9"}
-        {"index":{"_index":"katello_test_package","_type":"package","_id":"abc123-8"}}
+        {"index":{"_index":"katello_package","_type":"package","_id":"abc123-8"}}
         {"name":"abc123-8","id":"abc123-8","_id":"abc123-8","_type":"package","version":"0.9.10","epoch":"0","release":"1.0","repoids":["abcrepo"],"sortable_version":"01-0.01-9.02-10","sortable_release":"01-1.01-0"}
 
     headers: 
@@ -1080,12 +1080,12 @@ http_interactions:
       - "836"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":0,\"items\":[{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":4,\"ok\":true}}]}"
+      string: "{\"took\":0,\"items\":[{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_version\":4,\"ok\":true}},{\"index\":{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_version\":4,\"ok\":true}}]}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: post
-    uri: http://localhost:9200/katello_test_package/_refresh
+    uri: http://localhost:9200/katello_package/_refresh
     body: 
       encoding: ASCII-8BIT
       string: ""
@@ -1114,7 +1114,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -1141,7 +1141,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -1237,12 +1237,12 @@ http_interactions:
       - "1312"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":8,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":8,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-3\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-3\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-3\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-6\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-6\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-6\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-4\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-4\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-4\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-7\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-7\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-7\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-8\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-8\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-8\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -1269,7 +1269,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -1370,7 +1370,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: head
-    uri: http://localhost:9200/katello_test_package
+    uri: http://localhost:9200/katello_package
     body: 
       encoding: US-ASCII
       string: ""
@@ -1397,7 +1397,7 @@ http_interactions:
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 - request: 
     method: get
-    uri: http://localhost:9200/katello_test_package/_search?from=0&size=8
+    uri: http://localhost:9200/katello_package/_search?from=0&size=8
     body: 
       encoding: UTF-8
       string: |
@@ -1509,7 +1509,7 @@ http_interactions:
       - "567"
     body: 
       encoding: US-ASCII
-      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":3,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_test_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
+      string: "{\"took\":1,\"timed_out\":false,\"_shards\":{\"total\":3,\"successful\":3,\"failed\":0},\"hits\":{\"total\":3,\"max_score\":1.0,\"hits\":[{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-1\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-1\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-1\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-2\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-2\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-2\"}},{\"_index\":\"katello_package\",\"_type\":\"package\",\"_id\":\"abc123-5\",\"_score\":1.0,\"fields\":{\"id\":\"abc123-5\",\"repoids\":[\"abcrepo\"],\"name\":\"abc123-5\"}}]}}"
     http_version: 
   recorded_at: Thu, 05 Jun 2014 19:58:58 GMT
 recorded_with: VCR 2.9.2

--- a/test/fixtures/vcr_cassettes/glue_candlepin_provider.yml
+++ b/test/fixtures/vcr_cassettes/glue_candlepin_provider.yml
@@ -81,3 +81,119 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 15 May 2014 20:30:48 GMT
 recorded_with: VCR 2.9.0
+- request: 
+    method: post
+    uri: https://localhost:8443/candlepin/owners/
+    body: 
+      encoding: US-ASCII
+      string: "{\"key\":\"Organization_2\",\"displayName\":\"Organization 2\",\"contentPrefix\":\"/Organization_2/$env\"}"
+    headers: 
+      Accept: 
+      - application/json
+      Accept-Encoding: 
+      - gzip, deflate
+      Authorization: 
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello", oauth_nonce="3Ef8oVhlGQzDYfSLCB8nmL79iHRUbj85Sb26voUmilA", oauth_signature="xIdf6rXePvbklmEwSt2CIOYrJWo%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1400185841", oauth_version="1.0"
+      Accept-Language: 
+      - en
+      Content-Type: 
+      - application/json
+      Cp-User: 
+      - admin
+      Content-Length: 
+      - "94"
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Server: 
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid: 
+      - 9633aebb-b692-4c5f-8cab-9596db65eee1
+      X-Candlepin-Version: 
+      - 0.9.11-1
+      Content-Type: 
+      - application/json
+      Transfer-Encoding: 
+      - chunked
+      Date: 
+      - Thu, 15 May 2014 20:30:40 GMT
+    body: 
+      encoding: US-ASCII
+      string: "{\"parentOwner\":null,\"id\":\"ff8080814600f23d0146019467f00037\",\"key\":\"Organization_2\",\"displayName\":\"Organization 2\",\"contentPrefix\":\"/Organization_2/$env\",\"defaultServiceLevel\":null,\"upstreamConsumer\":null,\"logLevel\":null,\"href\":\"/owners/Organization_2\",\"created\":\"2014-05-15T20:30:41.648+0000\",\"updated\":\"2014-05-15T20:30:41.648+0000\"}"
+    http_version: 
+  recorded_at: Thu, 15 May 2014 20:30:41 GMT
+- request: 
+    method: delete
+    uri: https://localhost:8443/candlepin/environments/8
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding: 
+      - gzip, deflate
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="97lZiDdHuvZQHO5VwL9vMksOrItcE1zF8N2OvwJ9Vg", oauth_signature="dtW7%2FmWswjeUe2JvDXPqojmn8rE%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1400185842", oauth_version="1.0"
+      Cp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 204
+      message: No Content
+    headers: 
+      Server: 
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid: 
+      - f19b659c-9b31-44d2-ac8e-270d08f1fa22
+      X-Candlepin-Version: 
+      - 0.9.11-1
+      Date: 
+      - Thu, 15 May 2014 20:30:42 GMT
+    body: 
+      encoding: US-ASCII
+      string: ""
+    http_version: 
+  recorded_at: Thu, 15 May 2014 20:30:42 GMT
+- request: 
+    method: delete
+    uri: https://localhost:8443/candlepin/owners/Organization_2
+    body: 
+      encoding: US-ASCII
+      string: ""
+    headers: 
+      Accept: 
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding: 
+      - gzip, deflate
+      Authorization: 
+      - OAuth oauth_consumer_key="katello", oauth_nonce="nNSjw6MXX2LS2teUtDeGAVWC6N7qTgiKFZ2OI006Ec", oauth_signature="fBEL05IFF371VAiBG0BkP7zQuzw%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1400185842", oauth_version="1.0"
+      Cp-User: 
+      - admin
+      User-Agent: 
+      - Ruby
+  response: 
+    status: 
+      code: 204
+      message: No Content
+    headers: 
+      Server: 
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid: 
+      - d8d7ed54-e9b2-425a-9d1a-f1c0d58ae1a6
+      X-Candlepin-Version: 
+      - 0.9.11-1
+      Date: 
+      - Thu, 15 May 2014 20:30:42 GMT
+    body: 
+      encoding: US-ASCII
+      string: ""
+    http_version: 
+  recorded_at: Thu, 15 May 2014 20:30:42 GMT
+  recorded_with: VCR 2.9.0

--- a/test/glue/candlepin/consumer_test.rb
+++ b/test/glue/candlepin/consumer_test.rb
@@ -34,6 +34,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         unless @@dev_cve.nil?
           # To prevent deletion of the fixture object

--- a/test/glue/candlepin/owner_test.rb
+++ b/test/glue/candlepin/owner_test.rb
@@ -11,7 +11,7 @@ module Katello
     end
 
     def self.after_suite
-      true
+      super
     ensure
       VCR.eject_cassette
     end
@@ -24,8 +24,8 @@ module Katello
     end
 
     def self.after_suite
-      CandlepinOwnerSupport.destroy_organization(@@org.id)
       super
+      CandlepinOwnerSupport.destroy_organization(@@org.id)
     end
 
     def test_update_candlepin_owner_service_level

--- a/test/glue/candlepin/provider_test.rb
+++ b/test/glue/candlepin/provider_test.rb
@@ -1,9 +1,11 @@
 require 'katello_test_helper'
 require 'mocha/setup'
+require 'support/candlepin/owner_support'
 
 module Katello
   class GlueCandlepinProviderTestBase < ActiveSupport::TestCase
     def self.before_suite
+      super
       @loaded_fixtures = load_fixtures
 
       User.current = User.find(@loaded_fixtures['users']['admin']['id'])
@@ -11,12 +13,14 @@ module Katello
 
       @@dev      = KTEnvironment.find(@loaded_fixtures['katello_environments']['candlepin_dev']['id'])
       @@org      = Organization.find(@loaded_fixtures['taxonomies']['organization2']['id'])
+      @@org.setup_label_from_name
       @@provider = Provider.find(@loaded_fixtures['katello_providers']['candlepin_redhat']['id'])
 
       CandlepinOwnerSupport.set_owner(@@org)
     end
 
     def self.after_suite
+      super
       Resources::Candlepin::Owner.destroy(@@org.label)
     ensure
       VCR.eject_cassette

--- a/test/glue/elasticsearch/package_test.rb
+++ b/test/glue/elasticsearch/package_test.rb
@@ -34,6 +34,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       VCR.eject_cassette
     end
 

--- a/test/glue/pulp/consumer_test.rb
+++ b/test/glue/pulp/consumer_test.rb
@@ -105,6 +105,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         RepositorySupport.destroy_repo
         @@simple_server.del_pulp_consumer
@@ -137,6 +138,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         RepositorySupport.destroy_repo
         @@simple_server.del_pulp_consumer if defined? @@simple_server

--- a/test/glue/pulp/distribution_test.rb
+++ b/test/glue/pulp/distribution_test.rb
@@ -15,6 +15,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         RepositorySupport.destroy_repo
         VCR.eject_cassette

--- a/test/glue/pulp/erratum_test.rb
+++ b/test/glue/pulp/erratum_test.rb
@@ -19,6 +19,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         RepositorySupport.destroy_repo
         VCR.eject_cassette

--- a/test/glue/pulp/package_test.rb
+++ b/test/glue/pulp/package_test.rb
@@ -19,6 +19,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         RepositorySupport.destroy_repo
         VCR.eject_cassette

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -71,6 +71,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         delete_repo(@@fedora_17_x86_64)
         VCR.eject_cassette
@@ -137,6 +138,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         delete_repo(@@fedora_17_x86_64)
         VCR.eject_cassette
@@ -158,6 +160,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         delete_repo(@@fedora_17_x86_64)
         VCR.eject_cassette
@@ -178,6 +181,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         delete_repo(@@p_forge)
         VCR.eject_cassette
@@ -206,6 +210,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         delete_repo(@@fedora_17_x86_64)
         VCR.eject_cassette
@@ -305,6 +310,7 @@ module Katello
     end
 
     def self.after_suite
+      super
       run_as_admin do
         delete_repo(@@fedora_17_x86_64)
         VCR.eject_cassette

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -150,6 +150,31 @@ class ActiveSupport::TestCase
     stub_ping
   end
 
+  def self.stubbed_ping_response
+    status = {:services => {}}
+    ::Katello::Ping::SERVICES.each do |service|
+      status[:services][service] = {:status => Katello::Ping::OK_RETURN_CODE}
+    end
+    status
+  end
+
+  def self.stub_ping
+    Katello::Ping.stubs(:ping).returns(stubbed_ping_response)
+  end
+
+  def self.before_suite
+    stub_ping
+    super
+  end
+
+  def self.after_suite
+    stub_ping
+  end
+
+  def stub_ping
+    self.class.stub_ping
+  end
+
   def self.run_as_admin
     User.current = User.find(@loaded_fixtures['users']['admin']['id'])
     yield
@@ -160,18 +185,6 @@ class ActiveSupport::TestCase
     user ||= users(:admin)
     user = User.find(user) if user.id
     User.current = user
-  end
-
-  def stubbed_ping_response
-    status = {:services => {}}
-    ::Katello::Ping::SERVICES.each do |service|
-      status[:services][service] = {:status => Katello::Ping::OK_RETURN_CODE}
-    end
-    status
-  end
-
-  def stub_ping
-    Katello::Ping.stubs(:ping).returns(stubbed_ping_response)
   end
 
   def get_organization(org = nil)

--- a/test/models/distributor_test.rb
+++ b/test/models/distributor_test.rb
@@ -3,6 +3,7 @@ require 'katello_test_helper'
 module Katello
   class DistributorTest < ActiveSupport::TestCase
     def self.after_suite
+      super
       Distributor.delete_all
     end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -428,6 +428,8 @@ module Katello
       @view_repo = Repository.find(katello_repositories(:fedora_17_x86_64_library_view_1))
       @view_system.bound_repositories = [@view_repo]
       @view_system.save!
+
+      @dev_system =  System.find(katello_systems(:errata_server_dev))
     end
 
     def test_systems_with_applicability
@@ -436,9 +438,10 @@ module Katello
     end
 
     def test_import_system_applicability
-      mock_active_records(@lib_system, @view_system)
+      mock_active_records(@lib_system, @view_system, @dev_system)
       @lib_system.expects(:import_applicability)
       @view_system.expects(:import_applicability)
+      @dev_system.expects(:import_applicability)
       @lib_repo.import_system_applicability
     end
   end


### PR DESCRIPTION
Since the new Dynflow removes the limitation of on executor running, we need
to handle better the case to make sure only one action is running at a time.

It uses the Dynflow coordination mechanism to make sure we run the action only 
once.

Also, new Dynflow provides before_termination_hooks, that are safer than the 
at_exit.

Requires https://github.com/theforeman/foreman-tasks/pull/116

The RPMs for deps are in progress as well https://github.com/theforeman/foreman-packaging/pull/695

In the meantime, I've prepared scratch for testing https://inecas.fedorapeople.org/dynflow-scratch/ : You will need to update the
gemspec file on your setup
`/opt/rh/ruby193/root/usr/share/gems/specifications/katello-2.3.0.gemspec` to
`s.add_dependency(%q<foreman-tasks>, ["~> 0.7.0"])` instead the version that's in the current gemspec.