### PR TITLE
Fixes #10987: Restrict to Foreman 1.9

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -1,5 +1,5 @@
 Foreman::Plugin.register :katello do
-  requires_foreman '> 1.3'
+  requires_foreman '> 1.9'
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'), :after => :monitor_menu do
     menu :top_menu,

--- a/rubygem-katello.spec
+++ b/rubygem-katello.spec
@@ -75,7 +75,7 @@ Requires: katello-selinux
 Requires: candlepin-selinux
 Requires: createrepo >= 0.9.9-18%{?dist}
 Requires: elasticsearch
-Requires: foreman >= 1.7.0
+Requires: foreman >= 1.9.0
 Requires: java-openjdk >= 1:1.7.0
 Requires: java-openjdk < 1:1.8.0.45
 # Still Requires katello-common which clashes with
@@ -112,8 +112,8 @@ Requires: %{?scl_prefix}rubygem-deface < 1.0.0
 Requires: %{?scl_prefix}rubygem-strong_parameters
 Requires: %{?scl_prefix}rubygem-qpid_messaging >= 0.30.0
 Requires: %{?scl_prefix}rubygem-qpid_messaging < 0.31.0
-BuildRequires: foreman >= 1.7.0
-BuildRequires: foreman-assets >= 1.7.0
+BuildRequires: foreman >= 1.9.0
+BuildRequires: foreman-assets >= 1.9.0
 BuildRequires: %{?scl_prefix}rubygem-angular-rails-templates >= 0.0.4
 BuildRequires: %{?scl_prefix}rubygem-bastion >= 2.0.0
 BuildRequires: %{?scl_prefix}rubygem-bastion < 3.0.0


### PR DESCRIPTION
There are some functionality we are now using that are not available
in Foreman 1.8 and below such as the logging implementation.