### PR TITLE
Updated Sat Tools repository name. Fix #1208188

### DIFF
--- a/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
+++ b/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
@@ -8,7 +8,7 @@ subscription-manager register --org="<%= @host.rhsm_organization_label %>" --nam
 
 <% if @host.operatingsystem.name == "RedHat" %>
   # add the rhel rpms to install katello agent
-  subscription-manager repos --enable=rhel-*-rh-common-rpms
+  subscription-manager repos --enable=rhel-*-satellite-tools-*-rpms
 <% end %>
 
 echo "Installing Katello Agent"


### PR DESCRIPTION
The script that enables 'Satellite Tools' repository is incorrect. Since
the name for the repositories can be either one of the following:

* rhel-{5,6,7}-server-satellite-tools-6{,-beta}-rpms

the script mentioned subscription_manager_registration should be:

    subscription-manager repos --enable=rhel-*-sat-tools-*-rpms

and not:

    subscription-manager repos --enable=rhel-*-sat-tools-rpms