### PR TITLE
refs #11105 - updated default tagger to be VersionTagger

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,6 +1,6 @@
 [globalconfig]
 default_builder = tito.builder.GemBuilder
-default_tagger = tito.tagger.ReleaseTagger
+default_tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
 


### PR DESCRIPTION
As part of the branching process, we can update it to ReleaseTagger.  This makes it consistent with other repos in the organization (katello-agent, katello-installer).
