### PR TITLE
fixes #11117 - sort by id as secondary sort to ensure result order is…

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -84,6 +84,7 @@ module Katello
       sort_attr = "#{query.table_name}.#{sort_attr}" unless sort_attr.to_s.include?('.')
 
       query = query.order("#{sort_attr} #{params[:sort_order] || default_sort_order}")
+      query = query.order("#{query.table_name}.id DESC") #secondary order to ensure sort is deterministic
       query = query.includes(includes) if includes.length > 0
 
       if params[:full_result]


### PR DESCRIPTION
… deterministic

Otherwise under some versions of postgresql, if the column being sorted by had duplicates (such as errata update date), the sort with pagination was not deterministic, resulting in duplicates and missing entries.