### PR TITLE
fixes #11123 - actually assign content_host to capsule

### DIFF
--- a/db/migrate/20150423134004_add_content_host_id_to_smart_proxy.rb
+++ b/db/migrate/20150423134004_add_content_host_id_to_smart_proxy.rb
@@ -1,21 +1,6 @@
 class AddContentHostIdToSmartProxy < ActiveRecord::Migration
-  class SmartProxy < ActiveRecord::Base
-  end
-
-  class Katello::System < ActiveRecord::Base
-  end
-
   def change
     add_column :smart_proxies, :content_host_id, :integer
     add_foreign_key :smart_proxies, :katello_systems, :column => "content_host_id"
-
-    SmartProxy.all.each do |proxy|
-      content_host = ::Katello::System.where(:name => proxy.name).order("created_at DESC").first
-
-      if content_host
-        proxy.content_host_id = content_host.id
-        proxy.save!
-      end
-    end
   end
 end

--- a/db/migrate/20150715142649_assign_content_host_to_smart_proxies.rb
+++ b/db/migrate/20150715142649_assign_content_host_to_smart_proxies.rb
@@ -1,0 +1,21 @@
+class AssignContentHostToSmartProxies < ActiveRecord::Migration
+  def up
+    SmartProxy.reset_column_information
+
+    SmartProxy.all.each do |proxy|
+      content_host = ::Katello::System.where(:name => proxy.name).order("created_at DESC").first
+
+      if content_host
+        proxy.content_host_id = content_host.id
+        proxy.save!
+      end
+    end
+  end
+
+  def down
+    SmartProxy.all.each do |proxy|
+      proxy.content_host_id = nil
+      proxy.save!
+    end
+  end
+end


### PR DESCRIPTION
This failed silently.

After adding the database column, `SmartProxy.reset_column_information` needed to be called in order for Rails to correctly set and save the content_host_id. `save!` won't even raise, which made this really hard to find. See http://stackoverflow.com/questions/8935350/rails-3-1-cant-write-to-column-in-same-migration-that-adds-it.