### PR TITLE
fixes #11129 - add shebang to service-wait

### DIFF
--- a/deploy/script/service-wait
+++ b/deploy/script/service-wait
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Wrapper around /sbin/service command.
 #
 # Some services do not start or stop properly and return non-zero values


### PR DESCRIPTION
The lack of a shebang breaks katello-service on el6.
