### PR TITLE
Fixes #11183 - Fixed NaN sync logic for docker presenters

### DIFF
--- a/app/lib/actions/pulp/repository/presenters/docker_presenter.rb
+++ b/app/lib/actions/pulp/repository/presenters/docker_presenter.rb
@@ -13,7 +13,7 @@ module Actions
               download_details = details("sync_step_download")
               if content_completed?(download_details)
                 completion += 0.7
-              elsif content_started?(download_details)
+              elsif content_started?(download_details) && items_total(download_details) > 0
                 completion += 0.7 * items_done(download_details) / items_total(download_details)
               end
               completion


### PR DESCRIPTION
The docker presenter used to return an NaN for "progress completed"

This confused dynflow while serializing things and raised errors like
""
MultiJson::LoadError: 203: unexpected token at
'NaN,"progress_weight":10}'
`load'
""

This commit fixes that by handling the 0 case.