### PR TITLE
fixes #11028 - avoid race conditions on applicability indexng

### DIFF
--- a/app/lib/actions/katello/system/generate_applicability.rb
+++ b/app/lib/actions/katello/system/generate_applicability.rb
@@ -11,7 +11,7 @@ module Actions
           ::User.current = ::User.anonymous_admin
           systems = ::Katello::System.where(:id => input[:system_ids])
           systems.each do |system|
-            system.import_applicability
+            system.import_applicability(false)
           end
         ensure
           ::User.current = nil

--- a/app/lib/katello/util/support.rb
+++ b/app/lib/katello/util/support.rb
@@ -72,6 +72,19 @@ module Katello
         stringify(params.keys) - stringify(rule.keys)
       end
 
+      # Used for retrying active record transactions when race conditions could cause
+      #  RecordNotUnique exceptions
+      def self.active_record_retry(retries = 3)
+        yield
+      rescue ActiveRecord::RecordNotUnique => e
+        retries -= 1
+        if retries == 0
+          raise e
+        else
+          retry
+        end
+      end
+
       # We need this so that we can return
       # empty search results on an invalid query
       # Basically this is a empty array with a total

--- a/test/glue/pulp/consumer_test.rb
+++ b/test/glue/pulp/consumer_test.rb
@@ -188,12 +188,5 @@ module Katello
 
       assert tasks[:spawned_tasks].first['task_id']
     end
-
-    def test_import_applicability
-      erratum = Erratum.first
-      @@simple_server.expects(:errata_ids).returns([erratum.uuid])
-      @@simple_server.import_applicability
-      assert_equal [erratum], @@simple_server.reload.applicable_errata
-    end
   end
 end

--- a/test/models/system_test.rb
+++ b/test/models/system_test.rb
@@ -198,6 +198,37 @@ module Katello
     end
   end
 
+  class SystemImportApplicabilityTest < SystemTestBase
+    def setup
+      super
+      @enhancement_errata = katello_errata(:enhancement)
+    end
+
+    def test_partial_import
+      refute @errata_system.applicable_errata.empty?
+      refute_includes @errata_system.applicable_errata, @enhancement_errata
+
+      @errata_system.stubs(:pulp_errata_uuids).returns([@enhancement_errata.uuid])
+      @errata_system.import_applicability(true)
+
+      assert_equal [@enhancement_errata], @errata_system.reload.applicable_errata
+    end
+
+    def test_partial_import_empty
+      @errata_system.stubs(:pulp_errata_uuids).returns([])
+      @errata_system.import_applicability(true)
+
+      assert_empty @errata_system.reload.applicable_errata
+    end
+
+    def test_full_import
+      @errata_system.stubs(:pulp_errata_uuids).returns([@enhancement_errata.uuid])
+      @errata_system.import_applicability(false)
+
+      assert_equal [@enhancement_errata], @errata_system.reload.applicable_errata
+    end
+  end
+
   class SystemHostTest < SystemTestBase
     def setup
       super


### PR DESCRIPTION
this change attempts to avoid the effects race conditions in a couple ways:
* retrying the process up to 3 times
* only inserting or removing affected errata for a system, this should reduce the chance of hitting a duplicate entry