### PR TITLE
Fixes #11294: Prevent top level constant warning from Logging.

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -418,7 +418,7 @@ module Katello
     end
 
     def logger
-      Foreman::Logging.logger('katello/cp_proxy')
+      ::Foreman::Logging.logger('katello/cp_proxy')
     end
 
     def respond_for_index(options = {})

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -6,7 +6,7 @@ module Katello
     module Candlepin
       class Proxy
         def self.logger
-          Foreman::Logging.logger('katello/cp_proxy')
+          ::Foreman::Logging.logger('katello/cp_proxy')
         end
 
         def self.post(path, body)
@@ -50,7 +50,7 @@ module Katello
         self.ca_cert_file = cfg.ca_cert_file
 
         def self.logger
-          Foreman::Logging.logger('katello/cp_rest')
+          ::Foreman::Logging.logger('katello/cp_rest')
         end
 
         def self.default_headers(uuid = nil)
@@ -284,7 +284,7 @@ module Katello
 
       class UpstreamConsumer < HttpResource
         def self.logger
-          Foreman::Logging.logger('katello/cp_rest')
+          ::Foreman::Logging.logger('katello/cp_rest')
         end
 
         def self.resource(url, client_cert, client_key, ca_file)

--- a/app/models/katello/glue.rb
+++ b/app/models/katello/glue.rb
@@ -2,7 +2,7 @@ module Katello
   module Glue
     singleton_class.send :attr_writer, :logger
     def self.logger
-      @logger ||= Foreman::Logging.logger('katello/glue')
+      @logger ||= ::Foreman::Logging.logger('katello/glue')
     end
 
     def self.included(base)

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -198,7 +198,7 @@ module Katello
       end
 
       def import_logger
-        Foreman::Logging.logger('katello/manifest_import_logger')
+        ::Foreman::Logging.logger('katello/manifest_import_logger')
       end
 
       # TODO: break up method

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -148,7 +148,7 @@ module Katello
       require 'katello/permissions'
 
       Tire::Configuration.url(Katello.config.elastic_url)
-      bridge = Katello::TireBridge.new(Foreman::Logging.logger('katello/tire_rest'))
+      bridge = Katello::TireBridge.new(::Foreman::Logging.logger('katello/tire_rest'))
       Tire.configure { logger bridge, :level => bridge.level }
     end
 


### PR DESCRIPTION
The warning "warning: toplevel constant Logging referenced by
Katello::Foreman::Logging" appears many times throughout test runs.
Further it may be the cause of intermittent failures on Jenkins that
seem to result from the customized fixture setup being unset with
respect to referencing the Foreman fixtures.