### PR TITLE
Fixes #11203 - Spiffier rh repo enablement validation

### DIFF
--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -21,6 +21,7 @@ module Katello
           rescue_from Errors::ConflictException, :with => :rescue_from_conflict_exception
           rescue_from Errors::UnsupportedActionException, :with => :rescue_from_unsupported_action_exception
           rescue_from Errors::MaxContentHostsReachedException, :with => :rescue_from_max_content_hosts_reached_exception
+          rescue_from Errors::CdnSubstitutionError, :with => :rescue_from_bad_data
           rescue_from ActionController::ParameterMissing, :with => :rescue_from_missing_param
         end
 
@@ -73,6 +74,10 @@ module Katello
 
         def rescue_from_unsupported_action_exception(exception)
           respond_for_exception(exception, :status => :bad_request)
+        end
+
+        def rescue_from_bad_data(exception)
+          respond_for_exception(exception, :status => :unprocessable_entity)
         end
 
         def rescue_from_max_content_hosts_reached_exception(exception)

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -21,6 +21,8 @@ module Katello
 
     class CapsuleContentMissingConsumer < StandardError; end
 
+    class CdnSubstitutionError < StandardError; end
+
     class ConflictException < StandardError; end
 
     class ContentViewRepositoryOverlap < StandardError; end

--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -74,12 +74,7 @@ module Katello
       end
 
       def validate!
-        if substitutor.valid_substitutions?(content.contentUrl, substitutions)
-          return true
-        else
-          fail _("%{substitutions} are not valid substitutions for %{content_url}") %
-              { substitutions: substitutions, content_url: content.contentUrl }
-        end
+        substitutor.valid_substitutions(content, substitutions)
       end
 
       def substitutor


### PR DESCRIPTION
Prior to this commit when a user ran command like
 hammer repository-set enable --name="Red Hat
Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)" --basearch="x86_64"
--product "Red Hat Enterprise Linux Server" --organization="Default
Organization" --releasever="borked"

No error was being raised. This is because "Red Hat
Satellite Tools 6 Beta" did not use a release version in its content
url. So no red flags were being raised. This however caused a repo with
a bad name to get created . This broke the enablement code in the UI
causing a lot of pain.

This commit fixes this issue by complaining in clear terms to the user
that releasever is not an acceptable substitution and also prints the
url showing why its not acceptable

"""
["releasever"] cannot be specified for Red Hat Satellite Tools 6 Beta
(for RHEL 7 Server) (RPMs) as that information is not substituable in
 /content/beta/rhel/server/7/$basearch/sat-tools/6/os
"""