### PR TITLE
Fixes #11226 - Formalize deprecation warnings

### DIFF
--- a/app/services/katello/deprecation.rb
+++ b/app/services/katello/deprecation.rb
@@ -1,0 +1,7 @@
+module Katello
+  class Deprecation
+    def self.api_deprecation_warning(katello_version_deadline, info)
+      ActiveSupport::Deprecation.warn("Your API call uses deprecated behavior, it will be removed in version #{katello_version_deadline}, #{info}", caller)
+    end
+  end
+end


### PR DESCRIPTION
Custom deprecation warning that can be used on API endpoints