### PR TITLE
Fixes #11224: make incremental update CH count unique BZ 1228278.

### DIFF
--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -22,7 +22,7 @@ module Katello
 
     def self.for_systems(systems)
       joins("INNER JOIN #{System.table_name} on #{System.table_name}.environment_id = #{ContentViewEnvironment.table_name}.environment_id").
-           where("#{System.table_name}.content_view_id = #{ContentViewEnvironment.table_name}.content_view_id").where("#{System.table_name}.id" => systems)
+           where("#{System.table_name}.content_view_id = #{ContentViewEnvironment.table_name}.content_view_id").where("#{System.table_name}.id" => systems).uniq
     end
 
     # retrieve the owning environment for this content view environment.


### PR DESCRIPTION
The count for affected content hosts when doing an incremental update
was including content hosts multiple times in the count.  This commit
ensures the content hosts are unique by ensuring the content view
environments are unique.

http://projects.theforeman.org/issues/11224
https://bugzilla.redhat.com/show_bug.cgi?id=1228278