### PR TITLE
Fixes #11228 - skip the email step if it fails and warn the user

### DIFF
--- a/app/lib/actions/katello/content_view/errata_mail.rb
+++ b/app/lib/actions/katello/content_view/errata_mail.rb
@@ -19,6 +19,12 @@ module Actions
         def finalize
           ::User.current = nil
         end
+
+        def rescue_strategy_for_self
+          # If sending mail fails do not cause any calling tasks to fail
+          # but mark the task in a WARNING state with the error message.
+          Dynflow::Action::Rescue::Skip
+        end
       end
     end
   end

--- a/app/lib/actions/katello/repository/errata_mail.rb
+++ b/app/lib/actions/katello/repository/errata_mail.rb
@@ -20,6 +20,12 @@ module Actions
         def finalize
           ::User.current = nil
         end
+
+        def rescue_strategy_for_self
+          # If sending mail fails do not cause any calling tasks to fail
+          # but mark the task in a WARNING state with the error message.
+          Dynflow::Action::Rescue::Skip
+        end
       end
     end
   end


### PR DESCRIPTION
BZ1247387 - If the email server is not configured correctly we should skip this task and not fail in a fatal way. 