### PR TITLE
fixes #11234 - content dashboard - fix Sync Overview widget

### DIFF
--- a/app/helpers/katello/dashboard_helper.rb
+++ b/app/helpers/katello/dashboard_helper.rb
@@ -75,7 +75,7 @@ module Katello
       synced_products = []
 
       Product.in_org(current_organization).syncable_content.syncable.each do |prod|
-        if !prod.sync_status.start_time.nil?
+        if !prod.sync_status[:start_time].nil?
           syncing_products << prod
         else
           synced_products << prod
@@ -83,16 +83,24 @@ module Katello
       end
 
       syncing_products = syncing_products.sort do |a, b|
-        b.sync_status.start_time <=> a.sync_status.start_time
+        b.sync_status[:start_time] <=> a.sync_status[:start_time]
       end
 
       return (syncing_products + synced_products)[0..num]
     end
 
     def sync_percentage(product)
-      stat = product.sync_status.progress
+      stat = product.sync_status[:progress]
       return 0 if stat.total_size == 0
       "%.0f" % ((stat.total_size - stat.size_left) * 100 / stat.total_size).to_s
+    end
+
+    def sync_finish_time(product)
+      if product.sync_status[:finish_time].is_a?(String)
+        product.sync_status[:finish_time]
+      else
+        format_time product.sync_status[:finish_time]
+      end
     end
 
     def subscription_counts

--- a/app/views/katello/dashboard/_sync.haml
+++ b/app/views/katello/dashboard/_sync.haml
@@ -8,7 +8,7 @@
           .col_1
             %h5
               = link_to product.name, sync_management_index_path
-          - if product.sync_status.state == Katello::PulpSyncStatus::RUNNING
+          - if product.sync_status[:state] == Katello::PulpSyncStatus::RUNNING
             .col_progress{:title=>product.sync_status.progress.step}
               %span
                 .progressbar{:percentage=>sync_percentage(product)}
@@ -17,21 +17,21 @@
                 #{sync_percentage(product)}%
           - else
             .col_2
-              - if product.sync_status.state == Katello::PulpSyncStatus::ERROR
+              - if product.sync_status[:state] == Katello::PulpSyncStatus::ERROR
                 .icon-remove.fl
                   &nbsp;
                 #{_("Error")}
-              - elsif product.sync_status.state == Katello::PulpSyncStatus::FINISHED
+              - elsif product.sync_status[:state] == Katello::PulpSyncStatus::FINISHED
                 .icon-ok.fl
                   &nbsp;
                 #{_("Success")}
-              - elsif product.sync_status.state == Katello::PulpSyncStatus::CANCELED
+              - elsif product.sync_status[:state] == Katello::PulpSyncStatus::CANCELED
                 #{_("Cancelled")}
-              - elsif product.sync_status.state == Katello::PulpSyncStatus::WAITING
+              - elsif product.sync_status[:state] == Katello::PulpSyncStatus::WAITING
                 #{_("Waiting")}
-              - elsif product.sync_status.state == Katello::PulpSyncStatus::RUNNING
+              - elsif product.sync_status[:state] == Katello::PulpSyncStatus::RUNNING
                 #{_("Running")}
               - else
-                #{product.sync_status.state}
+                #{product.sync_status[:state]}
             .col_3
-              #{format_time product.sync_status.finish_time}
+              #{sync_finish_time(product)}


### PR DESCRIPTION
Fix to address:
- no longer able to access sync_status elements using '.attribute'
  (e.g. status.state), instead need to use hash access (e.g. status[:state])
- update finish_time to support string content