### PR TITLE
Fixes #10208: Fix auto-attach on activation keys with custom products.

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -104,7 +104,7 @@ module Katello
           end
 
           # rubocop:disable ParameterLists
-          def create(env_id, _key, name, type, facts, installed_products, autoheal = true, release_ver = nil,
+          def create(env_id, _key, name, type, facts, installed_products = [], autoheal = true, release_ver = nil,
                      service_level = "", uuid = "", capabilities = nil, activation_keys = [], guest_ids = [],
                      last_checkin = nil)
             # rubocop:enable ParameterLists
@@ -112,6 +112,8 @@ module Katello
             activation_key_ids = activation_keys.collect do |activation_key|
               activation_key.cp_name
             end
+
+            installed_products ||= []
 
             url = "/candlepin/environments/#{url_encode(env_id)}/consumers/"
             attrs = {:name => name,


### PR DESCRIPTION
When using custom products only in an activation key with auto attach,
we were sending a null value for installedProducts to Candlepin. This
caused Candlepin to error out iterating over a null value (instead of
an array). Here we make sure to send an array if installedProducts is
nil so that Candlepin processes the request properly and thus fix
auto attach with custom products.