### PR TITLE
Fixes #11253 All content view filters are shown in every content view

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -18,7 +18,7 @@ module Katello
     end
 
     def index_relation
-      query = ContentViewFilter.where(:content_view_id => (@content_view || ContentView.readable))
+      query = ContentViewFilter.where(:content_view_id => (@view || ContentView.readable))
       query = query.where(:name => params[:name]) unless params[:name].blank?
       query
     end

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -40,6 +40,11 @@ module Katello
     def test_index_with_content_view
       get :index, :content_view_id => @content_view.id
 
+      body = JSON.parse(response.body)
+      filter_count = ContentViewFilter.where(:content_view_id => @content_view.id).count
+      returned_filter_count = body["total"]
+
+      assert_equal returned_filter_count, filter_count
       assert_response :success
       assert_template 'api/v2/content_view_filters/index'
     end

--- a/test/fixtures/models/katello_content_view_filters.yml
+++ b/test/fixtures/models/katello_content_view_filters.yml
@@ -23,3 +23,8 @@ populated_filter_with_repos_and_filters:
   content_view_id: <%= ActiveRecord::Fixtures.identify(:library_view) %>
   type:            <%= Katello::ContentViewErratumFilter.name %>
 
+extra_filter:
+  name:            Extra Filter
+  content_view_id: <%= ActiveRecord::Fixtures.identify(:acme_default) %>
+  type:            <%= Katello::ContentViewErratumFilter.name %>
+  


### PR DESCRIPTION
@content_view should be @view as that is the global variable used in find_content_view, so as a result all content view filters were showing on every content view, instead of the filters specific to a content view.