### PR TITLE
fixes #11261 - wait a little after starting httpd

### DIFF
--- a/deploy/script/service-wait
+++ b/deploy/script/service-wait
@@ -12,7 +12,7 @@
 # This simple wrapper works with any service and just pass over the request
 # to /sbin/service, but for few problematic ones it waits until service is
 # fully started or stopped.
-# 
+#
 # To test the implementation use:
 #
 #   service-wait xxx test-wait
@@ -85,6 +85,9 @@ after_start() {
       # and create lock and pid files if they does not exist
       [ -f "/var/lock/subsys/postgresql" ] || touch "/var/lock/subsys/postgresql"
       [ -f "/var/run/postmaster.${POSTGRES_PORT}.pid" ] || head -n 1 "$POSTGRES_DATA/postmaster.pid" > "/var/run/postmaster.${POSTGRES_PORT}.pid"
+      sleep $ADDITIONAL_SLEEP
+      ;;
+    httpd)
       sleep $ADDITIONAL_SLEEP
       ;;
   esac


### PR DESCRIPTION
In the upgrade hooks we do a quick succession of httpd start/status, and it fails sometimes.  Thoughts?


Before:

```
[root@satellite ~]# service-wait httpd start; service-wait httpd status
Starting httpd: [Thu Jul 30 11:26:43 2015] [warn] module passenger_module is already loaded, skipping
                                                           [  OK  ]
httpd dead but subsys locked
```

After:

```
[root@satellite ~]# service-wait httpd start; service-wait httpd status
Starting httpd: [Thu Jul 30 11:27:27 2015] [warn] module passenger_module is already loaded, skipping
                                                           [  OK  ]
httpd (pid  4355) is running...
```