### PR TITLE
Fixes #11262: Only update Candlepin content for library repositories

### DIFF
--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -6,7 +6,7 @@ module Actions
           action_subject repository
           repository.update_attributes!(repo_params)
 
-          if (::Katello.config.use_cp && ::Katello.config.use_pulp)
+          if (::Katello.config.use_cp && ::Katello.config.use_pulp) && repository.library_instance?
             plan_action(::Actions::Candlepin::Product::ContentUpdate,
                         :content_id => repository.content_id,
                         :name => repository.name,


### PR DESCRIPTION
This prevents updating the Candlepin content for cloned repositories
to prevent certain attributes from being reset. For example, since
the cloned repositories may not have an associated gpg key url, a call
to update would set this value to nil in Candlepin and thus break GPG
key checks on signed packages for instances of the repository. This is
because library repositories and their clones are linked to the same content
object in Candlepin.