### PR TITLE
fixes #11270 Do not insert this many spaces

### DIFF
--- a/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/systems_bulk_actions_controller.rb
@@ -150,8 +150,8 @@ module Katello
                        :resource => { 'displayMessages' => [display_message] }
     end
 
-    api :POST, "/systems/bulk/available_incremental_updates", N_("Given a set of systems and errata, lists the content view versions \
-                                                                  and environments that need updating."), :deprecated => true
+    api :POST, "/systems/bulk/available_incremental_updates", N_("Given a set of systems and errata, lists the content view versions" \
+                                                                 " and environments that need updating."), :deprecated => true
     param_group :bulk_params
     param :errata_ids, Array, :desc => N_("List of Errata ids")
     def available_incremental_updates


### PR DESCRIPTION
Fixing multiple spaces in the option description:

    # hammer content-host -h | grep available-incremental-updates
     available-incremental-updates Given a set of systems and errata, lists the content view versions                                                                   and environments that need updating.