### PR TITLE
Fixes #11315:  ensure CVs are only shown once BZ 1250716.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-composite-available-content-views.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-composite-available-content-views.controller.js
@@ -15,6 +15,13 @@ angular.module('Bastion.content-views').controller('ContentViewCompositeAvailabl
         function ($scope, Nutupane, CurrentOrganization, ContentView) {
             var nutupane, params;
 
+            params = {
+                'full_result': true,
+                nondefault: true,
+                noncomposite: true,
+                'organization_id': CurrentOrganization
+            };
+
             nutupane = new Nutupane(ContentView, params);
             nutupane.table.initialLoad = false;
             $scope.detailsTable = nutupane.table;
@@ -27,16 +34,10 @@ angular.module('Bastion.content-views').controller('ContentViewCompositeAvailabl
                 }
                 filterIds.push(contentView.id);
 
-                params = {
-                    'organization_id': CurrentOrganization,
-                    'full_result': true,
-                    nondefault: true,
-                    noncomposite: true,
-                    "without[]": filterIds
-                };
+                params['without[]'] = filterIds;
 
                 nutupane.setParams(params);
-                nutupane.refresh();
+                nutupane.load(true);
             });
 
 


### PR DESCRIPTION
In the composite content view list CVs were being shown multiple
times because we were appending the results of a nutupane.refresh().
This commit ensures the rows will be replaced with the results of the
second call to nutupane.load().

http://projects.theforeman.org/issues/11315
https://bugzilla.redhat.com/show_bug.cgi?id=1250716