### PR TITLE
fixes #11322 - associate partition table and templates to Operating System upon creation

### DIFF
--- a/app/models/katello/concerns/operatingsystem_extensions.rb
+++ b/app/models/katello/concerns/operatingsystem_extensions.rb
@@ -1,0 +1,29 @@
+module Katello
+  module Concerns
+    module OperatingsystemExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        after_create :assign_templates!
+      end
+
+      def assign_templates!
+        # Automatically assign default templates
+        if self.family == 'Redhat'
+          TemplateKind.all.each do |kind|
+            if (template = ProvisioningTemplate.find_by_name(Setting["katello_default_#{kind.name}"]))
+              provisioning_templates << template unless provisioning_templates.include?(template)
+              if OsDefaultTemplate.where(:template_kind_id => kind.id, :operatingsystem_id => id).empty?
+                OsDefaultTemplate.create(:template_kind_id => kind.id, :provisioning_template_id => template.id, :operatingsystem_id => id)
+              end
+            end
+          end
+
+          if (ptable = Ptable.find_by_name(Setting["katello_default_ptable"]))
+            ptables << ptable unless ptables.include?(ptable)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -8,7 +8,6 @@ module Katello
         alias_method_chain :medium_uri, :content_uri
         alias_method_chain :mediumpath, :content
         alias_method_chain :boot_files_uri, :content
-        after_create :assign_templates!
       end
 
       module ClassMethods
@@ -43,22 +42,6 @@ module Katello
           else
             return family.gsub(' ', '_')
           end
-        end
-      end
-
-      def assign_templates!
-        # Automatically assign default templates
-        TemplateKind.all.each do |kind|
-          if (template = ProvisioningTemplate.find_by_name(Setting["katello_default_#{kind.name}"]))
-            provisioning_templates << template unless provisioning_templates.include?(template)
-            if OsDefaultTemplate.where(:template_kind_id => kind.id, :operatingsystem_id => id).empty?
-              OsDefaultTemplate.create(:template_kind_id => kind.id, :provisioning_template_id => template.id, :operatingsystem_id => id)
-            end
-          end
-        end
-
-        if (ptable = Ptable.find_by_name(Setting["katello_default_ptable"]))
-          ptables << ptable unless ptables.include?(ptable)
         end
       end
 

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -102,6 +102,7 @@ module Katello
       ::Location.send :include, Katello::Concerns::LocationExtensions
       ::Medium.send :include, Katello::Concerns::MediumExtensions
       ::Redhat.send :include, Katello::Concerns::RedhatExtensions
+      ::Operatingsystem.send :include, Katello::Concerns::OperatingsystemExtensions
       ::Organization.send :include, Katello::Concerns::OrganizationExtensions
       ::User.send :include, Katello::Concerns::UserExtensions
 

--- a/test/models/concerns/operatingsystem_extensions_test.rb
+++ b/test/models/concerns/operatingsystem_extensions_test.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class OperatingsystemExtensionsTest < ActiveSupport::TestCase
+    def setup
+      User.current = User.find(users(:admin))
+      @my_distro = OpenStruct.new(:name => 'RedHat', :family => 'Red Hat Enterprise Linux', :version => '9.0')
+    end
+
+    def test_assign_template
+      template = templates(:mystring2)
+      ptable = FactoryGirl.create(:ptable)
+
+      Setting.create(:name => 'katello_default_provision', :description => 'default template',
+                     :category => 'Setting::Katello', :settings_type => 'string',
+                     :default => template.name)
+
+      Setting.create(:name => 'katello_default_ptable', :description => 'default template',
+                     :category => 'Setting::Katello', :settings_type => 'string',
+                     :default => ptable.name)
+
+      os = ::Redhat.create_operating_system(@my_distro.name, '9', '0')
+      assert ::OsDefaultTemplate.where(:template_kind_id    => ::TemplateKind.find_by_name('provision').id,
+                                       :provisioning_template_id  => template.id,
+                                       :operatingsystem_id  => os.id).any?
+
+      assert os.ptables.include? ptable
+    end
+  end
+end

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -38,25 +38,5 @@ module Katello
       assert_equal ::Redhat.construct_name('Red Hat Enterprise Linux'), 'RedHat'
       assert_equal ::Redhat.construct_name('My Custom Linux'), 'My_Custom_Linux'
     end
-
-    def test_assign_template
-      template = templates(:mystring2)
-      ptable = FactoryGirl.create(:ptable)
-
-      Setting.create(:name => 'katello_default_provision', :description => 'default template',
-                     :category => 'Setting::Katello', :settings_type => 'string',
-                     :default => template.name)
-
-      Setting.create(:name => 'katello_default_ptable', :description => 'default template',
-                     :category => 'Setting::Katello', :settings_type => 'string',
-                     :default => ptable.name)
-
-      os = ::Redhat.create_operating_system(@my_distro.name, '9', '0')
-      assert ::OsDefaultTemplate.where(:template_kind_id    => ::TemplateKind.find_by_name('provision').id,
-                                       :provisioning_template_id  => template.id,
-                                       :operatingsystem_id  => os.id).any?
-
-      assert os.ptables.include? ptable
-    end
   end
 end


### PR DESCRIPTION
This commit is a minor change to the existing logic to ensure that when an Operating
System is created as part of a puppet checkin (e.g. the Katello server itself),
the resultant OS has the partition tables and provisioning templates associated.
Previously, this wasn't occuring because the OS created by foreman is using
Operatingsystem.create vs Redhat.create.  This makes sense as the server may
not be running Red Hat OS; howevever, it caused the redhat_extensions 'after_create'
filter to not get executed.