### PR TITLE
Fixes #11207 Autocomplete on scoped search displays some characters i…

### DIFF
--- a/app/controllers/katello/concerns/filtered_auto_complete_search.rb
+++ b/app/controllers/katello/concerns/filtered_auto_complete_search.rb
@@ -11,7 +11,7 @@ module Katello
             category = (['and', 'or', 'not', 'has'].include?(item.to_s.sub(/^.*\s+/, ''))) ? _('Operators') : ''
             part = item.to_s.sub(/^.*\b(and|or)\b/i) { |match| match.sub(/^.*\s+/, '') }
             completed = item.to_s.chomp(part)
-            {:completed => CGI.escapeHTML(completed), :part => CGI.escapeHTML(part), :label => item, :category => category}
+            {:completed => completed, :part => part, :label => item, :category => category}
           end
         rescue ScopedSearch::QueryNotSupported => e
           items = [{:error => e.to_s}]


### PR DESCRIPTION
…ncorrectly

We do not need to escape HTML here because it is being escaped by angular on the client side. Characters are being escaped twice is what is causing something like \&quot; to show up in the autocomplete. 

This differs from Foreman https://github.com/theforeman/foreman/blob/develop/app/controllers/concerns/foreman/controller/auto_complete_search.rb#L17 where they are not using angular, so the HTML is only escaped once. 

Since this is a browser rendering vulnerability, it makes sense to let the client side handle the escaping of HTML.