### PR TITLE
Fixes #11325 Pulp Errors on CV publish

### DIFF
--- a/app/lib/actions/pulp/repository/purge_empty_package_groups.rb
+++ b/app/lib/actions/pulp/repository/purge_empty_package_groups.rb
@@ -16,7 +16,7 @@ module Actions
           package_groups_to_delete = repo.package_groups.collect do |group|
             group.uuid if rpm_names.intersection(group.package_names).empty?
           end
-          criteria = {:association=>{"unit_id"=>{"$in"=>package_groups_to_delete.compact!}}}
+          criteria = {:association=>{"unit_id"=>{"$in"=>package_groups_to_delete.compact}}}
 
           ::Katello.pulp_server.extensions.repository.unassociate_units(repo.pulp_id, :filters => criteria)
         end


### PR DESCRIPTION
.compact! returns nil if there is nothing to be removed, so nil would be sent to pulp if there was nothing nil in package_groups_to_delete