### PR TITLE
Fixes #11140 - Improved reindex for backend search classes

### DIFF
--- a/app/models/katello/glue/pulp/pulp_content_unit.rb
+++ b/app/models/katello/glue/pulp/pulp_content_unit.rb
@@ -92,8 +92,10 @@ module Katello
           repo_unit_id = {}
           units_json.each do |unit_json|
             unit_json['repository_memberships'].each do |repo_pulp_id|
-              repo_unit_id[repo_pulp_id] ||= []
-              repo_unit_id[repo_pulp_id]  << unit_json['_id']
+              if Repository.exists?(:pulp_id => repo_pulp_id)
+                repo_unit_id[repo_pulp_id] ||= []
+                repo_unit_id[repo_pulp_id]  << unit_json['_id']
+              end
             end
           end
 


### PR DESCRIPTION
Prior this commit the reindex task assumed that [Katello::Package,
Katello::PuppetModule, Katello::Distribution, Katello::PackageGroup,
Katello::Erratum] all have an "each" method in the case of on error.
This caused an additional "No Such Method" error thrown every time indexing one of those
items failed.
This error handling has been fixed in this commit

Also included is a fix for Katello::Erattum import_all
We can now handle errata that point to repo memberships that do not
exist in katello (as in we ignore those associations).

This typically happens  either when user directly create/syncs a private repo
via pulp-admin (there by it existing in pulp but not katello) OR deletes a repo
and for some reason the repo membership for that errata did not get updated in pulp.