### PR TITLE
fixes #11436 - update repo destroy action to check if repo is deletable, in plan phase

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -12,6 +12,13 @@ module Actions
 
           skip_environment_update = options.fetch(:organization_destroy, false)
           action_subject(repository)
+
+          if !planned_destroy && !repository.assert_deletable
+            # The repository is going to be deleted in finalize, but it cannot be deleted.
+            # Stop now and inform the user.
+            fail repository.errors.messages.values.join("\n")
+          end
+
           plan_action(ContentViewPuppetModule::Destroy, repository) if repository.puppet?
           plan_action(Pulp::Repository::Destroy, pulp_id: repository.pulp_id)
           plan_action(Product::ContentDestroy, repository)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -490,18 +490,6 @@ module Katello
       end
     end
 
-    protected
-
-    def removable_unit_association
-      if yum?
-        self.rpms
-      elsif docker?
-        self.docker_images
-      else
-        fail "Content type not supported for removal"
-      end
-    end
-
     def assert_deletable
       if self.environment.try(:library?) && self.content_view.default?
         if self.environment.organization.being_deleted?
@@ -516,6 +504,18 @@ module Katello
 
           return false
         end
+      end
+    end
+
+    protected
+
+    def removable_unit_association
+      if yum?
+        self.rpms
+      elsif docker?
+        self.docker_images
+      else
+        fail "Content type not supported for removal"
       end
     end
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -49,14 +49,23 @@ module ::Actions::Katello::Repository
     let(:action_class) { ::Actions::Katello::Repository::Destroy }
     let(:pulp_action_class) { ::Actions::Pulp::Repository::Destroy }
     let(:unpublished_repository) { katello_repositories(:fedora_17_unpublished) }
+    let(:published_repository) { katello_repositories(:rhel_6_x86_64) }
 
     it 'plans' do
-      action       = create_action action_class
+      action = create_action action_class
       action.stubs(:action_subject).with(unpublished_repository)
       action.expects(:plan_self)
       plan_action action, unpublished_repository
       assert_action_planed_with action, pulp_action_class, pulp_id: unpublished_repository.pulp_id
       assert_action_planed_with action, ::Actions::Katello::Product::ContentDestroy, unpublished_repository
+    end
+
+    it "plan fails if repository is not deletable" do
+      action = create_action action_class
+      action.stubs(:action_subject).with(published_repository)
+      assert_raises(RuntimeError) do
+        plan_action action, published_repository
+      end
     end
   end
 


### PR DESCRIPTION
This small commit is to ensure that if a user attempts to delete a repository
(e.g. as a result of 'hammer repository-set disable') that the request
is immediately denied in the action plan phase; otherwise, other backend
actions (e.g. pulp/candlepin) will get executed on a repo that is not
deletable.