### PR TITLE
Refs #7887 - Improves a test in repository_test

### DIFF
--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -268,12 +268,14 @@ module Katello
     end
 
     def test_units_for_removal_yum
-      rpms = @fedora_17_x86_64.rpms.sample(2).sort
+      rpms = @fedora_17_x86_64.rpms.sample(2)
+      rpm_ids = rpms.map(&:id).sort
+      rpm_uuids = rpms.map(&:uuid).sort
 
       refute_empty rpms
-      assert_equal rpms, @fedora_17_x86_64.units_for_removal(rpms.map(&:id)).sort
-      assert_equal rpms, @fedora_17_x86_64.units_for_removal(rpms.map(&:id).map(&:to_s)).sort
-      assert_equal rpms, @fedora_17_x86_64.units_for_removal(rpms.map(&:uuid)).sort
+      assert_equal rpm_ids, @fedora_17_x86_64.units_for_removal(rpm_ids).map(&:id).sort
+      assert_equal rpm_ids, @fedora_17_x86_64.units_for_removal(rpm_ids.map(&:to_s)).map(&:id).sort
+      assert_equal rpm_uuids, @fedora_17_x86_64.units_for_removal(rpm_uuids).map(&:uuid).sort
     end
 
     def test_units_for_removal_puppet


### PR DESCRIPTION
Commit # 690b777d62eee0ef1800ddbab5990ac7fa7a7f03 had a flawed unit test
for test/models/repository_test.rb where 2 rpm objects were being
compared with no consistent sorting mechanism. This commit fixes it be
comparing rpm object's id and sorting on that.