### PR TITLE
Fixes #11470, add CH errata index permission, BZ1256494.

### DIFF
--- a/lib/katello/permissions/content_host_permissions.rb
+++ b/lib/katello/permissions/content_host_permissions.rb
@@ -6,7 +6,7 @@ Foreman::Plugin.find(:katello).security_block :content_hosts do
                'katello/content_hosts'        => [:auto_complete_search],
                'katello/api/v2/systems' => [:index, :show, :errata, :package_profile, :product_content,
                                             :report, :pools, :releases, :available_host_collections, :events],
-               'katello/api/v2/system_errata' => [:show],
+               'katello/api/v2/system_errata' => [:index, :show],
                'katello/api/v2/systems_bulk_actions' => [:applicable_errata],
                'katello/api/v2/host_collections' => [:systems],
                'katello/dashboard' => [:errata]


### PR DESCRIPTION
The content host errata index action was not mapped to any
permission.  This commit maps the action to the correct
view_content_hosts permission.

http://projects.theforeman.org/issues/11470
https://bugzilla.redhat.com/show_bug.cgi?id=1256494