### PR TITLE
fixes #11472 - Do not allow deletion of a content view version that is part of a composite view

### DIFF
--- a/app/lib/actions/katello/content_view/remove_version.rb
+++ b/app/lib/actions/katello/content_view/remove_version.rb
@@ -4,7 +4,7 @@ module Actions
       class RemoveVersion < Actions::EntryAction
         def plan(version)
           action_subject(version.content_view)
-          version.check_ready_to_destroy!
+          version.validate_destroyable!
 
           history = ::Katello::ContentViewHistory.create!(:content_view_version => version,
                                                           :user => ::User.current.login,

--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -3,7 +3,8 @@ module Actions
     module ContentViewVersion
       class Destroy < Actions::Base
         def plan(version, options = {})
-          version.check_ready_to_destroy! unless options[:skip_environment_check]
+          version.validate_destroyable!(options[:skip_environment_check])
+
           destroy_env_content = !options.fetch(:skip_destroy_env_content, false)
           repos = destroy_env_content ? version.repositories : version.archived_repos
           puppet_envs = destroy_env_content ? version.content_view_puppet_environments : [version.archive_puppet_environment]


### PR DESCRIPTION
Note: this commit also moves a few tests in the content_view_version_test that
were not getting executed due to their placement in the test file.