### PR TITLE
Fixes #11556: Fix regression with updating repository URLs in Pulp.

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -489,11 +489,9 @@ module Katello
       end
 
       def pulp_update_needed?
-        unless redhat? || previous_changes.key?('url')
-          allowed_changes = %w(url unprotected checksum_type docker_upstream_name)
-          allowed_changes << "name" if docker?
-          allowed_changes.any? { |key| previous_changes.key?(key) }
-        end
+        changeable_attributes = %w(url unprotected checksum_type docker_upstream_name)
+        changeable_attributes << "name" if docker?
+        changeable_attributes.any? { |key| previous_changes.key?(key) }
       end
 
       def sync(options = {})

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -129,6 +129,20 @@ module Katello
       assert_equal "ACME/library_label/custom/fedora_label/test",
         Glue::Pulp::Repos.custom_repo_path(env, product, "test")
     end
+
+    def test_pulp_update_needed?
+      refute @fedora_17_x86_64.pulp_update_needed?
+
+      @fedora_17_x86_64.url = 'https://www.google.com'
+      @fedora_17_x86_64.save!
+      assert @fedora_17_x86_64.pulp_update_needed?
+
+      @fedora_17_x86_64.stubs(:redhat?).returns(true)
+
+      @fedora_17_x86_64.url = 'https://www.yahoo.com'
+      @fedora_17_x86_64.save!
+      assert @fedora_17_x86_64.pulp_update_needed?
+    end
   end
 
   class GluePulpRepoAfterSyncTest < GluePulpRepoTestBase


### PR DESCRIPTION
A previous change that allowed updating Red Hat repository URLs when
the CDN URL was updated broke propogating of URLs changes to Pulp for
custom repositories.