### PR TITLE
fixes #11589 - minor update to product label validation

### DIFF
--- a/app/lib/katello/validators/product_unique_attribute_validator.rb
+++ b/app/lib/katello/validators/product_unique_attribute_validator.rb
@@ -5,9 +5,7 @@ module Katello
         unique = self.unique_attribute?(record, attribute, value)
 
         unless unique
-          message = _("Product with %{attribute} '%{id}' already exists in this organization.") %
-                    {:attribute => attribute, :id => value}
-          record.errors[attribute] << message
+          record.errors[attribute] << _("has already been taken for a product in this organization.")
         end
       end
 


### PR DESCRIPTION
Update to clean up format of validation error as well as
make it consistent with the similar error for repositories.

Before:
  Validation failed: Label Product with label 'zoo' already exists in this organization.

After:
  Validation failed: Label has already been taken for a product in this organization.