### PR TITLE
Ref #10040 - Minor fixes for the ostree repo create code

### DIFF
--- a/app/lib/actions/katello/content_view/node_metadata_generate.rb
+++ b/app/lib/actions/katello/content_view/node_metadata_generate.rb
@@ -15,7 +15,7 @@ module Actions
 
           concurrence do
             ::Katello::Repository.in_content_views([content_view]).in_environment(environment).each do |repo|
-              plan_action(Katello::Repository::NodeMetadataGenerate, repo)
+              plan_action(Katello::Repository::NodeMetadataGenerate, repo) unless repo.node_syncable?
             end
 
             cv_puppet_env = ::Katello::ContentViewPuppetEnvironment.in_environment(environment).

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -88,7 +88,7 @@ module Actions
           when ::Katello::Repository::DOCKER_TYPE
             [docker_distributor, nodes_distributor]
           when ::Katello::Repository::OSTREE_TYPE
-            [ostree_distributor, nodes_distributor]
+            [ostree_distributor]
           else
             fail _("Unexpected repo type %s") % input[:content_type]
           end
@@ -135,7 +135,8 @@ module Actions
 
         def ostree_distributor
           options = { id: input[:pulp_id],
-                      relative_path: input[:path] }
+                      relative_path: input[:path],
+                      auto_publish: true }
           Runcible::Models::OstreeDistributor.new(options)
         end
       end

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -176,7 +176,7 @@ module Katello
                       :auto_publish => true,
                       :relative_path => relative_path }
           dist = Runcible::Models::OstreeDistributor.new(options)
-          [dist, nodes_distributor]
+          [dist]
         else
           fail _("Unexpected repo type %s") % self.content_type
         end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -446,7 +446,7 @@ module Katello
     end
 
     def node_syncable?
-      environment && !(environment.library? && content_view.default? && puppet?) && !file?
+      environment && !(environment.library? && content_view.default? && puppet?) && !file? && !ostree?
     end
 
     def exist_for_environment?(environment, content_view, attribute = nil)

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -515,10 +515,12 @@ module Katello
       lib_yum_repo = Repository.find(katello_repositories(:rhel_6_x86_64))
       lib_puppet_repo = Repository.find(katello_repositories(:p_forge))
       lib_iso_repo = Repository.find(katello_repositories(:iso))
+      lib_ostree_repo = Repository.find(katello_repositories(:ostree_rhel7))
 
       assert lib_yum_repo.node_syncable?
       refute lib_puppet_repo.node_syncable?
       refute lib_iso_repo.node_syncable?
+      refute lib_ostree_repo.node_syncable?
     end
 
     def test_bad_checksum


### PR DESCRIPTION
1) Added the missing auto_publish : true setting for OSTree repo
creation
2) Removed the nodes distributor for ostree since we are changing that
mechanism to a different model. (Nodes distributor is also not supported
for ostree content.)