### PR TITLE
fixes #11627 - address inconsistency in wording on repository details

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -127,7 +127,7 @@
 
     <div class="detail" ng-show="repository.content_type == 'yum'">
       <span class="info-label" translate>Publish via HTTPS</span>
-      <span class="info-value" translate> true </span>
+      <span class="info-value" translate>Yes</span>
     </div>
 
     <div class="detail" ng-show="repository.content_type == 'yum'">


### PR DESCRIPTION
Simple change... Display 'Yes' versus 'true' for consistency.