### PR TITLE
fixes #11668 - Remove 'apply_info_task_id' from taxonomies

### DIFF
--- a/db/migrate/20150902164543_remove_apply_info_task_id_from_taxonomies.rb
+++ b/db/migrate/20150902164543_remove_apply_info_task_id_from_taxonomies.rb
@@ -1,0 +1,5 @@
+class RemoveApplyInfoTaskIdFromTaxonomies < ActiveRecord::Migration
+  def change
+    remove_column :taxonomies, :apply_info_task_id
+  end
+end


### PR DESCRIPTION
The apply_info_task_id column was previously used to support the 'custom info' feature. That feature was removed; therefore, this commit is dropping it from the schema.