### PR TITLE
fixes #11717 - ability to find puppet env for content view and lifecycle env

### DIFF
--- a/app/models/katello/concerns/environment_extensions.rb
+++ b/app/models/katello/concerns/environment_extensions.rb
@@ -8,6 +8,12 @@ module Katello
         has_one :content_view_puppet_environment, :class_name => "Katello::ContentViewPuppetEnvironment",
                                                   :foreign_key => :puppet_environment_id,
                                                   :dependent => :nullify, :inverse_of => :puppet_environment
+
+        has_one :content_view, :class_name => "Katello::ContentView", :through => :content_view_puppet_environment
+        has_one :lifecycle_environment, :class_name => "Katello::KTEnvironment", :through => :content_view_puppet_environment, :source => :environment
+
+        scoped_search :in => :content_view, :on => :name, :rename => :content_view, :complete_value => true
+        scoped_search :in => :lifecycle_environment, :on => :name, :rename => :lifecycle_environment, :complete_value => true
       end
 
       def content_view

--- a/app/models/katello/content_view_puppet_environment.rb
+++ b/app/models/katello/content_view_puppet_environment.rb
@@ -12,6 +12,8 @@ module Katello
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion",
                                       :inverse_of => :content_view_puppet_environments
 
+    has_one :content_view, :through => :content_view_version, :class_name => "Katello::ContentView"
+
     belongs_to :puppet_environment, :class_name => "Environment",
                                     :inverse_of => :content_view_puppet_environment, :dependent => :destroy
 

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -37,6 +37,10 @@ version = @object || @resource
 child :environments => :environments do
   attributes :id, :name, :label
 
+  node :puppet_environment_id do |environment|
+    version.puppet_env(environment).try(:puppet_environment).try(:id)
+  end
+
   node :permissions do |env|
     {
       :readable => env.readable?,

--- a/test/models/concerns/environment_extensions_test.rb
+++ b/test/models/concerns/environment_extensions_test.rb
@@ -10,8 +10,18 @@ module Katello
 
       @org = get_organization
       @org.label = @org.label.gsub(' ', '_')
-      @env = KTEnvironment.find(katello_environments(:dev))
-      @content_view = ContentView.find(katello_content_views(:library_dev_view))
+      @env = katello_environments(:dev)
+      @content_view = katello_content_views(:library_dev_view)
+      @content_view_puppet_env = katello_content_view_puppet_environments(:library_view_puppet_environment)
+      Environment.create!(:name => "env_for_test", :content_view_puppet_environment => @content_view_puppet_env)
+    end
+
+    def test_search_by_content_view
+      assert_includes Environment.search_for("content_view = \"#{@content_view_puppet_env.content_view.name}\""), @content_view_puppet_env.puppet_environment
+    end
+
+    def test_search_by_lifecycle_environment
+      assert_includes Environment.search_for("lifecycle_environment = #{@content_view_puppet_env.environment.name}"), @content_view_puppet_env.puppet_environment
     end
 
     def test_construct_katello_id


### PR DESCRIPTION
This adds two ways of discoverability
* for a contnet view versions api representation we currently list the lifecycle environments
    this now adds the puppet_environment_id
* adds the ability to search puppet environments for content_view and lifecycle_environment