### PR TITLE
refs #10970 - removing rspec flags

### DIFF
--- a/spec/models/gpg_key_spec.rb
+++ b/spec/models/gpg_key_spec.rb
@@ -1,7 +1,7 @@
 require 'katello_test_helper'
 
 module Katello
-  describe GpgKey, :katello => true do
+  describe GpgKey do
     include OrchestrationHelper
     include OrganizationHelperMethods
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -2,7 +2,7 @@ require 'katello_test_helper'
 require 'helpers/repo_test_data'
 
 module Katello
-  describe Product, :katello => true do
+  describe Product do
     include OrchestrationHelper
     include ProductHelperMethods
     include OrganizationHelperMethods

--- a/spec/models/pulp_task_status_spec.rb
+++ b/spec/models/pulp_task_status_spec.rb
@@ -1,7 +1,7 @@
 require 'katello_test_helper'
 
 module Katello
-  describe PulpTaskStatus, :katello => true do
+  describe PulpTaskStatus do
     include OrchestrationHelper
 
     describe "proxy TaskStatus for pulp task" do

--- a/spec/models/sync_plan_spec.rb
+++ b/spec/models/sync_plan_spec.rb
@@ -2,7 +2,7 @@ require 'katello_test_helper'
 require 'helpers/product_test_data'
 
 module Katello
-  describe SyncPlan, :katello => true do
+  describe SyncPlan do
     include OrchestrationHelper
 
     describe "SyncPlan should" do

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -107,7 +107,7 @@ module Katello
       end
     end
 
-    describe "update enabled_repos", :katello => true do
+    describe "update enabled_repos" do
       before do
         User.stubs(:consumer?).returns(true)
         System.stubs(:where).returns(@system)


### PR DESCRIPTION
we don't use them anymore, and also it appears that #describe() no
longer accepts them as method arguments