### PR TITLE
Fixes #11876 - Enable non basearch/releasever repos

### DIFF
--- a/app/views/katello/providers/redhat/_repos.html.erb
+++ b/app/views/katello/providers/redhat/_repos.html.erb
@@ -32,8 +32,12 @@
                      <% if result[:registry_name] %>
                        data-registry-name="<%= result[:registry_name] %>"
                      <% end %>
-                     data-releasever="<%= result[:substitutions][:releasever] %>"
-                     data-basearch="<%= result[:substitutions][:basearch] %>"
+                     <% if result[:substitutions][:releasever] %>
+                       data-releasever="<%= result[:substitutions][:releasever] %>"
+                     <% end %>
+                     <% if result[:substitutions][:basearch] %>
+                       data-basearch="<%= result[:substitutions][:basearch] %>"
+                     <% end %>
                      <% if result[:promoted] %>
                       disabled="disabled"
                      <% end %>


### PR DESCRIPTION
The UI code after commit 70f91b26dc04765f3b9c9cd14d12996ddace79ec sent releasever
and basearch info to the controller as empty values for repos that didnt need this information.
This caused the controller to complain that bad substitutions were given to it.
This commit fixes that issue by not sending that information if they are
not needed.