### PR TITLE
refs #11968: add content name to repository information returned

### DIFF
--- a/app/lib/actions/katello/repository_set/scan_cdn.rb
+++ b/app/lib/actions/katello/repository_set/scan_cdn.rb
@@ -73,6 +73,7 @@ module Actions
           { substitutions: substitutions,
             path:          mapper.path,
             repo_name:     mapper.name,
+            name:          mapper.content.name,
             pulp_id:       mapper.pulp_id,
             enabled:       !repo.nil?,
             promoted:      (!repo.nil? && repo.promoted?)

--- a/test/actions/katello/repository_set_test.rb
+++ b/test/actions/katello/repository_set_test.rb
@@ -107,6 +107,7 @@ module ::Actions::Katello::RepositorySet
                        [{"substitutions" => {"basearch" => "x86_64", "releasever" => "6Server"},
                          "path" => "/product/x86_64/6Server",
                          "repo_name" => "Content 123 x86_64 6Server",
+                         "name" => "Content 123",
                          "pulp_id" => "Empty_Organization-redhat_label-Content_123_x86_64_6Server",
                          "enabled" => false,
                          "promoted" => false}])


### PR DESCRIPTION
Currently, when a user invokes the API (or CLI) for 'available-repositories'
the repo_name returned is similar to:
   Red Hat Enterprise Linux 6 Server RPMs x86_64 6Server

The above includes the architecture and release version; however, that
information is also returned as separate attributes.  Since the name
can be used for operations such as enable, disable, info, it would
be better to return the name similar to the following:
  Red Hat Enterprise Linux 6 Server (RPMs)

This commit adds a 'name' to the information returned.