### PR TITLE
fixes #11970 - update to allow filtering puppet modules by repository

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -74,7 +74,7 @@ module Katello
       def index_relation
         collection = resource_class.scoped
         collection = filter_by_repos(Repository.readable, collection)
-        collection = filter_by_repos([@repo], collection) if @repo && !@repo.puppet?
+        collection = filter_by_repos([@repo], collection) if @repo
         collection = filter_by_content_view_version(@version, collection) if @version
         collection = filter_by_environment(@environment, collection) if @environment
         collection = filter_by_repos(Repository.readable.in_organization(@organization), collection) if @organization


### PR DESCRIPTION
This change is so that if a user invokes the puppet modules
controller index (aka repository content) with a repository,
the result set returned is for only the requested repository.

Without this change, all puppet modules are returned.