### PR TITLE
Refs #11924 - Return relation instead of array on Systems API test

### DIFF
--- a/test/controllers/api/v2/systems_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/systems_bulk_actions_controller_test.rb
@@ -121,7 +121,7 @@ module Katello
     end
 
     def test_destroy_systems
-      System.stubs(:where).returns([@system1, @system2])
+      System.stubs(:where).returns(System.where(:id => [@system1.id, @system2.id]))
       assert_sync_task(::Actions::Katello::System::Destroy, @system1)
       assert_sync_task(::Actions::Katello::System::Destroy, @system2)
 


### PR DESCRIPTION
On #11924, we are changing authorizable.rb to call where(nil) instead of
scoped (https://github.com/theforeman/foreman/pull/2754). The reason is
just that scoped isn't available on Rails 4 and where(nil) is the
equivalent in Rails 3.

This where(nil) is called upon any relationship that checks permissions
using authorizable, so deletable in
app/models/katello/authorization/system.rb is calling it. However,
.where will not work when it's called upon an Array.

Instead, I've just changed the stubbing to return an ActiveRecord
Relation. The real code (Katello::System.deletable.where(nil)) works
just fine without any changes.