### PR TITLE
Fixes #12047 - force loading of the strong_parameters gem

### DIFF
--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -12,6 +12,7 @@ require "foreman-tasks"
 require "rest_client"
 require "anemone"
 require "securerandom"
+require "strong_parameters"
 require 'foreman_docker'
 
 require "runcible"


### PR DESCRIPTION
This ensures the strong_parameters gem is loaded during initialization which may be referenced in files that don't have a requires statement causing "uninitialized constant" errors.