### PR TITLE
Refs #10970 Finishing model test fixes

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -176,7 +176,7 @@ class ActiveSupport::TestCase
 
   def mock_active_records(*records)
     records.each do |record|
-      record.class.stubs(:instantiate).with(has_entry('id', record.id.to_s)).returns(record)
+      record.class.stubs(:instantiate).with(has_entry('id', record.id.to_s), instance_of(Hash)).returns(record)
       record.stubs(:reload).returns(record)
     end
   end


### PR DESCRIPTION
instanitate's behavior must have changed in rails 4 and it takes in two hashes as arguments. I have updated the stubbed method to reflect this. All model tests are passing for rails 4.