### PR TITLE
Fixes #12129 Change sync status to use child node on products base ra…

### DIFF
--- a/app/views/katello/api/v2/products/base.json.rabl
+++ b/app/views/katello/api/v2/products/base.json.rabl
@@ -7,12 +7,16 @@ extends 'katello/api/v2/common/org_reference'
 
 attributes :provider_id
 attributes :sync_plan_id
-attributes :sync_status
 attributes :sync_summary
 attributes :gpg_key_id
 attributes :redhat? => :redhat
 
 attributes :available_content => :available_content, :if => params[:include_available_content]
+
+attributes :sync_status do
+    attributes :id, :product_id, :progress, :sync_id, :state, :raw_state, :start_time, :finish_time,
+                   :duration, :display_size, :size, :is_running, :error_details
+end
 
 child :sync_plan do
   attributes :name, :description, :sync_date, :interval, :next_sync


### PR DESCRIPTION
…bl template

using attributes with sync status is causing rails 4 to error when calling to_json. This can be fixed by using a child node. 

Opening this up on master to ease the rails 4 transition.