### PR TITLE
Fixes #12129 Change sync status to use node on products base rabl tem…

### DIFF
--- a/app/views/katello/api/v2/products/base.json.rabl
+++ b/app/views/katello/api/v2/products/base.json.rabl
@@ -7,12 +7,30 @@ extends 'katello/api/v2/common/org_reference'
 
 attributes :provider_id
 attributes :sync_plan_id
-attributes :sync_status
 attributes :sync_summary
 attributes :gpg_key_id
 attributes :redhat? => :redhat
 
 attributes :available_content => :available_content, :if => params[:include_available_content]
+
+node :sync_status do |product|
+  status = product.sync_status
+  {
+    :id => status[:id],
+    :product_id => status[:product_id],
+    :progress => status[:progress],
+    :sync_id => status[:sync_id],
+    :state => status[:state],
+    :raw_state => status[:raw_state],
+    :start_time => status[:start_time],
+    :finish_time => status[:finish_time],
+    :duration => status[:duration],
+    :display_size => status[:display_size],
+    :size => status[:size],
+    :is_running => status[:is_running],
+    :error_details => status[:error_details]
+  }
+end
 
 child :sync_plan do
   attributes :name, :description, :sync_date, :interval, :next_sync


### PR DESCRIPTION
…plate

using attributes with sync status is causing rails 4 to error when calling to_json. This can be fixed by using a node.

Opening this up on master to ease the rails 4 transition.