### PR TITLE
Refs #10970 Fixing controller tests

### DIFF
--- a/app/views/katello/api/v2/products/base.json.rabl
+++ b/app/views/katello/api/v2/products/base.json.rabl
@@ -7,12 +7,29 @@ extends 'katello/api/v2/common/org_reference'
 
 attributes :provider_id
 attributes :sync_plan_id
-attributes :sync_status
 attributes :sync_summary
 attributes :gpg_key_id
 attributes :redhat? => :redhat
 
 attributes :available_content => :available_content, :if => params[:include_available_content]
+
+node :sync_status do |product|
+  {
+    :id => product.sync_status[:id],
+    :product_id => product.sync_status[:product_id],
+    :progress => product.sync_status[:progress],
+    :sync_id => product.sync_status[:sync_id],
+    :state => product.sync_status[:state],
+    :raw_state => product.sync_status[:raw_state],
+    :start_time => product.sync_status[:start_time],
+    :finish_time => product.sync_status[:finish_time],
+    :duration => product.sync_status[:duration],
+    :display_size => product.sync_status[:display_size],
+    :size => product.sync_status[:size],
+    :is_running => product.sync_status[:is_running],
+    :error_details => product.sync_status[:error_details]
+  }
+end
 
 child :sync_plan do
   attributes :name, :description, :sync_date, :interval, :next_sync

--- a/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
@@ -45,7 +45,9 @@ module Katello
       post :create, :content_view_filter_id => @filter.id, :name => "testpkg", :version => "10.0"
 
       assert_response :success
-      assert_template "katello/api/v2/content_view_filter_rules/show"
+
+      assert_template :layout => 'katello/api/v2/layouts/resource'
+      assert_template 'katello/api/v2/common/create'
       assert_equal @filter.reload.package_rules.first.name, "testpkg"
       assert_equal @filter.package_rules.first.version, "10.0"
     end

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -78,7 +78,8 @@ module Katello
       post :create, :content_view_id => @content_view.id, :name => "My Filter", :type => "rpm"
 
       assert_response :success
-      assert_template "katello/api/v2/content_view_filters/show"
+      assert_template :layout => 'katello/api/v2/layouts/resource'
+      assert_template 'katello/api/v2/common/create'
       assert_includes @content_view.reload.filters.map(&:name), "My Filter"
     end
 

--- a/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
@@ -47,7 +47,10 @@ module Katello
       post :create, :content_view_id => @content_view.id, :name => "abrt", :author => "johndoe"
 
       assert_response :success
-      assert_template "katello/api/v2/content_view_puppet_modules/show"
+
+      assert_template :layout => 'katello/api/v2/layouts/resource'
+      assert_template "katello/api/v2/content_view_puppet_modules/create"
+
       assert_includes @content_view.reload.puppet_modules.map(&:name), "abrt"
     end
 

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -75,7 +75,8 @@ module Katello
         :organization_id => @organization.id
 
       assert_response :success
-      assert_template "katello/api/v2/content_views/show"
+      assert_template :layout =>'katello/api/v2/layouts/resource'
+      assert_template 'katello/api/v2/common/create'
     end
 
     def test_create_fail_without_organization_id

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -34,7 +34,8 @@ module Katello
       get :show, :repository_id => @repo.id, :id => @tag.id
 
       assert_response :success
-      assert_template "katello/api/v2/errata/show"
+      assert_template "katello/api/v2/docker_tags/show"
+      assert_template :layout => 'katello/api/v2/layouts/resource'
     end
   end
 end


### PR DESCRIPTION
assert_template seems not to be functioning properly in rails 3, seeing as 

    -- a/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
    +++ b/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
    @@ -47,7 +47,7 @@ module Katello
           post :create, :content_view_id => @content_view.id, :name => "abrt", :author => "johndoe"
 
           assert_response :success
    -      assert_template %w(katello/api/v2/content_view_puppet_modules/show)
    +      assert_template %w(katello/api/v2/thisshouldntwork/show)
           assert_includes @content_view.reload.puppet_modules.map(&:name), "abrt"
         end

is passing, these are the updated tests for rails 4