### PR TITLE
fixes #12182 - add permission_name to kt_environments model

### DIFF
--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -262,5 +262,9 @@ module Katello
     def self.humanize_class_name
       _("Lifecycle Environment")
     end
+
+    def self.permission_name
+      'lifecycle_environments'
+    end
   end
 end


### PR DESCRIPTION
This is necessary to address errors like the one below when attempting to edit a capsule:
ERF42-5434 [Foreman::Exception]: unknown permission view_katello/kt_environments