### PR TITLE
Refs #11924 - Return relation instead of array on Systems API test

### DIFF
--- a/test/controllers/api/v2/systems_controller_test.rb
+++ b/test/controllers/api/v2/systems_controller_test.rb
@@ -150,7 +150,8 @@ module Katello
       input = {
         :id => @system.id
       }
-      System.stubs(:where).returns(@system)
+      where_stub = System.where(:id => @system.id)
+      System.stubs(:where).returns(where_stub)
       System.any_instance.stubs(:first).returns(@system)
       assert_sync_task(::Actions::Katello::System::AutoAttachSubscriptions) do |sys|
         sys.must_equal @system
@@ -190,7 +191,8 @@ module Katello
         :id => @system.id,
         :name => 'newname'
       }
-      System.stubs(:where).returns(@system)
+      where_stub = System.where(:id => @system.id)
+      System.stubs(:where).returns(where_stub)
       System.any_instance.stubs(:first).returns(@system)
       @controller.expects(:system_params).returns(input)
       assert_sync_task(::Actions::Katello::System::Update) do |sys, inp|


### PR DESCRIPTION
**Problem**

On #11924, we are changing authorizable.rb to call where(nil) instead of
scoped (theforeman/foreman#2754). The reason is
just that scoped isn't available on Rails 4 and where(nil) is the
equivalent in Rails 3.

This where(nil) is called upon any relationship that checks permissions
using authorizable, so deletable in app/models/katello/authorization/
system.rb is calling it. However, .where will not work when it's
called upon an Array.

**Solution**

I've just changed the stubbing to return an ActiveRecord Relation.
The real code (Katello::System.deletable.where(nil)) works just fine
without any changes. Try it on the console. After Rails 4 is merged, no
more PRs like this would be needed.