### PR TITLE
refs #10970 - 'location' was colliding with a named something...

### DIFF
--- a/test/models/association_test.rb
+++ b/test/models/association_test.rb
@@ -2,7 +2,7 @@ require 'katello_test_helper'
 
 module Katello
   describe 'associations' do
-    def location(model, association)
+    def source_code_location(model, association)
       path     = "#{Katello::Engine.root}/app/models/katello/#{model.name.underscore}.rb"
       location = if File.exist? path
                    content     = File.read path
@@ -34,21 +34,21 @@ module Katello
               it('has :inverse_of option') do
                 unless association.class_name.start_with?("ForemanTasks::")
                   assert(association.options.key?(:inverse_of),
-                         "inverse association cannot be found without the option set #{location(model, association)}")
+                         "inverse association cannot be found without the option set #{source_code_location(model, association)}")
                 end
               end
 
               it("inverse association exists") do
                 unless association.class_name.start_with?("ForemanTasks::")
                   assert(association.inverse_of,
-                         "the inverse association which would take care of deletion avoiding FK errors could not be found  #{location(model, association)}")
+                         "the inverse association which would take care of deletion avoiding FK errors could not be found  #{source_code_location(model, association)}")
                 end
               end
 
               it('is using correct foreign_key') do
                 unless association.class_name.start_with?("ForemanTasks::")
                   assert model.column_names.include?(fk = association.foreign_key.to_s),
-                         "unknown foreign_key #{fk}  #{location(model, association)}"
+                         "unknown foreign_key #{fk}  #{source_code_location(model, association)}"
                 end
               end
 
@@ -79,7 +79,7 @@ module Katello
                        'conditioned association is not responsible for :dependent objects'
                      else
                        'without the :dependent option this will lead to FK errors'
-                     end + location(model, association))
+                     end + source_code_location(model, association))
             end
 
             it('is using correct foreign_key') do
@@ -90,7 +90,7 @@ module Katello
               other_model = class_name.constantize
               foreign_key = association.foreign_key.to_s
               assert other_model.column_names.include?(foreign_key),
-                     "unknown foreign_key #{foreign_key} on #{other_model}" + location(model, association)
+                     "unknown foreign_key #{foreign_key} on #{other_model}" + source_code_location(model, association)
             end
           end
         end


### PR DESCRIPTION
so I renamed it to 'source_code_location'