### PR TITLE
fixes #12302 - do not import facts if foreman host in built mode

### DIFF
--- a/app/models/katello/system.rb
+++ b/app/models/katello/system.rb
@@ -189,7 +189,7 @@ module Katello
     end
 
     def update_foreman_facts
-      return unless self.foreman_host
+      return unless self.foreman_host && !self.foreman_host.build?
       rhsm_facts = self.facts
       rhsm_facts[:_type] = RhsmFactName::FACT_TYPE
       rhsm_facts[:_timestamp] = DateTime.now.to_s


### PR DESCRIPTION


Facts cannot be imported while a host is in build mode, so when trying to do subscription-manager in kickstart %post, you get this error, and the content host is never registered:

```
ERF42-9911 [Foreman::Exception]: Host is pending for Build (Foreman::Exception)
/home/vagrant/foreman/app/models/host/base.rb:108:in `import_facts'
/home/vagrant/katello/app/models/katello/system.rb:196:in `update_foreman_facts'
/home/vagrant/katello/app/lib/actions/katello/system/create.rb:34:in `plan'
```
