### PR TITLE
Refs #10970 Fix mass assignment security error on Environment

### DIFF
--- a/test/models/concerns/environment_extensions_test.rb
+++ b/test/models/concerns/environment_extensions_test.rb
@@ -13,7 +13,14 @@ module Katello
       @env = katello_environments(:dev)
       @content_view = katello_content_views(:library_dev_view)
       @content_view_puppet_env = katello_content_view_puppet_environments(:library_view_puppet_environment)
-      Environment.create!(:name => "env_for_test", :content_view_puppet_environment => @content_view_puppet_env)
+      @environment = Environment.new
+      @environment.name = "env_for_test"
+      @environment.content_view_puppet_environment = @content_view_puppet_env
+      @environment.save!
+    end
+
+    def teardown
+      @environment.destroy!
     end
 
     def test_search_by_content_view


### PR DESCRIPTION
Environment model concern tests were using mass assignment of attrs
which is no longer supported.