### PR TITLE
fixes #12315 - move rhsm routes to a separate resource list

### DIFF
--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -7,7 +7,7 @@ end
 
 Katello::Engine.routes.draw do
   scope :api, :module => :api do
-    match '/rhsm' => 'v2/root#resource_list', :via => :get
+    match '/rhsm' => 'v2/root#rhsm_resource_list', :via => :get
 
     scope :path => :rhsm, :module => :rhsm, :as => :rhsm do
       # subscription-manager support

--- a/test/controllers/api/v2/root_controller_spec.rb
+++ b/test/controllers/api/v2/root_controller_spec.rb
@@ -11,5 +11,30 @@ module Katello
 
       assert_response :success
     end
+
+    def test_rhsm_resource_list
+      results = JSON.parse(get(:rhsm_resource_list).body)
+
+      rhsm_results = results.select { |r| r['href'].start_with?("/rhsm") }
+      katello_results = results.select { |r| r['href'].start_with?("/katello") }
+
+      # results are only for rhsm resources
+      refute_empty rhsm_results
+      assert_empty katello_results
+
+      # href & rel have values
+      assert_empty results.select { |r| r['href'].blank? }
+      assert_empty results.select { |r| r['rel'].blank? }
+
+      # none hrefs end with an id
+      assert_empty rhsm_results.select { |r| r['href'].end_with?(:id) || r['href'].end_with?(:guest_id) }
+
+      # check for a few of the expected routes
+      refute_empty rhsm_results.select { |r| r['href'] == "/rhsm/consumers" && r['rel'] == 'consumers' }
+      refute_empty rhsm_results.select { |r| r['href'] == "/rhsm/owners/:organization_id/environments" && r['rel'] == 'environments' }
+      refute_empty rhsm_results.select { |r| r['href'] == "/rhsm/owners/:organization_id/pools" && r['rel'] == 'pools' }
+
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
Without this change, when user invokes a GET /katello/api they receive
several rhsm resources that are invalid.  In addition, when they invoke
GET /rhsm they receive all of the /katello/api resources.

This change results in 2 separate set of resources to be returned
by GET /katello/api and GET /rhsm.

Note: the GET /rhsm is required by rhsm to be able to determine if
the server support various resources (e.g. release_version, environments...etc).