### PR TITLE
fixes #12353 - api - get hostgroup - extend response to include katello attributes

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hostgroups_controller_extensions.rb
@@ -38,6 +38,13 @@ module Katello
         def update
           process_response @hostgroup.update_attributes(params[:hostgroup])
         end
+
+        api :GET, "/hostgroups/:id", N_("Show a host group")
+        param :id, :identifier, :required => true
+        def show
+          @render_template = 'katello/api/v2/hostgroups_extensions/show'
+          render @render_template
+        end
       end
     end
   end

--- a/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
+++ b/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
@@ -1,0 +1,3 @@
+object @hostgroup
+extends 'api/v2/hostgroups/show'
+attributes :content_source_id, :content_source_name, :content_view_id, :content_view_name, :lifecycle_environment_id, :lifecycle_environment_name


### PR DESCRIPTION
This commit will extend the api for GET api/v2/hostgroups/:id to
include the attributes that are added by katello.  The following
is an example:

    "content_source_id": 1,
    "content_source_name": "fortello.devel",
    "content_view_id": 2,
    "content_view_name": "app view 1",
    "lifecycle_environment_id": 1,
    "lifecycle_environment_name": "Library",