### PR TITLE
Fixes #12373 - Lock VCR gem to version prior to 3.0 release 

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "factory_girl_rails"
   gem.add_development_dependency "minitest-tags"
   gem.add_development_dependency "mocha"
-  gem.add_development_dependency "vcr"
+  gem.add_development_dependency "vcr", "< 3.0.0"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "rubocop-checkstyle_formatter"
 


### PR DESCRIPTION
VCR version 3.0 introduces several breaking changes:

3.0.0
    [Breaking] test support for 1.8.7, 1.9.2, 2.0.0, 2.1.0, ree, jruby 1.8mode, rbx 1.8mode
    [Breaking] the possible return value VCR.configuration, it now might return nil
    [Breaking] the possible return value VCR.cassette_serializers, it now might return nil
    [Breaking] the possible return value VCR.cassette_persisters, it now might return nil
    [Breaking] the possible return value VCR.library_hooks, it now might return nil
    [Breaking] the possible return value VCR.request_ignorer, it now might return nil
    [Breaking] the possible return value VCR.request_matchers, it now might return nil
    [Breaking] the threadness of VCR, by using Mutex
    [Adding] a new :compressed value for serializers that stores in gzipped files
    [Adding] support for farady's RackBuilder if it exists
    [Changing] the cucumber scenario naming mechanism