### PR TITLE
fixes #12382 - capsule content - update API for consistency and to fix CLI

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -20,30 +20,29 @@ module Katello
     api :GET, '/capsules/:id/content/lifecycle_environments', 'List the lifecycle environments attached to the capsule'
     param_group :lifecycle_environments
     def lifecycle_environments
-      @lifecycle_environments = capsule_content.lifecycle_environments(params[:organization_id]).readable
+      environments = capsule_content.lifecycle_environments(params[:organization_id]).readable
+      respond_for_lifecycle_environments_index(environments)
     end
 
     api :GET, '/capsules/:id/content/available_lifecycle_environments', 'List the lifecycle environments not attached to the capsule'
     param_group :lifecycle_environments
     def available_lifecycle_environments
-      @lifecycle_environments = capsule_content.available_lifecycle_environments(params[:organization_id]).readable
-      render 'katello/api/v2/capsule_content/lifecycle_environments'
+      environments = capsule_content.available_lifecycle_environments(params[:organization_id]).readable
+      respond_for_lifecycle_environments_index(environments)
     end
 
     api :POST, '/capsules/:id/content/lifecycle_environments', 'Add lifecycle environments to the capsule'
     param_group :update_lifecycle_environments
     def add_lifecycle_environment
       capsule_content.add_lifecycle_environment(@environment)
-      @lifecycle_environments = capsule_content.lifecycle_environments
-      render 'katello/api/v2/capsule_content/lifecycle_environments'
+      respond_for_lifecycle_environments_index(capsule_content.lifecycle_environments)
     end
 
     api :DELETE, '/capsules/:id/content/lifecycle_environments/:environment_id',  'Remove lifecycle environments from the capsule'
     param_group :update_lifecycle_environments
     def remove_lifecycle_environment
       capsule_content.remove_lifecycle_environment(@environment)
-      @lifecycle_environments = capsule_content.lifecycle_environments
-      render 'katello/api/v2/capsule_content/lifecycle_environments'
+      respond_for_lifecycle_environments_index(capsule_content.lifecycle_environments)
     end
 
     api :POST, '/capsules/:id/content/sync',  'Synchronize the content to the capsule'
@@ -56,6 +55,15 @@ module Katello
     end
 
     protected
+
+    def respond_for_lifecycle_environments_index(environments)
+      collection = {
+        :results => environments,
+        :total => environments.size,
+        :subtotal => environments.size
+      }
+      respond_for_index(:collection => collection, :template => :lifecycle_environments)
+    end
 
     def find_capsule
       @capsule = SmartProxy.authorized(:manage_capsule_content).with_features(SmartProxy::PULP_NODE_FEATURE).find(params[:id])

--- a/app/views/katello/api/v2/capsule_content/lifecycle_environments.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/lifecycle_environments.json.rabl
@@ -1,5 +1,7 @@
-object false
+object Katello::Util::Data.ostructize(@collection)
 
-child @lifecycle_environments => :results do
-  extends("katello/api/v2/environments/show")
+extends("katello/api/v2/common/metadata")
+
+child :results => :results do
+  extends('katello/api/v2/environments/show')
 end


### PR DESCRIPTION
This commit contains minor changes to the 'capsule content' APIs for both
consistency and to fix behaviors in the CLI.

With the current APIs, the CLI will not render results.  As a result,
the output looks like the scenario below.  With these changes, we are
returning the result more consistent with other 'list' or 'index'
results.

hammer> capsule content available-lifecycle-environments --id 8 --organization-id 1
---|----------|-------------
ID | NAME | ORGANIZATION
---|----------|-------------
    |            |
---|----------|-------------