### PR TITLE
fixes #12384 - capsule content api - update the message returned

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -58,7 +58,10 @@ module Katello
     protected
 
     def find_capsule
-      @capsule = SmartProxy.authorized(:manage_capsule_content).with_features(SmartProxy::PULP_NODE_FEATURE).find(params[:id])
+      @capsule = SmartProxy.authorized(:manage_capsule_content).find(params[:id])
+      unless @capsule && @capsule.has_feature?(SmartProxy::PULP_NODE_FEATURE)
+        fail _("This request may only be performed on a Capsule that has the Pulp Node feature.")
+      end
     end
 
     def find_environment


### PR DESCRIPTION
Change the text returned to the user when the APIs are invoked
for a capsule that doesn't have the pulp node feature.

Previously, it would return:
"Couldn't find SmartProxy with id=1 [WHERE "features"."name" IN ('Pulp Node')]"