### PR TITLE
fixes #12385 - capsule content - update message when removing environment

### DIFF
--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -30,8 +30,10 @@ module Katello
     def remove_lifecycle_environment(environment)
       @capsule.lifecycle_environments.find(environment)
       unless @capsule.lifecycle_environments.destroy(environment)
-        fail "could not remove the lifecycle environment form capsule"
+        fail _("Could not remove the lifecycle environment from the capsule")
       end
+    rescue ActiveRecord::RecordNotFound
+      raise _("Lifecycle environment was not attached to the capsule; therefore, no changes were made.")
     end
 
     def available_lifecycle_environments(organization_id = nil)


### PR DESCRIPTION
Currently, if the user attempts to remove a lifecycle environment from
a capsule and that environment is not currently associated, they will
see an error similar to:

Couldn't find Katello::KTEnvironment with id=3 [WHERE "katello_capsule_lifecycle_environments"."capsule_id" = 10]

This commit is to provide a more user friendly response.