### PR TITLE
Fixes #12408 - Create repos of supported types

### DIFF
--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -1,0 +1,35 @@
+module Katello
+  class RepositoryType
+    class << self
+      def def_field(*names)
+        class_eval do
+          names.each do |name|
+            define_method(name) do |*args|
+              args.empty? ? instance_variable_get("@#{name}") : instance_variable_set("@#{name}", *args)
+            end
+          end
+        end
+      end
+    end
+
+    def_field :allow_creation_by_user
+    attr_reader :id
+
+    def initialize(id)
+      @id = id.to_sym
+      allow_creation_by_user(true)
+    end
+
+    def <=>(other)
+      self.id.to_s <=> other.id.to_s
+    end
+
+    def as_json(options = {})
+      ret = super(options)
+      ret[:name] = self.id.to_s
+      ret[:creatable] = @allow_creation_by_user
+      ret.delete("allow_creation_by_user")
+      ret
+    end
+  end
+end

--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -1,0 +1,33 @@
+module Katello
+  class RepositoryTypeManager
+    @repository_types = {}
+    class << self
+      private :new
+      attr_reader :repository_types
+
+      # Plugin constructor
+      def register(id, &block)
+        unless find(id).present?
+          repository_type = ::Katello::RepositoryType.new(id)
+          repository_type.instance_eval(&block) if block_given?
+          repository_types[id.to_s] = repository_type
+        end
+      end
+
+      def creatable_repository_types
+        repository_types.select do |repo_type, _|
+          creatable_by_user?(repo_type)
+        end
+      end
+
+      def creatable_by_user?(repository_type)
+        return false unless (type = find(repository_type))
+        type.allow_creation_by_user
+      end
+
+      def find(repository_type)
+        repository_types[repository_type.to_s]
+      end
+    end
+  end
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -213,6 +213,7 @@ Katello::Engine.routes.draw do
           collection do
             post :sync_complete
             get :auto_complete_search
+            get :repository_types
           end
         end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
@@ -47,7 +47,10 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
 
         $scope.repository = new Repository({'product_id': $scope.$stateParams.productId, unprotected: true,
             'checksum_type': null});
-        $scope.repositoryTypes = [{}, {name: 'yum'}, {name: 'puppet'}, {name: 'docker'}];
+
+        Repository.repositoryTypes({'creatable': true}, function (data) {
+            $scope.repositoryTypes = data;
+        });
 
         $scope.$watch('repository.name', function () {
             if ($scope.repositoryForm.name) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repository.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repository.factory.js
@@ -19,7 +19,8 @@ angular.module('Bastion.repositories').factory('Repository',
                 sync: { method: 'POST', params: { action: 'sync' } },
                 removePackages: { method: 'PUT', params: { action: 'remove_packages'}},
                 removeContent: { method: 'PUT', params: { action: 'remove_content'}},
-                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
+                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
+                repositoryTypes: {method: 'GET', isArray: true, params: {id: 'repository_types'}}
             }
         );
 

--- a/engines/bastion_katello/test/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/repositories/new/new-repository.controller.test.js
@@ -20,6 +20,11 @@ describe('Controller: NewRepositoryController', function() {
         $scope.$stateParams = {productId: 1};
         $scope.repositoryForm = $injector.get('MockForm');
 
+        Repository.repositoryTypes = function (data, func) {
+            $scope.repositoryTypesTestData = data;
+            $scope.repositoryTypesTestCalled = true;
+        };
+
         $controller('NewRepositoryController', {
             $scope: $scope,
             $http: $http,
@@ -33,7 +38,8 @@ describe('Controller: NewRepositoryController', function() {
     });
 
     it('should define a set of repository types', function() {
-        expect($scope.repositoryTypes).toBeDefined();
+        expect($scope.repositoryTypesTestCalled).toBe(true);
+        expect($scope.repositoryTypesTestData["creatable"]).toBeDefined();
     });
 
     it('should fetch available GPG Keys', function() {

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -203,6 +203,7 @@ module Katello
     initializer 'katello.register_plugin', :after => :finisher_hook do
       require 'katello/plugin'
       require 'katello/permissions'
+      require 'katello/repository_types'
     end
 
     rake_tasks do

--- a/lib/katello/permissions/product_permissions.rb
+++ b/lib/katello/permissions/product_permissions.rb
@@ -14,7 +14,7 @@ Foreman::Plugin.find(:katello).security_block :products do
                'katello/errata' => [:short_details, :auto_complete],
                'katello/packages' => [:details, :auto_complete],
                'katello/puppet_modules' => [:show],
-               'katello/repositories' => [:auto_complete_library],
+               'katello/repositories' => [:auto_complete_library, :repository_types],
                'katello/content_search' => [:index,
                                             :products,
                                             :repos,

--- a/lib/katello/repository_types.rb
+++ b/lib/katello/repository_types.rb
@@ -1,0 +1,3 @@
+Dir["#{File.expand_path('../repository_types', __FILE__)}/*.rb"].each do |file|
+  require file
+end

--- a/lib/katello/repository_types/docker.rb
+++ b/lib/katello/repository_types/docker.rb
@@ -1,0 +1,1 @@
+Katello::RepositoryTypeManager.register(::Katello::Repository::DOCKER_TYPE)

--- a/lib/katello/repository_types/file.rb
+++ b/lib/katello/repository_types/file.rb
@@ -1,0 +1,3 @@
+Katello::RepositoryTypeManager.register(::Katello::Repository::FILE_TYPE) do
+  allow_creation_by_user false
+end

--- a/lib/katello/repository_types/puppet.rb
+++ b/lib/katello/repository_types/puppet.rb
@@ -1,0 +1,1 @@
+Katello::RepositoryTypeManager.register(::Katello::Repository::PUPPET_TYPE)

--- a/lib/katello/repository_types/yum.rb
+++ b/lib/katello/repository_types/yum.rb
@@ -1,0 +1,1 @@
+Katello::RepositoryTypeManager.register(::Katello::Repository::YUM_TYPE)

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -46,6 +46,29 @@ module Katello
       assert_template 'api/v2/repositories/index'
     end
 
+    def test_repository_types
+      get :repository_types
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal RepositoryTypeManager.repository_types.size, body.size
+      body.each do |repo|
+        assert RepositoryTypeManager.find(repo["name"]).present?
+      end
+    end
+
+    def test_creatable_repository_types
+      get :repository_types, :creatable => "true"
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal RepositoryTypeManager.creatable_repository_types.size, body.size
+      body.each do |repo|
+        assert RepositoryTypeManager.find(repo["name"]).present?
+        assert RepositoryTypeManager.creatable_by_user?(repo["name"])
+      end
+    end
+
     def assert_response_ids(response, expected)
       body = JSON.parse(response.body)
       found_ids = body['results'].map { |item| item['id'] }
@@ -377,7 +400,8 @@ module Katello
 
     def test_create_without_label_or_name
       post :create, :product_id => @product.id
-      assert_response 500
+      #should raise an error along the lines of invalid content type provided
+      assert_response 422
     end
 
     def test_create_protected

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -43,6 +43,12 @@ def load_permissions
   end
 end
 
+def load_repository_types
+  Dir["#{File.expand_path("#{Katello::Engine.root}/lib/katello/repository_types", __FILE__)}/*.rb"].each do |file|
+    load file
+  end
+end
+
 module FixtureTestCase
   extend ActiveSupport::Concern
 
@@ -62,6 +68,7 @@ module FixtureTestCase
     FIXTURES = load_fixtures(ActiveRecord::Base)
 
     load_permissions
+    load_repository_types
     configure_vcr
 
     Setting::Katello.load_defaults


### PR DESCRIPTION
We need to have ability to allow creation of repos based on available
content types. This is due to the fact that content types like 'ostree'
are going to be availble only for specific arches. We need logic to get
a list of supported content types and only allow creations of those.