### PR TITLE
Refs #12331 - Fixes authorization tests 

### DIFF
--- a/lib/katello/tasks/test.rake
+++ b/lib/katello/tasks/test.rake
@@ -42,6 +42,7 @@ namespace :test do
       test_task = Rake::TestTask.new('katello_test_task') do |t|
         t.libs << ["test", "#{Katello::Engine.root}/test"]
         t.test_files = [
+          "#{Katello::Engine.root}/test/models/**/*_test.rb",
           "#{Katello::Engine.root}/test/**/*_test.rb",
         ]
         t.verbose = true


### PR DESCRIPTION
This is not a long term fix, but the authorization tests errors that are only showing up in the full test suite can be avoided by rearranging the tests to run in a different order.