### PR TITLE
Fixes #12447 - Remove readable_products method from content view

### DIFF
--- a/app/models/katello/authorization/content_view.rb
+++ b/app/models/katello/authorization/content_view.rb
@@ -58,14 +58,6 @@ module Katello
         query.joins(:content_view_version)
              .where("#{Katello::ContentViewVersion.table_name}.content_view_id" => content_views.pluck(:id))
       end
-
-      def readable_products(product_ids = nil)
-        query = Katello::Product.scoped
-        query = query.where(:id => product_ids) if product_ids
-
-        query.joins(:repositories => :content_view_version)
-             .where("#{Katello::ContentViewVersion.table_name}.content_view_id" => ContentView.readable.pluck(:id))
-      end
     end
   end
 end

--- a/test/models/authorization/content_view_authorization_test.rb
+++ b/test/models/authorization/content_view_authorization_test.rb
@@ -39,14 +39,6 @@ module Katello
     def test_readable_repositories_with_ids
       refute_empty ContentView.readable_repositories([Repository.first.id])
     end
-
-    def test_readable_products
-      refute_empty ContentView.readable_products
-    end
-
-    def test_readable_products_with_ids
-      refute_empty ContentView.readable_products([Product.first.id])
-    end
   end
 
   class ContentViewAuthorizationNoPermsTest < AuthorizationTestBase
@@ -91,25 +83,6 @@ module Katello
 
     def test_readable_repositories_with_ids
       assert_empty ContentView.readable_repositories([Repository.first.id])
-    end
-
-    def test_readable_products
-      assert_empty ContentView.readable_products
-    end
-
-    def test_readable_products_with_ids
-      assert_empty ContentView.readable_products([Product.first.id])
-    end
-
-    def test_readable_products_with_search
-      prod = Katello::Repository.find(katello_repositories(:rhel_6_x86_64_composite_view_version_1)).product
-      view = katello_content_views(:library_view)
-      view2 = katello_content_views(:composite_view)
-      setup_current_user_with_permissions(:name => "view_content_views",
-                                          :search => "name=\"#{view.name}\"")
-
-      assert_empty(ContentView.readable_products - view.products)
-      assert_equal ContentView.readable_products(view2.products.pluck(:id)), [prod]
     end
   end
 end


### PR DESCRIPTION
This method is no longer used and can be removed, all associated tests are removed as well.