### PR TITLE
Fixes #12468 - Add attr_accessible to Organization label for Rails 4

### DIFF
--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -32,8 +32,9 @@ module Katello
         has_many :org_tasks, :dependent => :destroy, :class_name => "Katello::TaskStatus", :inverse_of => :organization
 
         attr_accessor :statistics
+        attr_accessible :label
 
-        scope :having_name_or_label, ->(name_or_label) { { :conditions => ["name = :id or label = :id", {:id => name_or_label}] } }
+        scope :having_name_or_label, ->(name_or_label) { where("name = :id or label = :id", :id => name_or_label) }
         scoped_search :on => :label, :complete_value => :true
 
         after_create :associate_default_capsule


### PR DESCRIPTION
Multiple tests try to mass_assign :label by calling
Organization.create!(:name => '', :label => ''), but that's not allowed
on Rails 4 without explicitly marking it as allowed.

See spec/models/pulp_task_status_spec.rb line 62 for an example.