### PR TITLE
Refs #10970 - Docker Image Test fixes

### DIFF
--- a/test/models/docker_image_test.rb
+++ b/test/models/docker_image_test.rb
@@ -13,8 +13,8 @@ module Katello
       @repo = Repository.find(katello_repositories(:redis))
 
       ids = @images.map { |attrs| attrs[:_id] }
-      Runcible::Extensions::Repository.any_instance.stubs(:pulp_docker_image_ids).
-        with(REPO_ID).returns(ids)
+      ::Katello::Repository.any_instance.stubs(:pulp_docker_image_ids).
+       returns(ids)
       Runcible::Extensions::DockerImage.any_instance.stubs(:find_all_by_unit_ids).
         with(ids).returns(@images)
       Runcible::Extensions::Repository.any_instance.stubs(:retrieve_with_details).


### PR DESCRIPTION
pulp_docker_image_ids is a Repository instance method and the stub needed to be changed.