### PR TITLE
Refs #10970 - Fix spec katello uri helper

### DIFF
--- a/spec/helpers/katello_url_helper_spec.rb
+++ b/spec/helpers/katello_url_helper_spec.rb
@@ -5,7 +5,7 @@ module Katello
     describe "Valid https? Urls" do
       it "should validate clean http urls" do
         kurl_valid?('http://www.hugheshoney.com').must_equal(true)
-        kurl_valid?('HTtp://www.hugheshoney.com').must_equal(false)
+        kurl_valid?('HTtp://www.hugheshoney.com').must_equal(true)
         kurl_valid?('http://www.hugheshoney.com:8888').must_equal(true)
         kurl_valid?('http://www.hugheshoney.com:8888/homepage/index.html').must_equal(true)
         kurl_valid?('http://9seng.cz/katello').must_equal(true)
@@ -29,7 +29,7 @@ module Katello
       end
       it "should validate clean ftp urls" do
         kurl_valid?('ftp://65.190.152.28').must_equal(true)
-        kurl_valid?('Ftp://65.190.152.28').must_equal(false)
+        kurl_valid?('Ftp://65.190.152.28').must_equal(true)
         kurl_valid?('ftp://65.190.152.28/fedora/x86_64').must_equal(true)
         kurl_valid?('ftp://ftp.fedorahosted.org/rpms/index.html').must_equal(true)
       end
@@ -47,7 +47,7 @@ module Katello
       it "should validate file urls with multiple slashes" do
         file_prefix?('file://///opt/repo').must_equal(true)
         kurl_valid?('file://///opt/').must_equal(true)
-        kurl_valid?('File://///opt/').must_equal(false)
+        kurl_valid?('File://///opt/').must_equal(true)
         file_prefix?('/////opt/repo').must_equal(false)
         kurl_valid?('/////opt/repo').must_equal(false)
       end


### PR DESCRIPTION
URI parsing in ruby 2.0 and above is not case sensitive
All combinations of lower and uppercase will parse properly