### PR TITLE
fixes #12459 - allow override of sync url when syncing

### DIFF
--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -7,6 +7,7 @@ module Actions
         input_format do
           param :pulp_id
           param :task_id # In case we need just pair this action with existing sync task
+          param :source_url # allow overriding the feed URL
         end
 
         def invoke_external_task
@@ -24,6 +25,9 @@ module Actions
               # set threads per sync
               sync_options[:num_threads] ||= SETTINGS[:katello][:pulp][:sync_threads]
             end
+
+            sync_options[:feed] = input[:source_url] if input[:source_url]
+
             sync_options[:validate] = !(SETTINGS[:katello][:pulp][:skip_checksum_validation])
 
             output[:pulp_tasks] = pulp_tasks =

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -159,12 +159,12 @@ module ::Actions::Katello::Repository
     let(:pulp_action_class) { ::Actions::Pulp::Repository::Sync }
 
     it 'plans' do
-      action       = create_action action_class
+      action = create_action action_class
       action.stubs(:action_subject).with(repository)
       plan_action action, repository
 
       assert_action_planed_with(action, pulp_action_class,
-                                pulp_id: repository.pulp_id, task_id: nil)
+                                pulp_id: repository.pulp_id, task_id: nil, source_url: nil)
       assert_action_planed action, ::Actions::Katello::Repository::IndexContent
       assert_action_planed_with action, ::Actions::Katello::Repository::ErrataMail do |repo, _task_id, contents_changed|
         contents_changed.must_be_kind_of Dynflow::ExecutionPlan::OutputReference
@@ -173,12 +173,22 @@ module ::Actions::Katello::Repository
     end
 
     it 'passes the task id to pulp sync action when provided' do
-      action       = create_action action_class
+      action = create_action action_class
       action.stubs(:action_subject).with(repository)
       plan_action action, repository, '123'
 
       assert_action_planed_with(action, pulp_action_class,
-                                pulp_id: repository.pulp_id, task_id: '123')
+                                pulp_id: repository.pulp_id, task_id: '123', source_url: nil)
+    end
+
+    it 'passes the source URL to pulp sync action when provided' do
+      action = create_action action_class
+      action.stubs(:action_subject).with(repository)
+      plan_action action, repository, nil, 'file:///tmp/'
+
+      assert_action_planed_with(action, pulp_action_class,
+                                pulp_id: repository.pulp_id, task_id: nil,
+                                source_url: 'file:///tmp/')
     end
 
     describe 'progress' do

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -472,7 +472,33 @@ module Katello
       end
 
       post :sync, :id => @repository.id
+      assert_response :success
+    end
 
+    def test_sync_with_url_override
+      assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, source_url|
+        repo.id.must_equal(@repository.id)
+        pulp_task_id.must_equal(nil)
+        source_url.must_equal('file:///tmp/')
+      end
+      post :sync, :id => @repository.id, :source_url => 'file:///tmp/'
+      assert_response :success
+    end
+
+    def test_sync_with_bad_url_override
+      post :sync, :id => @repository.id, :source_url => 'file:|||tmp/'
+      assert_response 400
+    end
+
+    def test_sync_no_feed_urls
+      repo = katello_repositories(:feedless_fedora_17_x86_64)
+      post :sync, :id => repo.id
+      assert_response 400
+    end
+
+    def test_sync_no_feed_urls_with_override
+      repo = katello_repositories(:feedless_fedora_17_x86_64)
+      post :sync, :id => repo.id, :source_url => 'http://www.wikipedia.org'
       assert_response :success
     end
 


### PR DESCRIPTION
This patch allows API callers to pass an optional "source_url" to repo sync.
This allows repos to be synced from locations such as mounted USB volumes
without requiring permenant alteration of the sync URL associated with the
repo.