### PR TITLE
Fixes #12476 - Refactor max content host validator for rails 4

### DIFF
--- a/app/models/katello/system_host_collection.rb
+++ b/app/models/katello/system_host_collection.rb
@@ -8,7 +8,7 @@ module Katello
     validate :validate_max_content_hosts_not_exceeded
 
     def validate_max_content_hosts_not_exceeded
-      if new_record?
+      if new_record? && self.host_collection_id
         host_collection = HostCollection.find(self.host_collection_id)
         if (host_collection) && (!host_collection.unlimited_content_hosts) && (host_collection.systems.size >= host_collection.max_content_hosts)
           errors.add :base,

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -6,6 +6,7 @@ module Katello
   class Api::V2::HostCollectionsControllerTest < ActionController::TestCase
     def models
       @system = katello_systems(:simple_server)
+      @system_two = katello_systems(:simple_server2)
       @host_collection = katello_host_collections(:simple_host_collection)
       @organization = get_organization
 
@@ -64,6 +65,59 @@ module Katello
       assert_equal results['system_ids'], [@system.id]
 
       assert_template 'api/v2/host_collections/create'
+    end
+
+    def test_validate_systems
+      max_content_hosts = 1
+      content_host_name = 'Collection A'
+      post :create, :organization_id => @organization,
+                    :host_collection => {:name => content_host_name, :description => 'Collection A, World Cup 2014',
+                                         :max_content_hosts => max_content_hosts, :unlimited_content_hosts => false,
+                                         :system_ids => [@system.id, @system_two.id]}
+
+      results = JSON.parse(response.body)
+      error_message = "You cannot have more than #{max_content_hosts} content host(s) associated with host collection #{content_host_name}."
+
+      assert_response 422
+      assert results["errors"]["base"].include?(error_message)
+    end
+
+    def test_max_content_host_validator
+      put :update, :id => @host_collection.id, :organization_id => @organization.id,
+                   :max_content_hosts => 2, :unlimited_content_hosts => false, :system_ids => [@system.id, @system_two.id]
+
+      assert_response :success
+
+      put :update, :id => @host_collection.id, :organization_id => @organization.id,
+                   :max_content_hosts => 1
+
+      results = JSON.parse(response.body)
+      error_message = "may not be less than the number of content hosts associated with the host collection."
+
+      assert_response 422
+      assert results["errors"]["max_content_host"].include?(error_message)
+    end
+
+    def test_max_content_host_zero
+      put :update, :id => @host_collection.id, :organization_id => @organization.id,
+                   :max_content_hosts => 0, :unlimited_content_hosts => false
+
+      results = JSON.parse(response.body)
+      error_message = "must be a positive integer value."
+
+      assert_response 422
+      assert results["displayMessage"].include?(error_message)
+    end
+
+    def test_nil_max_content_hosts
+      put :update, :id => @host_collection.id, :organization_id => @organization.id,
+                   :unlimited_content_hosts => false
+
+      results = JSON.parse(response.body)
+      error_message = "must be given a value if this host collection is not unlimited."
+
+      assert_response 422
+      assert results["displayMessage"].include?(error_message)
     end
 
     def test_create_with_system_uuid


### PR DESCRIPTION
This is a change for rails4 but also the validate_max_content_hosts_not_exceeded in system_host_collection.rb was not working properly when creating a host collection. A test was added to ensure this.