### PR TITLE
fixes #12534 - hide Client, Workstation and ComputeNode kickstart repos from enablement

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -39,7 +39,9 @@ module Katello
 
       repos = repos.select do |repo|
         if repo[:path].include?('kickstart')
-          repo[:substitutions][:releasever].include?('Server') ? repo[:enabled] : true
+          variants = ['Server', 'Client', 'ComputeNode', 'Workstation']
+          has_variant = variants.any? { |v| repo[:substitutions][:releasever].include?(v) }
+          has_variant ? repo[:enabled] : true
         else
           true
         end

--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -71,7 +71,9 @@ module Katello
     def exclude_rolling_kickstart_repos(repos)
       repos.select do |repo|
         if repo[:path].include?('kickstart')
-          repo[:substitutions][:releasever].include?('Server') ? repo[:enabled] : true
+          variants = ['Server', 'Client', 'ComputeNode', 'Workstation']
+          has_variant = variants.any? { |v| repo[:substitutions][:releasever].include?(v) }
+          has_variant ? repo[:enabled] : true
         else
           true
         end


### PR DESCRIPTION
In an earlier commit (9c6f26bae5114cf8e8177b1d966d3786b0b327ef), we updated
RH repository enablement to hide the Server (e.g 7Server) kickstart repositories.
This was done for various reasons, as it impacted provisioning and management
of that content (as the underlying content could change as new releases of the
OS were distributed).

We need this same logic to also apply to other variants of the OS,
which includes Client (Desktop), Workstation and ComputeNode.

Note: these changes will apply for UI, API and CLI.