### PR TITLE
Refs #12468 - Add attr_acccessible to organization label 

### DIFF
--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -32,6 +32,7 @@ module Katello
         has_many :org_tasks, :dependent => :destroy, :class_name => "Katello::TaskStatus", :inverse_of => :organization
 
         attr_accessor :statistics
+        attr_accessible :label
 
         scope :having_name_or_label, ->(name_or_label) { { :conditions => ["name = :id or label = :id", {:id => name_or_label}] } }
         scoped_search :on => :label, :complete_value => :true


### PR DESCRIPTION
Multiple tests try to mass_assign :label by calling
Organization.create!(:name => '', :label => ''), but that's not allowed
with attr_accessible without explicitly marking it as allowed.

See spec/models/pulp_task_status_spec.rb line 62 for an example.

This depends on https://github.com/theforeman/foreman/pull/2922 , both
PRs should be merged at the same time. See the failures in that jenkins job for that PR happen on Katello because this attribute accessible is missing.