### PR TITLE
fixes #12553 - Organizations : fix api docs for 'resource' vs 'organization'

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -16,7 +16,7 @@ module Katello
     end
 
     def_param_group :resource do
-      param :resource, Hash, :required => true, :action_aware => true do
+      param :organization, Hash, :required => true, :action_aware => true do
         param :name, String, :required => true
         param :description, String, :required => false
         param :user_ids, Array, N_("User IDs"), :required => false


### PR DESCRIPTION
The current organization api controller is creating a set of params for 'resource'. It should be 'organization'.

E.g.

resource
resource[name]
resource[description]
...

versus:

organization
organization[name]
organization[description]
...