### PR TITLE
Fixes #12552 - Update url helper spec to be 1.9.x and 2.0+ compatible

### DIFF
--- a/app/helpers/katello/katello_url_helper.rb
+++ b/app/helpers/katello/katello_url_helper.rb
@@ -18,7 +18,8 @@ module Katello
     private
 
     def valid_for_prefixes(url, prefixes)
-      prefixes.include?(URI.parse(url).scheme)
+      return false unless (scheme = URI.parse(url).scheme).present?
+      prefixes.include?(scheme.downcase)
     rescue URI::InvalidURIError
       return false
     end

--- a/spec/helpers/katello_url_helper_spec.rb
+++ b/spec/helpers/katello_url_helper_spec.rb
@@ -5,7 +5,7 @@ module Katello
     describe "Valid https? Urls" do
       it "should validate clean http urls" do
         kurl_valid?('http://www.hugheshoney.com').must_equal(true)
-        kurl_valid?('HTtp://www.hugheshoney.com').must_equal(false)
+        kurl_valid?('HTtp://www.hugheshoney.com').must_equal(true)
         kurl_valid?('http://www.hugheshoney.com:8888').must_equal(true)
         kurl_valid?('http://www.hugheshoney.com:8888/homepage/index.html').must_equal(true)
         kurl_valid?('http://9seng.cz/katello').must_equal(true)
@@ -29,7 +29,7 @@ module Katello
       end
       it "should validate clean ftp urls" do
         kurl_valid?('ftp://65.190.152.28').must_equal(true)
-        kurl_valid?('Ftp://65.190.152.28').must_equal(false)
+        kurl_valid?('Ftp://65.190.152.28').must_equal(true)
         kurl_valid?('ftp://65.190.152.28/fedora/x86_64').must_equal(true)
         kurl_valid?('ftp://ftp.fedorahosted.org/rpms/index.html').must_equal(true)
       end
@@ -47,7 +47,7 @@ module Katello
       it "should validate file urls with multiple slashes" do
         file_prefix?('file://///opt/repo').must_equal(true)
         kurl_valid?('file://///opt/').must_equal(true)
-        kurl_valid?('File://///opt/').must_equal(false)
+        kurl_valid?('File://///opt/').must_equal(true)
         file_prefix?('/////opt/repo').must_equal(false)
         kurl_valid?('/////opt/repo').must_equal(false)
       end


### PR DESCRIPTION
Adapting the test to support the URI class diferences between versions
- 1.9.x URI class is case-sensitive
- 2.0+ URI class is not case-sensitive