### PR TITLE
Fixes #12564 - URI does not downcase scheme in Rails 4

### DIFF
--- a/app/helpers/katello/katello_url_helper.rb
+++ b/app/helpers/katello/katello_url_helper.rb
@@ -18,7 +18,8 @@ module Katello
     private
 
     def valid_for_prefixes(url, prefixes)
-      prefixes.include?(URI.parse(url).scheme)
+      return false unless (scheme = URI.parse(url).scheme).present?
+      prefixes.include?(scheme.downcase)
     rescue URI::InvalidURIError
       return false
     end


### PR DESCRIPTION
Tests on spec/helpers/katello_url_helper_spec.rb fail on Rails 4,
because URI.parse(url).scheme will return scheme without
downcasing it. We can add a fix for this helper in a
backwards-compatible manner.