### PR TITLE
Fixes #12537 - Marketing Products shown in the database on manifest i…

### DIFF
--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -264,13 +264,8 @@ module Katello
 
           product_in_katello_ids.concat(adjusted_eng_products.map { |p| p["id"] })
 
-          unless product_in_katello_ids.include?(marketing_product_id)
-            Glue::Candlepin::Product.import_from_cp(Resources::Candlepin::Product.get(marketing_product_id)[0]) do |p|
-              p.provider = self
-              p.organization_id = self.organization.id
-            end
-            product_in_katello_ids << marketing_product_id
-          end
+          marketing_product = Katello::Product.find_by_cp_id(marketing_product_id)
+          marketing_product.destroy if marketing_product
         end
 
         product_to_remove_ids = (product_in_katello_ids - products_in_candlepin_ids).uniq


### PR DESCRIPTION
…mport

Marketing Products no longer need to be stored in katello_products because they are stored in katello_subscriptions.