### PR TITLE
Fixes #12622 - undefined method candlepin_consumer_info for <Katello::System>

### DIFF
--- a/lib/katello/tasks/reindex.rake
+++ b/lib/katello/tasks/reindex.rake
@@ -72,10 +72,7 @@ namespace :katello do
           notes = []
           facts = fetch_resource { object.pulp_facts }
           notes << "Pulp Consumer #{object.uuid} was not found." if facts.nil?
-          candlepin_consumer_info = nil
-          if object.respond_to? :candlepin_consumer_info
-            candlepin_consumer_info = fetch_resource { object.candlepin_consumer_info }
-          end
+          candlepin_consumer_info = fetch_resource { Katello::Resources::Candlepin::Consumer.get(object.uuid) } 
           notes << "Candlepin Consumer was not available for #{object.name}." if candlepin_consumer_info.nil?
           notes << "Foreman Host was not available for #{object.name}." if object.foreman_host.nil?
 

--- a/lib/katello/tasks/reindex.rake
+++ b/lib/katello/tasks/reindex.rake
@@ -72,7 +72,10 @@ namespace :katello do
           notes = []
           facts = fetch_resource { object.pulp_facts }
           notes << "Pulp Consumer #{object.uuid} was not found." if facts.nil?
-          candlepin_consumer_info = fetch_resource { object.candlepin_consumer_info }
+          candlepin_consumer_info = nil
+          if object.respond_to? :candlepin_consumer_info
+            candlepin_consumer_info = fetch_resource { object.candlepin_consumer_info }
+          end
           notes << "Candlepin Consumer was not available for #{object.name}." if candlepin_consumer_info.nil?
           notes << "Foreman Host was not available for #{object.name}." if object.foreman_host.nil?
 

--- a/test/lib/tasks/reindex_test.rb
+++ b/test/lib/tasks/reindex_test.rb
@@ -18,12 +18,12 @@ module Katello
     end
 
     describe 'Report Bad Objects' do
-      test "runs and acknowledges messages when candlepin return empty response for given uuid" do
+      test 'runs and acknowledges messages when candlepin return empty response for given uuid' do
         Katello::Resources::Candlepin::Consumer.expects(:get).with(system.uuid).returns(nil)
         @reindex_helper.report_bad_objects([[system, @exception]], Katello::System)
       end
 
-     test "runs and doesn't print any message when candlepin return valid response for given system uuid" do
+      test 'runs and should not print any message when candlepin return valid response for given system uuid' do
         Katello::Resources::Candlepin::Consumer.expects(:get).with(system.uuid).returns(true)
         @reindex_helper.report_bad_objects([[system, @exception]], Katello::System)
       end

--- a/test/lib/tasks/reindex_test.rb
+++ b/test/lib/tasks/reindex_test.rb
@@ -1,0 +1,32 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class ReindexHelperTest < ActiveSupport::TestCase
+    let(:system) { katello_systems(:simple_server) }
+
+    setup do
+      Rake.application.rake_require 'katello/tasks/reindex'
+      @exception = StandardError.new('Custom Error Message')
+      @exception.set_backtrace('Backtrace')
+      system.stubs(:pulp_facts).returns('some_facts')
+      @reindex_helper = ReindexHelper.new
+    end
+
+    def teardown
+      system.destroy
+    end
+
+    describe 'Report Bad Objects' do
+      test "runs and acknowledges messages when candlepin return empty response for given uuid" do
+        Katello::Resources::Candlepin::Consumer.expects(:get).with(system.uuid).returns(nil)
+        @reindex_helper.report_bad_objects([[system, @exception]], Katello::System)
+      end
+
+     test "runs and doesn't print any message when candlepin return valid response for given system uuid" do
+        Katello::Resources::Candlepin::Consumer.expects(:get).with(system.uuid).returns(true)
+        @reindex_helper.report_bad_objects([[system, @exception]], Katello::System)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In certain cases rake tasks # foreman-rake katello:reindex throws exception 
```
Re-indexing Katello::System
The following Katello::System items could not be indexed due to various reasons.
Please check /usr/share/foreman/log/reindex.log for more detailed information.
Object: #<Katello::System id: 21, uuid: nil, name: "katello.example.com", description: "Initial Registration Params", location: "None", environment_id: 11, created_at: "2015-07-06 14:31:41", updated_at: "2015-07-06 14:31:41", type: "Katello::System", content_view_id: 12, host_id: nil>
rake aborted!
undefined method `candlepin_consumer_info' for #<Katello::System:0x0000000d4361d0>
```