### PR TITLE
fix BZ1286523

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -73,8 +73,8 @@ module Katello
 
     def self.for_version(version)
       major, minor = version.to_s.split('.')
-      query = where(:major => major)
-      query.where(:minor => minor) if minor
+      minor = 0 if minor.nil?
+      query = where(:major => major, :minor => minor)
       query
     end
 


### PR DESCRIPTION
I have a content-view 'iam' with 2 versions (2.0 and 2.1)

```bash
# hammer content-view list --organization rhit
----------------|------|-------|-----------|-----------------
CONTENT VIEW ID | NAME | LABEL | COMPOSITE | REPOSITORY IDS
----------------|------|-------|-----------|-----------------
10              | iam  | iam   |           | 9, 6, 5, 1, 2, 7

# hammer content-view version list
---|---------|---------|-------------------------
ID | NAME    | VERSION | LIFECYCLE ENVIRONMENTS
---|---------|---------|-------------------------
16 | iam 2.1 | 2.1     | qa
14 | iam 2.0 | 2.0     | Library
```

When I try to promote v2.1 to stage via hammer, I got this error consistently
```bash
# hammer content-view version promote --content-view-id 10 --to-lifecycle-environment stage --version='2.1' --organization rhit
Could not promote the content view:
  Error: content_view_version found more than once
```

I tracked the issue down to this file
```
/opt/rh/ruby193/root/usr/share/gems/gems/katello-2.2.0.76/app/models/katello/content_view_version.rb
```
```ruby
    def self.for_version(version)
      major, minor = version.to_s.split('.')
      query = where(:major => major)
      query.where(:minor => minor) if minor <--- #1
Rails.logger.debug '!!DEBUG!!'
Rails.logger.debug version.to_s
Rails.logger.debug minor.to_s
Rails.logger.debug query.to_sql
      query
    end
```

```
-- log --
2015-11-30 06:26:46 [D] !!DEBUG!!
2015-11-30 06:26:46 [D] 2.1
2015-11-30 06:26:46 [D] 1
2015-11-30 06:26:46 [D] SELECT "katello_content_view_versions".* FROM "katello_content_view_versions" INNER JOIN "katello_content_views" ON "katello_content_views"."id" = "katello_content_view_versions"."content_view_id" WHERE "katello_content_views"."id" IN (1, 4, 8, 3, 7, 6, 10) AND "katello_content_view_versions"."content_view_id" = 10 AND "katello_content_view_versions"."major" = 2
-- log --
```

Variable 'version' and 'minor' is getting the right figure, but somehow clause #1 does absolutely nothing, as **"minor" = 1** does not appears in the query.

This bug is visible in Satellite 6.1.4 (katello-2.2), might affect the latest katello as well. 

Bugzilla 1286523 is created (https://bugzilla.redhat.com/show_bug.cgi?id=1286523)