### PR TITLE
Refs #10970 - Rails 4 fixes viewing list/remove subscription tab

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -45,7 +45,7 @@ module Katello
     param :id, :number, :desc => N_("Subscription identifier"), :required => true
     def show
       @resource = Katello::Pool.with_identifier(params[:id])
-      respond(@resource)
+      respond(:resource => @resource)
     end
 
     def available

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -1,6 +1,9 @@
 module Katello
   class Pool < Katello::Model
     include Katello::Authorization::Pool
+
+    attr_accessor :quantity_attached
+
     belongs_to :subscription, :inverse_of => :pools, :class_name => "Katello::Subscription"
 
     has_many :activation_keys, :through => :pool_activation_keys, :class_name => "Katello::ActivationKey"

--- a/app/presenters/katello/activation_key_subscription_presenter.rb
+++ b/app/presenters/katello/activation_key_subscription_presenter.rb
@@ -4,7 +4,7 @@ module Katello
 
     def initialize(subscription)
       @subscription = Katello::Pool.find_by(:cp_id => subscription["id"])
-      @subscription["quantity_attached"] = subscription.try(:[], :amount)
+      @subscription.quantity_attached = subscription.try(:[], :amount)
     end
   end
 end

--- a/app/presenters/katello/system_subscription_presenter.rb
+++ b/app/presenters/katello/system_subscription_presenter.rb
@@ -4,7 +4,7 @@ module Katello
 
     def initialize(entitlement)
       @subscription = Katello::Pool.find_by(:cp_id => entitlement["pool"]["id"])
-      @subscription["quantity_attached"] = entitlement.try(:[], :quantity)
+      @subscription.quantity_attached = entitlement.try(:[], :quantity)
     end
   end
 end


### PR DESCRIPTION
Strong parameters was preventing quantity_attached from being added to a Pool/Subscription in rails 4.  Subscription details were not showing in the UI as well.