### PR TITLE
Fixes #12672 - Update katello url helper to be ruby 2.2.2 compat

### DIFF
--- a/app/helpers/katello/katello_url_helper.rb
+++ b/app/helpers/katello/katello_url_helper.rb
@@ -8,17 +8,23 @@ module Katello
     end
 
     def kurl_valid?(url)
-      valid_for_prefixes(url, PROTOCOLS)
+      validate_host(url) && validate_scheme(url, PROTOCOLS)
     end
 
     def file_prefix?(url)
-      valid_for_prefixes(url, [FILEPREFIX])
+      validate_scheme(url, [FILEPREFIX])
     end
 
     private
 
-    def valid_for_prefixes(url, prefixes)
-      return false unless (scheme = URI.parse(url).scheme).present?
+    def validate_host(url)
+      URI.parse(url).host.present?
+    rescue URI::InvalidURIError
+      return false
+    end
+
+    def validate_scheme(url, prefixes)
+      return false if (scheme = URI.parse(url).scheme).blank?
       prefixes.include?(scheme.downcase)
     rescue URI::InvalidURIError
       return false

--- a/spec/helpers/katello_url_helper_spec.rb
+++ b/spec/helpers/katello_url_helper_spec.rb
@@ -35,21 +35,18 @@ module Katello
       end
 
       it "should validate file urls" do
-        kurl_valid?('file://opt/repo').must_equal(true)
-        kurl_valid?('/opt/repo').must_equal(false)
-      end
-
-      it "should validate file urls" do
-        kurl_valid?('file://opt/repo-is-long/').must_equal(true)
-        kurl_valid?('/opt/repo-for-me').must_equal(false)
+        file_prefix?('file://opt/repo').must_equal(true)
+        file_prefix?('/opt/repo').must_equal(false)
+        file_prefix?('file://opt/repo-is-long/').must_equal(true)
+        file_prefix?('/opt/repo-for-me').must_equal(false)
       end
 
       it "should validate file urls with multiple slashes" do
         file_prefix?('file://///opt/repo').must_equal(true)
-        kurl_valid?('file://///opt/').must_equal(true)
-        kurl_valid?('File://///opt/').must_equal(true)
+        file_prefix?('file://///opt/').must_equal(true)
+        file_prefix?('File://///opt/').must_equal(true)
         file_prefix?('/////opt/repo').must_equal(false)
-        kurl_valid?('/////opt/repo').must_equal(false)
+        file_prefix?('/////opt/repo').must_equal(false)
       end
 
       it "should validate not fully qualified domain names" do


### PR DESCRIPTION
The URI parsing behavior of ruby 2.2.2 has changed from 2.0 and 2.1

A url without a host is considered invalid.
When parsing a url without a host in 2.0 and 2.1 an exception is
thrown, caught, and false is returned. This is the expected
behavior.

When parsing a url without a host in 2.2.2 no exception is thrown.
Updating the method to explicitly check for the presense of a host;
restoring the intended behavior.