### PR TITLE
Fixes #12689 - use time obj instead of datestamp on export action

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -141,18 +141,18 @@ module Katello
 
     api :POST, "/repositories/:id/export", N_("Export a repository")
     param :id, :identifier, :required => true, :desc => N_("repository ID")
-    param :since, Date, :desc => N_("Optional date of last export (ex: 2010-01-01T12:00:00), useful for exporting deltas. If not specified, a full export will occur."), :required => false
+    param :since, Date, :desc => N_("Optional date of last export (ex: 2010-01-01T12:00:00Z), useful for exporting deltas. If not specified, a full export will occur."), :required => false
     def export
       if params[:since].present?
         begin
-          params[:since].to_time
+          params[:since].to_datetime
         rescue
           raise HttpErrors::BadRequest, _("Invalid date provided.")
         end
       end
 
       task = async_task(::Actions::Katello::Repository::Export,
-                        @repository, params[:since])
+                        @repository, params[:since].try(:to_datetime))
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/repository/export.rb
+++ b/app/lib/actions/katello/repository/export.rb
@@ -15,7 +15,7 @@ module Actions
         def plan(repo, since = nil, export_suffix = 'repo_export')
           pulp_override_config = {'export_dir' => File.join(Setting['pulp_export_destination'],
                                                             export_suffix)}
-          pulp_override_config[:start_date] = since.to_time.iso8601 if since
+          pulp_override_config[:start_date] = since.iso8601 if since
 
           plan_action(Pulp::Repository::DistributorPublish,
                       pulp_id: repo.pulp_id,

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -305,11 +305,12 @@ module ::Actions::Katello::Repository
 
     it 'export with date' do
       action = create_action action_class
-      plan_action(action, repository, '20100101T00:00:00')
+      # we expect the TZ designation to get converted to an offset
+      plan_action(action, repository, '20100101T00:00:00Z'.to_datetime)
       assert_action_planed_with(action, ::Actions::Pulp::Repository::DistributorPublish,
                                 pulp_id: repository.pulp_id,
                                 distributor_type_id: 'export_distributor',
-                                override_config: {"export_dir" => "/tmp/katello-repo-exports/repo_export", :start_date => "2010-01-01T00:00:00Z"})
+                                override_config: {"export_dir" => "/tmp/katello-repo-exports/repo_export", :start_date => "2010-01-01T00:00:00+00:00"})
     end
 
     it 'export with export suffix' do


### PR DESCRIPTION
Previously, the "since" date for repo export was a timestamp. This caused TZ
issues due to what appears to be a behavior difference in Rails 4.

Instead, use a time object when calling the export action. This way the TZ is
unambiguous. Note that this patch does not alter the actual API, just the way
the action is invoked.