### PR TITLE
fixes #12651 - update repo content to enable cli to support filtering by org

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -4,6 +4,7 @@ module Katello
     include Katello::Concerns::Api::V2::RepositoryContentController
 
     api :GET, "/errata", N_("List errata")
+    param :organization_id, :number, :desc => N_("organization identifier")
     param :content_view_version_id, :identifier, :desc => N_("content view version identifier")
     param :content_view_filter_id, :identifier, :desc => N_("content view filter identifier")
     param :repository_id, :number, :desc => N_("repository identifier")

--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -3,11 +3,6 @@ module Katello
     apipie_concern_subst(:a_resource => N_("a package group"), :resource => "package_groups")
     include Katello::Concerns::Api::V2::RepositoryContentController
 
-    api :GET, "package_groups/:id", N_("show package groups by id")
-    def index
-      super
-    end
-
     def available_for_content_view_filter(filter, collection)
       collection_ids = []
       current_ids = filter.package_group_rules.map(&:uuid)

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -5,15 +5,6 @@ module Katello
 
     before_filter :find_repositories, :only => :auto_complete_name
 
-    api :GET, "/packages", N_("List packages")
-    api :GET, "/repositories/:repository_id/packages", N_("List packages")
-    param :content_view_version_id, :identifier, :desc => N_("content view version identifier")
-    param :repository_id, :number, :desc => N_("repository identifier")
-    param_group :search, Api::V2::ApiController
-    def index
-      super
-    end
-
     def auto_complete_name
       page_size = Katello::Concerns::FilteredAutoCompleteSearch::PAGE_SIZE
       rpms = Rpm.in_repositories(@repositories)

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -20,6 +20,7 @@ module Katello
       api :GET, "/content_views/:content_view_id/filters/:filter_id/:resource_id", N_("List :resource_id")
       api :GET, "/content_view_filters/:content_view_filter_id/:resource_id", N_("List :resource_id")
       api :GET, "/repositories/:repository_id/:resource_id", N_("List :resource_id")
+      param :organization_id, :number, :desc => N_("organization identifier")
       param :content_view_version_id, :identifier, :desc => N_("content view version identifier")
       param :content_view_filter_id, :identifier, :desc => N_("content view filter identifier")
       param :repository_id, :number, :desc => N_("repository identifier")


### PR DESCRIPTION
This commit is primarily to address a behavior observed with the hammer-cli-katello
where the 'list' commands for puppet-module, package, package group and erratum
could not be filtered by organization.  As a result, all results would be returned
regardless of organization input.

E.g. this change will fix scenarios such as the following:

    puppet-module list --organization-id 1
    package list --organization-id 1
    package-group list --organization-id 1
    erratum list --organization-id 1