### PR TITLE
Refs #10970 - Rails4 Substitute find_or_create_by with first_or_create

### DIFF
--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -39,7 +39,7 @@ module Katello
       def import_all(uuids = nil, additive = false)
         all_items = uuids ? content_unit_class.fetch_by_uuids(uuids) : content_unit_class.fetch_all
         all_items.each do |item_json|
-          item = self.find_or_create_by(:uuid => item_json['_id'])
+          item = self.where(:uuid => item_json['_id']).first_or_create
           item.update_from_json(item_json)
         end
         update_repository_associations(all_items, additive)

--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -16,7 +16,7 @@ module Katello
       def import_candlepin_ids(organization)
         candlepin_ids = self.get_candlepin_ids(organization)
         candlepin_ids.each do |cp_id|
-          self.find_or_create_by(:cp_id => cp_id) unless cp_id.nil?
+          self.where(:cp_id => cp_id).first_or_create unless cp_id.nil?
         end
       end
 

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -32,7 +32,7 @@ module Katello
       end
 
       def import_pool(cp_pool_id)
-        pool = Katello::Pool.find_or_create_by(:cp_id => cp_pool_id)
+        pool = Katello::Pool.where(:cp_id => cp_pool_id).first_or_create
         pool.import_data
       end
     end
@@ -129,7 +129,7 @@ module Katello
         end
         related_keys = ::Katello::ActivationKey.where(:cp_id => activation_key_ids.compact)
         related_keys.each do |key|
-          Katello::PoolActivationKey.find_or_create_by(:activation_key_id => key.id, :pool_id => self.id)
+          Katello::PoolActivationKey.where(:activation_key_id => key.id, :pool_id => self.id).first_or_create
         end
       end
 

--- a/app/models/katello/glue/candlepin/subscription.rb
+++ b/app/models/katello/glue/candlepin/subscription.rb
@@ -49,7 +49,7 @@ module Katello
         cp_product_ids.each do |cp_id|
           product = ::Katello::Product.where(:cp_id => cp_id)
           if product.any?
-            ::Katello::SubscriptionProduct.find_or_create_by(:subscription_id => self.id, :product_id => product.first.id)
+            ::Katello::SubscriptionProduct.where(:subscription_id => self.id, :product_id => product.first.id).first_or_create
           end
         end
       end

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -292,7 +292,7 @@ module Katello
         if self.content_view.default? || force
           errata_json.each do |erratum_json|
             begin
-              erratum = Erratum.find_or_create_by(:uuid => erratum_json['_id'])
+              erratum = Erratum.where(:uuid => erratum_json['_id']).first_or_create
             rescue ActiveRecord::RecordNotUnique
               retry
             end
@@ -307,7 +307,7 @@ module Katello
         if self.content_view.default? || force
           rpms_json.each do |rpm_json|
             begin
-              rpm = Rpm.find_or_create_by(:uuid => rpm_json['_id'])
+              rpm = Rpm.where(:uuid => rpm_json['_id']).first_or_create
             rescue ActiveRecord::RecordNotUnique
               retry
             end
@@ -321,7 +321,7 @@ module Katello
         if self.content_view.default? || force
           puppet_modules_json.each do |puppet_module_json|
             begin
-              puppet_module = Katello::PuppetModule.find_or_create_by(:uuid => puppet_module_json['_id'])
+              puppet_module = Katello::PuppetModule.where(:uuid => puppet_module_json['_id']).first_or_create
             rescue ActiveRecord::RecordNotUnique
               retry
             end
@@ -355,7 +355,7 @@ module Katello
       def index_db_package_groups
         package_group_json.each do |pg_json|
           begin
-            package_group = Katello::PackageGroup.find_or_create_by(:uuid => pg_json['_id'])
+            package_group = Katello::PackageGroup.where(:uuid => pg_json['_id']).first_or_create
           rescue ActiveRecord::RecordNotUnique
             retry
           end
@@ -382,7 +382,7 @@ module Katello
         docker_tags.destroy_all
 
         docker_images_json.each do |image_json|
-          image = DockerImage.find_or_create_by(:uuid => image_json[:_id])
+          image = DockerImage.where(:uuid => image_json[:_id]).first_or_create
           image.update_from_json(image_json)
           create_docker_tags(image, image_json[:tags])
         end
@@ -411,7 +411,7 @@ module Katello
         return if tags.empty?
 
         tags.each do |tag|
-          DockerTag.find_or_create_by(:repository_id => id, :docker_image_id => image.id, :name => tag)
+          DockerTag.where(:repository_id => id, :docker_image_id => image.id, :name => tag).first_or_create
         end
       end
 

--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -3,7 +3,7 @@ module Katello
     def architecture
       name = facts['lscpu.architecture']
       name = "x86_64" if name == "amd64"
-      Architecture.find_or_create_by(:name => name) unless name.blank?
+      Architecture.where(:name => name).first_or_create unless name.blank?
     end
 
     def model
@@ -12,7 +12,7 @@ module Katello
       else
         name = facts['dmi::system::product_name']
       end
-      ::Model.find_or_create_by(:name => name.strip) unless name.blank?
+      ::Model.where(:name => name.strip).first_or_create unless name.blank?
     end
 
     #reqiured to be defined, even if they return nil

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,7 @@ end
  {:name => "Katello Kickstart Default Finish",    :source => "finish-katello.erb",         :template_kind => kinds[:finish]},
  {:name => "subscription_manager_registration",   :source => "snippets/_subscription_manager_registration.erb", :snippet => true}].each do |template|
   template[:template] = File.read(File.join(Katello::Engine.root, "app/views/foreman/unattended", template.delete(:source)))
-  ProvisioningTemplate.find_or_create_by(:name => template["name"]) do |pt|
+  ProvisioningTemplate.where(:name => template["name"]).first_or_create do |pt|
     pt.vendor = "Katello"
     pt.default = true
     pt.locked = true
@@ -61,7 +61,7 @@ ProvisioningTemplate.where(:default => true).each do |template|
 end
 
 # Proxy features
-feature = Feature.find_or_create_by(:name => 'Pulp')
+feature = Feature.where(:name => 'Pulp').first_or_create
 if feature.nil? || feature.errors.any?
   fail "Unable to create proxy feature: #{format_errors feature}"
 end
@@ -114,7 +114,7 @@ permissions = [
 ]
 
 permissions.each do |resource, permission|
-  Permission.find_or_create_by(:resource_type => resource, :name => permission)
+  Permission.where(:resource_type => resource, :name => permission).first_or_create
 end
 
 default_permissions = {
@@ -132,7 +132,7 @@ end
 Setting.find_by!(:name => "dynflow_enable_console").update_attributes!(:value => true) if Rails.env.development?
 
 ["Pulp", "Pulp Node"].each do |input|
-  f = Feature.find_or_create_by(:name => input)
+  f = Feature.where(:name => input).first_or_create
   fail "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
 end
 
@@ -161,9 +161,9 @@ notifications = [
 ]
 
 notifications.each do |notification|
-  ::MailNotification.find_or_create_by(:name => notification[:name],
-                                       :description => notification[:description],
-                                       :mailer => notification[:mailer],
-                                       :method => notification[:method],
-                                       :subscription_type => notification[:subscription_type])
+  ::MailNotification.where(:name => notification[:name],
+                           :description => notification[:description],
+                           :mailer => notification[:mailer],
+                           :method => notification[:method],
+                           :subscription_type => notification[:subscription_type]).first_or_create
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -15,11 +15,11 @@ module Katello
       as_admin do
         @organization = get_organization
 
-        # Organization.find_or_create_by_label!(:name=>ProductTestData::ORG_ID, :label => 'admin-org-37070')
+        # Organization.where(:name=>ProductTestData::ORG_ID, :label => 'admin-org-37070').first_or_create
         # ForemanTasks.trigger(::Actions::Katello::Organization::Create, @organization)
       end
 
-      @provider     = Provider.find_or_create_by!(:name => "customprovider", :organization => @organization, :provider_type => Provider::CUSTOM)
+      @provider     = Provider.where(:name => "customprovider", :organization => @organization, :provider_type => Provider::CUSTOM).first_or_create
       @cdn_mock = Resources::CDN::CdnResource.new("https://cdn.redhat.com", :ssl_client_cert => "456", :ssl_ca_file => "fake-ca.pem", :ssl_client_key => "123")
       @substitutor_mock = Util::CdnVarSubstitutor.new(@cdn_mock)
       @substitutor_mock.stubs(:precalculate).returns do |_paths|

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -31,7 +31,7 @@ module Katello
 
     def test_smart_proxy_ids_with_katello
       content_source = FactoryGirl.create(:smart_proxy,
-                                          :features => [Feature.find_or_create_by(:name => "Pulp Node")])
+                                          :features => [Feature.where(:name => "Pulp Node").first_or_create])
       @foreman_host.content_source = content_source
       assert @foreman_host.smart_proxy_ids.include?(@foreman_host.content_source_id)
     end


### PR DESCRIPTION
find_or_create_by with old hash style is deprected in rails 4, updating to use where(args).first_or_create