### PR TITLE
Refs #10970 - scope search adjustment for AR group clause

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -36,6 +36,7 @@ module Katello
       @resource_class ||= "Katello::#{resource_name.classify}".constantize
     end
 
+    # rubocop:disable MethodLength
     def scoped_search(query, default_sort_by, default_sort_order, options = {})
       resource = options[:resource_class] || resource_class
       includes = options.fetch(:includes, [])
@@ -44,8 +45,12 @@ module Katello
       total = query.count
       query = resource.search_for(*search_options).where("#{resource.table_name}.id" => query)
 
-      query = query.select(group).group(group) if group
-      sub_total = query.count
+      if group.present?
+        query = query.select(group).group(group)
+        sub_total = query.count.length
+      else
+        sub_total = query.count
+      end
 
       sort_attr = params[:sort_by] || default_sort_by
 


### PR DESCRIPTION
If count is used with a group clause, the return value is a hash
with keys representing the aggregate columns and values of the
respective amounts. This is not the value we are expecting when
calculating the sub_total of a query. Adjusting the sub_total
calculation to handle both group and non-group query counts.

http://apidock.com/rails/v4.1.8/ActiveRecord/Calculations/count