### PR TITLE
Fixes #12673 - Errata Date filter using Updated vs Issued

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -28,6 +28,7 @@ module Katello
     param :start_date, String, :desc => N_("erratum: start date (YYYY-MM-DD)")
     param :end_date, String, :desc => N_("erratum: end date (YYYY-MM-DD)")
     param :types, Array, :desc => N_("erratum: types (enhancement, bugfix, security)")
+    param :date_type, String, :desc => N_("erratum: search using the 'Issued On' or 'Updated On' column of the errata. Values are 'issued'/'updated'")
     def create
       rule_clazz = ContentViewFilter.rule_class_for(@filter)
 
@@ -106,7 +107,7 @@ module Katello
 
       params.fetch(:content_view_filter_rule, {}).
             permit(:uuid, :name, :version, :min_version, :max_version,
-                    :errata_id, :start_date, :end_date,
+                    :errata_id, :start_date, :end_date, :date_type,
                     :types => [], :errata_ids => [])
     end
 

--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -21,8 +21,15 @@ module Katello
       collection = filter_by_content_view(filter, collection)
       ids = Katello::ContentViewErratumFilterRule.where(:content_view_filter_id => filter.id).pluck("errata_id")
       collection = collection.where("errata_id not in (?)", ids) unless ids.empty?
-      collection = collection.where('issued  >= ?', params[:start_date]) if params[:start_date]
-      collection = collection.where('issued  <= ?', params[:end_date]) if params[:end_date]
+
+      date_type = params[:date_type].present? ? params[:date_type] : ContentViewErratumFilterRule::UPDATED
+      unless ContentViewErratumFilterRule::DATE_TYPES.include?(date_type)
+        msg = _("Invalid params provided - date_type must be one of %s" % ContentViewErratumFilterRule::DATE_TYPES.join(","))
+        fail HttpErrors::UnprocessableEntity, msg
+      end
+
+      collection = collection.where("#{date_type} >= ?", params[:start_date]) if params[:start_date]
+      collection = collection.where("#{date_type} <= ?", params[:end_date]) if params[:end_date]
       collection = collection.of_type(params[:types]) if params[:types]
       collection
     end

--- a/app/lib/katello/util/package_clause_generator.rb
+++ b/app/lib/katello/util/package_clause_generator.rb
@@ -52,7 +52,7 @@ module Katello
       # output -> {"filename" => {"$in" => {"foo.el6.noarch", "..."}}} <- Packages belonging to those errata
       def package_clauses_for_errata(errata_clauses = [])
         errata_clauses = {"$or" => errata_clauses}
-        pkg_filenames = Katello::Erratum.list_filenames_by_clauses(errata_clauses)
+        pkg_filenames = Katello::Erratum.list_filenames_by_clauses(@repo, errata_clauses)
         {'filename' => {"$in" => pkg_filenames}} unless pkg_filenames.empty?
       end
 

--- a/app/models/katello/content_view_erratum_filter.rb
+++ b/app/models/katello/content_view_erratum_filter.rb
@@ -28,7 +28,7 @@ module Katello
           date_range = {}
           date_range["$gte"] = start_date.to_time.as_json unless start_date.blank?
           date_range["$lte"] = end_date.to_time.as_json unless end_date.blank?
-          rule_clauses << { "issued" => date_range }
+          rule_clauses << { erratum_rules.first.pulp_date_type => date_range }
         end
         unless types.blank?
           # {"type": {"$in": ["security", "enhancement", "bugfix"]}

--- a/app/models/katello/content_view_erratum_filter_rule.rb
+++ b/app/models/katello/content_view_erratum_filter_rule.rb
@@ -2,6 +2,10 @@ module Katello
   class ContentViewErratumFilterRule < Katello::Model
     self.include_root_in_json = false
 
+    ISSUED = "issued"
+    UPDATED = "updated"
+    DATE_TYPES = [ISSUED, UPDATED]
+
     belongs_to :filter,
                :class_name => "Katello::ContentViewErratumFilter",
                :inverse_of => :erratum_rules,
@@ -13,8 +17,20 @@ module Katello
     validates :errata_id, :uniqueness => { :scope => :content_view_filter_id }, :allow_blank => true
     validates_with Validators::ContentViewErratumFilterRuleValidator
 
+    validates :date_type,
+      :if => proc { |o| o.start_date || o.end_date },
+      :inclusion => {
+        :in => DATE_TYPES,
+        :allow_blank => false,
+        :message => (_("must be one of the following: %s") % DATE_TYPES.join(', '))
+      }
+
     def filter_has_date_or_type_rule?
       filter.erratum_rules.any? { |rule| rule.start_date || rule.end_date || !rule.types.blank? }
+    end
+
+    def pulp_date_type
+      self.date_type == ISSUED ? "issued" : "updated"
     end
   end
 end

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -93,9 +93,11 @@ module Katello
       update_packages(json['pkglist']) unless json['pkglist'].blank?
     end
 
-    def self.list_filenames_by_clauses(clauses)
+    def self.list_filenames_by_clauses(repo, clauses)
       errata = Katello.pulp_server.extensions.errata.search(Katello::Erratum::CONTENT_TYPE, :filters => clauses)
-      Katello::ErratumPackage.joins(:erratum).where("#{Erratum.table_name}.uuid" => errata.map { |e| e['_id'] }).pluck(:filename)
+      Katello::ErratumPackage.joins(:erratum => :repository_errata).
+          where("#{RepositoryErratum.table_name}.repository_id" => repo.id,
+                "#{Erratum.table_name}.uuid" => errata.map { |e| e['_id'] }).pluck(:filename)
     end
 
     private

--- a/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
@@ -12,5 +12,6 @@ attributes :errata_id, :if => lambda { |rule| rule.respond_to?(:errata_id) && !r
 attributes :start_date, :if => lambda { |rule| rule.respond_to?(:start_date) && !rule.start_date.blank? }
 attributes :end_date, :if => lambda { |rule| rule.respond_to?(:end_date) && !rule.end_date.blank? }
 attributes :types, :if => lambda { |rule| rule.respond_to?(:types) && !rule.types.blank? }
+attributes :date_type, :if => lambda { |rule| rule.respond_to?(:date_type) }
 
 extends 'katello/api/v2/common/timestamps'

--- a/db/migrate/20151203230940_add_date_type_to_content_view_erratum_filter_rules.rb
+++ b/db/migrate/20151203230940_add_date_type_to_content_view_erratum_filter_rules.rb
@@ -1,0 +1,6 @@
+class AddDateTypeToContentViewErratumFilterRules < ActiveRecord::Migration
+  def change
+    add_column :katello_content_view_erratum_filter_rules, :date_type, :string, :default => "updated", :null => false
+    update "UPDATE katello_content_view_erratum_filter_rules SET date_type = 'issued'"
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
@@ -83,6 +83,12 @@ angular.module('Bastion.content-views').controller('AvailableErrataFilterControl
             nutupane.refresh();
         };
 
+        $scope.updateDateType = function () {
+            nutupane.addParam("sort_by", $scope.rule["date_type"] );
+            nutupane.addParam("date_type", $scope.rule["date_type"]);
+            nutupane.refresh();
+        };
+
         $scope.$watch('rule.start_date', function (start) {
             if (start) {
                 filterByDate(start, 'start_date');

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/date-type-errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/date-type-errata-filter.controller.js
@@ -35,6 +35,10 @@ angular.module('Bastion.content-views').controller('DateTypeErrataFilterControll
                     $scope.types[type] = true;
                 }
             });
+
+            if (angular.isUndefined($scope.rule['date_type'])) {
+                $scope.rule['date_type'] = "updated";
+            }
         });
 
         $scope.updateTypes = function (types) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/errata-filter.controller.js
@@ -16,7 +16,8 @@ angular.module('Bastion.content-views').controller('ErrataFilterController',
         $scope.rule = {
             errataType: 'all',
             'start_date': null,
-            'end_date': null
+            'end_date': null,
+            'date_type': "updated"
         };
 
         $scope.date = {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/date-type-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/date-type-errata.html
@@ -33,6 +33,22 @@
   </label>
 
 </div>
+<div bst-form-group label="{{ 'Date Type' | translate }}">
+  <label class="radio-inline">
+    <input type="radio"
+           ng-model="rule.date_type"
+           ng-change="updateDateType()"
+           value="updated"/>
+    <span translate>Updated On</span>
+  </label>
+  <label class="radio-inline">
+    <input type="radio"
+           ng-model="rule.date_type"
+           ng-change="updateDateType()"
+           value="issued"/>
+    <span translate>Issued On</span>
+  </label>
+</div>
 
 <div bst-form-group label="{{ 'Start Date' | translate }}">
   <div class="input-group">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
@@ -31,6 +31,7 @@
         <th bst-table-column translate>Errata ID</th>
         <th bst-table-column translate>Errata Type</th>
         <th bst-table-column translate>Issued</th>
+        <th bst-table-column translate>Updated</th>
         <th bst-table-column translate>Title</th>
       </tr>
     </thead>
@@ -43,6 +44,9 @@
         </td>
         <td bst-table-cell>
           {{ errata.issued | date:'M/d/yy' }}
+        </td>
+        <td bst-table-cell>
+          {{ errata.updated | date:'M/d/yy' }}
         </td>
         <td bst-table-cell>{{ errata.title }}</td>
       </tr>

--- a/engines/bastion_katello/test/content-views/details/filters/available-errata-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/available-errata-filter.controller.test.js
@@ -87,4 +87,24 @@ describe('Controller: AvailableErrataFilterController', function() {
         expect($scope.nutupane.getParam('end_date')).toBe(date.toISOString().split('T')[0]);
     });
 
+    it("should update the errata by when asked to search on the updated date", function () {
+        spyOn($scope.nutupane, 'refresh');
+        $scope.rule['date_type'] = "updated" ;
+        $scope.updateDateType();
+
+        expect($scope.nutupane.refresh).toHaveBeenCalled();
+        expect($scope.nutupane.getParam('sort_by')).toBe("updated");
+        expect($scope.nutupane.getParam('date_type')).toBe("updated");
+    });
+
+    it("should update the errata by when asked to search on the issued date", function () {
+        spyOn($scope.nutupane, 'refresh');
+        $scope.rule['date_type'] = "issued" ;
+        $scope.updateDateType();
+
+        expect($scope.nutupane.refresh).toHaveBeenCalled();
+        expect($scope.nutupane.getParam('sort_by')).toBe("issued");
+        expect($scope.nutupane.getParam('date_type')).toBe("issued");
+    });
+
 });

--- a/test/controllers/api/v2/errata_controller_test.rb
+++ b/test/controllers/api/v2/errata_controller_test.rb
@@ -78,7 +78,19 @@ module Katello
       response_ids = body["results"].map { |item| item["errata_id"] }
 
       assert_response :success
-      assert !(response_ids.include? filtered_id)
+      refute response_ids.include? filtered_id
+      assert response_ids.length > 0
+    end
+
+    def test_index_available_errata_for_content_view_filter_with_updated
+      filtered_id = @errata_filter.erratum_rules.first["errata_id"]
+
+      get :index, :filterId => @errata_filter, :available_for => "content_view_filter", :date_type => "updated"
+      body = JSON.parse(response.body)
+      response_ids = body["results"].map { |item| item["errata_id"] }
+
+      assert_response :success
+      refute response_ids.include? filtered_id
       assert response_ids.length > 0
     end
 

--- a/test/fixtures/models/katello_content_view_erratum_filter_rules.yml
+++ b/test/fixtures/models/katello_content_view_erratum_filter_rules.yml
@@ -3,3 +3,4 @@ erratum_rule:
   content_view_filter_id:  <%= ActiveRecord::Fixtures.identify(:populated_erratum_filter) %>
   created_at:              <%= Time.now %>
   updated_at:              <%= Time.now %>
+  date_type:               issued

--- a/test/lib/util/package_clause_generator_test.rb
+++ b/test/lib/util/package_clause_generator_test.rb
@@ -115,7 +115,7 @@ module Katello
       assert_errata_rules([foo_rule, goo_rule], expected_errata)
     end
 
-    def test_errata_dates
+    def test_errata_dates_default
       from = Date.today.to_s
       to = Date.today.to_s
 
@@ -123,8 +123,36 @@ module Katello
       foo_rule = FactoryGirl.create(:katello_content_view_erratum_filter_rule,
                                     :filter => @filter, :start_date => from, :end_date => to)
 
+      expected = [{"updated" => {"$gte" => from.to_time.as_json,
+                                 "$lte" => to.to_time.as_json}}]
+      assert_errata_rules([foo_rule], expected)
+    end
+
+    def test_errata_dates_issued
+      from = Date.today.to_s
+      to = Date.today.to_s
+
+      @filter = FactoryGirl.create(:katello_content_view_erratum_filter, :content_view => @content_view)
+      foo_rule = FactoryGirl.create(:katello_content_view_erratum_filter_rule,
+                                    :date_type => ContentViewErratumFilterRule::ISSUED,
+                                    :filter => @filter, :start_date => from, :end_date => to)
+
       expected = [{"issued" => {"$gte" => from.to_time.as_json,
                                 "$lte" => to.to_time.as_json}}]
+      assert_errata_rules([foo_rule], expected)
+    end
+
+    def test_errata_dates_updated
+      from = Date.today.to_s
+      to = Date.today.to_s
+
+      @filter = FactoryGirl.create(:katello_content_view_erratum_filter, :content_view => @content_view)
+      foo_rule = FactoryGirl.create(:katello_content_view_erratum_filter_rule,
+                                    :date_type => ContentViewErratumFilterRule::UPDATED,
+                                    :filter => @filter, :start_date => from, :end_date => to)
+
+      expected = [{"updated" => {"$gte" => from.to_time.as_json,
+                                 "$lte" => to.to_time.as_json}}]
       assert_errata_rules([foo_rule], expected)
     end
 
@@ -143,7 +171,7 @@ module Katello
 
       @filter = FactoryGirl.create(:katello_content_view_erratum_filter, :content_view => @content_view)
       foo_rule = FactoryGirl.create(:katello_content_view_erratum_filter_rule,
-                                    :filter => @filter, :start_date => from.to_s,
+                                    :filter => @filter, :start_date => from.to_s, :date_type => "issued",
                                     :end_date => to.to_s, :types => [:enhancement, :security])
 
       expected = [{"$and" => [{"issued" => {"$gte" => from.to_s.to_time.as_json,


### PR DESCRIPTION
Looking at an example erratum ->
https://rhn.redhat.com/errata/RHSA-2015-2355.html
we notice that some tend to have different "Updated On" vs "Issued On"
dates.

This commit adds functionality to let the user filter by using the
"Updated On" date field as opposed to "Issued On" date.

By default all filters (and existing filters) will filter by  "issued on" date to
keep consistency with prior functionality. But facilities have been
added at both UI/API to now change that.

Example usages at the hammer level, notice the new --use-issued-date
flag.

hammer content-view filter rule create --content-type=erratum
--start-date=... --end-date=.. --use-issued-date=yes

To rely on updated change the --used-issued-date to no

hammer content-view filter rule create --content-type=erratum
--start-date=... --end-date=.. --use-issued-date=no

UI has been changed accordingly in
1) Filter Errata By Id
2) Filter Errata By Date and Type pages