### PR TITLE
refs #10970 - explicitly describe rabl contents for ping

### DIFF
--- a/app/views/katello/api/v2/ping/show.json.rabl
+++ b/app/views/katello/api/v2/ping/show.json.rabl
@@ -2,5 +2,10 @@ object Katello::Util::Data.ostructize(@resource)
 
 attribute :status
 child :services => :services do
-  attributes :foreman_tasks, :foreman_auth, :candlepin, :candlepin_auth, :pulp, :pulp_auth
+  [:foreman_tasks, :foreman_auth, :candlepin, :candlepin_auth, :pulp, :pulp_auth].each do |service|
+    child service => service do
+      attribute :status
+      attribute :duration_ms
+    end
+  end
 end


### PR DESCRIPTION
In the Rails4 environment, `hammer ping` was receiving an incorrectly
formatted hash [1] after we switched to Rails4. This was causing Hammer
to throw a `IndexError (string not matched)` [2] error that was a result of the
openstruct strings that were getting returned in the hash.

[1]
```
{
    "status" => "ok",
    "services" => {
        "foreman_tasks" => "#<OpenStruct status=\"ok\", duration_ms=\"189\">",
        "candlepin" => "#<OpenStruct status=\"ok\", duration_ms=\"32\">",
        "candlepin_auth" => "#<OpenStruct status=\"ok\", duration_ms=\"32\">",
        "pulp" => "#<OpenStruct status=\"ok\", duration_ms=\"59\">",
        "pulp_auth" => "#<OpenStruct status=\"ok\", duration_ms=\"27\">"
    }
}
```

[2]
```
IndexError (string not matched):
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/ping.rb:57:in `[]='
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/ping.rb:57:in `block (2 levels) in send_request'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/ping.rb:56:in `each'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/ping.rb:56:in `block in send_request'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/ping.rb:55:in `tap'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/ping.rb:55:in `send_request'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/ping.rb:49:in `execute'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/gems/hammer_cli-0.4.0/lib/hammer_cli/abstract.rb:23:in `run'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/gems/hammer_cli-0.4.0/lib/hammer_cli/abstract.rb:23:in `run'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/gems/clamp-1.0.0/lib/clamp/command.rb:133:in `run'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/gems/hammer_cli-0.4.0/bin/hammer:125:in `<top (required)>'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/bin/hammer:23:in `load'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/bin/hammer:23:in `<main>'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/bin/ruby_executable_hooks:15:in `eval'
    /home/vagrant/.rvm/gems/ruby-2.2.2@hammer/bin/ruby_executable_hooks:15:in `<main>'
```