### PR TITLE
[DO NOT MERGE] Fixes #12758 - duplicate key in jenkins

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -119,6 +119,7 @@ class ActiveSupport::TestCase
 
   before do
     stub_ping
+    ActiveRecord::Base.connection.tables.each { |t| ActiveRecord::Base.connection.execute("SELECT setval(#{t}_id_seq, (SELECT MAX(id) FROM #{t} ))") rescue ActiveRecord::StatementInvalid }
   end
 
   def self.stubbed_ping_response


### PR DESCRIPTION
Testing resetting the primary keys in the database to see if that is the issue.