### PR TITLE
Fixes #12917 - can't update release version of content host

### DIFF
--- a/app/views/katello/api/v2/systems/base.json.rabl
+++ b/app/views/katello/api/v2/systems/base.json.rabl
@@ -6,10 +6,14 @@ node(:id) { |resource| resource.uuid }
 attributes :id => :katello_id
 attributes :uuid, :name, :description
 attributes :location
-attributes :content_view, :content_view_id
+attributes :content_view_id
 attributes :distribution
 attributes :katello_agent_installed? => :katello_agent_installed
 attributes :registered_by
+
+child :content_view => :content_view do
+  attributes :id, :name, :label
+end
 
 child :environment => :environment do
   extends 'katello/api/v2/environments/show'


### PR DESCRIPTION
Looks like the json is using ```[:content_view_id]``` instead of ```[:content_view][:id]```