### PR TITLE
Fixes #12925 - Reduced Repository Model size

### DIFF
--- a/app/models/katello/concerns/repository_types/docker_extensions.rb
+++ b/app/models/katello/concerns/repository_types/docker_extensions.rb
@@ -1,0 +1,86 @@
+module Katello
+  module Concerns
+    module RepositoryTypes
+      module DockerExtensions
+        extend ActiveSupport::Concern
+        DOCKER_TYPE = 'docker'
+
+        module ClassMethods
+          def clone_docker_repo_path(options)
+            repo = options[:repository]
+            org = repo.organization.label.downcase
+            if options[:environment]
+              cve = ContentViewEnvironment.where(:environment_id => options[:environment],
+                                                 :content_view_id => options[:content_view]).first
+              view = repo.content_view.label
+              product = repo.product.label
+              env, _ = cve.label.split('/')
+              "#{org}-#{env.downcase}-#{view}-#{product}-#{repo.label}"
+            else
+              content_path = repo.relative_path.gsub("#{org}-", '')
+              "#{org}-#{options[:content_view].label}-#{options[:version].version}-#{content_path}"
+            end
+          end
+        end
+
+        included do
+          before_create :downcase_pulp_id
+          has_many :repository_docker_images, :class_name => "Katello::RepositoryDockerImage", :dependent => :destroy
+          has_many :docker_images, :through => :repository_docker_images
+          has_many :docker_tags, :dependent => :destroy, :class_name => "Katello::DockerTag"
+
+          validates :docker_upstream_name, :allow_blank => true, :if => :docker?, :format => {
+            :with => /\A([a-z0-9\-_]{4,30}\/)?[a-z0-9\-_\.]{3,30}\z/,
+            :message => (_("must be a valid docker name"))
+          }
+
+          validate :ensure_valid_docker_attributes, :if => :docker?
+          validate :ensure_docker_repo_unprotected, :if => :docker?
+
+          scope :docker_type, -> { where(:content_type => DOCKER_TYPE) }
+        end
+
+        def downcase_pulp_id
+          # Docker doesn't support uppercase letters in repository names.  Since the pulp_id
+          # is currently being used for the name, it will be downcased for this content type.
+          if self.content_type == Repository::DOCKER_TYPE
+            self.pulp_id = self.pulp_id.downcase
+          end
+        end
+
+        def container_repository_name
+          pulp_id if docker?
+        end
+
+        def ensure_valid_docker_attributes
+          if url.blank? != docker_upstream_name.blank?
+            field = url.blank? ? :url : :docker_upstream_name
+            errors.add(field, N_("cannot be blank. Either provide all or no sync information."))
+            errors.add(:base, N_("Repository URL or Upstream Name is empty. Both are required for syncing from the upstream."))
+          end
+        end
+
+        def ensure_docker_repo_unprotected
+          unless unprotected
+            errors.add(:base, N_("Docker Repositories are not protected at this time. " \
+                                 "They need to be published via http to be available to containers."))
+          end
+        end
+
+        def docker?
+          content_type == DOCKER_TYPE
+        end
+
+        def remove_docker_content(images)
+          self.docker_tags.where(:docker_image_id => images.map(&:id)).destroy_all
+          self.docker_images -= images
+
+          # destroy any orphan docker images
+          images.reload.each do |image|
+            image.destroy if image.repositories.empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/repository_types/puppet_extensions.rb
+++ b/app/models/katello/concerns/repository_types/puppet_extensions.rb
@@ -1,0 +1,33 @@
+module Katello
+  module Concerns
+    module RepositoryTypes
+      module PuppetExtensions
+        extend ActiveSupport::Concern
+        PUPPET_TYPE = 'puppet'
+        included do
+          has_many :repository_puppet_modules, :class_name => "Katello::RepositoryPuppetModule", :dependent => :destroy
+          has_many :puppet_modules, :through => :repository_puppet_modules
+
+          scope :puppet_type, -> { where(:content_type => PUPPET_TYPE) }
+          scope :non_puppet, -> { where("content_type != ?", PUPPET_TYPE) }
+        end
+
+        def puppet?
+          content_type == PUPPET_TYPE
+        end
+
+        def name_conflicts
+          if puppet?
+            modules = PuppetModule.search("*", :repoids => self.pulp_id,
+                                               :fields => [:name],
+                                               :page_size => self.puppet_modules.count)
+
+            modules.map(&:name).group_by(&:to_s).select { |_, v| v.size > 1 }.keys
+          else
+            []
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/repository_types/yum_extensions.rb
+++ b/app/models/katello/concerns/repository_types/yum_extensions.rb
@@ -1,0 +1,46 @@
+module Katello
+  module Concerns
+    module RepositoryTypes
+      module YumExtensions
+        extend ActiveSupport::Concern
+        YUM_TYPE = 'yum'
+
+        module ClassMethods
+          def with_errata(errata)
+            joins(:repository_errata).where("#{Katello::RepositoryErratum.table_name}.erratum_id" => errata)
+          end
+        end
+
+        included do
+          has_many :repository_errata, :class_name => "Katello::RepositoryErratum", :dependent => :destroy
+          has_many :errata, :through => :repository_errata
+
+          has_many :repository_rpms, :class_name => "Katello::RepositoryRpm", :dependent => :destroy
+          has_many :rpms, :through => :repository_rpms
+
+          has_many :repository_package_groups, :class_name => "Katello::RepositoryPackageGroup", :dependent => :destroy
+          has_many :package_groups, :through => :repository_package_groups
+
+          scope :yum_type, -> { where(:content_type => YUM_TYPE) }
+        end
+
+        def yum?
+          content_type == YUM_TYPE
+        end
+
+        def packages_without_errata
+          if errata_filenames.any?
+            self.rpms.where("#{Rpm.table_name}.filename NOT in (?)", errata_filenames)
+          else
+            self.rpms
+          end
+        end
+
+        def errata_filenames
+          Katello::ErratumPackage.joins(:erratum => :repository_errata).
+              where("#{RepositoryErratum.table_name}.repository_id" => self.id).pluck("#{ Katello::ErratumPackage.table_name}.filename")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moved content related functionality to individual modules




Repository model is close to breaking the max class length rubo cop limit.
According to our rubocop metrics, max length per class is 500 lines. Repository.rb is very close to crossing that.
https://github.com/Katello/katello/blob/master/app/models/katello/repository.rb

One approach is to split functionality to different modules and include it in the main model.

This commit attempts to address that.