### PR TITLE
Fixes #12984 - Can't remove activation keys

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -19,7 +19,7 @@ module Katello
     has_many :systems, :through => :system_activation_keys
 
     has_many :pools, :through => :pool_activation_keys, :class_name => "Katello::Pool"
-    has_many :pool_activation_keys, :class_name => "Katello::PoolActivationKey", :dependent => :destroy, :inverse_of => :activation_keys
+    has_many :pool_activation_keys, :class_name => "Katello::PoolActivationKey", :dependent => :destroy, :inverse_of => :activation_key
     has_many :subscription_facet_activation_keys, :class_name => "Katello::SubscriptionFacetActivationKey", :dependent => :destroy
     has_many :subscription_facets, :through => :subscription_facet_activation_keys
 

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -136,6 +136,10 @@ module Katello
       assert_template 'api/v2/common/async'
     end
 
+    def test_destroy_object
+      assert @activation_key.destroy
+    end
+
     def test_destroy_protected
       allowed_perms = [@destroy_permission]
       denied_perms = [@view_permission, @create_permission, @update_permission]


### PR DESCRIPTION
The inverse_of should be singular, making it the same as it is in [pool_activation_key.rb](https://github.com/Katello/katello/blob/master/app/models/katello/pool_activation_key.rb#L4)