### PR TITLE
Fixes #13096 - Add precompile assets to Katello engine 

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -66,6 +66,10 @@ module Katello
       SETTINGS[:katello] = {:assets => {:precompile => precompile } }
     end
 
+    initializer 'katello.assets.precompile', :after => 'katello.configure_assets' do |app|
+      app.config.assets.precompile += SETTINGS[:katello][:assets][:precompile]
+    end
+
     initializer "katello.apipie" do
       Apipie.configuration.checksum_path += ['/katello/api/']
       require 'katello/apipie/validators'


### PR DESCRIPTION
To avoid the option development.rb config.assets.raise_runtime_errors
raise errors on Katello because the bastion assets are not loaded, we
have to find them and add them to assets.precompile.
The Bastion engine contains this information so we can add these assets
in an initializer.