### PR TITLE
Refs #13096 - Remove configure_assets initializer from assets group

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -40,7 +40,7 @@ module Katello
       require_dependency File.expand_path('../../../app/models/setting/katello.rb', __FILE__) if (Setting.table_exists? rescue(false))
     end
 
-    initializer 'katello.configure_assets', :group => :assets do
+    initializer 'katello.configure_assets' do
       def find_assets(args = {})
         type = args.fetch(:type, nil)
         asset_dir = "#{Katello::Engine.root}/app/assets/#{type}/"


### PR DESCRIPTION
The assets group is no longer used in Rails 4, so it's not even running.

The initializer that precompiles assets relies on configure_assets, so
Katello will fail to precompile assets with  undefined method `[]' as
SETTINGS[:katello][:precompile][:assets] isn't set by the time it tries
to load them.