### PR TITLE
fixes #13057 - composite views: add option to restrict publish and promotion

### DIFF
--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -6,7 +6,7 @@ module Actions
 
         def plan(version, environment, is_force = false)
           action_subject(version.content_view)
-          version.check_ready_to_promote!
+          version.check_ready_to_promote!(environment)
 
           fail ::Katello::HttpErrors::BadRequest, _("Cannot promote environment out of sequence. Use force to bypass restriction.") if !is_force && !version.promotable?(environment)
 

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -247,8 +247,9 @@ module Katello
       PackageGroup.in_repositories(archived_repos).uniq
     end
 
-    def check_ready_to_promote!
+    def check_ready_to_promote!(to_env)
       fail _("Default content view versions cannot be promoted") if default?
+      content_view.check_composite_action_allowed!(to_env)
     end
 
     def validate_destroyable!(skip_environment_check = false)

--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -12,6 +12,9 @@ class Setting::Katello < Setting
         self.set('katello_default_ptable', N_("Default partitioning table for new Operating Systems"), 'Kickstart default'),
         self.set('content_action_accept_timeout', N_("Time in seconds to wait for a Host to pickup a remote action"), 20),
         self.set('content_action_finish_timeout', N_("Time in seconds to wait for a Host to finish a remote action"), 3600),
+        self.set('restrict_composite_view', N_("If set to true, a composite content view may not be published or "\
+                 "promoted, unless the component content view versions that it includes exist in the target environment."),
+                 false),
         self.set('pulp_sync_node_action_accept_timeout', N_("Time in seconds to wait for a pulp node to remote action"), 20),
         self.set('pulp_sync_node_action_finish_timeout', N_("Time in seconds to wait for a pulp node to finish sync"), 12.hours.to_i),
         self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."), true),


### PR DESCRIPTION
This commit adds an optional 'setting' to enable a user to
restrict/deny composite content view publishing and promotion,
if any of the composite's component content view versions are
not currently in the target environment.

E.g.

If a component view version 3.0 (e.g. CVV-A-3.0) is associated
with the composite view:
- the composite view may not be published, if CVV-A-3.0 is not in Library
- the composite view version may not be promoted, if the target environment
  (e.g. Dev) does not contain CVV-A-3.0.