### PR TITLE
Fixes #13202 - Host collections not available to add to content hosts

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -155,7 +155,7 @@ module Katello
     def available_host_collections
       system_org_id = @system.environment.organization_id
 
-      collection = HostCollection.readable.where(:organization_id => system_org_id).where("id not in (?)", @system.host_collection_ids)
+      collection = HostCollection.readable.where(:organization_id => system_org_id).where.not(:id => @system.host_collection_ids)
 
       respond_for_index(:collection => scoped_search(collection, :name, :desc, :resource_class => HostCollection))
     end


### PR DESCRIPTION
I am not seeing host collections available to content hosts in the UI, this change allowed me to view them. Unfortunately, I was unsuccessful at recreating the bug in a test.