### PR TITLE
Fixes #13206 - delete system object when deleting host

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -12,7 +12,7 @@ module Katello
         alias_method_chain :smart_proxy_ids, :katello
 
         has_one :content_host, :class_name => "Katello::System", :foreign_key => :host_id,
-                               :dependent => :restrict_with_exception, :inverse_of => :foreman_host
+                               :dependent => :destroy, :inverse_of => :foreman_host
         belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hosts
 
         has_many :host_installed_packages, :class_name => "::Katello::HostInstalledPackage", :foreign_key => :host_id, :dependent => :destroy

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -24,9 +24,11 @@ module Katello
       @foreman_host.environment = new_puppet_environment
     end
 
-    def teardown
-      @foreman_host.content_host.destroy
-      @foreman_host.reload.destroy
+    def test_destroy_host
+      system_id = @foreman_host.content_host.id
+
+      assert @foreman_host.destroy
+      assert_nil Katello::System.find_by_id(system_id)
     end
 
     def test_smart_proxy_ids_with_katello


### PR DESCRIPTION
Backend object deletions are now handled by host destroy action, so no problem to cascade the system object deletion